### PR TITLE
add missing note

### DIFF
--- a/samples/MEI2013/Music/Lyrics/multiple_verses.mei
+++ b/samples/MEI2013/Music/Lyrics/multiple_verses.mei
@@ -425,6 +425,17 @@
                       <note xml:id="d1e1053" tstamp.ges="56" pname="a" oct="4" dur="8" dur.ges="8p"
                         beam="t1" tuplet="m1" stem.dir="up"/>
                     </beam>
+                    <note pname="g" oct="4" dur="8" tuplet="t1" stem.dir="up" syl="den-//fer//ge-">
+                      <verse n="1">
+                        <syl wordpos="m" con="d">den</syl>
+                      </verse>
+                      <verse n="2">
+                        <syl wordpos="t" con="s">fer</syl>
+                      </verse>
+                      <verse n="3">
+                        <syl wordpos="m" con="d">ge</syl>
+                      </verse>
+                    </note>
                   </tuplet>
                 </layer>
               </staff>


### PR DESCRIPTION
Measure 4 on the first staff missed the third note of the tuplet. This
commit adds the note, nevertheless it still misses an xml:id.
