### PR TITLE
Fixed: removed sameas attribute in Grieg opus 43 example

### DIFF
--- a/samples/MEI2013/Music/Complete examples/Grieg_op.43_butterfly.mei
+++ b/samples/MEI2013/Music/Complete examples/Grieg_op.43_butterfly.mei
@@ -1246,38 +1246,67 @@
                        <layer n="2">
                          <space dur="4"/>
                          <beam>
-                         <note sameas="#d418069e2484"/>
+                           <note xml:id="d418069e2487"
+                                    pname="d"
+                                    oct="5"
+                                    dur="16"
+                                    stem.dir="down"/>
                            <note xml:id="d418069e2505"
                                  pname="g"
                                  accid="n"
                                  oct="5"
                                  dur="16"
                                  stem.dir="down"/>
-                           <note sameas="#d418069e2525"/>
+                           <note xml:id="d418069e2524"
+                               pname="c"
+                               accid="s"
+                               oct="5"
+                               dur="16"
+                               stem.dir="down"
+                               accid.ges="s"/>
                            <chord xml:id="d418150e1" dur="16" stem.dir="down">
                               <note xml:id="d418069e2550" pname="d" oct="5"/>
                               <note xml:id="d418069e2568" pname="g" oct="5"/>
                            </chord>
                          </beam>
                          <beam>
-                           <note sameas="#d418069e2583"/>                           
+                           <note xml:id="d418069e2588"
+                              pname="b"
+                              oct="4"
+                              dur="16"
+                              stem.dir="down"
+                              syl="&lt;"/>
                            <chord xml:id="d418154e1" dur="16" stem.dir="down">
                               <note xml:id="d418069e2613" pname="d" oct="5"/>
                               <note xml:id="d418069e2635" pname="g" oct="5"/>
                            </chord>
-                           <note sameas="#d418069e2650"/>
+                           <note xml:id="d418069e2654"
+                              pname="a"
+                              oct="4"
+                              dur="16"
+                              stem.dir="down"/>
                            <chord xml:id="d418158e1" dur="16" stem.dir="down">
                               <note xml:id="d418069e2676" pname="b" oct="4"/>
                               <note xml:id="d418069e2698" pname="d" oct="5"/>
                            </chord>
                          </beam>
                          <beam>
-                           <note sameas="#d418069e2713"/>
+                           <note xml:id="d418069e2715"
+                              pname="g"
+                              accid="n"
+                              oct="4"
+                              dur="16"
+                              stem.dir="down"/>
                            <chord xml:id="d418162e1" dur="16" stem.dir="down">
                               <note xml:id="d418069e2745" pname="b" oct="4"/>
                               <note xml:id="d418069e2771" pname="d" oct="5"/>
                            </chord>
-                           <note sameas="#d418069e2786"/>
+                           <note xml:id="d418069e2783"
+                              pname="f"
+                              oct="4"
+                              dur="16"
+                              stem.dir="down"
+                              accid.ges="s"/>
                            <chord xml:id="d418166e1" dur="16" stem.dir="down">
                               <note xml:id="d418069e2818" pname="b" oct="4"/>
                               <note xml:id="d418069e2844" pname="d" oct="5"/>


### PR DESCRIPTION
Previously, @sameas was used within note elements in some places in the Grieg opus 43 example, specifically in measure 7 where the notes were not the same and were actually supposed to have different durations. This fixes this problem and has the correct note durations.
