### PR TITLE
Fixed: TravisCI will now checkout a specific tag for TEI Stylesheets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 before_install:
     - sudo apt-get install ant
     - sudo apt-get install jing
-    - git clone --depth=1 https://github.com/TEIC/Stylesheets.git
+    - git clone --branch $TEI_STYLESHEET_VERSION --depth=1 https://github.com/TEIC/Stylesheets.git
 
 before_script:
     - ./build.sh -t $TRAVIS_BUILD_DIR/Stylesheets/ all


### PR DESCRIPTION
The $TEI_STYLESHEET_VERSION environment variable is set on the TravisCI website. This can be changed to the latest tag; currently it is set to 7.39.0, the latest release.

Refs #239
