### PR TITLE
Changed ornament to ornam

### DIFF
--- a/source/specs/mei-source.xml
+++ b/source/specs/mei-source.xml
@@ -6181,7 +6181,7 @@
         </attDef>
       </attList>
     </classSpec>
-    <classSpec ident="att.ornament.log" module="MEI.shared" type="atts">
+    <classSpec ident="att.ornam.log" module="MEI.shared" type="atts">
       <desc>Logical domain attributes.</desc>
       <classes>
         <memberOf key="att.controlevent"/>
@@ -6191,7 +6191,7 @@
         <memberOf key="att.timestamp2.musical"/>
       </classes>
     </classSpec>
-    <classSpec ident="att.ornament.vis" module="MEI.shared" type="atts">
+    <classSpec ident="att.ornam.vis" module="MEI.shared" type="atts">
       <desc>Visual domain attributes.</desc>
       <classes>
         <memberOf key="att.color"/>
@@ -6202,13 +6202,13 @@
         <memberOf key="att.xy"/>
       </classes>
     </classSpec>
-    <classSpec ident="att.ornament.ges" module="MEI.shared" type="atts">
+    <classSpec ident="att.ornam.ges" module="MEI.shared" type="atts">
       <desc>Gestural domain attributes.</desc>
       <classes>
         <memberOf key="att.duration.performed"/>
       </classes>
     </classSpec>
-    <classSpec ident="att.ornament.anl" module="MEI.shared" type="atts">
+    <classSpec ident="att.ornam.anl" module="MEI.shared" type="atts">
       <desc>Analytical domain attributes.</desc>
       <classes>
         <memberOf key="att.common.anl"/>
@@ -14445,16 +14445,16 @@
           standard.</p>
       </remarks>
     </elementSpec>
-    <elementSpec ident="ornament" module="MEI.shared">
+    <elementSpec ident="ornam" module="MEI.shared">
       <desc>An element indicating an ornament that is not a mordent, turn, or trill.
       </desc>
       <classes>
         <memberOf key="att.common"/>
         <memberOf key="att.facsimile"/>
-        <memberOf key="att.ornament.log"/>
-        <memberOf key="att.ornament.vis"/>
-        <memberOf key="att.ornament.ges"/>
-        <memberOf key="att.ornament.anl"/>
+        <memberOf key="att.ornam.log"/>
+        <memberOf key="att.ornam.vis"/>
+        <memberOf key="att.ornam.ges"/>
+        <memberOf key="att.ornam.anl"/>
         <memberOf key="att.typed"/>
         <memberOf key="model.controleventLike"/>
       </classes>
@@ -14469,9 +14469,9 @@
           </rng:choice>
         </rng:zeroOrMore>
       </content>
-      <constraintSpec ident="ornament_start-type_attributes_required" scheme="isoschematron">
+      <constraintSpec ident="ornam_start-type_attributes_required" scheme="isoschematron">
         <constraint>
-          <sch:rule context="mei:ornament">
+          <sch:rule context="mei:ornam">
             <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
               the attributes: startid, tstamp, tstamp.ges or tstamp.real</sch:assert>
           </sch:rule>


### PR DESCRIPTION
This commit changes the new element ornament to the shorter ornam. This is in keeping with other abbreviated element names. Related attribute classes att.ornament.\* were changed as well to att.ornam.*.

Fixes #253
