### PR TITLE
Added string datatype to data.HEADSHAPE

### DIFF
--- a/schemata/mei-all.rng
+++ b/schemata/mei-all.rng
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<grammar xmlns="http://relaxng.org/ns/structure/1.0" xmlns:xlink="http://www.w3.org/1999/xlink"
-   datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
-   ns="http://www.music-encoding.org/ns/mei">
-   <!--
-Schema generated from ODD source 2016-04-14T14:57:56Z. .
-TEI Edition: Version 3.0.0
+<grammar xmlns="http://relaxng.org/ns/structure/1.0"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"
+         ns="http://www.music-encoding.org/ns/mei"><!--
+Schema generated from ODD source 2016-04-21T18:50:59Z. .
+TEI Edition: 
 TEI Edition Location: http://www.tei-c.org/Vault/P5//
   
--->
-   <!---->
-   <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="tei"
-      uri="http://www.tei-c.org/ns/1.0"/>
-   <div ns="http://www.w3.org/2000/svg" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+--><!---->
+   <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+           prefix="tei"
+           uri="http://www.tei-c.org/ns/1.0"/>
+   <div ns="http://www.w3.org/2000/svg"
+        datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
       <define name="Boolean.datatype">
          <choice>
             <value>false</value>
@@ -1302,7 +1303,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="XLINK.xmlns.attrib"/>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="xlink:type" a:defaultValue="simple">
+                       name="xlink:type"
+                       a:defaultValue="simple">
                <value>simple</value>
             </attribute>
          </optional>
@@ -1326,7 +1328,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="xlink:show" a:defaultValue="other">
+                       name="xlink:show"
+                       a:defaultValue="other">
                <choice>
                   <value>other</value>
                </choice>
@@ -1334,7 +1337,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="xlink:actuate" a:defaultValue="onLoad">
+                       name="xlink:actuate"
+                       a:defaultValue="onLoad">
                <value>onLoad</value>
             </attribute>
          </optional>
@@ -1347,7 +1351,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="XLINK.xmlns.attrib"/>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="xlink:type" a:defaultValue="simple">
+                       name="xlink:type"
+                       a:defaultValue="simple">
                <value>simple</value>
             </attribute>
          </optional>
@@ -1369,7 +1374,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="xlink:show" a:defaultValue="other">
+                       name="xlink:show"
+                       a:defaultValue="other">
                <choice>
                   <value>other</value>
                </choice>
@@ -1377,7 +1383,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="xlink:actuate" a:defaultValue="onLoad">
+                       name="xlink:actuate"
+                       a:defaultValue="onLoad">
                <value>onLoad</value>
             </attribute>
          </optional>
@@ -1390,7 +1397,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="XLINK.xmlns.attrib"/>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="xlink:type" a:defaultValue="simple">
+                       name="xlink:type"
+                       a:defaultValue="simple">
                <value>simple</value>
             </attribute>
          </optional>
@@ -1412,7 +1420,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="xlink:show" a:defaultValue="embed">
+                       name="xlink:show"
+                       a:defaultValue="embed">
                <choice>
                   <value>embed</value>
                </choice>
@@ -1420,7 +1429,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="xlink:actuate" a:defaultValue="onLoad">
+                       name="xlink:actuate"
+                       a:defaultValue="onLoad">
                <value>onLoad</value>
             </attribute>
          </optional>
@@ -1433,7 +1443,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="XLINK.xmlns.attrib"/>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="xlink:type" a:defaultValue="simple">
+                       name="xlink:type"
+                       a:defaultValue="simple">
                <value>simple</value>
             </attribute>
          </optional>
@@ -1455,7 +1466,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="xlink:show" a:defaultValue="replace">
+                       name="xlink:show"
+                       a:defaultValue="replace">
                <choice>
                   <value>new</value>
                   <value>replace</value>
@@ -1464,7 +1476,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="xlink:actuate" a:defaultValue="onRequest">
+                       name="xlink:actuate"
+                       a:defaultValue="onRequest">
                <value>onRequest</value>
             </attribute>
          </optional>
@@ -1594,13 +1607,15 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="preserveAspectRatio" a:defaultValue="xMidYMid meet">
+                       name="preserveAspectRatio"
+                       a:defaultValue="xMidYMid meet">
                <ref name="PreserveAspectRatioSpec.datatype"/>
             </attribute>
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="zoomAndPan" a:defaultValue="magnify">
+                       name="zoomAndPan"
+                       a:defaultValue="magnify">
                <choice>
                   <value>disable</value>
                   <value>magnify</value>
@@ -1608,8 +1623,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </attribute>
          </optional>
          <optional>
-            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="version"
-               a:defaultValue="1.1">
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="version"
+                       a:defaultValue="1.1">
                <value type="string" datatypeLibrary="">1.1</value>
             </attribute>
          </optional>
@@ -1620,13 +1636,15 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="contentScriptType" a:defaultValue="text/ecmascript">
+                       name="contentScriptType"
+                       a:defaultValue="text/ecmascript">
                <ref name="ContentType.datatype"/>
             </attribute>
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="contentStyleType" a:defaultValue="text/css">
+                       name="contentStyleType"
+                       a:defaultValue="text/css">
                <ref name="ContentType.datatype"/>
             </attribute>
          </optional>
@@ -1840,7 +1858,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="preserveAspectRatio" a:defaultValue="xMidYMid meet">
+                       name="preserveAspectRatio"
+                       a:defaultValue="xMidYMid meet">
                <ref name="PreserveAspectRatioSpec.datatype"/>
             </attribute>
          </optional>
@@ -1995,7 +2014,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </attribute>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="preserveAspectRatio" a:defaultValue="xMidYMid meet">
+                       name="preserveAspectRatio"
+                       a:defaultValue="xMidYMid meet">
                <ref name="PreserveAspectRatioSpec.datatype"/>
             </attribute>
          </optional>
@@ -2028,7 +2048,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
       <define name="attlist.style" combine="interleave">
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="xml:space" a:defaultValue="preserve">
+                       name="xml:space"
+                       a:defaultValue="preserve">
                <value>preserve</value>
             </attribute>
          </optional>
@@ -2972,7 +2993,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="preserveAspectRatio" a:defaultValue="xMidYMid meet">
+                       name="preserveAspectRatio"
+                       a:defaultValue="xMidYMid meet">
                <ref name="PreserveAspectRatioSpec.datatype"/>
             </attribute>
          </optional>
@@ -3003,7 +3025,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <attribute name="name"/>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="rendering-intent" a:defaultValue="auto">
+                       name="rendering-intent"
+                       a:defaultValue="auto">
                <choice>
                   <value>auto</value>
                   <value>perceptual</value>
@@ -3284,7 +3307,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="preserveAspectRatio" a:defaultValue="xMidYMid meet">
+                       name="preserveAspectRatio"
+                       a:defaultValue="xMidYMid meet">
                <ref name="PreserveAspectRatioSpec.datatype"/>
             </attribute>
          </optional>
@@ -3554,8 +3578,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="SVG.FilterPrimitiveWithIn.attrib"/>
          <attribute name="in2"/>
          <optional>
-            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="mode"
-               a:defaultValue="normal">
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="mode"
+                       a:defaultValue="normal">
                <choice>
                   <value>normal</value>
                   <value>multiply</value>
@@ -3589,8 +3614,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="SVG.FilterColor.attrib"/>
          <ref name="SVG.FilterPrimitiveWithIn.attrib"/>
          <optional>
-            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="type"
-               a:defaultValue="matrix">
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="type"
+                       a:defaultValue="matrix">
                <choice>
                   <value>matrix</value>
                   <value>saturate</value>
@@ -3656,8 +3682,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="SVG.FilterPrimitiveWithIn.attrib"/>
          <attribute name="in2"/>
          <optional>
-            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="operator"
-               a:defaultValue="over">
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="operator"
+                       a:defaultValue="over">
                <choice>
                   <value>over</value>
                   <value>in</value>
@@ -3736,8 +3763,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </attribute>
          </optional>
          <optional>
-            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="edgeMode"
-               a:defaultValue="duplicate">
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="edgeMode"
+                       a:defaultValue="duplicate">
                <choice>
                   <value>duplicate</value>
                   <value>wrap</value>
@@ -3837,7 +3865,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="xChannelSelector" a:defaultValue="A">
+                       name="xChannelSelector"
+                       a:defaultValue="A">
                <choice>
                   <value>R</value>
                   <value>G</value>
@@ -3848,7 +3877,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="yChannelSelector" a:defaultValue="A">
+                       name="yChannelSelector"
+                       a:defaultValue="A">
                <choice>
                   <value>R</value>
                   <value>G</value>
@@ -3950,7 +3980,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="SVG.External.attrib"/>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="preserveAspectRatio" a:defaultValue="xMidYMid meet">
+                       name="preserveAspectRatio"
+                       a:defaultValue="xMidYMid meet">
                <ref name="PreserveAspectRatioSpec.datatype"/>
             </attribute>
          </optional>
@@ -4024,8 +4055,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="SVG.FilterColor.attrib"/>
          <ref name="SVG.FilterPrimitiveWithIn.attrib"/>
          <optional>
-            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="operator"
-               a:defaultValue="erode">
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="operator"
+                       a:defaultValue="erode">
                <choice>
                   <value>erode</value>
                   <value>dilate</value>
@@ -4189,7 +4221,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="stitchTiles" a:defaultValue="noStitch">
+                       name="stitchTiles"
+                       a:defaultValue="noStitch">
                <choice>
                   <value>stitch</value>
                   <value>noStitch</value>
@@ -4197,8 +4230,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </attribute>
          </optional>
          <optional>
-            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="type"
-               a:defaultValue="turbulence">
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="type"
+                       a:defaultValue="turbulence">
                <choice>
                   <value>fractalNoise</value>
                   <value>turbulence</value>
@@ -4685,13 +4719,15 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="preserveAspectRatio" a:defaultValue="xMidYMid meet">
+                       name="preserveAspectRatio"
+                       a:defaultValue="xMidYMid meet">
                <ref name="PreserveAspectRatioSpec.datatype"/>
             </attribute>
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="zoomAndPan" a:defaultValue="magnify">
+                       name="zoomAndPan"
+                       a:defaultValue="magnify">
                <choice>
                   <value>disable</value>
                   <value>magnify</value>
@@ -4764,8 +4800,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             <attribute name="max"/>
          </optional>
          <optional>
-            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="restart"
-               a:defaultValue="always">
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="restart"
+                       a:defaultValue="always">
                <choice>
                   <value>always</value>
                   <value>never</value>
@@ -4780,8 +4817,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             <attribute name="repeatDur"/>
          </optional>
          <optional>
-            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="fill"
-               a:defaultValue="remove">
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="fill"
+                       a:defaultValue="remove">
                <choice>
                   <value>remove</value>
                   <value>freeze</value>
@@ -4795,8 +4833,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
       </define>
       <define name="SVG.AnimationValue.attrib">
          <optional>
-            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="calcMode"
-               a:defaultValue="linear">
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="calcMode"
+                       a:defaultValue="linear">
                <choice>
                   <value>discrete</value>
                   <value>linear</value>
@@ -4830,8 +4869,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
       </define>
       <define name="SVG.AnimationAddtion.attrib">
          <optional>
-            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="additive"
-               a:defaultValue="replace">
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="additive"
+                       a:defaultValue="replace">
                <choice>
                   <value>replace</value>
                   <value>sum</value>
@@ -4840,7 +4880,8 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               name="accumulate" a:defaultValue="none">
+                       name="accumulate"
+                       a:defaultValue="none">
                <choice>
                   <value>none</value>
                   <value>sum</value>
@@ -4933,8 +4974,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="SVG.AnimationTiming.attrib"/>
          <ref name="SVG.AnimationAddtion.attrib"/>
          <optional>
-            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="calcMode"
-               a:defaultValue="paced">
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="calcMode"
+                       a:defaultValue="paced">
                <choice>
                   <value>discrete</value>
                   <value>linear</value>
@@ -5030,8 +5072,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="SVG.AnimationValue.attrib"/>
          <ref name="SVG.AnimationAddtion.attrib"/>
          <optional>
-            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="type"
-               a:defaultValue="translate">
+            <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                       name="type"
+                       a:defaultValue="translate">
                <choice>
                   <value>translate</value>
                   <value>scale</value>
@@ -5632,215 +5675,145 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_data.ACCIDENTAL.EXPLICIT">
       <choice>
          <value>s</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Sharp.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sharp.</a:documentation>
          <value>f</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Flat.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Flat.</a:documentation>
          <value>ss</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double sharp
-            (written as 2 sharps).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double sharp (written as 2 sharps).</a:documentation>
          <value>x</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double sharp
-            (written using croix).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double sharp (written using croix).</a:documentation>
          <value>ff</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double
-            flat.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double flat.</a:documentation>
          <value>xs</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Triple sharp
-            (written as a croix followed by a sharp).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Triple sharp (written as a croix followed by a sharp).</a:documentation>
          <value>sx</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Triple sharp
-            (written as a sharp followed by a croix).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Triple sharp (written as a sharp followed by a croix).</a:documentation>
          <value>ts</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Triple sharp
-            (written as 3 sharps).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Triple sharp (written as 3 sharps).</a:documentation>
          <value>tf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Triple
-            flat.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Triple flat.</a:documentation>
          <value>n</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Natural.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Natural.</a:documentation>
          <value>nf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Natural +
-            flat; used to cancel preceding double flat.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Natural + flat; used to cancel preceding double flat.</a:documentation>
          <value>ns</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Natural +
-            sharp; used to cancel preceding double sharp.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Natural + sharp; used to cancel preceding double sharp.</a:documentation>
          <value>su</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sharp note
-            raised by quarter tone (sharp modified by arrow).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sharp note raised by quarter tone (sharp modified by arrow).</a:documentation>
          <value>sd</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sharp note
-            lowered by quarter tone (sharp modified by arrow).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sharp note lowered by quarter tone (sharp modified by arrow).</a:documentation>
          <value>fu</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Flat note
-            raised by quarter tone (flat modified by arrow).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Flat note raised by quarter tone (flat modified by arrow).</a:documentation>
          <value>fd</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Flat note
-            lowered by quarter tone (flat modified by arrow).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Flat note lowered by quarter tone (flat modified by arrow).</a:documentation>
          <value>nu</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Natural note
-            raised by quarter tone (natural modified by arrow).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Natural note raised by quarter tone (natural modified by arrow).</a:documentation>
          <value>nd</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Natural note
-            lowered by quarter tone (natural modified by arrow).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Natural note lowered by quarter tone (natural modified by arrow).</a:documentation>
          <value>1qf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">1/4-tone
-            flat accidental.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">1/4-tone flat accidental.</a:documentation>
          <value>3qf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">3/4-tone
-            flat accidental.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">3/4-tone flat accidental.</a:documentation>
          <value>1qs</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">1/4-tone
-            sharp accidental.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">1/4-tone sharp accidental.</a:documentation>
          <value>3qs</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">3/4-tone
-            sharp accidental.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">3/4-tone sharp accidental.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.ACCIDENTAL.IMPLICIT">
       <choice>
          <value>s</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Sharp.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sharp.</a:documentation>
          <value>f</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Flat.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Flat.</a:documentation>
          <value>ss</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double
-            sharp.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double sharp.</a:documentation>
          <value>ff</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double
-            flat.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double flat.</a:documentation>
          <value>n</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Natural.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Natural.</a:documentation>
          <value>su</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Three
-            quarter-tones sharp.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Three quarter-tones sharp.</a:documentation>
          <value>sd</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Quarter-tone
-            sharp.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Quarter-tone sharp.</a:documentation>
          <value>fu</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Quarter-tone
-            flat.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Quarter-tone flat.</a:documentation>
          <value>fd</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Three
-            quarter-tones flat.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Three quarter-tones flat.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.ARTICULATION">
       <choice>
          <value>acc</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Accent
-            (Unicode 1D17B).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Accent (Unicode 1D17B).</a:documentation>
          <value>stacc</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Staccato
-            (Unicode 1D17C).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Staccato (Unicode 1D17C).</a:documentation>
          <value>ten</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Tenuto
-            (Unicode 1D17D).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Tenuto (Unicode 1D17D).</a:documentation>
          <value>stacciss</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Staccatissimo (Unicode 1D17E).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Staccatissimo (Unicode 1D17E).</a:documentation>
          <value>marc</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Marcato
-            (Unicode 1D17F).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Marcato (Unicode 1D17F).</a:documentation>
          <value>marc-stacc</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Marcato +
-            staccato (Unicode 1D180).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Marcato + staccato (Unicode 1D180).</a:documentation>
          <value>spicc</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Spiccato.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Spiccato.</a:documentation>
          <value>doit</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Main note
-            followed by short slide to higher, indeterminate pitch (Unicode
-            1D185).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Main note followed by short slide to higher, indeterminate pitch (Unicode 1D185).</a:documentation>
          <value>scoop</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Main note
-            preceded by short slide from lower, indeterminate pitch (Unicode
-            1D186).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Main note preceded by short slide from lower, indeterminate pitch (Unicode 1D186).</a:documentation>
          <value>rip</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Main note
-            preceded by long slide from lower, often indeterminate pitch; also known as
-            "squeeze".</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Main note preceded by long slide from lower, often indeterminate pitch; also known as "squeeze".</a:documentation>
          <value>plop</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Main note
-            preceded by "slide" from higher, indeterminate pitch.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Main note preceded by "slide" from higher, indeterminate pitch.</a:documentation>
          <value>fall</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Main note
-            followed by short "slide" to lower, indeterminate pitch.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Main note followed by short "slide" to lower, indeterminate pitch.</a:documentation>
          <value>longfall</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Main note
-            followed by long "slide" to lower, indeterminate pitch.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Main note followed by long "slide" to lower, indeterminate pitch.</a:documentation>
          <value>bend</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">"lip slur"
-            to lower pitch, then return to written pitch.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">"lip slur" to lower pitch, then return to written pitch.</a:documentation>
          <value>flip</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Main note
-            followed by quick upward rise, then descent in pitch (Unicode 1D187).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Main note followed by quick upward rise, then descent in pitch (Unicode 1D187).</a:documentation>
          <value>smear</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Unicode
-            1D188).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Unicode 1D188).</a:documentation>
          <value>shake</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Alternation
-            between written pitch and next highest overtone (brass instruments) or note minor third
-            higher (woodwinds).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Alternation between written pitch and next highest overtone (brass instruments) or note minor third higher (woodwinds).</a:documentation>
          <value>dnbow</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Down bow
-            (Unicode 1D1AA).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Down bow (Unicode 1D1AA).</a:documentation>
          <value>upbow</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Up bow
-            (Unicode 1D1AB).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Up bow (Unicode 1D1AB).</a:documentation>
          <value>harm</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Harmonic
-            (Unicode 1D1AC).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Harmonic (Unicode 1D1AC).</a:documentation>
          <value>snap</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Snap
-            pizzicato (Unicode 1D1AD).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Snap pizzicato (Unicode 1D1AD).</a:documentation>
          <value>fingernail</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Fingernail
-            (Unicode 1D1B3).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Fingernail (Unicode 1D1B3).</a:documentation>
          <value>ten-stacc</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Tenuto +
-            staccato (Unicode 1D182).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Tenuto + staccato (Unicode 1D182).</a:documentation>
          <value>damp</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stop harp
-            string from sounding (Unicode 1D1B4).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stop harp string from sounding (Unicode 1D1B4).</a:documentation>
          <value>dampall</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stop all
-            harp strings from sounding (Unicode 1D1B5).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stop all harp strings from sounding (Unicode 1D1B5).</a:documentation>
          <value>open</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Full (as
-            opposed to stopped) tone.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Full (as opposed to stopped) tone.</a:documentation>
          <value>stop</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">"muffled"
-            tone.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">"muffled" tone.</a:documentation>
          <value>dbltongue</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double
-            tongue (Unicode 1D18A).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double tongue (Unicode 1D18A).</a:documentation>
          <value>trpltongue</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Triple
-            tongue (Unicode 1D18B).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Triple tongue (Unicode 1D18B).</a:documentation>
          <value>heel</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Use heel
-            (organ pedal).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Use heel (organ pedal).</a:documentation>
          <value>toe</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Use toe
-            (organ pedal).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Use toe (organ pedal).</a:documentation>
          <value>tap</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Percussive
-            effect on guitar string(s).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Percussive effect on guitar string(s).</a:documentation>
          <value>lhpizz</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Left-hand
-            pizzicato.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Left-hand pizzicato.</a:documentation>
          <value>dot</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Uninterpreted dot.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Uninterpreted dot.</a:documentation>
          <value>stroke</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Uninterpreted stroke.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Uninterpreted stroke.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.AUGMENTDOT">
@@ -5851,51 +5824,37 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_data.BARPLACE">
       <choice>
          <value>mensur</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Between
-            staves only.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Between staves only.</a:documentation>
          <value>staff</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Between and
-            across staves as necessary.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Between and across staves as necessary.</a:documentation>
          <value>takt</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Short line
-            above staff or through top line.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Short line above staff or through top line.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.BARRENDITION">
       <choice>
          <value>dashed</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Dashed line
-            (Unicode 1D104).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Dashed line (Unicode 1D104).</a:documentation>
          <value>dotted</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Dotted
-            line.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Dotted line.</a:documentation>
          <value>dbl</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Unicode
-            1D101).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Unicode 1D101).</a:documentation>
          <value>dbldashed</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double
-            dashed line.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double dashed line.</a:documentation>
          <value>dbldotted</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double
-            dotted line.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double dotted line.</a:documentation>
          <value>end</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Unicode
-            1D102).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Unicode 1D102).</a:documentation>
          <value>invis</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Bar line not
-            rendered.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Bar line not rendered.</a:documentation>
          <value>rptstart</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Repeat start
-            (Unicode 1D106).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Repeat start (Unicode 1D106).</a:documentation>
          <value>rptboth</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Repeat start
-            and end.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Repeat start and end.</a:documentation>
          <value>rptend</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Repeat end
-            (Unicode 1D107).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Repeat end (Unicode 1D107).</a:documentation>
          <value>single</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Unicode
-            1D100).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(Unicode 1D100).</a:documentation>
       </choice>
    </define>
    <define name="mei_data.BEAM">
@@ -5957,88 +5916,63 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_data.CLEFSHAPE">
       <choice>
          <value>G</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">G clef
-            (Unicode 1D11E).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">G clef (Unicode 1D11E).</a:documentation>
          <value>GG</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double G
-            clef.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double G clef.</a:documentation>
          <value>F</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">F clef
-            (Unicode 1D122).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">F clef (Unicode 1D122).</a:documentation>
          <value>C</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">C clef
-            (Unicode 1D121).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">C clef (Unicode 1D121).</a:documentation>
          <value>perc</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Drum clef
-            (Unicode 1D125 or Unicode 1D126).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Drum clef (Unicode 1D125 or Unicode 1D126).</a:documentation>
          <value>TAB</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Tablature
-            "clef"; i.e. usually "TAB" rendered vertically.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Tablature "clef"; i.e. usually "TAB" rendered vertically.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.CLUSTER">
       <choice>
          <value>white</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">White
-            keys.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">White keys.</a:documentation>
          <value>black</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Black
-            keys.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Black keys.</a:documentation>
          <value>chromatic</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Mixed black
-            and white keys.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Mixed black and white keys.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.COLORNAMES">
       <choice>
          <value>aqua</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #00FFFF
-            / RGB:0,255,255</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #00FFFF / RGB:0,255,255</a:documentation>
          <value>black</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #000000
-            / RGB:0,0,0</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #000000 / RGB:0,0,0</a:documentation>
          <value>blue</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #0000FF
-            / RGB:0,0,255</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #0000FF / RGB:0,0,255</a:documentation>
          <value>fuchsia</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #FF00FF
-            / RGB:255,0,255</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #FF00FF / RGB:255,0,255</a:documentation>
          <value>gray</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #808080
-            / RGB:128,128,128</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #808080 / RGB:128,128,128</a:documentation>
          <value>green</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #008000
-            / RGB:0,128,0</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #008000 / RGB:0,128,0</a:documentation>
          <value>lime</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #00FF00
-            / RGB:0,255,0</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #00FF00 / RGB:0,255,0</a:documentation>
          <value>maroon</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #800000
-            / RGB:128,0,0</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #800000 / RGB:128,0,0</a:documentation>
          <value>navy</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #000080
-            / RGB:0,0,128</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #000080 / RGB:0,0,128</a:documentation>
          <value>olive</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #808000
-            / RGB:128,128,0</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #808000 / RGB:128,128,0</a:documentation>
          <value>purple</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #800080
-            / RGB:128,0,128</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #800080 / RGB:128,0,128</a:documentation>
          <value>red</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #FF0000
-            / RGB:255,0,0</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #FF0000 / RGB:255,0,0</a:documentation>
          <value>silver</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #C0C0C0
-            / RGB:208,208,208</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #C0C0C0 / RGB:208,208,208</a:documentation>
          <value>teal</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #008080
-            / RGB:0,128,128</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #008080 / RGB:0,128,128</a:documentation>
          <value>white</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #FFFFFF
-            / RGB:255,255,255</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #FFFFFF / RGB:255,255,255</a:documentation>
          <value>yellow</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #FFFF00
-            / RGB:255,255,0</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Hex: #FFFF00 / RGB:255,255,0</a:documentation>
       </choice>
    </define>
    <define name="mei_data.COLORVALUES">
@@ -6050,28 +5984,24 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             <param name="pattern">#[0-9A-Fa-f]{8,8}</param>
          </data>
          <data type="token">
-            <param name="pattern"
-               >rgb\((\s*(([01]?[0-9]?[0-9])|2[0-4][0-9]|25[0-5])\s*,\s*){2}([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\s*\)</param>
+            <param name="pattern">rgb\((\s*(([01]?[0-9]?[0-9])|2[0-4][0-9]|25[0-5])\s*,\s*){2}([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\s*\)</param>
          </data>
          <data type="token">
-            <param name="pattern"
-               >rgba\(\s*(([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\s*,\s*){3}(0(\.\d+)?|1(\.0+)?)\s*\)|rgba\(\s*(((\d{1,2})?%|100%)\s*,\s*){2}(\d{1,2}%|100%)\s*,\s*(0(\.\d+)?|1(\.0+)?)\s*\)</param>
+            <param name="pattern">rgba\(\s*(([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\s*,\s*){3}(0(\.\d+)?|1(\.0+)?)\s*\)|rgba\(\s*(((\d{1,2})?%|100%)\s*,\s*){2}(\d{1,2}%|100%)\s*,\s*(0(\.\d+)?|1(\.0+)?)\s*\)</param>
          </data>
          <data type="token">
-            <param name="pattern"
-               >hsl\(\s*((\d{1,2})|[12]\d{2}|3[0-5]\d|360)\s*,\s*(\d{1,2}%|100%)\s*,\s*(\d{1,2}%|100%)\s*\)</param>
+            <param name="pattern">hsl\(\s*((\d{1,2})|[12]\d{2}|3[0-5]\d|360)\s*,\s*(\d{1,2}%|100%)\s*,\s*(\d{1,2}%|100%)\s*\)</param>
          </data>
          <data type="token">
-            <param name="pattern"
-               >hsla\(\s*(\d{1,2}|[12]\d{2}|3[0-5]\d|360)\s*,\s*(\d{1,2}%|100%)\s*,\s*(\d{1,2}%|100%)\s*,\s*(0(\.\d+)?|1(\.0+)?)\s*\)</param>
+            <param name="pattern">hsla\(\s*(\d{1,2}|[12]\d{2}|3[0-5]\d|360)\s*,\s*(\d{1,2}%|100%)\s*,\s*(\d{1,2}%|100%)\s*,\s*(0(\.\d+)?|1(\.0+)?)\s*\)</param>
          </data>
       </choice>
    </define>
    <define name="mei_data.COLOR">
       <choice>
-         <ref name="mei_data.COLORNAMES"/>
-         <ref name="mei_data.COLORVALUES"/>
-      </choice>
+          <ref name="mei_data.COLORNAMES"/>
+          <ref name="mei_data.COLORVALUES"/>
+        </choice>
    </define>
    <define name="mei_data.DEGREES">
       <data type="decimal">
@@ -6102,29 +6032,33 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_data.DURATION.gestural">
       <choice>
-         <ref name="mei_data.DURATION.gestural.prop"/>
-         <ref name="mei_data.DURATION.gestural.pat"/>
-         <ref name="mei_data.DURATION.mensural"/>
-      </choice>
+          <ref name="mei_data.DURATION.gestural.prop"/>
+          <ref name="mei_data.DURATION.gestural.pat"/>
+          <ref name="mei_data.DURATION.mensural"/>
+        </choice>
    </define>
    <define name="mei_data.ENCLOSURE">
       <choice>
          <value>paren</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Parentheses.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Parentheses.</a:documentation>
          <value>brack</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Square
-            brackets.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Square brackets.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.FILL">
       <choice>
          <value>void</value>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled</a:documentation>
          <value>solid</value>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Filled</a:documentation>
          <value>top</value>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Top half filled</a:documentation>
          <value>bottom</value>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Bottom half filled</a:documentation>
          <value>left</value>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Left half filled</a:documentation>
          <value>right</value>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Right half filled</a:documentation>
       </choice>
    </define>
    <define name="mei_data.FINGER.FRET">
@@ -6146,10 +6080,10 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_data.FONTSIZE">
       <choice>
-         <ref name="mei_data.FONTSIZENUMERIC"/>
-         <ref name="mei_data.FONTSIZETERM"/>
-         <ref name="mei_data.PERCENT"/>
-      </choice>
+          <ref name="mei_data.FONTSIZENUMERIC"/>
+          <ref name="mei_data.FONTSIZETERM"/>
+          <ref name="mei_data.PERCENT"/>
+        </choice>
    </define>
    <define name="mei_data.FONTSIZENUMERIC">
       <data type="token">
@@ -6175,45 +6109,33 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_data.FONTSIZETERM">
       <choice>
          <value>xx-small</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative
-            font size.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative font size.</a:documentation>
          <value>x-small</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative
-            font size.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative font size.</a:documentation>
          <value>small</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative
-            font size.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative font size.</a:documentation>
          <value>medium</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative
-            font size.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative font size.</a:documentation>
          <value>large</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative
-            font size.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative font size.</a:documentation>
          <value>x-large</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative
-            font size.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative font size.</a:documentation>
          <value>xx-large</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative
-            font size.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative font size.</a:documentation>
          <value>smaller</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative
-            font size.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative font size.</a:documentation>
          <value>larger</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative
-            font size.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative font size.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.FONTSTYLE">
       <choice>
          <value>italic</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Text slants
-            to right.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Text slants to right.</a:documentation>
          <value>normal</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Unadorned.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unadorned.</a:documentation>
          <value>oblique</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Text slants
-            to the left.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Text slants to the left.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.FONTWEIGHT">
@@ -6236,95 +6158,72 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_data.GLISSANDO">
       <choice>
          <value>i</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">First
-            note/chord in glissando.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">First note/chord in glissando.</a:documentation>
          <value>m</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Note/chord
-            that's neither first nor last in glissando.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Note/chord that's neither first nor last in glissando.</a:documentation>
          <value>t</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Last note in
-            glissando.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Last note in glissando.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.GRACE">
       <choice>
          <value>acc</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Time
-            "stolen" from following note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Time "stolen" from following note.</a:documentation>
          <value>unacc</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Time
-            "stolen" from previous note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Time "stolen" from previous note.</a:documentation>
          <value>unknown</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">No
-            interpretation regarding performed value of grace note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">No interpretation regarding performed value of grace note.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.HEADSHAPE">
       <choice>
-         <value>quarter</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Filled,
-            rotated oval (Unicode 1D158).</a:documentation>
-         <value>half</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled,
-            rotated oval (Unicode 1D157).</a:documentation>
-         <value>whole</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled,
-            rotated oval (Unicode 1D15D).</a:documentation>
-         <value>backslash</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled
-            backslash (~ reflection of Unicode 1D10D).</a:documentation>
-         <value>circle</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled
-            circle (Unicode 25CB).</a:documentation>
-         <value>+</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Plus sign
-            (Unicode 1D144).</a:documentation>
-         <value>diamond</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled
-            diamond (Unicode 1D1B9).</a:documentation>
-         <value>isotriangle</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled
-            isosceles triangle (Unicode 1D148).</a:documentation>
-         <value>oval</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled,
-            unrotated oval (Unicode 2B2D).</a:documentation>
-         <value>piewedge</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled
-            downward-pointing wedge (Unicode 1D154).</a:documentation>
-         <value>rectangle</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled
-            rectangle (Unicode 25AD).</a:documentation>
-         <value>rtriangle</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled
-            right triangle (Unicode 1D14A).</a:documentation>
-         <value>semicircle</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled
-            semi-circle (Unicode 1D152).</a:documentation>
-         <value>slash</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled
-            slash (~ Unicode 1D10D).</a:documentation>
-         <value>square</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled
-            square (Unicode 1D146).</a:documentation>
-         <value>x</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">X (Unicode
-            1D143).</a:documentation>
-      </choice>
+          <choice>
+            <value>quarter</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Filled, rotated oval (Unicode 1D158).</a:documentation>
+            <value>half</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled, rotated oval (Unicode 1D157).</a:documentation>
+            <value>whole</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled, rotated oval (Unicode 1D15D).</a:documentation>
+            <value>backslash</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled backslash (~ reflection of Unicode 1D10D).</a:documentation>
+            <value>circle</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled circle (Unicode 25CB).</a:documentation>
+            <value>+</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Plus sign (Unicode 1D144).</a:documentation>
+            <value>diamond</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled diamond (Unicode 1D1B9).</a:documentation>
+            <value>isotriangle</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled isosceles triangle (Unicode 1D148).</a:documentation>
+            <value>oval</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled, unrotated oval (Unicode 2B2D).</a:documentation>
+            <value>piewedge</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled downward-pointing wedge (Unicode 1D154).</a:documentation>
+            <value>rectangle</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled rectangle (Unicode 25AD).</a:documentation>
+            <value>rtriangle</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled right triangle (Unicode 1D14A).</a:documentation>
+            <value>semicircle</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled semi-circle (Unicode 1D152).</a:documentation>
+            <value>slash</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled slash (~ Unicode 1D10D).</a:documentation>
+            <value>square</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled square (Unicode 1D146).</a:documentation>
+            <value>x</value>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">X (Unicode 1D143).</a:documentation>
+         </choice>
+          <data type="string"/>
+        </choice>
    </define>
    <define name="mei_data.HORIZONTALALIGNMENT">
       <choice>
          <value>left</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Left
-            aligned.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Left aligned.</a:documentation>
          <value>right</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Right
-            aligned.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Right aligned.</a:documentation>
          <value>center</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Centered.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Centered.</a:documentation>
          <value>justify</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Left and
-            right aligned.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Left and right aligned.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.INEUMEFORM">
@@ -6400,21 +6299,17 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_data.KEYSIGTOKEN">
       <data type="token">
-         <param name="pattern"
-            >[a-g][0-9](s|f|ss|x|ff|xs|sx|ts|tf|n|nf|ns|su|sd|fu|fd|nu|nd|1qf|3qf|1qs|3qs)</param>
+         <param name="pattern">[a-g][0-9](s|f|ss|x|ff|xs|sx|ts|tf|n|nf|ns|su|sd|fu|fd|nu|nd|1qf|3qf|1qs|3qs)</param>
       </data>
    </define>
    <define name="mei_data.LAYERSCHEME">
       <choice>
          <value>1</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Single
-            layer.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Single layer.</a:documentation>
          <value>2o</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Two layers
-            with opposing stems.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Two layers with opposing stems.</a:documentation>
          <value>2f</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Two layers
-            with 'floating' stems.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Two layers with 'floating' stems.</a:documentation>
          <value>3o</value>
          <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
          <value>3f</value>
@@ -6424,65 +6319,45 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_data.LIGATUREFORM">
       <choice>
          <value>recta</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Notes are
-            "squeezed" together.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Notes are "squeezed" together.</a:documentation>
          <value>obliqua</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Individual
-            notes are replaced by an oblique figure.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Individual notes are replaced by an oblique figure.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.LINEFORM">
       <choice>
          <value>dashed</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Dashed
-            line.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Dashed line.</a:documentation>
          <value>dotted</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Dotted
-            line.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Dotted line.</a:documentation>
          <value>solid</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Straight,
-            uninterrupted line.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Straight, uninterrupted line.</a:documentation>
          <value>wavy</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Undulating
-            line.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Undulating line.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.LINESTARTENDSYMBOL">
       <choice>
          <value>angledown</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">90 degree
-            turn down (similar to Unicode 231D at end of line, 231C at start).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">90 degree turn down (similar to Unicode 231D at end of line, 231C at start).</a:documentation>
          <value>angleup</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">90 degree
-            turn up (similar to Unicode 231F at end of line, 231E at start).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">90 degree turn up (similar to Unicode 231F at end of line, 231E at start).</a:documentation>
          <value>angleright</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">90 degree
-            turn right (syntactic sugar for "angledown" for vertical or angled
-            lines).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">90 degree turn right (syntactic sugar for "angledown" for vertical or angled lines).</a:documentation>
          <value>angleleft</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">90 degree
-            turn left (syntactic sugar for "angleup" for vertical or angled
-            lines).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">90 degree turn left (syntactic sugar for "angleup" for vertical or angled lines).</a:documentation>
          <value>arrow</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Filled,
-            triangular arrowhead (similar to SMuFL U+EB78).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Filled, triangular arrowhead (similar to SMuFL U+EB78).</a:documentation>
          <value>arrowopen</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Open
-            triangular arrowhead (similar to SMuFL U+EB8A).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Open triangular arrowhead (similar to SMuFL U+EB8A).</a:documentation>
          <value>arrowwhite</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled,
-            triangular arrowhead (similar to SMuFL U+EB82).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unfilled, triangular arrowhead (similar to SMuFL U+EB82).</a:documentation>
          <value>harpoonleft</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Harpoon-shaped arrowhead left of line (similar to arrowhead of Unicode
-            U+21BD).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Harpoon-shaped arrowhead left of line (similar to arrowhead of Unicode U+21BD).</a:documentation>
          <value>harpoonright</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Harpoon-shaped arrowhead right of line (similar to arrowhead of Unicode
-            U+21BC).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Harpoon-shaped arrowhead right of line (similar to arrowhead of Unicode U+21BC).</a:documentation>
          <value>none</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">No start
-            symbol.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">No start symbol.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.LINESTARTENDSYMBOLSIZE">
@@ -6493,21 +6368,18 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_data.LINEWIDTH">
       <choice>
-         <ref name="mei_data.LINEWIDTHTERM"/>
-         <ref name="mei_data.MEASUREMENTABS"/>
-      </choice>
+          <ref name="mei_data.LINEWIDTHTERM"/>
+          <ref name="mei_data.MEASUREMENTABS"/>
+        </choice>
    </define>
    <define name="mei_data.LINEWIDTHTERM">
       <choice>
          <value>narrow</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Default line
-            width.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Default line width.</a:documentation>
          <value>medium</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Twice as
-            wide as narrow.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Twice as wide as narrow.</a:documentation>
          <value>wide</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Twice as
-            wide as medium.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Twice as wide as medium.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.MEASUREBEAT">
@@ -6528,109 +6400,77 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_data.MELODICFUNCTION">
       <choice>
          <value>aln</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Accented
-            lower neighbor.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Accented lower neighbor.</a:documentation>
          <value>ant</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Anticipation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Anticipation.</a:documentation>
          <value>app</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Appogiatura.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Appogiatura.</a:documentation>
          <value>apt</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Accented
-            passing tone.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Accented passing tone.</a:documentation>
          <value>arp</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Arpeggio
-            tone (chordal tone).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Arpeggio tone (chordal tone).</a:documentation>
          <value>arp7</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Arpeggio
-            tone (7th added to the chord).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Arpeggio tone (7th added to the chord).</a:documentation>
          <value>aun</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Accented
-            upper neighbor.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Accented upper neighbor.</a:documentation>
          <value>chg</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Changing
-            tone.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Changing tone.</a:documentation>
          <value>cln</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Chromatic
-            lower neighbor.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Chromatic lower neighbor.</a:documentation>
          <value>ct</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Chord tone
-            (i.e., not an embellishment).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Chord tone (i.e., not an embellishment).</a:documentation>
          <value>ct7</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Chord tone
-            (7th added to the chord).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Chord tone (7th added to the chord).</a:documentation>
          <value>cun</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Chromatic
-            upper neighbor.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Chromatic upper neighbor.</a:documentation>
          <value>cup</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Chromatic
-            unaccented passing tone.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Chromatic unaccented passing tone.</a:documentation>
          <value>et</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Escape
-            tone.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Escape tone.</a:documentation>
          <value>ln</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Lower
-            neighbor.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Lower neighbor.</a:documentation>
          <value>ped</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Pedal
-            tone.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Pedal tone.</a:documentation>
          <value>rep</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Repeated
-            tone.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Repeated tone.</a:documentation>
          <value>ret</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Retardation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Retardation.</a:documentation>
          <value>23ret</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">2-3
-            retardation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">2-3 retardation.</a:documentation>
          <value>78ret</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">7-8
-            retardation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">7-8 retardation.</a:documentation>
          <value>sus</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Suspension.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Suspension.</a:documentation>
          <value>43sus</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">4-3
-            suspension.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">4-3 suspension.</a:documentation>
          <value>98sus</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">9-8
-            suspension.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">9-8 suspension.</a:documentation>
          <value>76sus</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">7-6
-            suspension.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">7-6 suspension.</a:documentation>
          <value>un</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Upper
-            neighbor.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Upper neighbor.</a:documentation>
          <value>un7</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Upper
-            neighbor (7th added to the chord).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Upper neighbor (7th added to the chord).</a:documentation>
          <value>upt</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unaccented
-            passing tone.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unaccented passing tone.</a:documentation>
          <value>upt7</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unaccented
-            passing tone (7th added to the chord).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unaccented passing tone (7th added to the chord).</a:documentation>
       </choice>
    </define>
    <define name="mei_data.MENSURATIONSIGN">
       <choice>
          <value>C</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Tempus
-            imperfectum.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Tempus imperfectum.</a:documentation>
          <value>O</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Tempus
-            perfectum.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Tempus perfectum.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.METERSIGN">
       <choice>
          <value>common</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Common time;
-            i.e. 4/4.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Common time; i.e. 4/4.</a:documentation>
          <value>cut</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Cut time;
-            i.e. 2/2.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Cut time; i.e. 2/2.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.MIDICHANNEL">
@@ -6647,530 +6487,355 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_data.MIDINAMES">
       <choice>
          <value>Acoustic_Grand_Piano</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #0.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #0.</a:documentation>
          <value>Bright_Acoustic_Piano</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #1.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #1.</a:documentation>
          <value>Electric_Grand_Piano</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #2.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #2.</a:documentation>
          <value>Honky-tonk_Piano</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #3.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #3.</a:documentation>
          <value>Electric_Piano_1</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #4.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #4.</a:documentation>
          <value>Electric_Piano_2</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #5.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #5.</a:documentation>
          <value>Harpsichord</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #6.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #6.</a:documentation>
          <value>Clavi</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #7.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #7.</a:documentation>
          <value>Celesta</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #8.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #8.</a:documentation>
          <value>Glockenspiel</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #9.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #9.</a:documentation>
          <value>Music_Box</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #10.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #10.</a:documentation>
          <value>Vibraphone</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #11.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #11.</a:documentation>
          <value>Marimba</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #12.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #12.</a:documentation>
          <value>Xylophone</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #13.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #13.</a:documentation>
          <value>Tubular_Bells</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #14.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #14.</a:documentation>
          <value>Dulcimer</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #15.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #15.</a:documentation>
          <value>Drawbar_Organ</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #16.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #16.</a:documentation>
          <value>Percussive_Organ</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #17.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #17.</a:documentation>
          <value>Rock_Organ</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #18.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #18.</a:documentation>
          <value>Church_Organ</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #19.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #19.</a:documentation>
          <value>Reed_Organ</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #20.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #20.</a:documentation>
          <value>Accordion</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #21.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #21.</a:documentation>
          <value>Harmonica</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #22.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #22.</a:documentation>
          <value>Tango_Accordion</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #23.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #23.</a:documentation>
          <value>Acoustic_Guitar_nylon</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #24.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #24.</a:documentation>
          <value>Acoustic_Guitar_steel</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #25.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #25.</a:documentation>
          <value>Electric_Guitar_jazz</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #26.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #26.</a:documentation>
          <value>Electric_Guitar_clean</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #27.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #27.</a:documentation>
          <value>Electric_Guitar_muted</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #28.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #28.</a:documentation>
          <value>Overdriven_Guitar</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #29.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #29.</a:documentation>
          <value>Distortion_Guitar</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #30.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #30.</a:documentation>
          <value>Guitar_harmonics</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #31.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #31.</a:documentation>
          <value>Acoustic_Bass</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #32.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #32.</a:documentation>
          <value>Electric_Bass_finger</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #33.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #33.</a:documentation>
          <value>Electric_Bass_pick</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #34.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #34.</a:documentation>
          <value>Fretless_Bass</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #35.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #35.</a:documentation>
          <value>Slap_Bass_1</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #36.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #36.</a:documentation>
          <value>Slap_Bass_2</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #37.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #37.</a:documentation>
          <value>Synth_Bass_1</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #38.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #38.</a:documentation>
          <value>Synth_Bass_2</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #39.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #39.</a:documentation>
          <value>Violin</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #40.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #40.</a:documentation>
          <value>Viola</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #41.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #41.</a:documentation>
          <value>Cello</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #42.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #42.</a:documentation>
          <value>Contrabass</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #43.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #43.</a:documentation>
          <value>Tremolo_Strings</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #44.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #44.</a:documentation>
          <value>Pizzicato_Strings</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #45.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #45.</a:documentation>
          <value>Orchestral_Harp</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #46.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #46.</a:documentation>
          <value>Timpani</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #47.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #47.</a:documentation>
          <value>String_Ensemble_1</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #48.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #48.</a:documentation>
          <value>String_Ensemble_2</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #49.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #49.</a:documentation>
          <value>SynthStrings_1</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #50.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #50.</a:documentation>
          <value>SynthStrings_2</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #51.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #51.</a:documentation>
          <value>Choir_Aahs</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #52.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #52.</a:documentation>
          <value>Voice_Oohs</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #53.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #53.</a:documentation>
          <value>Synth_Voice</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #54.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #54.</a:documentation>
          <value>Orchestra_Hit</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #55.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #55.</a:documentation>
          <value>Trumpet</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #56.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #56.</a:documentation>
          <value>Trombone</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #57.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #57.</a:documentation>
          <value>Tuba</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #58.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #58.</a:documentation>
          <value>Muted_Trumpet</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #59.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #59.</a:documentation>
          <value>French_Horn</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #60.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #60.</a:documentation>
          <value>Brass_Section</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #61.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #61.</a:documentation>
          <value>SynthBrass_1</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #62.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #62.</a:documentation>
          <value>SynthBrass_2</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #63.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #63.</a:documentation>
          <value>Soprano_Sax</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #64.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #64.</a:documentation>
          <value>Alto_Sax</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #65.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #65.</a:documentation>
          <value>Tenor_Sax</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #66.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #66.</a:documentation>
          <value>Baritone_Sax</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #67.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #67.</a:documentation>
          <value>Oboe</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #68.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #68.</a:documentation>
          <value>English_Horn</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #69.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #69.</a:documentation>
          <value>Bassoon</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #70.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #70.</a:documentation>
          <value>Clarinet</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #71.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #71.</a:documentation>
          <value>Piccolo</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #72.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #72.</a:documentation>
          <value>Flute</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #73.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #73.</a:documentation>
          <value>Recorder</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #74.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #74.</a:documentation>
          <value>Pan_Flute</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #75.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #75.</a:documentation>
          <value>Blown_Bottle</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #76.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #76.</a:documentation>
          <value>Shakuhachi</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #77.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #77.</a:documentation>
          <value>Whistle</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #78.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #78.</a:documentation>
          <value>Ocarina</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #79.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #79.</a:documentation>
          <value>Lead_1_square</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #80.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #80.</a:documentation>
          <value>Lead_2_sawtooth</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #81.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #81.</a:documentation>
          <value>Lead_3_calliope</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #82.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #82.</a:documentation>
          <value>Lead_4_chiff</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #83.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #83.</a:documentation>
          <value>Lead_5_charang</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #84.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #84.</a:documentation>
          <value>Lead_6_voice</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #85.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #85.</a:documentation>
          <value>Lead_7_fifths</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #86.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #86.</a:documentation>
          <value>Lead_8_bass_and_lead</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #87.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #87.</a:documentation>
          <value>Pad_1_new_age</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #88.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #88.</a:documentation>
          <value>Pad_2_warm</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #89.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #89.</a:documentation>
          <value>Pad_3_polysynth</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #90.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #90.</a:documentation>
          <value>Pad_4_choir</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #91.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #91.</a:documentation>
          <value>Pad_5_bowed</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #92.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #92.</a:documentation>
          <value>Pad_6_metallic</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #93.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #93.</a:documentation>
          <value>Pad_7_halo</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #94.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #94.</a:documentation>
          <value>Pad_8_sweep</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #95.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #95.</a:documentation>
          <value>FX_1_rain</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #96.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #96.</a:documentation>
          <value>FX_2_soundtrack</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #97.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #97.</a:documentation>
          <value>FX_3_crystal</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #98.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #98.</a:documentation>
          <value>FX_4_atmosphere</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #99.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #99.</a:documentation>
          <value>FX_5_brightness</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #100.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #100.</a:documentation>
          <value>FX_6_goblins</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #101.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #101.</a:documentation>
          <value>FX_7_echoes</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #102.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #102.</a:documentation>
          <value>FX_8_sci-fi</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #103.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #103.</a:documentation>
          <value>Sitar</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #104.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #104.</a:documentation>
          <value>Banjo</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #105.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #105.</a:documentation>
          <value>Shamisen</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #106.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #106.</a:documentation>
          <value>Koto</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #107.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #107.</a:documentation>
          <value>Kalimba</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #108.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #108.</a:documentation>
          <value>Bagpipe</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #109.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #109.</a:documentation>
          <value>Fiddle</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #110.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #110.</a:documentation>
          <value>Shanai</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #111.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #111.</a:documentation>
          <value>Tinkle_Bell</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #112.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #112.</a:documentation>
          <value>Agogo</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #113.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #113.</a:documentation>
          <value>Steel_Drums</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #114.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #114.</a:documentation>
          <value>Woodblock</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #115.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #115.</a:documentation>
          <value>Taiko_Drum</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #116.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #116.</a:documentation>
          <value>Melodic_Tom</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #117.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #117.</a:documentation>
          <value>Synth_Drum</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #118.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #118.</a:documentation>
          <value>Reverse_Cymbal</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #119.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #119.</a:documentation>
          <value>Guitar_Fret_Noise</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #120.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #120.</a:documentation>
          <value>Breath_Noise</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #121.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #121.</a:documentation>
          <value>Seashore</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #122.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #122.</a:documentation>
          <value>Bird_Tweet</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #123.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #123.</a:documentation>
          <value>Telephone_Ring</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #124.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #124.</a:documentation>
          <value>Helicopter</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #125.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #125.</a:documentation>
          <value>Applause</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #126.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #126.</a:documentation>
          <value>Gunshot</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program
-            #127.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Program #127.</a:documentation>
          <value>Acoustic_Bass_Drum</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #35.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #35.</a:documentation>
          <value>Bass_Drum_1</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #36.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #36.</a:documentation>
          <value>Side_Stick</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #37.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #37.</a:documentation>
          <value>Acoustic_Snare</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #38.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #38.</a:documentation>
          <value>Hand_Clap</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #39.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #39.</a:documentation>
          <value>Electric_Snare</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #40.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #40.</a:documentation>
          <value>Low_Floor_Tom</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #41.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #41.</a:documentation>
          <value>Closed_Hi_Hat</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #42.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #42.</a:documentation>
          <value>High_Floor_Tom</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #43.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #43.</a:documentation>
          <value>Pedal_Hi-Hat</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #44.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #44.</a:documentation>
          <value>Low_Tom</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #45.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #45.</a:documentation>
          <value>Open_Hi-Hat</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #46.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #46.</a:documentation>
          <value>Low-Mid_Tom</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #47.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #47.</a:documentation>
          <value>Hi-Mid_Tom</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #48.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #48.</a:documentation>
          <value>Crash_Cymbal_1</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #49.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #49.</a:documentation>
          <value>High_Tom</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #50.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #50.</a:documentation>
          <value>Ride_Cymbal_1</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #51.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #51.</a:documentation>
          <value>Chinese_Cymbal</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #52.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #52.</a:documentation>
          <value>Ride_Bell</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #53.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #53.</a:documentation>
          <value>Tambourine</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #54.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #54.</a:documentation>
          <value>Splash_Cymbal</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #55.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #55.</a:documentation>
          <value>Cowbell</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #56.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #56.</a:documentation>
          <value>Crash_Cymbal_2</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #57.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #57.</a:documentation>
          <value>Vibraslap</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #58.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #58.</a:documentation>
          <value>Ride_Cymbal_2</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #59.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #59.</a:documentation>
          <value>Hi_Bongo</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #60.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #60.</a:documentation>
          <value>Low_Bongo</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #61.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #61.</a:documentation>
          <value>Mute_Hi_Conga</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #62.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #62.</a:documentation>
          <value>Open_Hi_Conga</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #63.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #63.</a:documentation>
          <value>Low_Conga</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #64.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #64.</a:documentation>
          <value>High_Timbale</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #65.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #65.</a:documentation>
          <value>Low_Timbale</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #66.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #66.</a:documentation>
          <value>High_Agogo</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #67.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #67.</a:documentation>
          <value>Low_Agogo</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #68.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #68.</a:documentation>
          <value>Cabasa</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #69.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #69.</a:documentation>
          <value>Maracas</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #70.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #70.</a:documentation>
          <value>Short_Whistle</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #71.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #71.</a:documentation>
          <value>Long_Whistle</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #72.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #72.</a:documentation>
          <value>Short_Guiro</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #73.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #73.</a:documentation>
          <value>Long_Guiro</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #74.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #74.</a:documentation>
          <value>Claves</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #75.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #75.</a:documentation>
          <value>Hi_Wood_Block</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #76.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #76.</a:documentation>
          <value>Low_Wood_Block</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #77.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #77.</a:documentation>
          <value>Mute_Cuica</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #78.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #78.</a:documentation>
          <value>Open_Cuica</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #79.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #79.</a:documentation>
          <value>Mute_Triangle</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #80.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #80.</a:documentation>
          <value>Open_Triangle</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key
-            #81.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key #81.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.MIDIVALUE">
@@ -7216,63 +6881,47 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_data.NOTATIONTYPE">
       <choice>
          <value>cmn</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Common Music
-            Notation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Common Music Notation.</a:documentation>
          <value>mensural</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Mensural
-            notation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Mensural notation.</a:documentation>
          <value>mensural.black</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Black
-            mensural notation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Black mensural notation.</a:documentation>
          <value>mensural.white</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">White
-            mensural notation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">White mensural notation.</a:documentation>
          <value>neume</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Neumatic
-            notation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Neumatic notation.</a:documentation>
          <value>tab</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Tablature
-            notation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Tablature notation.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.NOTEHEADMODIFIER">
       <choice>
-         <ref name="mei_data.NOTEHEADMODIFIER.list"/>
-         <ref name="mei_data.NOTEHEADMODIFIER.pat"/>
-      </choice>
+          <ref name="mei_data.NOTEHEADMODIFIER.list"/>
+          <ref name="mei_data.NOTEHEADMODIFIER.pat"/>
+        </choice>
    </define>
    <define name="mei_data.NOTEHEADMODIFIER.list">
       <choice>
          <value>slash</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Slash (upper
-            right to lower left).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Slash (upper right to lower left).</a:documentation>
          <value>backslash</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Backslash
-            (upper left to lower right).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Backslash (upper left to lower right).</a:documentation>
          <value>vline</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Vertical
-            line.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Vertical line.</a:documentation>
          <value>hline</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Horizontal
-            line.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Horizontal line.</a:documentation>
          <value>centerdot</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Center
-            dot.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Center dot.</a:documentation>
          <value>paren</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosing
-            parentheses.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosing parentheses.</a:documentation>
          <value>brack</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosing
-            square brackets.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosing square brackets.</a:documentation>
          <value>box</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosing
-            box.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosing box.</a:documentation>
          <value>circle</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosing
-            circle.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosing circle.</a:documentation>
          <value>dblwhole</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosing
-            "fences".</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosing "fences".</a:documentation>
       </choice>
    </define>
    <define name="mei_data.NOTEHEADMODIFIER.pat">
@@ -7356,33 +7005,26 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_data.ROTATION">
       <choice>
-         <ref name="mei_data.DEGREES"/>
-         <ref name="mei_data.ROTATIONDIRECTION"/>
-      </choice>
+          <ref name="mei_data.DEGREES"/>
+          <ref name="mei_data.ROTATIONDIRECTION"/>
+        </choice>
    </define>
    <define name="mei_data.ROTATIONDIRECTION">
       <choice>
          <value>none</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">No
-            rotation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">No rotation.</a:documentation>
          <value>down</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Rotated 180
-            degrees.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Rotated 180 degrees.</a:documentation>
          <value>left</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Rotated 270
-            degrees clockwise.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Rotated 270 degrees clockwise.</a:documentation>
          <value>ne</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Rotated 45
-            degrees clockwise.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Rotated 45 degrees clockwise.</a:documentation>
          <value>nw</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Rotated 315
-            degrees clockwise.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Rotated 315 degrees clockwise.</a:documentation>
          <value>se</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Rotated 135
-            degrees clockwise.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Rotated 135 degrees clockwise.</a:documentation>
          <value>sw</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Rotated 225
-            degrees clockwise.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Rotated 225 degrees clockwise.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.SCALEDEGREE">
@@ -7393,11 +7035,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_data.SIZE">
       <choice>
          <value>normal</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Default
-            size.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Default size.</a:documentation>
          <value>cue</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reduced
-            size.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reduced size.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.SLASH">
@@ -7417,96 +7057,73 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_data.STAFFREL">
       <choice>
          <value>above</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Written
-            above staff.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Written above staff.</a:documentation>
          <value>below</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Written
-            below staff.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Written below staff.</a:documentation>
          <value>within</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Written on
-            staff.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Written on staff.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.STEMDIRECTION">
       <choice>
-         <ref name="mei_data.STEMDIRECTION.basic"/>
-         <ref name="mei_data.STEMDIRECTION.extended"/>
-      </choice>
+          <ref name="mei_data.STEMDIRECTION.basic"/>
+          <ref name="mei_data.STEMDIRECTION.extended"/>
+        </choice>
    </define>
    <define name="mei_data.STEMDIRECTION.basic">
       <choice>
          <value>up</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem points
-            upwards.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem points upwards.</a:documentation>
          <value>down</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem points
-            downwards.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem points downwards.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.STEMDIRECTION.extended">
       <choice>
          <value>left</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem points
-            left.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem points left.</a:documentation>
          <value>right</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem points
-            right.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem points right.</a:documentation>
          <value>ne</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem points
-            up and right.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem points up and right.</a:documentation>
          <value>se</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem points
-            down and right.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem points down and right.</a:documentation>
          <value>nw</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem points
-            up and left.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem points up and left.</a:documentation>
          <value>sw</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem points
-            down and left.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem points down and left.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.STEMMODIFIER">
       <choice>
          <value>none</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">No
-            modifications to stem.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">No modifications to stem.</a:documentation>
          <value>1slash</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">1 slash
-            through stem.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">1 slash through stem.</a:documentation>
          <value>2slash</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">2 slashes
-            through stem.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">2 slashes through stem.</a:documentation>
          <value>3slash</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">3 slashes
-            through stem.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">3 slashes through stem.</a:documentation>
          <value>4slash</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">4 slashes
-            through stem.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">4 slashes through stem.</a:documentation>
          <value>5slash</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">5 slashes
-            through stem.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">5 slashes through stem.</a:documentation>
          <value>6slash</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">6 slashes
-            through stem.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">6 slashes through stem.</a:documentation>
          <value>sprech</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">X placed on
-            stem.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">X placed on stem.</a:documentation>
          <value>z</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Z placed on
-            stem.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Z placed on stem.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.STEMPOSITION">
       <choice>
          <value>left</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem
-            attached to left side of note head.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem attached to left side of note head.</a:documentation>
          <value>right</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem
-            attached to right side of note head.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem attached to right side of note head.</a:documentation>
          <value>center</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem is
-            originates from center of note head.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Stem is originates from center of note head.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.STRINGNUMBER">
@@ -7515,17 +7132,13 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_data.TEMPERAMENT">
       <choice>
          <value>equal</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Equal or
-            12-tone temperament.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Equal or 12-tone temperament.</a:documentation>
          <value>just</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Just
-            intonation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Just intonation.</a:documentation>
          <value>mean</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Meantone
-            intonation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Meantone intonation.</a:documentation>
          <value>pythagorean</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Pythagorean
-            tuning.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Pythagorean tuning.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.TEMPOVALUE">
@@ -7540,80 +7153,53 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_data.TEXTRENDITIONLIST">
       <choice>
          <value>italic</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Italicized
-            (slanted to right).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Italicized (slanted to right).</a:documentation>
          <value>oblique</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Oblique
-            (slanted to left).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Oblique (slanted to left).</a:documentation>
          <value>smcaps</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Small
-            capitals.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Small capitals.</a:documentation>
          <value>bold</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative
-            font weight.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative font weight.</a:documentation>
          <value>bolder</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative
-            font weight.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative font weight.</a:documentation>
          <value>lighter</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative
-            font weight.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Relative font weight.</a:documentation>
          <value>box</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosed in
-            box.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosed in box.</a:documentation>
          <value>circle</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosed in
-            ellipse/circle.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosed in ellipse/circle.</a:documentation>
          <value>dbox</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosed in
-            diamond.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosed in diamond.</a:documentation>
          <value>tbox</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosed in
-            triangle.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosed in triangle.</a:documentation>
          <value>bslash</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Struck
-            through by '\' (back slash).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Struck through by '\' (back slash).</a:documentation>
          <value>fslash</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Struck
-            through by '/' (forward slash).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Struck through by '/' (forward slash).</a:documentation>
          <value>line-through</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Struck
-            through by '-'; may be qualified to indicate multiple lines, e.g.
-            line-through(2).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Struck through by '-'; may be qualified to indicate multiple lines, e.g. line-through(2).</a:documentation>
          <value>none</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Not
-            rendered, invisible.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Not rendered, invisible.</a:documentation>
          <value>overline</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Line above
-            the text; may be qualified to indicate multiple lines, e.g.
-            overline(3).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Line above the text; may be qualified to indicate multiple lines, e.g. overline(3).</a:documentation>
          <value>overstrike</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">obscured by
-            other text, such as 'XXXXX'</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">obscured by other text, such as 'XXXXX'</a:documentation>
          <value>strike</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Struck
-            through by '-'; equivalent to line-through; may be qualified to indicate multiple lines,
-            e.g. strike(3).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Struck through by '-'; equivalent to line-through; may be qualified to indicate multiple lines, e.g. strike(3).</a:documentation>
          <value>sub</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Subscript.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Subscript.</a:documentation>
          <value>sup</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Superscript.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Superscript.</a:documentation>
          <value>underline</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Underlined;
-            may be qualified to indicate multiple lines, e.g. underline(2).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Underlined; may be qualified to indicate multiple lines, e.g. underline(2).</a:documentation>
          <value>ltr</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Left-to-right (BIDI embed).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Left-to-right (BIDI embed).</a:documentation>
          <value>rtl</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Right-to-left (BIDI embed).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Right-to-left (BIDI embed).</a:documentation>
          <value>lro</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Left-to-right (BIDI override).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Left-to-right (BIDI override).</a:documentation>
          <value>rlo</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Right-to-left (BIDI override).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Right-to-left (BIDI override).</a:documentation>
       </choice>
    </define>
    <define name="mei_data.TEXTRENDITIONPAR">
@@ -7628,9 +7214,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_data.TEXTRENDITION">
       <choice>
-         <ref name="mei_data.TEXTRENDITIONLIST"/>
-         <ref name="mei_data.TEXTRENDITIONPAR"/>
-      </choice>
+          <ref name="mei_data.TEXTRENDITIONLIST"/>
+          <ref name="mei_data.TEXTRENDITIONPAR"/>
+        </choice>
    </define>
    <define name="mei_data.TIE">
       <data type="token">
@@ -7745,44 +7331,31 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_data.BETYPE">
       <choice>
          <value>byte</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Bytes.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Bytes.</a:documentation>
          <value>smil</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Synchronized
-            Multimedia Integration Language.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Synchronized Multimedia Integration Language.</a:documentation>
          <value>midi</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI
-            clicks.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI clicks.</a:documentation>
          <value>mmc</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI machine
-            code.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI machine code.</a:documentation>
          <value>mtc</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI time
-            code.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI time code.</a:documentation>
          <value>smpte-25</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">SMPTE 25
-            EBU.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">SMPTE 25 EBU.</a:documentation>
          <value>smpte-24</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">SMPTE 24
-            Film Sync.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">SMPTE 24 Film Sync.</a:documentation>
          <value>smpte-df30</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">SMPTE 30
-            Drop.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">SMPTE 30 Drop.</a:documentation>
          <value>smpte-ndf30</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">SMPTE 30
-            Non-Drop.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">SMPTE 30 Non-Drop.</a:documentation>
          <value>smpte-df29.97</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">SMPTE 29.97
-            Drop.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">SMPTE 29.97 Drop.</a:documentation>
          <value>smpte-ndf29.97</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">SMPTE 29.97
-            Non-Drop.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">SMPTE 29.97 Non-Drop.</a:documentation>
          <value>tcf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">AES
-            Time-code character format.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">AES Time-code character format.</a:documentation>
          <value>time</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">ISO 24-hour
-            time format: HH:MM:SS.ss.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">ISO 24-hour time format: HH:MM:SS.ss.</a:documentation>
       </choice>
    </define>
    <define name="mei_macro.availabilityPart">
@@ -7819,47 +7392,33 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_data.DURATION.cmn">
       <choice>
          <value>long</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Quadruple
-            whole note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Quadruple whole note.</a:documentation>
          <value>breve</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double whole
-            note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Double whole note.</a:documentation>
          <value>1</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Whole
-            note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Whole note.</a:documentation>
          <value>2</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Half
-            note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Half note.</a:documentation>
          <value>4</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Quarter
-            note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Quarter note.</a:documentation>
          <value>8</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">8th
-            note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">8th note.</a:documentation>
          <value>16</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">16th
-            note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">16th note.</a:documentation>
          <value>32</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">32nd
-            note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">32nd note.</a:documentation>
          <value>64</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">64th
-            note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">64th note.</a:documentation>
          <value>128</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">128th
-            note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">128th note.</a:documentation>
          <value>256</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">256th
-            note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">256th note.</a:documentation>
          <value>512</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">512th
-            note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">512th note.</a:documentation>
          <value>1024</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">1024th
-            note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">1024th note.</a:documentation>
          <value>2048</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">2048th
-            note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">2048th note.</a:documentation>
       </choice>
    </define>
    <define name="mei_data.DURATION.mensural">
@@ -7887,135 +7446,83 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_data.ORNAM.cmn">
       <data type="token">
-         <param name="pattern"
-            >[A|a|b|I|i|K|k|M|m|N|n|S|s|T|t|O]|(A|a|S|s|K|k)?(T|t|M|m)(I|i|S|s)?</param>
+         <param name="pattern">[A|a|b|I|i|K|k|M|m|N|n|S|s|T|t|O]|(A|a|S|s|K|k)?(T|t|M|m)(I|i|S|s)?</param>
       </data>
    </define>
    <define name="mei_data.FRBRRELATIONSHIP">
       <choice>
          <value>hasAbridgement</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is an
-            abridgement, condensation, or expurgation of the current entity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is an abridgement, condensation, or expurgation of the current entity.</a:documentation>
          <value>isAbridgementOf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal
-            relationship of hasAbridgement.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal relationship of hasAbridgement.</a:documentation>
          <value>hasAdaptation</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is an
-            adaptation, paraphrase, free translation, variation (music), harmonization (music), or
-            fantasy (music) of the current entity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is an adaptation, paraphrase, free translation, variation (music), harmonization (music), or fantasy (music) of the current entity.</a:documentation>
          <value>isAdaptationOf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal
-            relationship of hasAdaptation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal relationship of hasAdaptation.</a:documentation>
          <value>hasAlternate</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is an
-            alternate format or simultaneously released edition of the current
-            entity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is an alternate format or simultaneously released edition of the current entity.</a:documentation>
          <value>isAlternateOf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal
-            relationship of hasAlternate.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal relationship of hasAlternate.</a:documentation>
          <value>hasArrangement</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is an
-            arrangement (music) of the current entity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is an arrangement (music) of the current entity.</a:documentation>
          <value>isArrangementOf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal
-            relationship of hasArrangement.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal relationship of hasArrangement.</a:documentation>
          <value>hasComplement</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a
-            cadenza, libretto, choreography, ending for unfinished work, incidental music, or
-            musical setting of a text of the current entity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a cadenza, libretto, choreography, ending for unfinished work, incidental music, or musical setting of a text of the current entity.</a:documentation>
          <value>isComplementOf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal
-            relationship of hasComplement.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal relationship of hasComplement.</a:documentation>
          <value>hasEmbodiment</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a
-            physical embodiment of the current abstract entity; describes the
-            expression-to-manifestation relationship.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a physical embodiment of the current abstract entity; describes the expression-to-manifestation relationship.</a:documentation>
          <value>isEmbodimentOf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal
-            relationship of hasEmbodiment.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal relationship of hasEmbodiment.</a:documentation>
          <value>hasExemplar</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is an
-            exemplar of the class of things represented by the current entity; describes the
-            manifestation-to-item relationship.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is an exemplar of the class of things represented by the current entity; describes the manifestation-to-item relationship.</a:documentation>
          <value>isExemplarOf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal
-            relationship of hasExamplar.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal relationship of hasExamplar.</a:documentation>
          <value>hasImitation</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a
-            parody, imitation, or travesty of the current entity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a parody, imitation, or travesty of the current entity.</a:documentation>
          <value>isImitationOf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal
-            relationship of hasImitation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal relationship of hasImitation.</a:documentation>
          <value>hasPart</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a
-            chapter, section, part, etc.; volume of a multivolume manifestation; volume/issue of
-            serial; intellectual part of a multipart work; illustration for a text; sound aspect of
-            a film; soundtrack for a film on separate medium; soundtrack for a film embedded in
-            film; monograph in a series; physical component of a particular copy; the binding of a
-            book of the current entity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a chapter, section, part, etc.; volume of a multivolume manifestation; volume/issue of serial; intellectual part of a multipart work; illustration for a text; sound aspect of a film; soundtrack for a film on separate medium; soundtrack for a film embedded in film; monograph in a series; physical component of a particular copy; the binding of a book of the current entity.</a:documentation>
          <value>isPartOf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal
-            relationship of hasPart.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal relationship of hasPart.</a:documentation>
          <value>hasRealization</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a
-            realization of the current entity; describes the work-to-expression
-            relationship.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a realization of the current entity; describes the work-to-expression relationship.</a:documentation>
          <value>isRealizationOf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal
-            relationship of hasRealization.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal relationship of hasRealization.</a:documentation>
          <value>hasReconfiguration</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target has
-            been reconfigured: bound with, split into, extracted from the current
-            entity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target has been reconfigured: bound with, split into, extracted from the current entity.</a:documentation>
          <value>isReconfigurationOf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal
-            relationship of hasReconfiguration.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal relationship of hasReconfiguration.</a:documentation>
          <value>hasReproduction</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a
-            reproduction, microreproduction, macroreproduction, reprint, photo-offset reprint, or
-            facsimile of the current entity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a reproduction, microreproduction, macroreproduction, reprint, photo-offset reprint, or facsimile of the current entity.</a:documentation>
          <value>isReproductionOf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal
-            relationship of hasReproduction.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal relationship of hasReproduction.</a:documentation>
          <value>hasRevision</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a
-            revised edition, enlarged edition, or new state (graphic) of the current
-            entity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a revised edition, enlarged edition, or new state (graphic) of the current entity.</a:documentation>
          <value>isRevisionOf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal
-            relationship of hasRevision.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal relationship of hasRevision.</a:documentation>
          <value>hasSuccessor</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a
-            sequel or succeeding work of the current entity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a sequel or succeeding work of the current entity.</a:documentation>
          <value>isSuccessorOf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal
-            relationship of hasSuccessor.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal relationship of hasSuccessor.</a:documentation>
          <value>hasSummarization</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a
-            digest or abstract of the current entity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a digest or abstract of the current entity.</a:documentation>
          <value>isSummarizationOf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal
-            relationship of hasSummarization.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal relationship of hasSummarization.</a:documentation>
          <value>hasSupplement</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is an
-            index, concordance, teacher's guide, gloss, supplement, or appendix of the current
-            entity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is an index, concordance, teacher's guide, gloss, supplement, or appendix of the current entity.</a:documentation>
          <value>isSupplementOf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal
-            relationship of hasSupplement.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal relationship of hasSupplement.</a:documentation>
          <value>hasTransformation</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a
-            dramatization, novelization, versification, or screenplay of the current
-            entity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a dramatization, novelization, versification, or screenplay of the current entity.</a:documentation>
          <value>isTransformationOf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal
-            relationship of hasTransformation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal relationship of hasTransformation.</a:documentation>
          <value>hasTranslation</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a
-            literal translation or transcription (music) of the current entity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Target is a literal translation or transcription (music) of the current entity.</a:documentation>
          <value>isTranslationOf</value>
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal
-            relationship of hasTranslation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Reciprocal relationship of hasTranslation.</a:documentation>
       </choice>
    </define>
    <define name="mei_att.notationtype.attributes">
@@ -8025,9 +7532,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.notationtype.attribute.notationtype">
       <optional>
          <attribute name="notationtype">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               classification of the notation contained or described by the element bearing this
-               attribute.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains classification of the notation contained or described by the element bearing this attribute.</a:documentation>
             <ref name="mei_data.NOTATIONTYPE"/>
          </attribute>
       </optional>
@@ -8035,22 +7540,21 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.notationtype.attribute.notationsubtype">
       <optional>
          <attribute name="notationsubtype">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               any sub-classification of the notation contained or described by the element,
-               additional to that given by its notationtype attribute.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides any sub-classification of the notation contained or described by the element, additional to that given by its notationtype attribute.</a:documentation>
             <data type="NMTOKEN"/>
          </attribute>
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.notationtype-notationsubtype-When_notationsubtype-constraint-1">
+            id="mei-att.notationtype-notationsubtype-When_notationsubtype-constraint-1">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="mei:*[@notationsubtype]">
-         <sch:assert test="@notationtype">An element with a notationsubtype attribute must have a
-            notationtype attribute.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="mei:*[@notationsubtype]">
+                <sch:assert test="@notationtype">An element with a notationsubtype attribute must
+                  have a notationtype attribute.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.accid.anl.attributes">
       <ref name="mei_att.common.anl.attributes"/>
@@ -8066,15 +7570,12 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.accid.log.attribute.func">
       <optional>
          <attribute name="func">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the function of an accidental.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the function of an accidental.</a:documentation>
             <choice>
                <value>caution</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Cautionary accidental.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Cautionary accidental.</a:documentation>
                <value>edit</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Editorial accidental.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Editorial accidental.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -8098,8 +7599,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.accidental.attribute.accid">
       <optional>
          <attribute name="accid">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures
-               a written accidental.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures a written accidental.</a:documentation>
             <ref name="mei_data.ACCIDENTAL.EXPLICIT"/>
          </attribute>
       </optional>
@@ -8110,21 +7610,21 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.accidental.performed.attribute.accid.ges">
       <optional>
          <attribute name="accid.ges">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the performed pitch inflection.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the performed pitch inflection.</a:documentation>
             <ref name="mei_data.ACCIDENTAL.IMPLICIT"/>
          </attribute>
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.accidental.performed-accid.ges-check_accid_duplication-constraint-2">
+            id="mei-att.accidental.performed-accid.ges-check_accid_duplication-constraint-2">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@accid.ges">
-         <sch:assert role="warning" test="not(. eq ../@accid)">The value of @accid.ges should not
-            duplicate the value of @accid.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@accid.ges">
+                <sch:assert role="warning" test="not(. eq ../@accid)">The value of @accid.ges should
+                  not duplicate the value of @accid.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.annot.anl.attributes">
       <ref name="mei_att.common.anl.attributes"/>
@@ -8172,11 +7672,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.articulation.attribute.artic">
       <optional>
          <attribute name="artic">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes
-               the written articulation(s). Articulations are normally encoded in order from the
-               note head outward; that is, away from the stem. See additional notes at att.vis.note.
-               Only articulations should be encoded in the artic attribute; for example, fingerings
-               should be encoded using the &lt;fingering&gt; element.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes the written articulation(s). Articulations are normally encoded in order from the note head outward; that is, away from the stem. See additional notes at att.vis.note. Only articulations should be encoded in the artic attribute; for example, fingerings should be encoded using the &lt;fingering&gt; element.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.ARTICULATION"/>
@@ -8191,8 +7687,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.articulation.performed.attribute.artic.ges">
       <optional>
          <attribute name="artic.ges">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               performed articulation that differs from the written value.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records performed articulation that differs from the written value.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.ARTICULATION"/>
@@ -8207,21 +7702,21 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.augmentdots.attribute.dots">
       <optional>
          <attribute name="dots">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the number of augmentation dots required by a dotted duration.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the number of augmentation dots required by a dotted duration.</a:documentation>
             <ref name="mei_data.AUGMENTDOT"/>
          </attribute>
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.augmentdots-dots-dots_attribute_requires_dur-constraint-3">
+            id="mei-att.augmentdots-dots-dots_attribute_requires_dur-constraint-3">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="mei:*[@dots]">
-         <sch:assert test="@dur">An element with a dots attribute must also have a dur
-            attribute.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="mei:*[@dots]">
+                <sch:assert test="@dur">An element with a dots attribute must also have a dur
+                  attribute.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.authorized.attributes">
       <ref name="mei_att.authorized.attribute.authority"/>
@@ -8230,9 +7725,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.authorized.attribute.authority">
       <optional>
          <attribute name="authority">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A name or
-               label associated with the controlled vocabulary from which the value is
-               taken.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A name or label associated with the controlled vocabulary from which the value is taken.</a:documentation>
             <data type="string"/>
          </attribute>
       </optional>
@@ -8240,9 +7733,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.authorized.attribute.authURI">
       <optional>
          <attribute name="authURI">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The
-               web-accessible location of the controlled vocabulary from which the value is
-               taken.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The web-accessible location of the controlled vocabulary from which the value is taken.</a:documentation>
             <ref name="mei_data.URI"/>
          </attribute>
       </optional>
@@ -8260,8 +7751,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.barLine.log.attribute.form">
       <optional>
          <attribute name="form">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the appearance and usually the function of the bar line.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the appearance and usually the function of the bar line.</a:documentation>
             <ref name="mei_data.BARRENDITION"/>
          </attribute>
       </optional>
@@ -8279,8 +7769,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.barplacement.attribute.barplace">
       <optional>
          <attribute name="barplace">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the location of a bar line.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the location of a bar line.</a:documentation>
             <ref name="mei_data.BARPLACE"/>
          </attribute>
       </optional>
@@ -8288,14 +7777,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.barplacement.attribute.taktplace">
       <optional>
          <attribute name="taktplace">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">If takt
-               bar lines are to be used, then the taktplace attribute may be used to denote the
-               staff location of the shortened bar line. The location may include staff lines,
-               spaces, and the spaces directly above and below the staff. The value ranges between 0
-               (just below the staff) to 2 * number of staff lines (directly above the staff). For
-               example, on a 5-line staff the lines would be numbered 1,3,5,7, and 9 while the
-               spaces would be numbered 0,2,4,6,8,10. For example, a value of '9' puts the bar line
-               through the top line of a 5-line staff.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">If takt bar lines are to be used, then the taktplace attribute may be used to denote the staff location of the shortened bar line. The location may include staff lines, spaces, and the spaces directly above and below the staff. The value ranges between 0 (just below the staff) to 2 * number of staff lines (directly above the staff). For example, on a 5-line staff the lines would be numbered 1,3,5,7, and 9 while the spaces would be numbered 0,2,4,6,8,10. For example, a value of '9' puts the bar line through the top line of a 5-line staff.</a:documentation>
             <ref name="mei_data.STAFFLOC"/>
          </attribute>
       </optional>
@@ -8308,8 +7790,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.beaming.vis.attribute.beam.color">
       <optional>
          <attribute name="beam.color">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Color of
-               beams, including those associated with tuplets.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Color of beams, including those associated with tuplets.</a:documentation>
             <ref name="mei_data.COLOR"/>
          </attribute>
       </optional>
@@ -8317,18 +7798,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.beaming.vis.attribute.beam.rend">
       <optional>
          <attribute name="beam.rend">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes
-               whether a beam is "feathered" and in which direction.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes whether a beam is "feathered" and in which direction.</a:documentation>
             <choice>
                <value>acc</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Beam
-                  lines grow farther apart from left to right.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Beam lines grow farther apart from left to right.</a:documentation>
                <value>rit</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Beam
-                  lines grow closer together from left to right.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Beam lines grow closer together from left to right.</a:documentation>
                <value>norm</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Beam
-                  lines are equally-spaced over the entire length of the beam.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Beam lines are equally-spaced over the entire length of the beam.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -8336,8 +7813,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.beaming.vis.attribute.beam.slope">
       <optional>
          <attribute name="beam.slope">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures
-               beam slope.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures beam slope.</a:documentation>
             <data type="decimal"/>
          </attribute>
       </optional>
@@ -8348,9 +7824,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.bibl.attribute.analog">
       <optional>
          <attribute name="analog">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               a reference to a field or element in another descriptive encoding system to which
-               this MEI element is comparable.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a reference to a field or element in another descriptive encoding system to which this MEI element is comparable.</a:documentation>
             <data type="string"/>
          </attribute>
       </optional>
@@ -8361,9 +7835,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.calendared.attribute.calendar">
       <optional>
          <attribute name="calendar">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the calendar system to which a date belongs, for example, Gregorian, Julian, Roman,
-               Mosaic, Revolutionary, Islamic, etc.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the calendar system to which a date belongs, for example, Gregorian, Julian, Roman, Mosaic, Revolutionary, Islamic, etc.</a:documentation>
             <data type="NMTOKEN"/>
          </attribute>
       </optional>
@@ -8374,9 +7846,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.canonical.attribute.codedval">
       <optional>
          <attribute name="codedval">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">a value
-               that represents or identifies the element content. May serve as a primary key in a
-               web-accessible database identified by the authURI attribute.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">a value that represents or identifies the element content. May serve as a primary key in a web-accessible database identified by the authURI attribute.</a:documentation>
             <list>
                <oneOrMore>
                   <data type="NMTOKEN"/>
@@ -8424,10 +7894,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.chord.vis.attribute.cluster">
       <optional>
          <attribute name="cluster">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               a single, alternative note head should be displayed instead of individual note heads.
-               The highest and lowest notes of the chord usually indicate the upper and lower
-               boundaries of the cluster note head.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates a single, alternative note head should be displayed instead of individual note heads. The highest and lowest notes of the chord usually indicate the upper and lower boundaries of the cluster note head.</a:documentation>
             <ref name="mei_data.CLUSTER"/>
          </attribute>
       </optional>
@@ -8438,27 +7905,24 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.classcodeident.attribute.classcode">
       <optional>
          <attribute name="classcode">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               a reference to the controlled vocabulary from which the term is drawn. The value must
-               match the value of an ID attribute on a classCode element given elsewhere in the
-               document.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a reference to the controlled vocabulary from which the term is drawn. The value must match the value of an ID attribute on a classCode element given elsewhere in the document.</a:documentation>
             <ref name="mei_data.URI"/>
          </attribute>
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.classcodeident-classcode-check_classcodeTarget-constraint-4">
+            id="mei-att.classcodeident-classcode-check_classcodeTarget-constraint-4">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@classcode">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@classcode attribute should
-            have content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:classCode/@xml:id"
-            >The value in @classcode should correspond to the @xml:id attribute of a classCode
-            element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@classcode">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@classcode attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:classCode/@xml:id">The value in @classcode should correspond to the @xml:id attribute of a classCode
+                  element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.clef.anl.attributes">
       <ref name="mei_att.common.anl.attributes"/>
@@ -8476,9 +7940,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.clef.log.attribute.cautionary">
       <optional>
          <attribute name="cautionary">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the function of the clef. A "cautionary" clef does not change the following
-               pitches.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the function of the clef. A "cautionary" clef does not change the following pitches.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -8498,8 +7960,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.cleffing.log.attribute.clef.shape">
       <optional>
          <attribute name="clef.shape">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes a
-               value for the clef symbol.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes a value for the clef symbol.</a:documentation>
             <ref name="mei_data.CLEFSHAPE"/>
          </attribute>
       </optional>
@@ -8507,10 +7968,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.cleffing.log.attribute.clef.line">
       <optional>
          <attribute name="clef.line">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               a default value for the position of the clef. The value must be in the range between
-               1 and the number of lines on the staff. The numbering of lines starts with the lowest
-               line of the staff.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a default value for the position of the clef. The value must be in the range between 1 and the number of lines on the staff. The numbering of lines starts with the lowest line of the staff.</a:documentation>
             <ref name="mei_data.CLEFLINE"/>
          </attribute>
       </optional>
@@ -8518,8 +7976,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.cleffing.log.attribute.clef.dis">
       <optional>
          <attribute name="clef.dis">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the amount of octave displacement to be applied to the clef.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the amount of octave displacement to be applied to the clef.</a:documentation>
             <ref name="mei_data.OCTAVE.DIS"/>
          </attribute>
       </optional>
@@ -8527,8 +7984,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.cleffing.log.attribute.clef.dis.place">
       <optional>
          <attribute name="clef.dis.place">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the direction of octave displacement to be applied to the clef.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the direction of octave displacement to be applied to the clef.</a:documentation>
             <ref name="mei_data.PLACE"/>
          </attribute>
       </optional>
@@ -8540,8 +7996,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.cleffing.vis.attribute.clef.color">
       <optional>
          <attribute name="clef.color">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the color of the clef.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the color of the clef.</a:documentation>
             <ref name="mei_data.COLOR"/>
          </attribute>
       </optional>
@@ -8549,8 +8004,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.cleffing.vis.attribute.clef.visible">
       <optional>
          <attribute name="clef.visible">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Determines whether the clef is to be displayed.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Determines whether the clef is to be displayed.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -8573,8 +8027,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.clefshape.attribute.shape">
       <optional>
          <attribute name="shape">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               a clef's shape.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes a clef's shape.</a:documentation>
             <ref name="mei_data.CLEFSHAPE"/>
          </attribute>
       </optional>
@@ -8585,9 +8038,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.color.attribute.color">
       <optional>
          <attribute name="color">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to
-               indicate visual appearance. Do not confuse this with the musical term 'color' as used
-               in pre-CMN notation.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to indicate visual appearance. Do not confuse this with the musical term 'color' as used in pre-CMN notation.</a:documentation>
             <ref name="mei_data.COLOR"/>
          </attribute>
       </optional>
@@ -8598,12 +8049,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.coloration.attribute.colored">
       <optional>
          <attribute name="colored">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               this feature is 'colored'; that is, it is a participant in a change in rhythmic
-               values. In mensural notation, coloration is indicated by colored notes (red, black,
-               etc.) where void notes would otherwise occur. In CMN, coloration is indicated by an
-               inverse color; that is, the note head is void when it would otherwise be filled and
-               vice versa.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates this feature is 'colored'; that is, it is a participant in a change in rhythmic values. In mensural notation, coloration is indicated by colored notes (red, black, etc.) where void notes would otherwise occur. In CMN, coloration is indicated by an inverse color; that is, the note head is void when it would otherwise be filled and vice versa.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -8615,8 +8061,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.common.attribute.n">
       <optional>
          <attribute name="n">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               a number-like designation for an element.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a number-like designation for an element.</a:documentation>
          </attribute>
       </optional>
    </define>
@@ -8628,8 +8073,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.commonPart.attribute.label">
       <optional>
          <attribute name="label">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               a name or label for an element. The value may be any string.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a name or label for an element. The value may be any string.</a:documentation>
             <data type="string"/>
          </attribute>
       </optional>
@@ -8637,9 +8081,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.commonPart.attribute.xmlbase">
       <optional>
          <attribute name="xml:base">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               a base URI reference with which applications can resolve relative URI references into
-               absolute URI references.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a base URI reference with which applications can resolve relative URI references into absolute URI references.</a:documentation>
             <ref name="mei_data.URI"/>
          </attribute>
       </optional>
@@ -8661,8 +8103,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.coordinated.attribute.ulx">
       <optional>
          <attribute name="ulx">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the upper-left corner x coordinate.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the upper-left corner x coordinate.</a:documentation>
             <data type="nonNegativeInteger"/>
          </attribute>
       </optional>
@@ -8670,8 +8111,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.coordinated.attribute.uly">
       <optional>
          <attribute name="uly">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the upper-left corner y coordinate.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the upper-left corner y coordinate.</a:documentation>
             <data type="nonNegativeInteger"/>
          </attribute>
       </optional>
@@ -8679,8 +8119,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.coordinated.attribute.lrx">
       <optional>
          <attribute name="lrx">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the lower-right corner x coordinate.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the lower-right corner x coordinate.</a:documentation>
             <data type="nonNegativeInteger"/>
          </attribute>
       </optional>
@@ -8688,8 +8127,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.coordinated.attribute.lry">
       <optional>
          <attribute name="lry">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the lower-left corner x coordinate.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the lower-left corner x coordinate.</a:documentation>
             <data type="nonNegativeInteger"/>
          </attribute>
       </optional>
@@ -8702,9 +8140,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.curvature.attribute.bezier">
       <optional>
          <attribute name="bezier">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the placement of Bezier control points as a series of pairs of space-separated
-               values; e.g., 19 45 -32 118.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the placement of Bezier control points as a series of pairs of space-separated values; e.g., 19 45 -32 118.</a:documentation>
             <list>
                <oneOrMore>
                   <data type="decimal"/>
@@ -8717,13 +8153,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.curvature.attribute.bulge">
       <optional>
          <attribute name="bulge">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               a curve as one or more pairs of values with respect to an imaginary line connecting
-               the starting and ending points of the curve. The first value captures a distance to
-               the left (positive value) or right (negative value) of the line, expressed in virtual
-               units. The second value of each pair represents a point along the line, expressed as
-               a percentage of the line's length. N.B. An MEI virtual unit (VU) is half the distance
-               between adjacent staff lines.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes a curve as one or more pairs of values with respect to an imaginary line connecting the starting and ending points of the curve. The first value captures a distance to the left (positive value) or right (negative value) of the line, expressed in virtual units. The second value of each pair represents a point along the line, expressed as a percentage of the line's length. N.B. An MEI virtual unit (VU) is half the distance between adjacent staff lines.</a:documentation>
             <list>
                <oneOrMore>
                   <data type="decimal"/>
@@ -8736,19 +8166,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.curvature.attribute.curvedir">
       <optional>
          <attribute name="curvedir">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               a curve with a generic term indicating the direction of curvature.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes a curve with a generic term indicating the direction of curvature.</a:documentation>
             <choice>
                <value>above</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Upward
-                  curve.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Upward curve.</a:documentation>
                <value>below</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Downward curve.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Downward curve.</a:documentation>
                <value>mixed</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                  "meandering" curve, both above and below the items it pertains
-                  to.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A "meandering" curve, both above and below the items it pertains to.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -8760,8 +8185,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.curverend.attribute.lform">
       <optional>
          <attribute name="lform">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the line style of a curve.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the line style of a curve.</a:documentation>
             <ref name="mei_data.LINEFORM"/>
          </attribute>
       </optional>
@@ -8769,8 +8193,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.curverend.attribute.lwidth">
       <optional>
          <attribute name="lwidth">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Width of
-               a curved line.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Width of a curved line.</a:documentation>
             <ref name="mei_data.LINEWIDTH"/>
          </attribute>
       </optional>
@@ -8788,26 +8211,24 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.custos.log.attribute.target">
       <optional>
          <attribute name="target">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes
-               the target note when its pitch differs from the pitch at which the custos
-               appears.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes the target note when its pitch differs from the pitch at which the custos appears.</a:documentation>
             <ref name="mei_data.URI"/>
          </attribute>
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.custos.log-target-check_custosTarget-constraint-5">
+            id="mei-att.custos.log-target-check_custosTarget-constraint-5">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="mei:custos/@target">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@target attribute should
-            have content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:note/@xml:id">The
-            value in @target should correspond to the @xml:id attribute of a note
-            element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="mei:custos/@target">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@target attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:note/@xml:id">The value in @target should correspond to the @xml:id attribute of a note
+                  element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.custos.vis.attributes">
       <ref name="mei_att.altsym.attributes"/>
@@ -8826,8 +8247,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.datable.attribute.enddate">
       <optional>
          <attribute name="enddate">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               the end point of a date range in standard ISO form.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the end point of a date range in standard ISO form.</a:documentation>
             <ref name="mei_data.ISODATE"/>
          </attribute>
       </optional>
@@ -8835,8 +8255,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.datable.attribute.isodate">
       <optional>
          <attribute name="isodate">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               the value of a textual date in standard ISO form.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides the value of a textual date in standard ISO form.</a:documentation>
             <ref name="mei_data.ISODATE"/>
          </attribute>
       </optional>
@@ -8844,8 +8263,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.datable.attribute.notafter">
       <optional>
          <attribute name="notafter">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               an upper boundary for an uncertain date in standard ISO form.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains an upper boundary for an uncertain date in standard ISO form.</a:documentation>
             <ref name="mei_data.ISODATE"/>
          </attribute>
       </optional>
@@ -8853,8 +8271,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.datable.attribute.notbefore">
       <optional>
          <attribute name="notbefore">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               a lower boundary, in standard ISO form, for an uncertain date.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a lower boundary, in standard ISO form, for an uncertain date.</a:documentation>
             <ref name="mei_data.ISODATE"/>
          </attribute>
       </optional>
@@ -8862,8 +8279,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.datable.attribute.startdate">
       <optional>
          <attribute name="startdate">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               the starting point of a date range in standard ISO form.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the starting point of a date range in standard ISO form.</a:documentation>
             <ref name="mei_data.ISODATE"/>
          </attribute>
       </optional>
@@ -8874,8 +8290,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.datapointing.attribute.data">
       <optional>
          <attribute name="data">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to
-               link metadata elements to one or more data-containing elements.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to link metadata elements to one or more data-containing elements.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.URI"/>
@@ -8885,18 +8300,18 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.datapointing-data-check_dataTarget-constraint-6">
+            id="mei-att.datapointing-data-check_dataTarget-constraint-6">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@data">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@data attribute should have
-            content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*[ancestor::mei:music]/@xml:id"
-            >The value in @data should correspond to the @xml:id attribute of a descendant of the
-            music element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@data">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@data attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*[ancestor::mei:music]/@xml:id">The value in @data should correspond to the @xml:id attribute of a descendant of
+                  the music element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.declaring.attributes">
       <ref name="mei_att.declaring.attribute.decls"/>
@@ -8904,9 +8319,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.declaring.attribute.decls">
       <optional>
          <attribute name="decls">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Identifies one or more metadata elements within the header, which are understood to
-               apply to the element bearing this attribute and its content.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies one or more metadata elements within the header, which are understood to apply to the element bearing this attribute and its content.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.URI"/>
@@ -8916,18 +8329,18 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.declaring-decls-check_declsTarget-constraint-7">
+            id="mei-att.declaring-decls-check_declsTarget-constraint-7">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@decls">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@decls attribute should
-            have content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*[ancestor::mei:meiHead]/@xml:id"
-            >Each value in @decls should correspond to the @xml:id attribute of an element within
-            the metadata header.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@decls">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@decls attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*[ancestor::mei:meiHead]/@xml:id">Each value in @decls should correspond to the @xml:id attribute of an element
+                  within the metadata header.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.dimensions.attributes">
       <ref name="mei_att.height.attributes"/>
@@ -8962,8 +8375,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.distances.attribute.dynam.dist">
       <optional>
          <attribute name="dynam.dist">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the default distance from the staff for dynamic marks.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the default distance from the staff for dynamic marks.</a:documentation>
             <ref name="mei_data.MEASUREMENTREL"/>
          </attribute>
       </optional>
@@ -8971,9 +8383,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.distances.attribute.harm.dist">
       <optional>
          <attribute name="harm.dist">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the default distance from the staff of harmonic indications, such as guitar chord
-               grids or functional labels.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the default distance from the staff of harmonic indications, such as guitar chord grids or functional labels.</a:documentation>
             <ref name="mei_data.MEASUREMENTREL"/>
          </attribute>
       </optional>
@@ -8981,8 +8391,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.distances.attribute.text.dist">
       <optional>
          <attribute name="text.dist">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Determines how far from the staff to render text elements.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Determines how far from the staff to render text elements.</a:documentation>
             <ref name="mei_data.MEASUREMENTREL"/>
          </attribute>
       </optional>
@@ -9000,15 +8409,12 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.dot.log.attribute.form">
       <optional>
          <attribute name="form">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the function of the dot.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the function of the dot.</a:documentation>
             <choice>
                <value>aug</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Augmentation dot.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Augmentation dot.</a:documentation>
                <value>div</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Dot of
-                  division.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Dot of division.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -9030,12 +8436,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.duration.additive.attribute.dur">
       <optional>
          <attribute name="dur">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               duration using optionally dotted, relative durational values provided by the
-               data.DURATION datatype. When the duration is "irrational", as is sometimes the case
-               with tuplets, multiple space-separated values that add up to the total duration may
-               be used. When dotted values are present, the dots attribute must be
-               ignored.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records duration using optionally dotted, relative durational values provided by the data.DURATION datatype. When the duration is "irrational", as is sometimes the case with tuplets, multiple space-separated values that add up to the total duration may be used. When dotted values are present, the dots attribute must be ignored.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.DURATION.additive"/>
@@ -9045,14 +8446,15 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.duration.additive-dur-ignore_dots_attribute-constraint-8">
+            id="mei-att.duration.additive-dur-ignore_dots_attribute-constraint-8">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="mei:*[contains(@dur, '.')]">
-         <sch:assert test="not(@dots)">An element with a dur attribute that contains dotted values
-            must not have a dots attribute.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="mei:*[contains(@dur, '.')]">
+                <sch:assert test="not(@dots)">An element with a dur attribute that contains dotted
+                  values must not have a dots attribute.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.duration.default.attributes">
       <ref name="mei_att.duration.default.attribute.dur.default"/>
@@ -9062,9 +8464,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.duration.default.attribute.dur.default">
       <optional>
          <attribute name="dur.default">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               a default duration in those situations when the first note, rest, chord, etc. in a
-               measure does not have a duration specified.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a default duration in those situations when the first note, rest, chord, etc. in a measure does not have a duration specified.</a:documentation>
             <ref name="mei_data.DURATION"/>
          </attribute>
       </optional>
@@ -9072,9 +8472,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.duration.default.attribute.num.default">
       <optional>
          <attribute name="num.default">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Along
-               with numbase.default, describes the default duration as a ratio. num.default is the
-               first value in the ratio.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Along with numbase.default, describes the default duration as a ratio. num.default is the first value in the ratio.</a:documentation>
             <data type="positiveInteger"/>
          </attribute>
       </optional>
@@ -9082,9 +8480,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.duration.default.attribute.numbase.default">
       <optional>
          <attribute name="numbase.default">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Along
-               with num.default, describes the default duration as a ratio. numbase.default is the
-               second value in the ratio.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Along with num.default, describes the default duration as a ratio. numbase.default is the second value in the ratio.</a:documentation>
             <data type="positiveInteger"/>
          </attribute>
       </optional>
@@ -9095,9 +8491,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.duration.musical.attribute.dur">
       <optional>
          <attribute name="dur">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the duration of a feature using the relative durational values provided by the
-               data.DURATION datatype.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the duration of a feature using the relative durational values provided by the data.DURATION datatype.</a:documentation>
             <ref name="mei_data.DURATION"/>
          </attribute>
       </optional>
@@ -9108,11 +8502,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.duration.performed.attribute.dur.ges">
       <optional>
          <attribute name="dur.ges">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               performed duration information that differs from the written duration. Its value may
-               be expressed in several forms; that is, ppq (MIDI clicks and MusicXML 'divisions'),
-               Humdrum **recip values, beats, seconds, or mensural duration
-               values.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records performed duration information that differs from the written duration. Its value may be expressed in several forms; that is, ppq (MIDI clicks and MusicXML 'divisions'), Humdrum **recip values, beats, seconds, or mensural duration values.</a:documentation>
             <ref name="mei_data.DURATION.gestural"/>
          </attribute>
       </optional>
@@ -9124,9 +8514,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.duration.ratio.attribute.num">
       <optional>
          <attribute name="num">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Along
-               with numbase, describes duration as a ratio. num is the first value in the ratio,
-               while numbase is the second.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Along with numbase, describes duration as a ratio. num is the first value in the ratio, while numbase is the second.</a:documentation>
             <data type="positiveInteger"/>
          </attribute>
       </optional>
@@ -9134,9 +8522,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.duration.ratio.attribute.numbase">
       <optional>
          <attribute name="numbase">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Along
-               with num, describes duration as a ratio. num is the first value in the ratio, while
-               numbase is the second.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Along with num, describes duration as a ratio. num is the first value in the ratio, while numbase is the second.</a:documentation>
             <data type="positiveInteger"/>
          </attribute>
       </optional>
@@ -9169,10 +8555,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.enclosingchars.attribute.enclose">
       <optional>
          <attribute name="enclose">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the characters often used to mark accidentals, articulations, and sometimes notes as
-               having a cautionary or editorial function. For an example of cautionary accidentals
-               enclosed in parentheses, see Read, p. 131, ex. 9-14.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the characters often used to mark accidentals, articulations, and sometimes notes as having a cautionary or editorial function. For an example of cautionary accidentals enclosed in parentheses, see Read, p. 131, ex. 9-14.</a:documentation>
             <ref name="mei_data.ENCLOSURE"/>
          </attribute>
       </optional>
@@ -9195,18 +8578,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.endings.attribute.ending.rend">
       <optional>
          <attribute name="ending.rend">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               where ending marks should be displayed.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes where ending marks should be displayed.</a:documentation>
             <choice>
                <value>top</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Ending
-                  rendered only above top staff.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Ending rendered only above top staff.</a:documentation>
                <value>barred</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Ending
-                  rendered above staves that have bar lines drawn across them.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Ending rendered above staves that have bar lines drawn across them.</a:documentation>
                <value>grouped</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Endings rendered above staff groups.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Endings rendered above staff groups.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -9224,8 +8603,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.extender.attribute.extender">
       <optional>
          <attribute name="extender">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the presence of an extension symbol, typically a line.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the presence of an extension symbol, typically a line.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -9256,10 +8634,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.fermatapresent.attribute.fermata">
       <optional>
          <attribute name="fermata">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the attachment of a fermata to this element. If visual information about the fermata
-               needs to be recorded, then a &lt;fermata&gt; element should be employed
-               instead.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the attachment of a fermata to this element. If visual information about the fermata needs to be recorded, then a &lt;fermata&gt; element should be employed instead.</a:documentation>
             <ref name="mei_data.PLACE"/>
          </attribute>
       </optional>
@@ -9270,9 +8645,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.filing.attribute.nonfiling">
       <optional>
          <attribute name="nonfiling">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the
-               number of initial characters (such as those constituing an article or preposition)
-               that should not be used for sorting a title or name.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the number of initial characters (such as those constituing an article or preposition) that should not be used for sorting a title or name.</a:documentation>
             <data type="positiveInteger"/>
          </attribute>
       </optional>
@@ -9291,8 +8664,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.grpSym.log.attribute.level">
       <optional>
          <attribute name="level">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the nesting level of staff grouping symbols.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the nesting level of staff grouping symbols.</a:documentation>
             <data type="positiveInteger"/>
          </attribute>
       </optional>
@@ -9310,26 +8682,24 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.handident.attribute.hand">
       <optional>
          <attribute name="hand">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Signifies
-               the hand responsible for an action. The value must be the ID of a &lt;hand&gt;
-               element declared in the header.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Signifies the hand responsible for an action. The value must be the ID of a &lt;hand&gt; element declared in the header.</a:documentation>
             <ref name="mei_data.URI"/>
          </attribute>
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.handident-hand-check_handTarget-constraint-9">
+            id="mei-att.handident-hand-check_handTarget-constraint-9">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@hand">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@hand attribute should have
-            content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:hand/@xml:id">Each
-            value in @hand should correspond to the @xml:id attribute of a hand
-            element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@hand">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@hand attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:hand/@xml:id">Each value in @hand should correspond to the @xml:id attribute of a hand
+                  element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.height.attributes">
       <ref name="mei_att.height.attribute.height"/>
@@ -9337,8 +8707,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.height.attribute.height">
       <optional>
          <attribute name="height">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Measurement of the vertical dimension of an entity.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Measurement of the vertical dimension of an entity.</a:documentation>
             <ref name="mei_data.MEASUREMENTABS"/>
          </attribute>
       </optional>
@@ -9349,8 +8718,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.horizontalalign.attribute.halign">
       <optional>
          <attribute name="halign">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               horizontal alignment.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records horizontal alignment.</a:documentation>
             <ref name="mei_data.HORIZONTALALIGNMENT"/>
          </attribute>
       </optional>
@@ -9361,10 +8729,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.id.attribute.xmlid">
       <optional>
          <attribute name="xml:id">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Regularizes the naming of an element and thus facilitates building links between it
-               and other resources. Each id attribute within a document must have a unique
-               value.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Regularizes the naming of an element and thus facilitates building links between it and other resources. Each id attribute within a document must have a unique value.</a:documentation>
             <data type="ID"/>
          </attribute>
       </optional>
@@ -9375,26 +8740,24 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.instrumentident.attribute.instr">
       <optional>
          <attribute name="instr">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               a way of pointing to a MIDI instrument definition. It must contain the ID of an
-               &lt;instrDef&gt; element elsewhere in the document.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a way of pointing to a MIDI instrument definition. It must contain the ID of an &lt;instrDef&gt; element elsewhere in the document.</a:documentation>
             <ref name="mei_data.URI"/>
          </attribute>
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.instrumentident-instr-check_instrTarget-constraint-10">
+            id="mei-att.instrumentident-instr-check_instrTarget-constraint-10">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@instr">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@instr attribute should
-            have content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:instrDef/@xml:id"
-            >The value in @instr should correspond to the @xml:id attribute of an instrDef
-            element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@instr">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@instr attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:instrDef/@xml:id">The value in @instr should correspond to the @xml:id attribute of an instrDef
+                  element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.internetmedia.attributes">
       <ref name="mei_att.internetmedia.attribute.mimetype"/>
@@ -9402,10 +8765,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.internetmedia.attribute.mimetype">
       <optional>
          <attribute name="mimetype">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies
-               the applicable MIME (multimedia internet mail extension) type. The value should be a
-               valid MIME media type defined by the Internet Engineering Task Force in RFC
-               2046.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies the applicable MIME (multimedia internet mail extension) type. The value should be a valid MIME media type defined by the Internet Engineering Task Force in RFC 2046.</a:documentation>
             <data type="string"/>
          </attribute>
       </optional>
@@ -9416,12 +8776,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.joined.attribute.join">
       <optional>
          <attribute name="join">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for
-               linking visually separate entities that form a single logical entity, for example,
-               multiple slurs broken across a system break that form a single musical phrase. Also
-               used to indicate a measure which metrically completes the current one. Record the
-               identifiers of the separately encoded components, excluding the one carrying the
-               attribute.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used for linking visually separate entities that form a single logical entity, for example, multiple slurs broken across a system break that form a single musical phrase. Also used to indicate a measure which metrically completes the current one. Record the identifiers of the separately encoded components, excluding the one carrying the attribute.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.URI"/>
@@ -9431,17 +8786,18 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.joined-join-check_joinTarget-constraint-11">
+            id="mei-att.joined-join-check_joinTarget-constraint-11">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@join">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@join attribute should have
-            content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">Each
-            value in @join should correspond to the @xml:id attribute of an element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@join">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@join attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">Each value in @join should correspond to the @xml:id attribute of an
+                  element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.keyAccid.anl.attributes">
       <ref name="mei_att.common.anl.attributes"/>
@@ -9477,8 +8833,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.keySig.log.attribute.sig">
       <optional>
          <attribute name="sig">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               where the key lies in the circle of fifths.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates where the key lies in the circle of fifths.</a:documentation>
             <ref name="mei_data.KEYSIGNATURE"/>
          </attribute>
       </optional>
@@ -9486,15 +8841,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.keySig.log.attribute.sig.mixed">
       <optional>
          <attribute name="sig.mixed">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Mixed key
-               signatures, e.g. those consisting of a mixture of flats and sharps (Read, p. 143, ex.
-               9-39), and key signatures with unorthodox placement of the accidentals (Read, p. 141)
-               must be indicated by setting the key.sig attribute to 'mixed' and providing explicit
-               key signature information in the key.sig.mixed attribute or in the &lt;keySig&gt;
-               element. It is intended that key.sig.mixed contain a series of tokens with each token
-               containing pitch name, accidental, and octave, such as 'a4 c5s e5f' that indicate
-               what key accidentals should be rendered and where they should be
-               placed.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Mixed key signatures, e.g. those consisting of a mixture of flats and sharps (Read, p. 143, ex. 9-39), and key signatures with unorthodox placement of the accidentals (Read, p. 141) must be indicated by setting the key.sig attribute to 'mixed' and providing explicit key signature information in the key.sig.mixed attribute or in the &lt;keySig&gt; element. It is intended that key.sig.mixed contain a series of tokens with each token containing pitch name, accidental, and octave, such as 'a4 c5s e5f' that indicate what key accidentals should be rendered and where they should be placed.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.KEYSIGTOKEN"/>
@@ -9506,8 +8853,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.keySig.log.attribute.mode">
       <optional>
          <attribute name="mode">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               major, minor, or other tonality.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates major, minor, or other tonality.</a:documentation>
             <ref name="mei_data.MODE"/>
          </attribute>
       </optional>
@@ -9519,9 +8865,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.keySig.vis.attribute.sig.showchange">
       <optional>
          <attribute name="sig.showchange">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Determines whether cautionary accidentals should be displayed at a key
-               change.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Determines whether cautionary accidentals should be displayed at a key change.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -9536,9 +8880,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.keySigDefault.log.attribute.key.accid">
       <optional>
          <attribute name="key.accid">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               an accidental for the tonic key, if one is required, e.g., if key.pname equals 'c'
-               and key.accid equals 's', then a tonic of C# is indicated.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains an accidental for the tonic key, if one is required, e.g., if key.pname equals 'c' and key.accid equals 's', then a tonic of C# is indicated.</a:documentation>
             <ref name="mei_data.ACCIDENTAL.IMPLICIT"/>
          </attribute>
       </optional>
@@ -9546,8 +8888,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.keySigDefault.log.attribute.key.mode">
       <optional>
          <attribute name="key.mode">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               major, minor, or other tonality.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates major, minor, or other tonality.</a:documentation>
             <ref name="mei_data.MODE"/>
          </attribute>
       </optional>
@@ -9555,8 +8896,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.keySigDefault.log.attribute.key.pname">
       <optional>
          <attribute name="key.pname">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the
-               pitch name of the tonic key, e.g. 'c' for the key of C.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the pitch name of the tonic key, e.g. 'c' for the key of C.</a:documentation>
             <ref name="mei_data.PITCHNAME"/>
          </attribute>
       </optional>
@@ -9564,8 +8904,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.keySigDefault.log.attribute.key.sig">
       <optional>
          <attribute name="key.sig">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               where the key lies in the circle of fifths.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates where the key lies in the circle of fifths.</a:documentation>
             <ref name="mei_data.KEYSIGNATURE"/>
          </attribute>
       </optional>
@@ -9573,15 +8912,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.keySigDefault.log.attribute.key.sig.mixed">
       <optional>
          <attribute name="key.sig.mixed">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Mixed key
-               signatures, e.g. those consisting of a mixture of flats and sharps (Read, p. 143, ex.
-               9-39), and key signatures with unorthodox placement of the accidentals (Read, p. 141)
-               must be indicated by setting the key.sig attribute to 'mixed' and providing explicit
-               key signature information in the key.sig.mixed attribute or in the &lt;keySig&gt;
-               element. It is intended that key.sig.mixed contain a series of tokens with each token
-               containing pitch name, accidental, and octave, such as 'a4 c5s e5f' that indicate
-               what key accidentals should be rendered and where they should be
-               placed.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Mixed key signatures, e.g. those consisting of a mixture of flats and sharps (Read, p. 143, ex. 9-39), and key signatures with unorthodox placement of the accidentals (Read, p. 141) must be indicated by setting the key.sig attribute to 'mixed' and providing explicit key signature information in the key.sig.mixed attribute or in the &lt;keySig&gt; element. It is intended that key.sig.mixed contain a series of tokens with each token containing pitch name, accidental, and octave, such as 'a4 c5s e5f' that indicate what key accidentals should be rendered and where they should be placed.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.KEYSIGTOKEN"/>
@@ -9597,8 +8928,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.keySigDefault.vis.attribute.key.sig.show">
       <optional>
          <attribute name="key.sig.show">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               whether the key signature should be displayed.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates whether the key signature should be displayed.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -9606,9 +8936,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.keySigDefault.vis.attribute.key.sig.showchange">
       <optional>
          <attribute name="key.sig.showchange">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Determines whether cautionary accidentals should be displayed at a key
-               change.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Determines whether cautionary accidentals should be displayed at a key change.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -9619,9 +8947,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.labels.addl.attribute.label.abbr">
       <optional>
          <attribute name="label.abbr">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               a label for a group of staves on pages after the first page. Usually, this label
-               takes an abbreviated form.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a label for a group of staves on pages after the first page. Usually, this label takes an abbreviated form.</a:documentation>
             <data type="string"/>
          </attribute>
       </optional>
@@ -9633,11 +8959,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.lang.attribute.xmllang">
       <optional>
          <attribute name="xml:lang">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Identifies the language of the element's content. The values for this attribute are
-               language 'tags' as defined in BCP 47. All language tags that make use of private use
-               sub-tags must be documented in a corresponding language element in the MEI header
-               whose id attribute is the same as the language tag's value.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the language of the element's content. The values for this attribute are language 'tags' as defined in BCP 47. All language tags that make use of private use sub-tags must be documented in a corresponding language element in the MEI header whose id attribute is the same as the language tag's value.</a:documentation>
             <data type="language"/>
          </attribute>
       </optional>
@@ -9645,8 +8967,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.lang.attribute.translit">
       <optional>
          <attribute name="translit">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies
-               the transliteration technique used. </a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies the transliteration technique used. </a:documentation>
             <data type="NMTOKEN"/>
          </attribute>
       </optional>
@@ -9664,25 +8985,24 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.layer.log.attribute.def">
       <optional>
          <attribute name="def">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               a mechanism for linking the layer to a layerDef element.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a mechanism for linking the layer to a layerDef element.</a:documentation>
             <ref name="mei_data.URI"/>
          </attribute>
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.layer.log-def-check_defTarget_layer-constraint-12">
+            id="mei-att.layer.log-def-check_defTarget_layer-constraint-12">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="layer/@def">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@def attribute should have
-            content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:layerDef/@xml:id"
-            >The value in @def should correspond to the @xml:id attribute of a layerDef
-            element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="layer/@def">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@def attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:layerDef/@xml:id">The value in @def should correspond to the @xml:id attribute of a layerDef
+                  element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.layer.vis.attributes">
       <ref name="mei_att.visibility.attributes"/>
@@ -9711,8 +9031,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.layerident.attribute.layer">
       <optional>
          <attribute name="layer">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Identifies the layer to which a feature applies.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the layer to which a feature applies.</a:documentation>
             <list>
                <oneOrMore>
                   <data type="positiveInteger"/>
@@ -9750,8 +9069,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.line.vis.attribute.form">
       <optional>
          <attribute name="form">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Visual
-               form of the line.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Visual form of the line.</a:documentation>
             <ref name="mei_data.LINEFORM"/>
          </attribute>
       </optional>
@@ -9759,8 +9077,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.line.vis.attribute.width">
       <optional>
          <attribute name="width">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Width of
-               the line.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Width of the line.</a:documentation>
             <ref name="mei_data.LINEWIDTH"/>
          </attribute>
       </optional>
@@ -9768,8 +9085,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.line.vis.attribute.endsym">
       <optional>
          <attribute name="endsym">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Symbol
-               rendered at end of line.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Symbol rendered at end of line.</a:documentation>
             <ref name="mei_data.LINESTARTENDSYMBOL"/>
          </attribute>
       </optional>
@@ -9777,8 +9093,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.line.vis.attribute.endsymsize">
       <optional>
          <attribute name="endsymsize">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the
-               relative size of the line-end symbol.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the relative size of the line-end symbol.</a:documentation>
             <ref name="mei_data.LINESTARTENDSYMBOLSIZE"/>
          </attribute>
       </optional>
@@ -9786,8 +9101,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.line.vis.attribute.startsym">
       <optional>
          <attribute name="startsym">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Symbol
-               rendered at start of line.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Symbol rendered at start of line.</a:documentation>
             <ref name="mei_data.LINESTARTENDSYMBOL"/>
          </attribute>
       </optional>
@@ -9795,8 +9109,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.line.vis.attribute.startsymsize">
       <optional>
          <attribute name="startsymsize">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the
-               relative size of the line-start symbol.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the relative size of the line-start symbol.</a:documentation>
             <ref name="mei_data.LINESTARTENDSYMBOLSIZE"/>
          </attribute>
       </optional>
@@ -9807,10 +9120,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.lineloc.attribute.line">
       <optional>
          <attribute name="line">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the line upon which a feature stands. The value must be in the range between 1 and
-               the number of lines on the staff. The numbering of lines starts with the lowest line
-               of the staff.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the line upon which a feature stands. The value must be in the range between 1 and the number of lines on the staff. The numbering of lines starts with the lowest line of the staff.</a:documentation>
             <ref name="mei_data.CLEFLINE"/>
          </attribute>
       </optional>
@@ -9825,8 +9135,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.linerend.attribute.lendsym">
       <optional>
          <attribute name="lendsym">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Symbol
-               rendered at end of line.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Symbol rendered at end of line.</a:documentation>
             <ref name="mei_data.LINESTARTENDSYMBOL"/>
          </attribute>
       </optional>
@@ -9834,8 +9143,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.linerend.attribute.lendsymsize">
       <optional>
          <attribute name="lendsymsize">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the
-               relative size of the line-end symbol.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the relative size of the line-end symbol.</a:documentation>
             <ref name="mei_data.LINESTARTENDSYMBOLSIZE"/>
          </attribute>
       </optional>
@@ -9843,8 +9151,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.linerend.attribute.lstartsym">
       <optional>
          <attribute name="lstartsym">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Symbol
-               rendered at start of line.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Symbol rendered at start of line.</a:documentation>
             <ref name="mei_data.LINESTARTENDSYMBOL"/>
          </attribute>
       </optional>
@@ -9852,8 +9159,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.linerend.attribute.lstartsymsize">
       <optional>
          <attribute name="lstartsymsize">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the
-               relative size of the line-start symbol.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the relative size of the line-start symbol.</a:documentation>
             <ref name="mei_data.LINESTARTENDSYMBOLSIZE"/>
          </attribute>
       </optional>
@@ -9865,8 +9171,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.linerend.base.attribute.lform">
       <optional>
          <attribute name="lform">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the line style of a line.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the line style of a line.</a:documentation>
             <ref name="mei_data.LINEFORM"/>
          </attribute>
       </optional>
@@ -9874,8 +9179,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.linerend.base.attribute.lwidth">
       <optional>
          <attribute name="lwidth">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Width of
-               a line.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Width of a line.</a:documentation>
             <ref name="mei_data.LINEWIDTH"/>
          </attribute>
       </optional>
@@ -9891,8 +9195,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.lyricstyle.attribute.lyric.align">
       <optional>
          <attribute name="lyric.align">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the alignment of lyric syllables associated with a note or chord.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the alignment of lyric syllables associated with a note or chord.</a:documentation>
             <ref name="mei_data.MEASUREMENTREL"/>
          </attribute>
       </optional>
@@ -9900,8 +9203,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.lyricstyle.attribute.lyric.fam">
       <optional>
          <attribute name="lyric.fam">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the
-               font family default value for lyrics.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the font family default value for lyrics.</a:documentation>
             <ref name="mei_data.FONTFAMILY"/>
          </attribute>
       </optional>
@@ -9909,8 +9211,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.lyricstyle.attribute.lyric.name">
       <optional>
          <attribute name="lyric.name">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the
-               font name default value for lyrics.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the font name default value for lyrics.</a:documentation>
             <ref name="mei_data.FONTNAME"/>
          </attribute>
       </optional>
@@ -9918,8 +9219,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.lyricstyle.attribute.lyric.size">
       <optional>
          <attribute name="lyric.size">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the
-               default font size value for lyrics.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the default font size value for lyrics.</a:documentation>
             <ref name="mei_data.FONTSIZE"/>
          </attribute>
       </optional>
@@ -9927,8 +9227,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.lyricstyle.attribute.lyric.style">
       <optional>
          <attribute name="lyric.style">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the
-               default font style value for lyrics.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the default font style value for lyrics.</a:documentation>
             <ref name="mei_data.FONTSTYLE"/>
          </attribute>
       </optional>
@@ -9936,8 +9235,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.lyricstyle.attribute.lyric.weight">
       <optional>
          <attribute name="lyric.weight">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the
-               default font weight value for lyrics.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the default font weight value for lyrics.</a:documentation>
             <ref name="mei_data.FONTWEIGHT"/>
          </attribute>
       </optional>
@@ -9957,10 +9255,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.measure.log.attribute.left">
       <optional>
          <attribute name="left">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the visual rendition of the left bar line. It is present here only for facilitation
-               of translation from legacy encodings which use it. Usually, it can be safely
-               ignored.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the visual rendition of the left bar line. It is present here only for facilitation of translation from legacy encodings which use it. Usually, it can be safely ignored.</a:documentation>
             <ref name="mei_data.BARRENDITION"/>
          </attribute>
       </optional>
@@ -9968,8 +9263,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.measure.log.attribute.right">
       <optional>
          <attribute name="right">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the function of the right bar line and is structurally important.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the function of the right bar line and is structurally important.</a:documentation>
             <ref name="mei_data.BARRENDITION"/>
          </attribute>
       </optional>
@@ -9980,50 +9274,35 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.measurement.attribute.unit">
       <optional>
          <attribute name="unit">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the unit of measurement. Suggested values include: 1] byte; 2] char; 3] cm; 4] in; 5]
-               issue; 6] mm; 7] page; 8] pc; 9] pt; 10] px; 11] record; 12] vol; 13]
-               vu</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the unit of measurement.
+Suggested values include: 1] byte; 2] char; 3] cm; 4] in; 5] issue; 6] mm; 7] page; 8] pc; 9] pt; 10] px; 11] record; 12] vol; 13] vu</a:documentation>
             <choice>
                <value>byte</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Byte.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Byte.</a:documentation>
                <value>char</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Character.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Character.</a:documentation>
                <value>cm</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Centimeter.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Centimeter.</a:documentation>
                <value>in</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Inch.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Inch.</a:documentation>
                <value>issue</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Serial
-                  issue.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Serial issue.</a:documentation>
                <value>mm</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Millimeter.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Millimeter.</a:documentation>
                <value>page</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Page.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Page.</a:documentation>
                <value>pc</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Pica.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Pica.</a:documentation>
                <value>pt</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Point.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Point.</a:documentation>
                <value>px</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Pixel.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Pixel.</a:documentation>
                <value>record</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Record.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Record.</a:documentation>
                <value>vol</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Serial
-                  volume.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Serial volume.</a:documentation>
                <value>vu</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MEI
-                  virtual unit.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MEI virtual unit.</a:documentation>
                <data type="NMTOKEN"/>
             </choice>
          </attribute>
@@ -10035,8 +9314,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.measurenumbers.attribute.mnum.visible">
       <optional>
          <attribute name="mnum.visible">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               whether measure numbers should be displayed.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates whether measure numbers should be displayed.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -10049,9 +9327,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mediabounds.attribute.begin">
       <optional>
          <attribute name="begin">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies
-               a point where the relevant content begins. A numerical value must be less and a time
-               value must be earlier than that given by the end attribute.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies a point where the relevant content begins. A numerical value must be less and a time value must be earlier than that given by the end attribute.</a:documentation>
             <text/>
          </attribute>
       </optional>
@@ -10059,10 +9335,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mediabounds.attribute.end">
       <optional>
          <attribute name="end">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies
-               a point where the relevant content ends. If not specified, the end of the content is
-               assumed to be the end point. A numerical value must be greater and a time value must
-               be later than that given by the begin attribute.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies a point where the relevant content ends. If not specified, the end of the content is assumed to be the end point. A numerical value must be greater and a time value must be later than that given by the begin attribute.</a:documentation>
             <text/>
          </attribute>
       </optional>
@@ -10070,9 +9343,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mediabounds.attribute.betype">
       <optional>
          <attribute name="betype">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Type of
-               values used in the begin/end attributes. The begin and end attributes can only be
-               interpreted meaningfully in conjunction with this attribute.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Type of values used in the begin/end attributes. The begin and end attributes can only be interpreted meaningfully in conjunction with this attribute.</a:documentation>
             <ref name="mei_data.BETYPE"/>
          </attribute>
       </optional>
@@ -10083,8 +9354,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.medium.attribute.medium">
       <optional>
          <attribute name="medium">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the writing medium.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the writing medium.</a:documentation>
             <data type="string"/>
          </attribute>
       </optional>
@@ -10094,8 +9364,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_att.meiversion.attribute.meiversion">
       <optional>
-         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="meiversion"
-            a:defaultValue="3.0.0">
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="meiversion"
+                    a:defaultValue="3.0.0">
             <a:documentation>Specifies a generic MEI version label.</a:documentation>
             <choice>
                <value>3.0.0</value>
@@ -10114,8 +9385,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mensur.log.attribute.dot">
       <optional>
          <attribute name="dot">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies
-               whether a dot is to be added to the base symbol.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies whether a dot is to be added to the base symbol.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -10123,8 +9393,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mensur.log.attribute.sign">
       <optional>
          <attribute name="sign">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The base
-               symbol in the mensuration sign/time signature of mensural notation.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The base symbol in the mensuration sign/time signature of mensural notation.</a:documentation>
             <ref name="mei_data.MENSURATIONSIGN"/>
          </attribute>
       </optional>
@@ -10135,19 +9404,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.meterconformance.attribute.metcon">
       <optional>
          <attribute name="metcon">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the relationship between the content of a staff or layer and the prevailing
-               meter.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the relationship between the content of a staff or layer and the prevailing meter.</a:documentation>
             <choice>
                <value>c</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Complete; i.e., conformant with the prevailing meter.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Complete; i.e., conformant with the prevailing meter.</a:documentation>
                <value>i</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Incomplete; i.e., not enough beats.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Incomplete; i.e., not enough beats.</a:documentation>
                <value>o</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Overfull; i.e., too many beats.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Overfull; i.e., too many beats.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -10159,9 +9423,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.meterconformance.bar.attribute.metcon">
       <optional>
          <attribute name="metcon">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the relationship between the content of a measure and the prevailing
-               meter.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the relationship between the content of a measure and the prevailing meter.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -10169,12 +9431,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.meterconformance.bar.attribute.control">
       <optional>
          <attribute name="control">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               whether or not a bar line is "controlling"; that is, if it indicates a point of
-               alignment across all the parts. Bar lines within a score are usually controlling;
-               that is, they "line up". Bar lines within parts may or may not be controlling. When
-               applied to &lt;measure&gt;, this attribute indicates the nature of the right barline
-               but not the left.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates whether or not a bar line is "controlling"; that is, if it indicates a point of alignment across all the parts. Bar lines within a score are usually controlling; that is, they "line up". Bar lines within parts may or may not be controlling. When applied to &lt;measure&gt;, this attribute indicates the nature of the right barline but not the left.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -10193,10 +9450,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.meterSig.log.attribute.count">
       <optional>
          <attribute name="count">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures
-               the number of beats in a measure, that is, the top number of the meter signature. It
-               must contain a decimal number or an additive expression that evaluates to a decimal
-               number, such as 2+3.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures the number of beats in a measure, that is, the top number of the meter signature. It must contain a decimal number or an additive expression that evaluates to a decimal number, such as 2+3.</a:documentation>
             <data type="string">
                <param name="pattern">\d+(\.\d+)?(\s*\+\s*\d+(\.\d+)?)*</param>
             </data>
@@ -10206,9 +9460,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.meterSig.log.attribute.sym">
       <optional>
          <attribute name="sym">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the use of a meter symbol instead of a numeric meter signature, that is, 'C' for
-               common time or 'C' with a slash for cut time.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the use of a meter symbol instead of a numeric meter signature, that is, 'C' for common time or 'C' with a slash for cut time.</a:documentation>
             <ref name="mei_data.METERSIGN"/>
          </attribute>
       </optional>
@@ -10216,9 +9468,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.meterSig.log.attribute.unit">
       <optional>
          <attribute name="unit">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               the number indicating the beat unit, that is, the bottom number of the meter
-               signature.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the number indicating the beat unit, that is, the bottom number of the meter signature.</a:documentation>
             <data type="decimal"/>
          </attribute>
       </optional>
@@ -10232,22 +9482,16 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.meterSig.vis.attribute.form">
       <optional>
          <attribute name="form">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               an indication of how the meter signature should be rendered.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains an indication of how the meter signature should be rendered.</a:documentation>
             <choice>
                <value>num</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Show
-                  only the number of beats.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Show only the number of beats.</a:documentation>
                <value>denomsym</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The
-                  lower number in the meter signature is replaced by a note
-                  symbol.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The lower number in the meter signature is replaced by a note symbol.</a:documentation>
                <value>norm</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Meter
-                  signature rendered using traditional numeric values.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Meter signature rendered using traditional numeric values.</a:documentation>
                <value>invis</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Meter
-                  signature not rendered.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Meter signature not rendered.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -10259,10 +9503,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.meterSigDefault.log.attribute.meter.count">
       <optional>
          <attribute name="meter.count">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures
-               the number of beats in a measure, that is, the top number of the meter signature. It
-               must contain a decimal number or an additive expression that evaluates to a decimal
-               number, such as 2+3.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures the number of beats in a measure, that is, the top number of the meter signature. It must contain a decimal number or an additive expression that evaluates to a decimal number, such as 2+3.</a:documentation>
             <data type="string">
                <param name="pattern">\d+(\.\d+)?(\s*\+\s*\d+(\.\d+)?)*</param>
             </data>
@@ -10272,9 +9513,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.meterSigDefault.log.attribute.meter.unit">
       <optional>
          <attribute name="meter.unit">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               the number indicating the beat unit, that is, the bottom number of the meter
-               signature.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the number indicating the beat unit, that is, the bottom number of the meter signature.</a:documentation>
             <data type="decimal"/>
          </attribute>
       </optional>
@@ -10287,22 +9526,16 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.meterSigDefault.vis.attribute.meter.rend">
       <optional>
          <attribute name="meter.rend">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               an indication of how the meter signature should be rendered.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains an indication of how the meter signature should be rendered.</a:documentation>
             <choice>
                <value>num</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Show
-                  only the number of beats.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Show only the number of beats.</a:documentation>
                <value>denomsym</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The
-                  lower number in the meter signature is replaced by a note
-                  symbol.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The lower number in the meter signature is replaced by a note symbol.</a:documentation>
                <value>norm</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Meter
-                  signature rendered using traditional numeric values.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Meter signature rendered using traditional numeric values.</a:documentation>
                <value>invis</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Meter
-                  signature not rendered.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Meter signature not rendered.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -10310,9 +9543,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.meterSigDefault.vis.attribute.meter.showchange">
       <optional>
          <attribute name="meter.showchange">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Determines whether a new meter signature should be displayed when the meter
-               signature changes.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Determines whether a new meter signature should be displayed when the meter signature changes.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -10320,9 +9551,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.meterSigDefault.vis.attribute.meter.sym">
       <optional>
          <attribute name="meter.sym">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the use of a meter symbol instead of a numeric meter signature, that is, 'C' for
-               common time or 'C' with a slash for cut time.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the use of a meter symbol instead of a numeric meter signature, that is, 'C' for common time or 'C' with a slash for cut time.</a:documentation>
             <ref name="mei_data.METERSIGN"/>
          </attribute>
       </optional>
@@ -10335,11 +9564,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mmtempo.attribute.mm">
       <optional>
          <attribute name="mm">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to
-               describe tempo in terms of beats (often the meter signature denominator) per minute,
-               ala M.M. (Maezel's Metronome). Do not confuse this attribute with midi.bpm or
-               midi.mspb. In MIDI, a beat is always defined as a quarter note, *not the numerator of
-               the time signature or the metronomic indication*.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to describe tempo in terms of beats (often the meter signature denominator) per minute, ala M.M. (Maezel's Metronome). Do not confuse this attribute with midi.bpm or midi.mspb. In MIDI, a beat is always defined as a quarter note, *not the numerator of the time signature or the metronomic indication*.</a:documentation>
             <ref name="mei_data.TEMPOVALUE"/>
          </attribute>
       </optional>
@@ -10347,8 +9572,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mmtempo.attribute.mm.unit">
       <optional>
          <attribute name="mm.unit">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures
-               the metronomic unit.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures the metronomic unit.</a:documentation>
             <ref name="mei_data.DURATION"/>
          </attribute>
       </optional>
@@ -10356,9 +9580,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mmtempo.attribute.mm.dots">
       <optional>
          <attribute name="mm.dots">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the number of augmentation dots required by a dotted metronome
-               unit.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the number of augmentation dots required by a dotted metronome unit.</a:documentation>
             <ref name="mei_data.AUGMENTDOT"/>
          </attribute>
       </optional>
@@ -10369,9 +9591,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.multinummeasures.attribute.multi.number">
       <optional>
          <attribute name="multi.number">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               whether programmatically calculated counts of multiple measures of rest (mRest) and
-               whole measure repeats (mRpt) in parts should be rendered.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates whether programmatically calculated counts of multiple measures of rest (mRest) and whole measure repeats (mRpt) in parts should be rendered.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -10387,33 +9607,29 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.name.attribute.nymref">
       <optional>
          <attribute name="nymref">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to
-               record a pointer to the regularized form of the name elsewhere in the
-               document.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to record a pointer to the regularized form of the name elsewhere in the document.</a:documentation>
             <ref name="mei_data.URI"/>
          </attribute>
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.name-nymref-check_nymrefTarget-constraint-13">
+            id="mei-att.name-nymref-check_nymrefTarget-constraint-13">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@nymref">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@nymref attribute should
-            have content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">The
-            value in @nymref should correspond to the @xml:id attribute of an element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@nymref">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@nymref attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">The value in @nymref should correspond to the @xml:id attribute of an
+                  element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.name.attribute.role">
       <optional>
          <attribute name="role">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to
-               specify further information about the entity referenced by this name, for example,
-               the occupation of a person or the status of a place. Use a standard value whenever
-               possible.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to specify further information about the entity referenced by this name, for example, the occupation of a person or the status of a place. Use a standard value whenever possible.</a:documentation>
             <text/>
          </attribute>
       </optional>
@@ -10425,8 +9641,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.notationstyle.attribute.music.name">
       <optional>
          <attribute name="music.name">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the
-               default music font name.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the default music font name.</a:documentation>
             <ref name="mei_data.MUSICFONT"/>
          </attribute>
       </optional>
@@ -10434,8 +9649,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.notationstyle.attribute.music.size">
       <optional>
          <attribute name="music.size">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the
-               default music font size.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the default music font size.</a:documentation>
             <ref name="mei_data.FONTSIZE"/>
          </attribute>
       </optional>
@@ -10464,8 +9678,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.note.ges.attribute.oct.ges">
       <optional>
          <attribute name="oct.ges">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               performed octave information that differs from the written value.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records performed octave information that differs from the written value.</a:documentation>
             <ref name="mei_data.OCTAVE"/>
          </attribute>
       </optional>
@@ -10473,8 +9686,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.note.ges.attribute.pname.ges">
       <optional>
          <attribute name="pname.ges">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               a performed pitch name that differs from the written value.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a performed pitch name that differs from the written value.</a:documentation>
             <ref name="mei_data.PITCHNAME.GES"/>
          </attribute>
       </optional>
@@ -10482,9 +9694,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.note.ges.attribute.pnum">
       <optional>
          <attribute name="pnum">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds a
-               pitch-to-number mapping, a base-40 or MIDI note number, for
-               example.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds a pitch-to-number mapping, a base-40 or MIDI note number, for example.</a:documentation>
             <ref name="mei_data.PITCHNUMBER"/>
          </attribute>
       </optional>
@@ -10533,8 +9743,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.noteheads.attribute.head.color">
       <optional>
          <attribute name="head.color">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures
-               the overall color of a notehead.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures the overall color of a notehead.</a:documentation>
             <ref name="mei_data.COLOR"/>
          </attribute>
       </optional>
@@ -10542,8 +9751,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.noteheads.attribute.head.fill">
       <optional>
          <attribute name="head.fill">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               how/if the notehead is filled.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes how/if the notehead is filled.</a:documentation>
             <ref name="mei_data.FILL"/>
          </attribute>
       </optional>
@@ -10551,9 +9759,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.noteheads.attribute.head.fillcolor">
       <optional>
          <attribute name="head.fillcolor">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures
-               the fill color of a notehead if different from the overall note
-               color.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures the fill color of a notehead if different from the overall note color.</a:documentation>
             <ref name="mei_data.COLOR"/>
          </attribute>
       </optional>
@@ -10561,8 +9767,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.noteheads.attribute.head.mod">
       <optional>
          <attribute name="head.mod">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               any additional symbols applied to the notehead.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records any additional symbols applied to the notehead.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.NOTEHEADMODIFIER"/>
@@ -10574,10 +9779,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.noteheads.attribute.head.rotation">
       <optional>
          <attribute name="head.rotation">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               rotation applied to the basic notehead shape. A positive value rotates the notehead
-               in a counter-clockwise fashion, while negative values produce clockwise
-               rotation.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes rotation applied to the basic notehead shape. A positive value rotates the notehead in a counter-clockwise fashion, while negative values produce clockwise rotation.</a:documentation>
             <ref name="mei_data.ROTATION"/>
          </attribute>
       </optional>
@@ -10585,8 +9787,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.noteheads.attribute.head.shape">
       <optional>
          <attribute name="head.shape">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to
-               override the head shape normally used for the given duration.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to override the head shape normally used for the given duration.</a:documentation>
             <ref name="mei_data.HEADSHAPE"/>
          </attribute>
       </optional>
@@ -10594,9 +9795,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.noteheads.attribute.head.visible">
       <optional>
          <attribute name="head.visible">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               if a feature should be rendered when the notation is presented graphically or sounded
-               when it is presented in an aural form.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates if a feature should be rendered when the notation is presented graphically or sounded when it is presented in an aural form.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -10607,8 +9806,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.octave.attribute.oct">
       <optional>
          <attribute name="oct">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures
-               written octave information.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures written octave information.</a:documentation>
             <ref name="mei_data.OCTAVE"/>
          </attribute>
       </optional>
@@ -10619,9 +9817,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.octavedefault.attribute.octave.default">
       <optional>
          <attribute name="octave.default">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               a default octave specification for use when the first note, rest, chord, etc. in a
-               measure does not have an octave value specified.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a default octave specification for use when the first note, rest, chord, etc. in a measure does not have an octave value specified.</a:documentation>
             <ref name="mei_data.OCTAVE"/>
          </attribute>
       </optional>
@@ -10633,8 +9829,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.octavedisplacement.attribute.dis">
       <optional>
          <attribute name="dis">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the amount of octave displacement.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the amount of octave displacement.</a:documentation>
             <ref name="mei_data.OCTAVE.DIS"/>
          </attribute>
       </optional>
@@ -10642,8 +9837,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.octavedisplacement.attribute.dis.place">
       <optional>
          <attribute name="dis.place">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the direction of octave displacement.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the direction of octave displacement.</a:documentation>
             <ref name="mei_data.PLACE"/>
          </attribute>
       </optional>
@@ -10654,10 +9848,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.onelinestaff.attribute.ontheline">
       <optional>
          <attribute name="ontheline">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Determines the placement of notes on a 1-line staff. A value of 'true' places all
-               notes on the line, while a value of 'false' places stems-up notes above the line and
-               stems-down notes below the line.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Determines the placement of notes on a 1-line staff. A value of 'true' places all notes on the line, while a value of 'false' places stems-up notes above the line and stems-down notes below the line.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -10668,9 +9859,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.optimization.attribute.optimize">
       <optional>
          <attribute name="optimize">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               whether staves without notes, rests, etc. should be displayed. When the value is
-               'true', empty staves are displayed.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates whether staves without notes, rests, etc. should be displayed. When the value is 'true', empty staves are displayed.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -10708,9 +9897,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_att.pad.log.attribute.num">
       <attribute name="num">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Amount of
-            "padding" to be added, in interline units; that is, in units of 1/2 the distance between
-            adjacent staff lines.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Amount of "padding" to be added, in interline units; that is, in units of 1/2 the distance between adjacent staff lines.</a:documentation>
          <data type="decimal"/>
       </attribute>
    </define>
@@ -10730,9 +9917,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.pages.attribute.page.height">
       <optional>
          <attribute name="page.height">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies
-               the height of the page; may be expressed in real-world units or staff
-               steps.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies the height of the page; may be expressed in real-world units or staff steps.</a:documentation>
             <ref name="mei_data.MEASUREMENTABS"/>
          </attribute>
       </optional>
@@ -10740,9 +9925,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.pages.attribute.page.width">
       <optional>
          <attribute name="page.width">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the width of the page; may be expressed in real-world units or staff
-               steps.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the width of the page; may be expressed in real-world units or staff steps.</a:documentation>
             <ref name="mei_data.MEASUREMENTABS"/>
          </attribute>
       </optional>
@@ -10750,8 +9933,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.pages.attribute.page.topmar">
       <optional>
          <attribute name="page.topmar">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the amount of whitespace at the top of a page.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the amount of whitespace at the top of a page.</a:documentation>
             <ref name="mei_data.MEASUREMENTABS"/>
          </attribute>
       </optional>
@@ -10759,8 +9941,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.pages.attribute.page.botmar">
       <optional>
          <attribute name="page.botmar">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the amount of whitespace at the bottom of a page.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the amount of whitespace at the bottom of a page.</a:documentation>
             <ref name="mei_data.MEASUREMENTABS"/>
          </attribute>
       </optional>
@@ -10768,8 +9949,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.pages.attribute.page.leftmar">
       <optional>
          <attribute name="page.leftmar">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the amount of whitespace at the left side of a page.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the amount of whitespace at the left side of a page.</a:documentation>
             <ref name="mei_data.MEASUREMENTABS"/>
          </attribute>
       </optional>
@@ -10777,8 +9957,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.pages.attribute.page.rightmar">
       <optional>
          <attribute name="page.rightmar">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the amount of whitespace at the right side of a page.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the amount of whitespace at the right side of a page.</a:documentation>
             <ref name="mei_data.MEASUREMENTABS"/>
          </attribute>
       </optional>
@@ -10786,9 +9965,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.pages.attribute.page.panels">
       <optional>
          <attribute name="page.panels">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the number of logical pages to be rendered on a single physical
-               page.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the number of logical pages to be rendered on a single physical page.</a:documentation>
             <ref name="mei_data.PAGE.PANELS"/>
          </attribute>
       </optional>
@@ -10796,8 +9973,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.pages.attribute.page.scale">
       <optional>
          <attribute name="page.scale">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               how the page should be scaled when rendered.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates how the page should be scaled when rendered.</a:documentation>
             <ref name="mei_data.PGSCALE"/>
          </attribute>
       </optional>
@@ -10841,9 +10017,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.pb.vis.attribute.folium">
       <optional>
          <attribute name="folium">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">States
-               the side of a leaf (as in a manuscript) on which the content following the &lt;pb&gt;
-               element occurs.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">States the side of a leaf (as in a manuscript) on which the content following the &lt;pb&gt; element occurs.</a:documentation>
             <choice>
                <value>verso</value>
                <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
@@ -10881,8 +10055,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.pitch.attribute.pname">
       <optional>
          <attribute name="pname">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               a written pitch name.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a written pitch name.</a:documentation>
             <ref name="mei_data.PITCHNAME"/>
          </attribute>
       </optional>
@@ -10897,9 +10070,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.placement.attribute.place">
       <optional>
          <attribute name="place">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures
-               the placement of the item with respect to the staff with which it is
-               associated.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures the placement of the item with respect to the staff with which it is associated.</a:documentation>
             <ref name="mei_data.STAFFREL"/>
          </attribute>
       </optional>
@@ -10910,10 +10081,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.plist.attribute.plist">
       <optional>
          <attribute name="plist">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               a space separated list of references that identify active participants in a
-               collection/relationship, such as notes under a phrase mark; that is, the entities
-               pointed "from".</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a space separated list of references that identify active participants in a collection/relationship, such as notes under a phrase mark; that is, the entities pointed "from".</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.URI"/>
@@ -10923,17 +10091,18 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.plist-plist-check_plistTarget-constraint-14">
+            id="mei-att.plist-plist-check_plistTarget-constraint-14">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@plist">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@plist attribute should
-            have content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">Each
-            value in @plist should correspond to the @xml:id attribute of an element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@plist">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@plist attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">Each value in @plist should correspond to the @xml:id attribute of an
+                  element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.pointing.attributes">
       <ref name="mei_att.pointing.attribute.xlinkactuate"/>
@@ -10945,23 +10114,16 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.pointing.attribute.xlinkactuate">
       <optional>
          <attribute name="xlink:actuate">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Defines
-               whether a link occurs automatically or must be requested by the
-               user.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Defines whether a link occurs automatically or must be requested by the user.</a:documentation>
             <choice>
                <value>onLoad</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Load
-                  the target resource(s) immediately.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Load the target resource(s) immediately.</a:documentation>
                <value>onRequest</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Load
-                  the target resource(s) upon user request.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Load the target resource(s) upon user request.</a:documentation>
                <value>none</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Do not
-                  permit loading of the target resource(s).</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Do not permit loading of the target resource(s).</a:documentation>
                <value>other</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Behavior other than allowed by the other values of this
-                  attribute.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Behavior other than allowed by the other values of this attribute.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -10969,9 +10131,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.pointing.attribute.xlinkrole">
       <optional>
          <attribute name="xlink:role">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Characterization of the relationship between resources. The value of the role
-               attribute must be a URI.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Characterization of the relationship between resources. The value of the role attribute must be a URI.</a:documentation>
             <ref name="mei_data.URI"/>
          </attribute>
       </optional>
@@ -10979,25 +10139,18 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.pointing.attribute.xlinkshow">
       <optional>
          <attribute name="xlink:show">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Defines
-               how a remote resource is rendered.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Defines how a remote resource is rendered.</a:documentation>
             <choice>
                <value>new</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Open
-                  in a new window.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Open in a new window.</a:documentation>
                <value>replace</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Load
-                  the referenced resource in the same window.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Load the referenced resource in the same window.</a:documentation>
                <value>embed</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Embed
-                  the referenced resource at the point of the link.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Embed the referenced resource at the point of the link.</a:documentation>
                <value>none</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Do not
-                  permit traversal to the referenced resource.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Do not permit traversal to the referenced resource.</a:documentation>
                <value>other</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Behavior other than permitted by the other values of this
-                  attribute.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Behavior other than permitted by the other values of this attribute.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -11005,9 +10158,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.pointing.attribute.target">
       <optional>
          <attribute name="target">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Allows
-               the use of one or more previously-undeclared URIs to identify passive participants in
-               a relationship; that is, the entities pointed "to".</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Allows the use of one or more previously-undeclared URIs to identify passive participants in a relationship; that is, the entities pointed "to".</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.URI"/>
@@ -11019,9 +10170,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.pointing.attribute.targettype">
       <optional>
          <attribute name="targettype">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Characterization of target resource(s) using any convenient classification scheme or
-               typology.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Characterization of target resource(s) using any convenient classification scheme or typology.</a:documentation>
             <data type="NMTOKEN"/>
          </attribute>
       </optional>
@@ -11032,9 +10181,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.quantity.attribute.quantity">
       <optional>
          <attribute name="quantity">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Numeric
-               value capturing a measurement or count. Can only be interpreted in combination with
-               the unit or currency attribute.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Numeric value capturing a measurement or count. Can only be interpreted in combination with the unit or currency attribute.</a:documentation>
             <data type="decimal">
                <param name="minInclusive">0</param>
             </data>
@@ -11047,8 +10194,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.relativesize.attribute.size">
       <optional>
          <attribute name="size">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the relative size of a feature.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the relative size of a feature.</a:documentation>
             <ref name="mei_data.SIZE"/>
          </attribute>
       </optional>
@@ -11059,10 +10205,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.responsibility.attribute.resp">
       <optional>
          <attribute name="resp">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures
-               information regarding responsibility for some aspect of the text's creation,
-               transcription, editing, or encoding. Its value must point to one or more identifiers
-               declared in the document header.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures information regarding responsibility for some aspect of the text's creation, transcription, editing, or encoding. Its value must point to one or more identifiers declared in the document header.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.URI"/>
@@ -11072,18 +10215,18 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.responsibility-resp-check_respTarget-constraint-15">
+            id="mei-att.responsibility-resp-check_respTarget-constraint-15">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@resp">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@resp attribute should have
-            content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*[ancestor::mei:meiHead]/@xml:id"
-            >The value in @resp should correspond to the @xml:id attribute of an element within the
-            metadata header.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@resp">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@resp attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*[ancestor::mei:meiHead]/@xml:id">The value in @resp should correspond to the @xml:id attribute of an element
+                  within the metadata header.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.rest.anl.attributes">
       <ref name="mei_att.common.anl.attributes"/>
@@ -11132,13 +10275,10 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.sb.vis.attribute.form">
       <optional>
          <attribute name="form">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               whether hash marks should be rendered between systems. See Read, p. 436, ex.
-               26-3.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates whether hash marks should be rendered between systems. See Read, p. 436, ex. 26-3.</a:documentation>
             <choice>
                <value>hash</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Display hash marks between systems.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Display hash marks between systems.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -11149,9 +10289,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.scalable.attribute.scale">
       <optional>
          <attribute name="scale">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Scale
-               factor to be applied to the feature to make it the desired display
-               size.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Scale factor to be applied to the feature to make it the desired display size.</a:documentation>
             <ref name="mei_data.PERCENT"/>
          </attribute>
       </optional>
@@ -11183,8 +10321,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.scoreDef.ges.attribute.tune.pname">
       <optional>
          <attribute name="tune.pname">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the
-               pitch name of a tuning reference pitch.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the pitch name of a tuning reference pitch.</a:documentation>
             <ref name="mei_data.PITCHNAME"/>
          </attribute>
       </optional>
@@ -11192,9 +10329,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.scoreDef.ges.attribute.tune.Hz">
       <optional>
          <attribute name="tune.Hz">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds a
-               value for cycles per second, i.e., Hertz, for a tuning reference
-               pitch.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds a value for cycles per second, i.e., Hertz, for a tuning reference pitch.</a:documentation>
             <data type="decimal"/>
          </attribute>
       </optional>
@@ -11202,8 +10337,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.scoreDef.ges.attribute.tune.temper">
       <optional>
          <attribute name="tune.temper">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               an indication of the tuning system, 'just', for example.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides an indication of the tuning system, 'just', for example.</a:documentation>
             <ref name="mei_data.TEMPERAMENT"/>
          </attribute>
       </optional>
@@ -11242,10 +10376,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.scoreDef.vis.attribute.vu.height">
       <optional>
          <attribute name="vu.height">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Defines
-               the height of a "virtual unit" (vu) in terms of real-world units. A single vu is half
-               the distance between the vertical center point of a staff line and that of an
-               adjacent staff line.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Defines the height of a "virtual unit" (vu) in terms of real-world units. A single vu is half the distance between the vertical center point of a staff line and that of an adjacent staff line.</a:documentation>
             <data type="token">
                <param name="pattern">\d+(\.\d+)?(cm|mm|in|pt|pc)</param>
             </data>
@@ -11267,8 +10398,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.section.vis.attribute.restart">
       <optional>
          <attribute name="restart">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               that staves begin again with this section.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that staves begin again with this section.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -11279,9 +10409,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.sequence.attribute.seq">
       <optional>
          <attribute name="seq">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to
-               assign a sequence number related to the order in which the encoded features carrying
-               this attribute are believed to have occurred.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to assign a sequence number related to the order in which the encoded features carrying this attribute are believed to have occurred.</a:documentation>
             <data type="positiveInteger"/>
          </attribute>
       </optional>
@@ -11292,8 +10420,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.slashcount.attribute.slash">
       <optional>
          <attribute name="slash">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the number of slashes present.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the number of slashes present.</a:documentation>
             <ref name="mei_data.SLASH"/>
          </attribute>
       </optional>
@@ -11304,9 +10431,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.slurpresent.attribute.slur">
       <optional>
          <attribute name="slur">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               that this element participates in a slur. If visual information about the slur needs
-               to be recorded, then a &lt;slur&gt; element should be employed.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that this element participates in a slur. If visual information about the slur needs to be recorded, then a &lt;slur&gt; element should be employed.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.SLUR"/>
@@ -11335,9 +10460,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.space.vis.attribute.compressable">
       <optional>
          <attribute name="compressable">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               whether a space is 'compressible', i.e., if it may be removed at the discretion of
-               processing software.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates whether a space is 'compressible', i.e., if it may be removed at the discretion of processing software.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -11351,8 +10474,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.spacing.attribute.spacing.packexp">
       <optional>
          <attribute name="spacing.packexp">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               a note's spacing relative to its time value.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes a note's spacing relative to its time value.</a:documentation>
             <data type="decimal"/>
          </attribute>
       </optional>
@@ -11360,8 +10482,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.spacing.attribute.spacing.packfact">
       <optional>
          <attribute name="spacing.packfact">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the note spacing of output.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the note spacing of output.</a:documentation>
             <data type="decimal"/>
          </attribute>
       </optional>
@@ -11369,10 +10490,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.spacing.attribute.spacing.staff">
       <optional>
          <attribute name="spacing.staff">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies
-               the minimum amount of space between adjacent staves in the same system; measured from
-               the bottom line of the staff above to the top line of the staff
-               below.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies the minimum amount of space between adjacent staves in the same system; measured from the bottom line of the staff above to the top line of the staff below.</a:documentation>
             <ref name="mei_data.MEASUREMENTREL"/>
          </attribute>
       </optional>
@@ -11380,11 +10498,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.spacing.attribute.spacing.system">
       <optional>
          <attribute name="spacing.system">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the space between adjacent systems; a pair of space-separated values (minimum and
-               maximum, respectively) provides a range between which a rendering system-supplied
-               value may fall, while a single value indicates a fixed amount of space; that is, the
-               minimum and maximum values are equal.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the space between adjacent systems; a pair of space-separated values (minimum and maximum, respectively) provides a range between which a rendering system-supplied value may fall, while a single value indicates a fixed amount of space; that is, the minimum and maximum values are equal.</a:documentation>
             <list>
                <ref name="mei_data.MEASUREMENTREL"/>
                <optional>
@@ -11407,25 +10521,24 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.staff.log.attribute.def">
       <optional>
          <attribute name="def">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               a mechanism for linking the staff to a staffDef element.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a mechanism for linking the staff to a staffDef element.</a:documentation>
             <ref name="mei_data.URI"/>
          </attribute>
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.staff.log-def-check_defTarget_staff-constraint-16">
+            id="mei-att.staff.log-def-check_defTarget_staff-constraint-16">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="staff/@def">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@def attribute should have
-            content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:staffDef/@xml:id"
-            >The value in @def should correspond to the @xml:id attribute of a staffDef
-            element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="staff/@def">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@def attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:staffDef/@xml:id">The value in @def should correspond to the @xml:id attribute of a staffDef
+                  element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.staff.vis.attributes">
       <ref name="mei_att.visibility.attributes"/>
@@ -11473,8 +10586,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.staffDef.vis.attribute.grid.show">
       <optional>
          <attribute name="grid.show">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Determines whether to display guitar chord grids.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Determines whether to display guitar chord grids.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -11482,8 +10594,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.staffDef.vis.attribute.layerscheme">
       <optional>
          <attribute name="layerscheme">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the number of layers and their stem directions.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the number of layers and their stem directions.</a:documentation>
             <ref name="mei_data.LAYERSCHEME"/>
          </attribute>
       </optional>
@@ -11491,8 +10602,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.staffDef.vis.attribute.lines">
       <optional>
          <attribute name="lines">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the number of staff lines.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the number of staff lines.</a:documentation>
             <data type="positiveInteger"/>
          </attribute>
       </optional>
@@ -11500,11 +10610,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.staffDef.vis.attribute.lines.color">
       <optional>
          <attribute name="lines.color">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures
-               the colors of the staff lines. The value is structured; that is, it should have the
-               same number of space-separated RGB values as the number of lines indicated by the
-               lines attribute. A line can be made invisible by assigning it the same RGB value as
-               the background, usually white.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures the colors of the staff lines. The value is structured; that is, it should have the same number of space-separated RGB values as the number of lines indicated by the lines attribute. A line can be made invisible by assigning it the same RGB value as the background, usually white.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.COLOR"/>
@@ -11516,8 +10622,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.staffDef.vis.attribute.lines.visible">
       <optional>
          <attribute name="lines.visible">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               whether all staff lines are visible.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records whether all staff lines are visible.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -11525,11 +10630,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.staffDef.vis.attribute.spacing">
       <optional>
          <attribute name="spacing">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the absolute distance (as opposed to the relative distances recorded in
-               &lt;scoreDef&gt; elements) between this staff and the preceding one in the same
-               system. This value is meaningless for the first staff in a system since the
-               spacing.system attribute indicates the spacing between systems.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the absolute distance (as opposed to the relative distances recorded in &lt;scoreDef&gt; elements) between this staff and the preceding one in the same system. This value is meaningless for the first staff in a system since the spacing.system attribute indicates the spacing between systems.</a:documentation>
             <ref name="mei_data.MEASUREMENTREL"/>
          </attribute>
       </optional>
@@ -11540,25 +10641,18 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.staffgroupingsym.attribute.symbol">
       <optional>
          <attribute name="symbol">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies
-               the symbol used to group a set of staves.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies the symbol used to group a set of staves.</a:documentation>
             <choice>
                <value>brace</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Curved
-                  symbol, i.e., {.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Curved symbol, i.e., {.</a:documentation>
                <value>bracket</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Square
-                  symbol, i.e., [, but with curved/angled top and bottom segments.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Square symbol, i.e., [, but with curved/angled top and bottom segments.</a:documentation>
                <value>bracketsq</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Square
-                  symbol, i.e., [, with horizontal top and bottom segments.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Square symbol, i.e., [, with horizontal top and bottom segments.</a:documentation>
                <value>line</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Line
-                  symbol, i.e., |, (wide) line without top and bottom curved/horizontal
-                  segments.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Line symbol, i.e., |, (wide) line without top and bottom curved/horizontal segments.</a:documentation>
                <value>none</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Grouping symbol missing.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Grouping symbol missing.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -11581,9 +10675,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.staffGrp.vis.attribute.barthru">
       <optional>
          <attribute name="barthru">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               whether bar lines go across the space between staves (true) or are only drawn across
-               the lines of each staff (false).</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates whether bar lines go across the space between staves (true) or are only drawn across the lines of each staff (false).</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -11594,9 +10686,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.staffident.attribute.staff">
       <optional>
          <attribute name="staff">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Signifies
-               the staff on which a notated event occurs or to which a control event applies.
-               Mandatory when applicable.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Signifies the staff on which a notated event occurs or to which a control event applies. Mandatory when applicable.</a:documentation>
             <list>
                <oneOrMore>
                   <data type="positiveInteger"/>
@@ -11611,8 +10701,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.staffloc.attribute.loc">
       <optional>
          <attribute name="loc">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the
-               staff location of the feature.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the staff location of the feature.</a:documentation>
             <ref name="mei_data.STAFFLOC"/>
          </attribute>
       </optional>
@@ -11624,8 +10713,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.staffloc.pitched.attribute.ploc">
       <optional>
          <attribute name="ploc">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures
-               staff location in terms of written pitch name.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures staff location in terms of written pitch name.</a:documentation>
             <ref name="mei_data.PITCHNAME"/>
          </attribute>
       </optional>
@@ -11633,8 +10721,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.staffloc.pitched.attribute.oloc">
       <optional>
          <attribute name="oloc">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               staff location in terms of written octave.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records staff location in terms of written octave.</a:documentation>
             <ref name="mei_data.OCTAVE"/>
          </attribute>
       </optional>
@@ -11646,25 +10733,24 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.startendid.attribute.endid">
       <optional>
          <attribute name="endid">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the final element in a sequence of events to which the feature
-               applies.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the final element in a sequence of events to which the feature applies.</a:documentation>
             <ref name="mei_data.URI"/>
          </attribute>
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.startendid-endid-check_endidTarget-constraint-17">
+            id="mei-att.startendid-endid-check_endidTarget-constraint-17">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@endid">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@endid attribute should
-            have content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">The
-            value in @endid should correspond to the @xml:id attribute of an element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@endid">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@endid attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">The value in @endid should correspond to the @xml:id attribute of an
+                  element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.startid.attributes">
       <ref name="mei_att.startid.attribute.startid"/>
@@ -11672,25 +10758,24 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.startid.attribute.startid">
       <optional>
          <attribute name="startid">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds a
-               reference to the first element in a sequence of events to which the feature
-               applies.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds a reference to the first element in a sequence of events to which the feature applies.</a:documentation>
             <ref name="mei_data.URI"/>
          </attribute>
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.startid-startid-check_startidTarget-constraint-18">
+            id="mei-att.startid-startid-check_startidTarget-constraint-18">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@startid">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@startid attribute should
-            have content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">The
-            value in @startid should correspond to the @xml:id attribute of an element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@startid">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@startid attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">The value in @startid should correspond to the @xml:id attribute of an
+                  element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.stems.attributes">
       <ref name="mei_att.stems.cmn.attributes"/>
@@ -11704,8 +10789,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.stems.attribute.stem.dir">
       <optional>
          <attribute name="stem.dir">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the direction of a stem.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the direction of a stem.</a:documentation>
             <ref name="mei_data.STEMDIRECTION"/>
          </attribute>
       </optional>
@@ -11713,8 +10797,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.stems.attribute.stem.len">
       <optional>
          <attribute name="stem.len">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes
-               the stem length.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes the stem length.</a:documentation>
             <ref name="mei_data.MEASUREMENTABS"/>
          </attribute>
       </optional>
@@ -11722,9 +10805,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.stems.attribute.stem.mod">
       <optional>
          <attribute name="stem.mod">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes
-               any stem "modifiers"; that is, symbols rendered on the stem, such as tremolo or
-               Sprechstimme indicators.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes any stem "modifiers"; that is, symbols rendered on the stem, such as tremolo or Sprechstimme indicators.</a:documentation>
             <ref name="mei_data.STEMMODIFIER"/>
          </attribute>
       </optional>
@@ -11732,8 +10813,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.stems.attribute.stem.pos">
       <optional>
          <attribute name="stem.pos">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the position of the stem in relation to the note head(s).</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the position of the stem in relation to the note head(s).</a:documentation>
             <ref name="mei_data.STEMPOSITION"/>
          </attribute>
       </optional>
@@ -11741,8 +10821,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.stems.attribute.stem.x">
       <optional>
          <attribute name="stem.x">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the output x coordinate of the stem's attachment point.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the output x coordinate of the stem's attachment point.</a:documentation>
             <data type="decimal"/>
          </attribute>
       </optional>
@@ -11750,8 +10829,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.stems.attribute.stem.y">
       <optional>
          <attribute name="stem.y">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the output y coordinate of the stem's attachment point.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the output y coordinate of the stem's attachment point.</a:documentation>
             <data type="decimal"/>
          </attribute>
       </optional>
@@ -11769,34 +10847,24 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.syl.log.attribute.con">
       <optional>
          <attribute name="con">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the symbols typically used to indicate breaks between syllables and their
-               functions.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the symbols typically used to indicate breaks between syllables and their functions.</a:documentation>
             <choice>
                <value>s</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Space
-                  (word separator).</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Space (word separator).</a:documentation>
                <value>d</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Dash
-                  (syllable separator).</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Dash (syllable separator).</a:documentation>
                <value>u</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Underscore (syllable extension).</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Underscore (syllable extension).</a:documentation>
                <value>t</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Tilde
-                  (syllable elision).</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Tilde (syllable elision).</a:documentation>
                <value>c</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Circumflex [angled line above] (syllable elision).</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Circumflex [angled line above] (syllable elision).</a:documentation>
                <value>v</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Caron
-                  [angled line below] (syllable elision).</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Caron [angled line below] (syllable elision).</a:documentation>
                <value>i</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Inverted breve [curved line above] (syllable elision).</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Inverted breve [curved line above] (syllable elision).</a:documentation>
                <value>b</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Breve
-                  [curved line below] (syllable elision).</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Breve [curved line below] (syllable elision).</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -11804,18 +10872,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.syl.log.attribute.wordpos">
       <optional>
          <attribute name="wordpos">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the position of a syllable within a word.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the position of a syllable within a word.</a:documentation>
             <choice>
                <value>i</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >(initial) first syllable.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(initial) first syllable.</a:documentation>
                <value>m</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >(medial) neither first nor last syllable.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(medial) neither first nor last syllable.</a:documentation>
                <value>t</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >(terminal) last syllable.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(terminal) last syllable.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -11832,8 +10896,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.syltext.attribute.syl">
       <optional>
          <attribute name="syl">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds an
-               associated sung text syllable.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds an associated sung text syllable.</a:documentation>
             <data type="string"/>
          </attribute>
       </optional>
@@ -11847,10 +10910,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.systems.attribute.system.leftline">
       <optional>
          <attribute name="system.leftline">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               whether the staves are joined at the left by a continuous line. The default value is
-               "true". Do not confuse this with the heavy vertical line used as a grouping
-               symbol.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates whether the staves are joined at the left by a continuous line. The default value is "true". Do not confuse this with the heavy vertical line used as a grouping symbol.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -11858,9 +10918,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.systems.attribute.system.leftmar">
       <optional>
          <attribute name="system.leftmar">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the amount of whitespace at the left system margin relative to
-               page.leftmar.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the amount of whitespace at the left system margin relative to page.leftmar.</a:documentation>
             <ref name="mei_data.MEASUREMENTABS"/>
          </attribute>
       </optional>
@@ -11868,9 +10926,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.systems.attribute.system.rightmar">
       <optional>
          <attribute name="system.rightmar">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the amount of whitespace at the right system margin relative to
-               page.rightmar.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the amount of whitespace at the right system margin relative to page.rightmar.</a:documentation>
             <ref name="mei_data.MEASUREMENTABS"/>
          </attribute>
       </optional>
@@ -11878,9 +10934,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.systems.attribute.system.topmar">
       <optional>
          <attribute name="system.topmar">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the distance from page's top edge to the first system; used for first page
-               only.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the distance from page's top edge to the first system; used for first page only.</a:documentation>
             <ref name="mei_data.MEASUREMENTABS"/>
          </attribute>
       </optional>
@@ -11891,23 +10945,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.targeteval.attribute.evaluate">
       <optional>
          <attribute name="evaluate">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies
-               the intended meaning when a participant in a relationship is itself a
-               pointer.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies the intended meaning when a participant in a relationship is itself a pointer.</a:documentation>
             <choice>
                <value>all</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">If an
-                  element pointed to is itself a pointer, then the target of that pointer will be
-                  taken, and so on, until an element is found which is not a
-                  pointer.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">If an element pointed to is itself a pointer, then the target of that pointer will be taken, and so on, until an element is found which is not a pointer.</a:documentation>
                <value>one</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">If an
-                  element pointed to is itself a pointer, then its target (whether a pointer or not)
-                  is taken as the target of this pointer.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">If an element pointed to is itself a pointer, then its target (whether a pointer or not) is taken as the target of this pointer.</a:documentation>
                <value>none</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">No
-                  further evaluation of targets is carried out beyond that needed to find the
-                  element(s) specified in plist or target attribute.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">No further evaluation of targets is carried out beyond that needed to find the element(s) specified in plist or target attribute.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -11927,28 +10972,16 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.tempo.log.attribute.func">
       <optional>
          <attribute name="func">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the function of a tempo indication.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the function of a tempo indication.</a:documentation>
             <choice>
                <value>continuous</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Marks
-                  a gradual change of tempo, such as "accel." or "rit."</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Marks a gradual change of tempo, such as "accel." or "rit."</a:documentation>
                <value>instantaneous</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Represents a static tempo instruction, such as a textual term like "Adagio", a
-                  metronome marking like "♩=70", or a combination of text and metronome
-                  indication.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Represents a static tempo instruction, such as a textual term like "Adagio", a metronome marking like "♩=70", or a combination of text and metronome indication.</a:documentation>
                <value>metricmod</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Captures a change in pulse rate (tempo) and/or pulse grouping (subdivision) in an
-                  "equation" of the form [tempo before change] = [tempo after
-                  change].</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures a change in pulse rate (tempo) and/or pulse grouping (subdivision) in an "equation" of the form [tempo before change] = [tempo after change].</a:documentation>
                <value>precedente</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Indicates a change in pulse rate (tempo) and/or pulse grouping (subdivision) in
-                  an "equation" of the form [tempo after change] = [tempo before change]. The term
-                  "precedente" often appears following the "equation" to distinquish this kind of
-                  historical usage from the modern metric modulation form.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates a change in pulse rate (tempo) and/or pulse grouping (subdivision) in an "equation" of the form [tempo after change] = [tempo before change]. The term "precedente" often appears following the "equation" to distinquish this kind of historical usage from the modern metric modulation form.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -11970,9 +11003,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.textstyle.attribute.text.fam">
       <optional>
          <attribute name="text.fam">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               a default value for the font family name of text (other than lyrics) when this
-               information is not provided on the individual elements.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a default value for the font family name of text (other than lyrics) when this information is not provided on the individual elements.</a:documentation>
             <ref name="mei_data.FONTFAMILY"/>
          </attribute>
       </optional>
@@ -11980,9 +11011,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.textstyle.attribute.text.name">
       <optional>
          <attribute name="text.name">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               a default value for the font name of text (other than lyrics) when this information
-               is not provided on the individual elements.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a default value for the font name of text (other than lyrics) when this information is not provided on the individual elements.</a:documentation>
             <ref name="mei_data.FONTNAME"/>
          </attribute>
       </optional>
@@ -11990,9 +11019,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.textstyle.attribute.text.size">
       <optional>
          <attribute name="text.size">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               a default value for the font size of text (other than lyrics) when this information
-               is not provided on the individual elements.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a default value for the font size of text (other than lyrics) when this information is not provided on the individual elements.</a:documentation>
             <ref name="mei_data.FONTSIZE"/>
          </attribute>
       </optional>
@@ -12000,9 +11027,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.textstyle.attribute.text.style">
       <optional>
          <attribute name="text.style">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               a default value for the font style of text (other than lyrics) when this information
-               is not provided on the individual elements.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a default value for the font style of text (other than lyrics) when this information is not provided on the individual elements.</a:documentation>
             <ref name="mei_data.FONTSTYLE"/>
          </attribute>
       </optional>
@@ -12010,9 +11035,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.textstyle.attribute.text.weight">
       <optional>
          <attribute name="text.weight">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               a default value for the font weight for text (other than lyrics) when this
-               information is not provided on the individual elements.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a default value for the font weight for text (other than lyrics) when this information is not provided on the individual elements.</a:documentation>
             <ref name="mei_data.FONTWEIGHT"/>
          </attribute>
       </optional>
@@ -12023,9 +11046,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.tiepresent.attribute.tie">
       <optional>
          <attribute name="tie">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               that this element participates in a tie. If visual information about the tie needs to
-               be recorded, then a &lt;tie&gt; element should be employed.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that this element participates in a tie. If visual information about the tie needs to be recorded, then a &lt;tie&gt; element should be employed.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.TIE"/>
@@ -12040,9 +11061,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.timestamp.musical.attribute.tstamp">
       <optional>
          <attribute name="tstamp">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes
-               the onset time in terms of musical time, i.e.,
-               beats[.fractional_beat_part].</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes the onset time in terms of musical time, i.e., beats[.fractional_beat_part].</a:documentation>
             <ref name="mei_data.BEAT"/>
          </attribute>
       </optional>
@@ -12054,10 +11073,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.timestamp.performed.attribute.tstamp.ges">
       <optional>
          <attribute name="tstamp.ges">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures
-               performed onset time in several forms; that is, ppq (MIDI clicks and MusicXML
-               'divisions'), Humdrum **recip values, beats, seconds, or mensural duration
-               values.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures performed onset time in several forms; that is, ppq (MIDI clicks and MusicXML 'divisions'), Humdrum **recip values, beats, seconds, or mensural duration values.</a:documentation>
             <ref name="mei_data.DURATION.gestural"/>
          </attribute>
       </optional>
@@ -12065,8 +11081,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.timestamp.performed.attribute.tstamp.real">
       <optional>
          <attribute name="tstamp.real">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to
-               record the onset time in terms of ISO time.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to record the onset time in terms of ISO time.</a:documentation>
             <ref name="mei_data.ISOTIME"/>
          </attribute>
       </optional>
@@ -12077,9 +11092,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.timestamp2.musical.attribute.tstamp2">
       <optional>
          <attribute name="tstamp2">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes
-               the ending point of an event in terms of musical time, i.e., a count of measures plus
-               a beat location.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes the ending point of an event in terms of musical time, i.e., a count of measures plus a beat location.</a:documentation>
             <ref name="mei_data.MEASUREBEAT"/>
          </attribute>
       </optional>
@@ -12091,9 +11104,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.transposition.attribute.trans.diat">
       <optional>
          <attribute name="trans.diat">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the amount of diatonic pitch shift, e.g., C to C♯ = 0, C to D♭ = 1, necessary to
-               calculate the sounded pitch from the written one.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the amount of diatonic pitch shift, e.g., C to C♯ = 0, C to D♭ = 1, necessary to calculate the sounded pitch from the written one.</a:documentation>
             <data type="decimal"/>
          </attribute>
       </optional>
@@ -12101,9 +11112,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.transposition.attribute.trans.semi">
       <optional>
          <attribute name="trans.semi">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the amount of pitch shift in semitones, e.g., C to C♯ = 1, C to D♭ = 1, necessary to
-               calculate the sounded pitch from the written one.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the amount of pitch shift in semitones, e.g., C to C♯ = 1, C to D♭ = 1, necessary to calculate the sounded pitch from the written one.</a:documentation>
             <data type="decimal"/>
          </attribute>
       </optional>
@@ -12114,10 +11123,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.tupletpresent.attribute.tuplet">
       <optional>
          <attribute name="tuplet">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               that this feature participates in a tuplet. If visual information about the tuplet
-               needs to be recorded, then a &lt;tuplet&gt; element should be
-               employed.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that this feature participates in a tuplet. If visual information about the tuplet needs to be recorded, then a &lt;tuplet&gt; element should be employed.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.TUPLET"/>
@@ -12133,9 +11139,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.typed.attribute.type">
       <optional>
          <attribute name="type">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Characterizes the element in some sense, using any convenient classification scheme
-               or typology.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Characterizes the element in some sense, using any convenient classification scheme or typology.</a:documentation>
             <data type="NMTOKEN"/>
          </attribute>
       </optional>
@@ -12143,22 +11147,21 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.typed.attribute.subtype">
       <optional>
          <attribute name="subtype">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provide
-               any sub-classification for the element, additional to that given by its type
-               attribute.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provide any sub-classification for the element, additional to that given by its type attribute.</a:documentation>
             <data type="NMTOKEN"/>
          </attribute>
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.typed-subtype-When_subtype-constraint-19">
+            id="mei-att.typed-subtype-When_subtype-constraint-19">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="mei:*[@subtype]">
-         <sch:assert test="@type">An element with a subtype attribute must have a type
-            attribute.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="mei:*[@subtype]">
+                <sch:assert test="@type">An element with a subtype attribute must have a type
+                  attribute.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.typography.attributes">
       <ref name="mei_att.typography.attribute.fontfam"/>
@@ -12170,8 +11173,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.typography.attribute.fontfam">
       <optional>
          <attribute name="fontfam">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               the name of a font-family.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the name of a font-family.</a:documentation>
             <ref name="mei_data.FONTFAMILY"/>
          </attribute>
       </optional>
@@ -12179,8 +11181,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.typography.attribute.fontname">
       <optional>
          <attribute name="fontname">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the
-               name of a font.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the name of a font.</a:documentation>
             <ref name="mei_data.FONTNAME"/>
          </attribute>
       </optional>
@@ -12188,10 +11189,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.typography.attribute.fontsize">
       <optional>
          <attribute name="fontsize">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the size of a font expressed in printers' points, i.e., 1/72nd of an inch, relative
-               terms, e.g., "small", "larger", etc., or percentage values relative to "normal" size,
-               e.g., "125%". </a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the size of a font expressed in printers' points, i.e., 1/72nd of an inch, relative terms, e.g., "small", "larger", etc., or percentage values relative to "normal" size, e.g., "125%". </a:documentation>
             <ref name="mei_data.FONTSIZE"/>
          </attribute>
       </optional>
@@ -12199,8 +11197,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.typography.attribute.fontstyle">
       <optional>
          <attribute name="fontstyle">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the style of a font, i.e, italic, oblique, or normal.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the style of a font, i.e, italic, oblique, or normal.</a:documentation>
             <ref name="mei_data.FONTSTYLE"/>
          </attribute>
       </optional>
@@ -12208,8 +11205,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.typography.attribute.fontweight">
       <optional>
          <attribute name="fontweight">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to
-               indicate bold type.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to indicate bold type.</a:documentation>
             <ref name="mei_data.FONTWEIGHT"/>
          </attribute>
       </optional>
@@ -12220,9 +11216,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.visibility.attribute.visible">
       <optional>
          <attribute name="visible">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               if a feature should be rendered when the notation is presented graphically or sounded
-               when it is presented in an aural form.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates if a feature should be rendered when the notation is presented graphically or sounded when it is presented in an aural form.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -12238,10 +11232,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.visualoffset.ho.attribute.ho">
       <optional>
          <attribute name="ho">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records a
-               horizontal adjustment to a feature's programmatically-determined location in terms of
-               staff interline distance; that is, in units of 1/2 the distance between adjacent
-               staff lines.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records a horizontal adjustment to a feature's programmatically-determined location in terms of staff interline distance; that is, in units of 1/2 the distance between adjacent staff lines.</a:documentation>
             <ref name="mei_data.MEASUREMENTREL"/>
          </attribute>
       </optional>
@@ -12252,9 +11243,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.visualoffset.to.attribute.to">
       <optional>
          <attribute name="to">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records a
-               timestamp adjustment of a feature's programmatically-determined location in terms of
-               musical time; that is, beats.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records a timestamp adjustment of a feature's programmatically-determined location in terms of musical time; that is, beats.</a:documentation>
             <ref name="mei_data.TSTAMPOFFSET"/>
          </attribute>
       </optional>
@@ -12265,10 +11254,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.visualoffset.vo.attribute.vo">
       <optional>
          <attribute name="vo">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the vertical adjustment of a feature's programmatically-determined location in terms
-               of staff interline distance; that is, in units of 1/2 the distance between adjacent
-               staff lines.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the vertical adjustment of a feature's programmatically-determined location in terms of staff interline distance; that is, in units of 1/2 the distance between adjacent staff lines.</a:documentation>
             <ref name="mei_data.MEASUREMENTREL"/>
          </attribute>
       </optional>
@@ -12285,9 +11271,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.visualoffset2.ho.attribute.startho">
       <optional>
          <attribute name="startho">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the horizontal adjustment of a feature's programmatically-determined start
-               point.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the horizontal adjustment of a feature's programmatically-determined start point.</a:documentation>
             <ref name="mei_data.MEASUREMENTREL"/>
          </attribute>
       </optional>
@@ -12295,9 +11279,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.visualoffset2.ho.attribute.endho">
       <optional>
          <attribute name="endho">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the horizontal adjustment of a feature's programmatically-determined end
-               point.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the horizontal adjustment of a feature's programmatically-determined end point.</a:documentation>
             <ref name="mei_data.MEASUREMENTREL"/>
          </attribute>
       </optional>
@@ -12309,9 +11291,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.visualoffset2.to.attribute.startto">
       <optional>
          <attribute name="startto">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records a
-               timestamp adjustment of a feature's programmatically-determined start
-               point.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records a timestamp adjustment of a feature's programmatically-determined start point.</a:documentation>
             <ref name="mei_data.TSTAMPOFFSET"/>
          </attribute>
       </optional>
@@ -12319,9 +11299,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.visualoffset2.to.attribute.endto">
       <optional>
          <attribute name="endto">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records a
-               timestamp adjustment of a feature's programmatically-determined end
-               point.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records a timestamp adjustment of a feature's programmatically-determined end point.</a:documentation>
             <ref name="mei_data.TSTAMPOFFSET"/>
          </attribute>
       </optional>
@@ -12333,9 +11311,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.visualoffset2.vo.attribute.startvo">
       <optional>
          <attribute name="startvo">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records a
-               vertical adjustment of a feature's programmatically-determined start
-               point.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records a vertical adjustment of a feature's programmatically-determined start point.</a:documentation>
             <ref name="mei_data.MEASUREMENTREL"/>
          </attribute>
       </optional>
@@ -12343,9 +11319,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.visualoffset2.vo.attribute.endvo">
       <optional>
          <attribute name="endvo">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records a
-               vertical adjustment of a feature's programmatically-determined end
-               point.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records a vertical adjustment of a feature's programmatically-determined end point.</a:documentation>
             <ref name="mei_data.MEASUREMENTREL"/>
          </attribute>
       </optional>
@@ -12356,20 +11330,12 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.whitespace.attribute.xmlspace">
       <optional>
          <attribute name="xml:space">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Allows
-               one to signal to an application whether an element's white space is "significant".
-               The behavior of xml:space cascades to all descendant elements, but it can be turned
-               off locally by setting the xml:space attribute to the value
-               "default".</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Allows one to signal to an application whether an element's white space is "significant". The behavior of xml:space cascades to all descendant elements, but it can be turned off locally by setting the xml:space attribute to the value "default".</a:documentation>
             <choice>
                <value>default</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Allows
-                  the application to handle white space as necessary. Not including an xml:space
-                  attribute produces the same result as using the default value.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Allows the application to handle white space as necessary. Not including an xml:space attribute produces the same result as using the default value.</a:documentation>
                <value>preserve</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Instructs the application to maintain white space "as-is", suggesting that it
-                  might have meaning.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Instructs the application to maintain white space "as-is", suggesting that it might have meaning.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -12380,8 +11346,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.width.attribute.width">
       <optional>
          <attribute name="width">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Measurement of the horizontal dimension of an entity.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Measurement of the horizontal dimension of an entity.</a:documentation>
             <ref name="mei_data.MEASUREMENTABS"/>
          </attribute>
       </optional>
@@ -12393,10 +11358,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.xy.attribute.x">
       <optional>
          <attribute name="x">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes
-               an x coordinate for a feature in an output coordinate system. When it is necessary to
-               record the placement of a feature in a facsimile image, use the facs
-               attribute.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes an x coordinate for a feature in an output coordinate system. When it is necessary to record the placement of a feature in a facsimile image, use the facs attribute.</a:documentation>
             <data type="decimal"/>
          </attribute>
       </optional>
@@ -12404,10 +11366,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.xy.attribute.y">
       <optional>
          <attribute name="y">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes
-               an y coordinate for a feature in an output coordinate system. When it is necessary to
-               record the placement of a feature in a facsimile image, use the facs
-               attribute.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes an y coordinate for a feature in an output coordinate system. When it is necessary to record the placement of a feature in a facsimile image, use the facs attribute.</a:documentation>
             <data type="decimal"/>
          </attribute>
       </optional>
@@ -12419,8 +11378,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.xy2.attribute.x2">
       <optional>
          <attribute name="x2">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes
-               the optional 2nd x coordinate.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes the optional 2nd x coordinate.</a:documentation>
             <data type="decimal"/>
          </attribute>
       </optional>
@@ -12428,8 +11386,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.xy2.attribute.y2">
       <optional>
          <attribute name="y2">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes
-               the optional 2nd y coordinate.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes the optional 2nd y coordinate.</a:documentation>
             <data type="decimal"/>
          </attribute>
       </optional>
@@ -13798,8 +12755,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_accid">
       <element name="accid">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(accidental)
-            – Records a temporary alteration to the pitch of a note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(accidental) – Records a temporary alteration to the pitch of a note.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
@@ -13812,8 +12768,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_actor">
       <element name="actor">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Name of an
-            actor appearing within a cast list.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Name of an actor appearing within a cast list.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -13828,9 +12783,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_address">
       <element name="address">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a
-            postal address, for example of a publisher, an organization, or an
-            individual.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a postal address, for example of a publisher, an organization, or an individual.</a:documentation>
          <choice>
             <oneOrMore>
                <ref name="mei_addrLine"/>
@@ -13847,8 +12800,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_addrLine">
       <element name="addrLine">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(address
-            line) – Single line of a postal address.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(address line) – Single line of a postal address.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -13865,9 +12817,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_annot">
       <element name="annot">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(annotation)
-            – Provides a short statement explaining the text or indicating the basis for an
-            assertion.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(annotation) – Provides a short statement explaining the text or indicating the basis for an assertion.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -13879,20 +12829,18 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </choice>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-annot-annot_content_constraint-constraint-20">
+                  id="mei-annot-annot_content_constraint-constraint-20">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0"
-               context="mei:annot[mei:head or mei:lg or mei:p or mei:quote or mei:table]">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:annot[mei:head or mei:lg or mei:p or mei:quote or mei:table]">
                <sch:assert test="not(mei:head[preceding-sibling::*[not(local-name()='head')]])">Head
-                  elements can only occur at the start of annot.</sch:assert>
+              elements can only occur at the start of annot.</sch:assert>
                <sch:assert test="not(*[../text()[normalize-space()]])">Mixed content is not allowed
-                  when head, lg, p, quote, or table is used.</sch:assert>
-               <sch:assert
-                  test="not(*[not(local-name() eq 'biblList' or local-name() eq 'castList' or local-name() eq 'head' or                local-name() eq 'lg' or local-name() eq 'list' or local-name() eq 'p' or local-name() eq 'quote' or                local-name() eq 'table')])"
-                  >Unstructured text not allowed when head, lg, p, quote, or table elements are
-                  used.</sch:assert>
+              when head, lg, p, quote, or table is used.</sch:assert>
+               <sch:assert test="not(*[not(local-name() eq 'biblList' or local-name() eq 'castList' or local-name() eq 'head' or                local-name() eq 'lg' or local-name() eq 'list' or local-name() eq 'p' or local-name() eq 'quote' or                local-name() eq 'table')])">Unstructured text not allowed when head, lg, p, quote, or table elements are
+              used.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.bibl.attributes"/>
@@ -13913,10 +12861,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_arranger">
       <element name="arranger">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A person or
-            organization who transcribes a musical composition, usually for a different medium from
-            that of the original; in an arrangement the musical substance remains essentially
-            unchanged.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A person or organization who transcribes a musical composition, usually for a different medium from that of the original; in an arrangement the musical substance remains essentially unchanged.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -13933,8 +12878,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_artic">
       <element name="artic">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >(articulation) – An indication of how to play a note or chord.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(articulation) – An indication of how to play a note or chord.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
@@ -13947,9 +12891,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_author">
       <element name="author">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The name of
-            the creator of the intellectual content of a non-musical, literary
-            work.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The name of the creator of the intellectual content of a non-musical, literary work.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -13966,23 +12908,20 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_barLine">
       <element name="barLine">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Vertical
-            line drawn through one or more staves that divides musical notation into metrical
-            units.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Vertical line drawn through one or more staves that divides musical notation into metrical units.</a:documentation>
          <empty/>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-barLine-Check_barLinetaktplace-constraint-21">
+                  id="mei-barLine-Check_barLinetaktplace-constraint-21">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:barLine[@taktplace]">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:barLine[@taktplace]">
                <sch:let name="staff" value="ancestor::mei:staff/@n"/>
                <sch:let name="staffpos"
-                  value="count(ancestor::mei:staff/preceding-sibling::mei:staff) + 1"/>
-               <sch:assert
-                  test="number(@taktplace) &lt;= number(2 * preceding::mei:staffDef[@n=$staff and @lines][1]/@lines)"
-                  >The value of @taktplace must be less than or equal to two times the number of
-                  staff lines.</sch:assert>
+                        value="count(ancestor::mei:staff/preceding-sibling::mei:staff) + 1"/>
+               <sch:assert test="number(@taktplace) &lt;= number(2 * preceding::mei:staffDef[@n=$staff and @lines][1]/@lines)">The value of @taktplace must be less than or equal to two times the number of staff
+              lines.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -13998,9 +12937,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_bibl">
       <element name="bibl">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >(bibliographic reference) – Provides a loosely-structured bibliographic citation in
-            which the sub-components may or may not be explicitly marked.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(bibliographic reference) – Provides a loosely-structured bibliographic citation in which the sub-components may or may not be explicitly marked.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14020,8 +12957,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_biblList">
       <element name="biblList">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">List of
-            bibliographic references.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">List of bibliographic references.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -14046,9 +12982,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_biblScope">
       <element name="biblScope">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(scope of
-            citation) – Defines the scope of a bibliographic reference, for example as a list of
-            page numbers, or a named subdivision of a larger work.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(scope of citation) – Defines the scope of a bibliographic reference, for example as a list of page numbers, or a named subdivision of a larger work.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14065,8 +12999,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_body">
       <element name="body">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the
-            whole of a single musical text, excluding any front or back matter.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the whole of a single musical text, excluding any front or back matter.</a:documentation>
          <oneOrMore>
             <ref name="mei_model.mdivLike"/>
          </oneOrMore>
@@ -14077,8 +13010,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_caption">
       <element name="caption">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A label
-            which accompanies an illustration or a table.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A label which accompanies an illustration or a table.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14095,8 +13027,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_castGrp">
       <element name="castGrp">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(cast group)
-            – Groups one or more individual castItem elements within a cast list.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(cast group) – Groups one or more individual castItem elements within a cast list.</a:documentation>
          <oneOrMore>
             <choice>
                <ref name="mei_castItem"/>
@@ -14112,9 +13043,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_castItem">
       <element name="castItem">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a
-            single entry within a cast list, describing either a single role or a list of
-            non-speaking roles.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a single entry within a cast list, describing either a single role or a list of non-speaking roles.</a:documentation>
          <oneOrMore>
             <choice>
                <text/>
@@ -14133,8 +13062,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_castList">
       <element name="castList">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a
-            single cast list or dramatis personae.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a single cast list or dramatis personae.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -14154,9 +13082,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_chord">
       <element name="chord">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-            simultaneous sounding of two or more notes in the same layer *with the same
-            duration*.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A simultaneous sounding of two or more notes in the same layer *with the same duration*.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_note"/>
@@ -14176,36 +13102,30 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_clef">
       <element name="clef">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indication
-            of the exact location of a particular note on the staff and, therefore, the other notes
-            as well.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indication of the exact location of a particular note on the staff and, therefore, the other notes as well.</a:documentation>
          <empty/>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-clef-Clef_position_lines-constraint-22">
+                  id="mei-clef-Clef_position_lines-constraint-22">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0"
-               context="mei:clef[ancestor::mei:staffDef[@lines]]">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:clef[ancestor::mei:staffDef[@lines]]">
                <sch:let name="thisstaff" value="ancestor::mei:staffDef/@n"/>
-               <sch:assert
-                  test="number(@line) &lt;= number(ancestor::mei:staffDef[@n=$thisstaff and @lines][1]/@lines)"
-                  >The clef position must be less than or equal to the number of lines of an
-                  ancestor staff.</sch:assert>
+               <sch:assert test="number(@line) &lt;= number(ancestor::mei:staffDef[@n=$thisstaff and @lines][1]/@lines)">The clef position must be less than or equal to the number of lines of an ancestor
+              staff.</sch:assert>
             </sch:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-clef-Clef_position_nolines-constraint-23">
+                  id="mei-clef-Clef_position_nolines-constraint-23">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0"
-               context="mei:clef[ancestor::mei:staffDef[not(@lines)]]">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:clef[ancestor::mei:staffDef[not(@lines)]]">
                <sch:let name="thisstaff" value="ancestor::mei:staffDef/@n"/>
-               <sch:assert
-                  test="number(@line) &lt;= number(preceding::mei:staffDef[@n=$thisstaff and @lines][1]/@lines)"
-                  >The clef position must be less than or equal to the number of lines of a
-                  preceding staff.</sch:assert>
+               <sch:assert test="number(@line) &lt;= number(preceding::mei:staffDef[@n=$thisstaff and @lines][1]/@lines)">The clef position must be less than or equal to the number of lines of a preceding
+              staff.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -14220,8 +13140,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_clefGrp">
       <element name="clefGrp">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(clef group)
-            – A set of simultaneously-occurring clefs.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(clef group) – A set of simultaneously-occurring clefs.</a:documentation>
          <oneOrMore>
             <ref name="mei_clef"/>
          </oneOrMore>
@@ -14237,8 +13156,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_composer">
       <element name="composer">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The name of
-            the creator of the intellectual content of a musical work.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The name of the creator of the intellectual content of a musical work.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14255,10 +13173,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_creation">
       <element name="creation">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Non-bibliographic details of the creation of an intellectual entity, in narrative form,
-            such as the date, place, and circumstances of its composition. More detailed information
-            may be captured within the history element.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Non-bibliographic details of the creation of an intellectual entity, in narrative form, such as the date, place, and circumstances of its composition. More detailed information may be captured within the history element.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14275,9 +13190,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_custos">
       <element name="custos">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Symbol
-            placed at the end of a line of music to indicate the first note of the next line.
-            Sometimes called a "direct".</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Symbol placed at the end of a line of music to indicate the first note of the next line. Sometimes called a "direct".</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
@@ -14291,9 +13204,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_date">
       <element name="date">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A string
-            identifying a point in time or the time period between two such
-            points.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A string identifying a point in time or the time period between two such points.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14313,8 +13224,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_depth">
       <element name="depth">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Description
-            of a measurement taken through a three-dimensional object.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Description of a measurement taken through a three-dimensional object.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14331,10 +13241,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_desc">
       <element name="desc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >(description) – Container for text that briefly describes the feature to which it is
-            attached, including its intended usage, purpose, or application as
-            appropriate.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(description) – Container for text that briefly describes the feature to which it is attached, including its intended usage, purpose, or application as appropriate.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14353,11 +13260,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_dir">
       <element name="dir">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(directive)
-            – An instruction expressed as a combination of text and symbols — such as segno and coda
-            symbols, fermatas over a bar line, etc., typically above, below, or between staves, but
-            not on the staff — that is not encoded elsewhere in more specific elements, like
-            &lt;tempo&gt; or &lt;dynam&gt;.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(directive) – An instruction expressed as a combination of text and symbols — such as segno and coda symbols, fermatas over a bar line, etc., typically above, below, or between staves, but not on the staff — that is not encoded elsewhere in more specific elements, like &lt;tempo&gt; or &lt;dynam&gt;.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14368,13 +13271,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </choice>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-dir-dir_start-type_attributes_required-constraint-24">
+                  id="mei-dir-dir_start-type_attributes_required-constraint-24">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:dir[not(ancestor::mei:syllable)]">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:dir[not(ancestor::mei:syllable)]">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -14390,9 +13294,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_distributor">
       <element name="distributor">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Person or
-            agency, other than a publisher, from which access (including electronic access) to a
-            bibliographic entity may be obtained.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Person or agency, other than a publisher, from which access (including electronic access) to a bibliographic entity may be obtained.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14408,9 +13310,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_div">
       <element name="div">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(division) –
-            Major structural division of text, such as a preface, chapter or
-            section.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(division) – Major structural division of text, such as a preface, chapter or section.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_model.headLike"/>
@@ -14432,71 +13332,42 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.lang.attributes"/>
          <optional>
             <attribute name="type">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Characterizes the element in some sense, using any convenient classification
-                  scheme or typology. Suggested values include: 1] abstract; 2] ack; 3] appendix; 4]
-                  bibliography; 5] colophon; 6] contents; 7] dedication; 8] frontispiece; 9]
-                  glossary; 10] half-title; 11] index; 12] annotations; 13]
-                  preface</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Characterizes the element in some sense, using any convenient classification scheme or typology.
+Suggested values include: 1] abstract; 2] ack; 3] appendix; 4] bibliography; 5] colophon; 6] contents; 7] dedication; 8] frontispiece; 9] glossary; 10] half-title; 11] index; 12] annotations; 13] preface</a:documentation>
                <choice>
                   <value>abstract</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                     summary of the content of a text as continuous prose.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A summary of the content of a text as continuous prose.</a:documentation>
                   <value>ack</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                     formal declaration of acknowledgement by the author in which persons and
-                     institutions are thanked for their part in the creation of a
-                     text.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A formal declaration of acknowledgement by the author in which persons and institutions are thanked for their part in the creation of a text.</a:documentation>
                   <value>appendix</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An
-                     ancillary self-contained section of a work, often providing additional but in
-                     some sense extra-canonical text.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An ancillary self-contained section of a work, often providing additional but in some sense extra-canonical text.</a:documentation>
                   <value>bibliography</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                     list of bibliographic citations.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A list of bibliographic citations.</a:documentation>
                   <value>colophon</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                     statement appearing at the end of a book describing the conditions of its
-                     physical production.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A statement appearing at the end of a book describing the conditions of its physical production.</a:documentation>
                   <value>contents</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                     table of contents, specifying the structure of a work and listing its
-                     constituents. The list element should be used to mark its
-                     structure.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A table of contents, specifying the structure of a work and listing its constituents. The list element should be used to mark its structure.</a:documentation>
                   <value>dedication</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                     formal offering or dedication of a text to one or more persons or institutions
-                     by the author.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A formal offering or dedication of a text to one or more persons or institutions by the author.</a:documentation>
                   <value>frontispiece</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                     pictorial frontispiece, possibly including some text.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A pictorial frontispiece, possibly including some text.</a:documentation>
                   <value>glossary</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                     list of terms associated with definition texts (‘glosses’).</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A list of terms associated with definition texts (‘glosses’).</a:documentation>
                   <value>half-title</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                     page containing only the title of a book — as opposed to the title page, which
-                     also lists subtitle, author, imprint and similar data.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A page containing only the title of a book — as opposed to the title page, which also lists subtitle, author, imprint and similar data.</a:documentation>
                   <value>index</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Any
-                     form of index to the work.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Any form of index to the work.</a:documentation>
                   <value>annotations</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                     section in which annotations on the text are gathered
-                     together.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A section in which annotations on the text are gathered together.</a:documentation>
                   <value>preface</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                     foreword or preface addressed to the reader in which the author or publisher
-                     explains the content, purpose, or origin of the text.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A foreword or preface addressed to the reader in which the author or publisher explains the content, purpose, or origin of the text.</a:documentation>
                   <data type="NMTOKEN"/>
                </choice>
             </attribute>
          </optional>
          <optional>
             <attribute name="subtype">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Provide any sub-classification for the element, additional to that given by its
-                  type attribute.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provide any sub-classification for the element, additional to that given by its type attribute.</a:documentation>
                <data type="NMTOKEN"/>
             </attribute>
          </optional>
@@ -14505,8 +13376,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_dot">
       <element name="dot">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Dot of
-            augmentation or division.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Dot of augmentation or division.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
@@ -14519,8 +13389,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_dynam">
       <element name="dynam">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(dynamic) –
-            Indication of the volume of a note, phrase, or section of music.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(dynamic) – Indication of the volume of a note, phrase, or section of music.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14530,23 +13399,25 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </choice>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-dynam-dynam_start-type_attributes_required-constraint-25">
+                  id="mei-dynam-dynam_start-type_attributes_required-constraint-25">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:dynam">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real"> Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:dynam">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real"> Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
             </sch:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-dynam-dynam_end-type_attributes-constraint-26">
+                  id="mei-dynam-dynam_end-type_attributes-constraint-26">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:dynam[@val2]">
-               <sch:assert test="@dur or @dur.ges or @endid or @tstamp2">When @val2 is present,
-                  either @dur, @dur.ges, @endid, or @tstamp2 must also be present.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:dynam[@val2]">
+               <sch:assert test="@dur or @dur.ges or @endid or @tstamp2">When @val2 is present, either
+              @dur, @dur.ges, @endid, or @tstamp2 must also be present.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -14562,12 +13433,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_edition">
       <element name="edition">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(edition
-            designation) – A word or text phrase that indicates a difference in either content or
-            form between the item being described and a related item previously issued by the same
-            publisher/distributor (e.g. 2nd edition, version 2.0, etc.), or simultaneously issued by
-            either the same publisher/distributor or another publisher/distributor (e.g. large print
-            edition, British edition, etc.).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(edition designation) – A word or text phrase that indicates a difference in either content or form between the item being described and a related item previously issued by the same publisher/distributor (e.g. 2nd edition, version 2.0, etc.), or simultaneously issued by either the same publisher/distributor or another publisher/distributor (e.g. large print edition, British edition, etc.).</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14582,9 +13448,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_editor">
       <element name="editor">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The name of
-            the individual(s), institution(s) or organization(s) acting in an editorial
-            capacity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The name of the individual(s), institution(s) or organization(s) acting in an editorial capacity.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14601,9 +13465,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_ending">
       <element name="ending">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Alternative
-            ending for a repeated passage of music; i.e., prima volta, seconda volta,
-            etc.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Alternative ending for a repeated passage of music; i.e., prima volta, seconda volta, etc.</a:documentation>
          <zeroOrMore>
             <ref name="mei_expansion"/>
          </zeroOrMore>
@@ -14633,8 +13495,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_event">
       <element name="event">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a
-            free-text event description.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a free-text event description.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -14670,8 +13531,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_eventList">
       <element name="eventList">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-            historical information given as a sequence of significant past events.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains historical information given as a sequence of significant past events.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -14704,9 +13564,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_expansion">
       <element name="expansion">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-            how a section may be programmatically expanded into its 'through-composed'
-            form.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates how a section may be programmatically expanded into its 'through-composed' form.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.plist.attributes"/>
@@ -14718,10 +13576,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_extent">
       <element name="extent">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to
-            express size in terms other than physical dimensions, such as number of pages, number of
-            records in file, number of bytes, performance duration for music, audio recordings and
-            visual projections, etc.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to express size in terms other than physical dimensions, such as number of pages, number of records in file, number of bytes, performance duration for music, audio recordings and visual projections, etc.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14738,10 +13593,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_funder">
       <element name="funder">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Names of
-            individuals, institutions, or organizations responsible for funding. Funders provide
-            financial support for a project; they are distinct from sponsors, who provide
-            intellectual support and authority.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Names of individuals, institutions, or organizations responsible for funding. Funders provide financial support for a project; they are distinct from sponsors, who provide intellectual support and authority.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14757,9 +13609,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_genre">
       <element name="genre">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Term or
-            terms that designate a category characterizing a particular style, form, or
-            content.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Term or terms that designate a category characterizing a particular style, form, or content.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14776,10 +13626,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_group">
       <element name="group">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a
-            composite musical text, grouping together a sequence of distinct musical texts (or
-            groups of such musical texts) which are regarded as a unit for some purpose, for
-            example, the collected works of a composer.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a composite musical text, grouping together a sequence of distinct musical texts (or groups of such musical texts) which are regarded as a unit for some purpose, for example, the collected works of a composer.</a:documentation>
          <choice>
             <ref name="mei_music"/>
             <ref name="mei_group"/>
@@ -14797,30 +13644,30 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_grpSym">
       <element name="grpSym">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(group
-            symbol) – A brace or bracket used to group two or more staves of a score or
-            part.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(group symbol) – A brace or bracket used to group two or more staves of a score or part.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.labelLike"/>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-grpSym-check_grpSym_attributes_scoreDef-constraint-27">
+                  id="mei-grpSym-check_grpSym_attributes_scoreDef-constraint-27">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:grpSym[parent::mei:scoreDef]">
-               <sch:assert test="@startid and @endid and @level">In scoreDef, grpSym must have
-                  startid, endid, and level attributes.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:grpSym[parent::mei:scoreDef]">
+               <sch:assert test="@startid and @endid and @level">In scoreDef, grpSym must have startid,
+              endid, and level attributes.</sch:assert>
             </sch:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-grpSym-check_grpSym_attributes_staffDef-constraint-28">
+                  id="mei-grpSym-check_grpSym_attributes_staffDef-constraint-28">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:grpSym[parent::mei:staffGrp]">
-               <sch:assert test="not(@startid or @endid or @level)">In staffGrp, grpSym must not
-                  have startid, endid, or level attributes.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:grpSym[parent::mei:staffGrp]">
+               <sch:assert test="not(@startid or @endid or @level)">In staffGrp, grpSym must not have
+              startid, endid, or level attributes.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -14834,9 +13681,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_head">
       <element name="head">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(heading) –
-            Contains any heading, for example, the title of a section of text, or the heading of a
-            list.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(heading) – Contains any heading, for example, the title of a section of text, or the heading of a list.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14855,8 +13700,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_height">
       <element name="height">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Description
-            of the vertical size of an object.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Description of the vertical size of an object.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14873,9 +13717,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_identifier">
       <element name="identifier">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An
-            alpha-numeric string that establishes the identity of the described
-            material.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An alpha-numeric string that establishes the identity of the described material.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14894,8 +13736,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_imprint">
       <element name="imprint">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Information
-            relating to the publication or distribution of a bibliographic item.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Information relating to the publication or distribution of a bibliographic item.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -14912,8 +13753,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_incip">
       <element name="incip">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(incipit) –
-            The opening music and/or words of a composition.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(incipit) – The opening music and/or words of a composition.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -14961,18 +13801,18 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_keyAccid">
       <element name="keyAccid">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(key
-            accidental) – Accidental in a key signature.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(key accidental) – Accidental in a key signature.</a:documentation>
          <empty/>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-keyAccid-Check_keyAccidPlacement-constraint-29">
+                  id="mei-keyAccid-Check_keyAccidPlacement-constraint-29">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:keyAccid">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:keyAccid">
                <sch:assert test="(@x and @y) or (@pname and @oct) or @loc">One of the following is
-                  required: @x and @y attribute pair, @pname and @oct attribute pair, or @loc
-                  attribute.</sch:assert>
+              required: @x and @y attribute pair, @pname and @oct attribute pair, or @loc
+              attribute.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -14983,16 +13823,12 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.keyAccid.vis.attributes"/>
          <optional>
             <attribute name="form">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Specifies whether enharmonic (written) values or implicit ("perform-able") values
-                  are allowed.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies whether enharmonic (written) values or implicit ("perform-able") values are allowed.</a:documentation>
                <choice>
                   <value>implicit</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Only performed values (sharp, flat, natural) allowed.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Only performed values (sharp, flat, natural) allowed.</a:documentation>
                   <value>explicit</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">All
-                     enharmonic (written) values allowed.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">All enharmonic (written) values allowed.</a:documentation>
                </choice>
             </attribute>
          </optional>
@@ -15001,8 +13837,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_keySig">
       <element name="keySig">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(key
-            signature) – Written key signature.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(key signature) – Written key signature.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.keyAccidLike"/>
          </zeroOrMore>
@@ -15017,8 +13852,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_label">
       <element name="label">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A container
-            for text that identifies the feature to which it is attached.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A container for text that identifies the feature to which it is attached.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -15037,8 +13871,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_layer">
       <element name="layer">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An
-            independent stream of events on a staff.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An independent stream of events on a staff.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_model.appLike"/>
@@ -15060,8 +13893,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.layer.anl.attributes"/>
          <optional>
             <attribute name="n">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                  non-negative integer value functioning as a "name".</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A non-negative integer value functioning as a "name".</a:documentation>
                <data type="nonNegativeInteger"/>
             </attribute>
          </optional>
@@ -15070,8 +13902,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_layerDef">
       <element name="layerDef">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(layer
-            definition) – Container for layer meta-information.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(layer definition) – Container for layer meta-information.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.labelLike"/>
          </zeroOrMore>
@@ -15086,8 +13917,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.layerDef.anl.attributes"/>
          <optional>
             <attribute name="n">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                  non-negative integer value functioning as a "name".</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A non-negative integer value functioning as a "name".</a:documentation>
                <data type="nonNegativeInteger"/>
             </attribute>
          </optional>
@@ -15096,8 +13926,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_lb">
       <element name="lb">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(line break)
-            – An empty formatting element that forces text to begin on a new line.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(line break) – An empty formatting element that forces text to begin on a new line.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
@@ -15105,8 +13934,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.typed.attributes"/>
          <optional>
             <attribute name="func">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">States
-                  whether the line break follows a single line or a line group.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">States whether the line break follows a single line or a line group.</a:documentation>
                <choice>
                   <value>line</value>
                   <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
@@ -15120,8 +13948,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_librettist">
       <element name="librettist">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Person or
-            organization who is a writer of the text of an opera, oratorio, etc.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Person or organization who is a writer of the text of an opera, oratorio, etc.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -15138,8 +13965,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_lyricist">
       <element name="lyricist">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Person or
-            organization who is a writer of the text of a song.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Person or organization who is a writer of the text of a song.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -15156,8 +13982,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_mdiv">
       <element name="mdiv">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(musical
-            division) – Contains a subdivision of the body of a musical text.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(musical division) – Contains a subdivision of the body of a musical text.</a:documentation>
          <choice>
             <group>
                <optional>
@@ -15180,20 +14005,18 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_mei">
       <element name="mei">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a
-            single MEI-conformant document, consisting of an MEI header and a musical text, either
-            in isolation or as part of an meiCorpus element.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a single MEI-conformant document, consisting of an MEI header and a musical text, either in isolation or as part of an meiCorpus element.</a:documentation>
          <ref name="mei_meiHead"/>
          <ref name="mei_music"/>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-mei-Check_staff-constraint-30">
+                  id="mei-mei-Check_staff-constraint-30">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:*[@staff]">
-               <sch:assert test="every $i in tokenize(@staff, '\s+') satisfies $i=//mei:staffDef/@n"
-                  >The values in @staff must correspond to @n attribute of a staffDef
-                  element.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:*[@staff]">
+               <sch:assert test="every $i in tokenize(@staff, '\s+') satisfies $i=//mei:staffDef/@n">The values in @staff must correspond to @n attribute of a staffDef
+              element.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.meiversion.attributes"/>
@@ -15203,9 +14026,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_music">
       <element name="music">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a
-            single musical text of any kind, whether unitary or composite, for example, an etude,
-            opera, song cycle, symphony, or anthology of piano solos.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a single musical text of any kind, whether unitary or composite, for example, an etude, opera, song cycle, symphony, or anthology of piano solos.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.resourceLike"/>
          </zeroOrMore>
@@ -15218,8 +14039,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_name">
       <element name="name">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Proper noun
-            or noun phrase.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Proper noun or noun phrase.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -15228,14 +14048,15 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
                <ref name="mei_model.transcriptionLike"/>
             </choice>
          </zeroOrMore>
-         <pattern xmlns="http://purl.oclc.org/dsdl/schematron" id="mei-name-nameParts-constraint-31">
+         <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
+                  id="mei-name-nameParts-constraint-31">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:name">
-               <sch:assert role="warning" test="not(mei:geogName or mei:persName or mei:corpName)"
-                  >Recommended practice is to use name elements to capture sub-parts of a generic
-                  name.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:name">
+               <sch:assert role="warning" test="not(mei:geogName or mei:persName or mei:corpName)">Recommended practice is to use name elements to capture sub-parts of a generic
+              name.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.bibl.attributes"/>
@@ -15246,38 +14067,28 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.name.attributes"/>
          <optional>
             <attribute name="type">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Characterizes the element in some sense, using any convenient classification
-                  scheme or typology. Suggested values include: 1] person; 2] corporation; 3]
-                  location; 4] process; 5] style; 6] time</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Characterizes the element in some sense, using any convenient classification scheme or typology.
+Suggested values include: 1] person; 2] corporation; 3] location; 4] process; 5] style; 6] time</a:documentation>
                <choice>
                   <value>person</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                     personal name.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A personal name.</a:documentation>
                   <value>corporation</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Name of a corporate body.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Name of a corporate body.</a:documentation>
                   <value>location</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Name of a location.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Name of a location.</a:documentation>
                   <value>process</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Name of a process or software application.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Name of a process or software application.</a:documentation>
                   <value>style</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Name of a musical style; i.e., form, genre, technique, etc.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Name of a musical style; i.e., form, genre, technique, etc.</a:documentation>
                   <value>time</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Name of a period of time.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Name of a period of time.</a:documentation>
                   <data type="NMTOKEN"/>
                </choice>
             </attribute>
          </optional>
          <optional>
             <attribute name="subtype">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Provide any sub-classification for the element, additional to that given by its
-                  type attribute.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provide any sub-classification for the element, additional to that given by its type attribute.</a:documentation>
                <data type="NMTOKEN"/>
             </attribute>
          </optional>
@@ -15286,8 +14097,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_note">
       <element name="note">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A single
-            pitched event. </a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A single pitched event. </a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_model.noteModifierLike"/>
@@ -15309,8 +14119,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_num">
       <element name="num">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(number) –
-            Numeric information in any form.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(number) – Numeric information in any form.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -15326,9 +14135,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.typed.attributes"/>
          <optional>
             <attribute name="value">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Numeric value capturing a measurement or count. Can only be interpreted in
-                  combination with the unit attribute.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Numeric value capturing a measurement or count. Can only be interpreted in combination with the unit attribute.</a:documentation>
                <data type="decimal"/>
             </attribute>
          </optional>
@@ -15337,8 +14144,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_ornam">
       <element name="ornam">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An element
-            indicating an ornament that is not a mordent, turn, or trill. </a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An element indicating an ornament that is not a mordent, turn, or trill. </a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -15349,13 +14155,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </choice>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-ornam-ornam_start-type_attributes_required-constraint-32">
+                  id="mei-ornam-ornam_start-type_attributes_required-constraint-32">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:ornam">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:ornam">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -15370,8 +14177,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_p">
       <element name="p">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(paragraph)
-            – One or more text phrases that form a logical prose passage.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(paragraph) – One or more text phrases that form a logical prose passage.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -15388,8 +14194,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_pad">
       <element name="pad">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(padding) –
-            An indication of extra visual space between notational elements.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(padding) – An indication of extra visual space between notational elements.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.pad.log.attributes"/>
@@ -15401,9 +14206,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_part">
       <element name="part">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An
-            alternative visual rendition of the score from the point of view of a particular
-            performer (or group of performers).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An alternative visual rendition of the score from the point of view of a particular performer (or group of performers).</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_model.appLike"/>
@@ -15428,8 +14231,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_parts">
       <element name="parts">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a
-            container for performers' parts.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a container for performers' parts.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.partLike"/>
          </zeroOrMore>
@@ -15445,8 +14247,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_pb">
       <element name="pb">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(page break)
-            – An empty formatting element that forces text to begin on a new page.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(page break) – An empty formatting element that forces text to begin on a new page.</a:documentation>
          <ref name="mei_macro.metaLike.page"/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
@@ -15462,9 +14263,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_pgDesc">
       <element name="pgDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(page
-            description) – Contains a brief prose description of the appearance or description of
-            the content of a physical page.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(page description) – Contains a brief prose description of the appearance or description of the content of a physical page.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -15481,9 +14280,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_pgFoot">
       <element name="pgFoot">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(page
-            footer) – A running footer on the first page. Also, used to temporarily override a
-            running footer on individual pages.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(page footer) – A running footer on the first page. Also, used to temporarily override a running footer on individual pages.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -15501,8 +14298,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.typed.attributes"/>
          <optional>
             <attribute name="halign">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Records horizontal alignment of the page footer.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records horizontal alignment of the page footer.</a:documentation>
                <ref name="mei_data.HORIZONTALALIGNMENT"/>
             </attribute>
          </optional>
@@ -15511,8 +14307,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_pgFoot2">
       <element name="pgFoot2">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(page footer
-            2) – A running footer on the pages following the first.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(page footer 2) – A running footer on the pages following the first.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -15530,9 +14325,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.typed.attributes"/>
          <optional>
             <attribute name="halign">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Records horizontal alignment of the page footer. Use multiple values to capture
-                  an alternating pattern.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records horizontal alignment of the page footer. Use multiple values to capture an alternating pattern.</a:documentation>
                <list>
                   <oneOrMore>
                      <ref name="mei_data.HORIZONTALALIGNMENT"/>
@@ -15545,9 +14338,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_pgHead">
       <element name="pgHead">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(page
-            header) – A running header on the first page. Also, used to temporarily override a
-            running header on individual pages.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(page header) – A running header on the first page. Also, used to temporarily override a running header on individual pages.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -15565,8 +14356,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.typed.attributes"/>
          <optional>
             <attribute name="halign">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Records horizontal alignment of the page header.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records horizontal alignment of the page header.</a:documentation>
                <ref name="mei_data.HORIZONTALALIGNMENT"/>
             </attribute>
          </optional>
@@ -15575,8 +14365,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_pgHead2">
       <element name="pgHead2">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(page header
-            2) – A running header on the pages following the first.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(page header 2) – A running header on the pages following the first.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -15594,9 +14383,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.typed.attributes"/>
          <optional>
             <attribute name="halign">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Records horizontal alignment of the page header. Use multiple values to capture
-                  an alternating pattern.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records horizontal alignment of the page header. Use multiple values to capture an alternating pattern.</a:documentation>
                <list>
                   <oneOrMore>
                      <ref name="mei_data.HORIZONTALALIGNMENT"/>
@@ -15609,36 +14396,35 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_phrase">
       <element name="phrase">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indication
-            of 1) a "unified melodic idea" or 2) performance technique.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indication of 1) a "unified melodic idea" or 2) performance technique.</a:documentation>
          <zeroOrMore>
             <ref name="mei_curve"/>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-phrase-phrase_start-_and_end-type_attributes_required-constraint-33">
+                  id="mei-phrase-phrase_start-_and_end-type_attributes_required-constraint-33">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:phrase">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:phrase">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
                <sch:assert test="@dur or @dur.ges or @endid or @tstamp2">Must have one of the
-                  attributes: dur, dur.ges, endid, or tstamp2.</sch:assert>
+              attributes: dur, dur.ges, endid, or tstamp2.</sch:assert>
             </sch:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-phrase-phrase_containing_curve-constraint-34">
+                  id="mei-phrase-phrase_containing_curve-constraint-34">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0"
-               context="mei:phrase[mei:curve[@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or              @startho or @endho or @to or @startto or @endto or @vo or @startvo or @endvo or @x or @y or @x2 or @y2]]">
-               <sch:assert
-                  test="not(@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or @startho or @endho or                @to or @startto or @endto or @vo or @startvo or @endvo or @x or @y or @x2 or @y2)"
-                  role="warning">The visual attributes of the phrase (@bezier, @bulge, @curvedir,
-                  @lform, @lwidth, @ho, @startho, @endho, @to, @startto, @endto, @vo, @startvo,
-                  @endvo, @x, @y, @x2, and @y2) will be overridden by visual attributes of the
-                  contained curve elements.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:phrase[mei:curve[@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or              @startho or @endho or @to or @startto or @endto or @vo or @startvo or @endvo or @x or @y or @x2 or @y2]]">
+               <sch:assert test="not(@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or @startho or @endho or                @to or @startto or @endto or @vo or @startvo or @endvo or @x or @y or @x2 or @y2)"
+                           role="warning">The visual attributes of the phrase (@bezier, @bulge, @curvedir,
+              @lform, @lwidth, @ho, @startho, @endho, @to, @startto, @endto, @vo, @startvo, @endvo,
+              @x, @y, @x2, and @y2) will be overridden by visual attributes of the contained curve
+              elements.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -15653,10 +14439,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_physLoc">
       <element name="physLoc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(physical
-            location) – Groups information about the current physical location of a bibliographic
-            item, such as the repository in which it is located and its shelf mark(s), and its
-            previous locations.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(physical location) – Groups information about the current physical location of a bibliographic item, such as the repository in which it is located and its shelf mark(s), and its previous locations.</a:documentation>
          <zeroOrMore>
             <group>
                <ref name="mei_model.repositoryLike"/>
@@ -15676,8 +14459,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_publisher">
       <element name="publisher">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Name of the
-            organization responsible for the publication of a bibliographic item.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Name of the organization responsible for the publication of a bibliographic item.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -15693,8 +14475,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_pubPlace">
       <element name="pubPlace">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(publication
-            place) – Name of the place where a bibliographic item was published.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(publication place) – Name of the place where a bibliographic item was published.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -15710,9 +14491,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_recipient">
       <element name="recipient">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The name of
-            the individual(s), institution(s) or organization(s) receiving
-            correspondence.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The name of the individual(s), institution(s) or organization(s) receiving correspondence.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -15728,9 +14507,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_relatedItem">
       <element name="relatedItem">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(related
-            item) – Contains or references another bibliographic item which is related to the
-            present one.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(related item) – Contains or references another bibliographic item which is related to the present one.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.biblLike"/>
          </zeroOrMore>
@@ -15742,42 +14519,26 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.targeteval.attributes"/>
          <ref name="mei_att.typed.attributes"/>
          <attribute name="rel">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the relationship between the &lt;relatedItem&gt; and the resource described in the
-               parent element, i.e., &lt;bibl&gt;, &lt;source&gt; or &lt;relatedItem&gt;. The values
-               are based on MODS version 3.4. The subject of these relations is always the
-               &lt;relatedItem&gt;, and the object is always the parent of the &lt;relatedItem&gt;.
-               "preceding" and "succeeding" indicate temporal order.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the relationship between the &lt;relatedItem&gt; and the resource described in the parent element, i.e., &lt;bibl&gt;, &lt;source&gt; or &lt;relatedItem&gt;. The values are based on MODS version 3.4. The subject of these relations is always the &lt;relatedItem&gt;, and the object is always the parent of the &lt;relatedItem&gt;. "preceding" and "succeeding" indicate temporal order.</a:documentation>
             <choice>
                <value>preceding</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Predecessor of the resource.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Predecessor of the resource.</a:documentation>
                <value>succeeding</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Successor to the resource.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Successor to the resource.</a:documentation>
                <value>original</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Original form of the resource.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Original form of the resource.</a:documentation>
                <value>host</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Parent
-                  containing the resource.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Parent containing the resource.</a:documentation>
                <value>constituent</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Intellectual or physical component of the resource.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Intellectual or physical component of the resource.</a:documentation>
                <value>otherVersion</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Version of the resource's intellectual content not changed enough to be a
-                  different work.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Version of the resource's intellectual content not changed enough to be a different work.</a:documentation>
                <value>otherFormat</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Version of the resource in a different physical format.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Version of the resource in a different physical format.</a:documentation>
                <value>isReferencedBy</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Published bibliographic description, review, abstract, or index of the resource's
-                  content.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Published bibliographic description, review, abstract, or index of the resource's content.</a:documentation>
                <value>references</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Cited
-                  or referred to in the resource.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Cited or referred to in the resource.</a:documentation>
             </choice>
          </attribute>
          <empty/>
@@ -15785,9 +14546,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_rend">
       <element name="rend">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(render) – A
-            formatting element indicating special visual rendering, e.g., bold or italicized, of a
-            text word or phrase.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(render) – A formatting element indicating special visual rendering, e.g., bold or italicized, of a text word or phrase.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -15804,8 +14563,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.whitespace.attributes"/>
          <optional>
             <attribute name="altrend">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used
-                  to extend the values of the rend attribute.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to extend the values of the rend attribute.</a:documentation>
                <list>
                   <oneOrMore>
                      <data type="NMTOKEN"/>
@@ -15815,9 +14573,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute name="rend">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Captures the appearance of the element's contents using MEI-defined
-                  descriptors.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures the appearance of the element's contents using MEI-defined descriptors.</a:documentation>
                <list>
                   <oneOrMore>
                      <ref name="mei_data.TEXTRENDITION"/>
@@ -15827,34 +14583,22 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute name="rotation">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                  positive value for rotation rotates the text in a counter-clockwise fashion, while
-                  negative values produce clockwise rotation.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A positive value for rotation rotates the text in a counter-clockwise fashion, while negative values produce clockwise rotation.</a:documentation>
                <ref name="mei_data.DEGREES"/>
             </attribute>
          </optional>
          <optional>
             <attribute name="valign">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Specifies the vertical position of the element content relative to the
-                  surrounding text.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies the vertical position of the element content relative to the surrounding text.</a:documentation>
                <choice>
                   <value>top</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Aligns the top of the content with the top of the surrounding
-                     text.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Aligns the top of the content with the top of the surrounding text.</a:documentation>
                   <value>middle</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Aligns the middle of the content with the middle of the surrounding
-                     text.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Aligns the middle of the content with the middle of the surrounding text.</a:documentation>
                   <value>bottom</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Aligns the bottom of the content with the bottom of the surrounding
-                     text.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Aligns the bottom of the content with the bottom of the surrounding text.</a:documentation>
                   <value>baseline</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Aligns the baseline of the content with the baseline of the surrounding
-                     text.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Aligns the baseline of the content with the baseline of the surrounding text.</a:documentation>
                </choice>
             </attribute>
          </optional>
@@ -15863,8 +14607,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_repository">
       <element name="repository">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Institution,
-            agency, or individual which holds a bibliographic item.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Institution, agency, or individual which holds a bibliographic item.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -15882,9 +14625,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_resp">
       <element name="resp">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >(responsibility) – A phrase describing the nature of intellectual
-            responsibility.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(responsibility) – A phrase describing the nature of intellectual responsibility.</a:documentation>
          <text/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.authorized.attributes"/>
@@ -15897,10 +14638,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_respStmt">
       <element name="respStmt">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >(responsibility statement) – Names one or more individuals, groups, or in rare cases,
-            mechanical processes, responsible for creation or realization of the intellectual or
-            artistic content.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(responsibility statement) – Names one or more individuals, groups, or in rare cases, mechanical processes, responsible for creation or realization of the intellectual or artistic content.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_resp"/>
@@ -15908,15 +14646,15 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </choice>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-respStmt-check_respStmt-constraint-35">
+                  id="mei-respStmt-check_respStmt-constraint-35">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0"
-               context="mei:*[local-name()='titleStmt' or local-name()='pubStmt' or local-name()='seriesStmt']/mei:respStmt">
-               <sch:assert role="warning" test="mei:resp or (count(mei:*[@role]) = count(mei:*))">If
-                  at least one resp element isn't present, all name-like elements should have a
-                  @role attribute.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:*[local-name()='titleStmt' or local-name()='pubStmt' or local-name()='seriesStmt']/mei:respStmt">
+               <sch:assert role="warning" test="mei:resp or (count(mei:*[@role]) = count(mei:*))">If at
+              least one resp element isn't present, all name-like elements should have a @role
+              attribute.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -15927,8 +14665,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_rest">
       <element name="rest">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-            non-sounding event found in the source being transcribed.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A non-sounding event found in the source being transcribed.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_dot"/>
@@ -15938,16 +14675,15 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </choice>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-rest-Check_restline-constraint-36">
+                  id="mei-rest-Check_restline-constraint-36">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:rest[@line]">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:rest[@line]">
                <sch:let name="thisstaff" value="ancestor::mei:staff/@n"/>
-               <sch:assert
-                  test="number(@line) &lt;= number(preceding::mei:staffDef[@n=$thisstaff and @lines][1]/@lines)"
-                  >The value of @line must be less than or equal to the number of lines on the
-                  staff.</sch:assert>
+               <sch:assert test="number(@line) &lt;= number(preceding::mei:staffDef[@n=$thisstaff and @lines][1]/@lines)">The value of @line must be less than or equal to the number of lines on the
+              staff.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -15961,8 +14697,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_role">
       <element name="role">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Name of a
-            dramatic role, as given in a cast list.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Name of a dramatic role, as given in a cast list.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -15977,8 +14712,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_roleDesc">
       <element name="roleDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(role
-            description) – Describes a character's role in a drama.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(role description) – Describes a character's role in a drama.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -15993,9 +14727,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_sb">
       <element name="sb">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(system
-            break) – An empty formatting element that forces musical notation to begin on a new
-            line.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(system break) – An empty formatting element that forces musical notation to begin on a new line.</a:documentation>
          <optional>
             <ref name="mei_custos"/>
          </optional>
@@ -16011,8 +14743,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_score">
       <element name="score">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Full score
-            view of the musical content.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Full score view of the musical content.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_model.appLike"/>
@@ -16037,8 +14768,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_scoreDef">
       <element name="scoreDef">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(score
-            definition) – Container for score meta-information.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(score definition) – Container for score meta-information.</a:documentation>
          <optional>
             <ref name="mei_model.chordTableLike"/>
          </optional>
@@ -16082,8 +14812,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_section">
       <element name="section">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Segment of
-            music data.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Segment of music data.</a:documentation>
          <zeroOrMore>
             <ref name="mei_expansion"/>
          </zeroOrMore>
@@ -16100,14 +14829,15 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </choice>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-section-Check_sectionexpansion-constraint-37">
+                  id="mei-section-Check_sectionexpansion-constraint-37">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:section[mei:expansion]">
-               <sch:assert test="descendant::mei:section|descendant::mei:ending|descendant::mei:rdg"
-                  >A section containing an expansion element must have descendant section, ending,
-                  or rdg elements.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:section[mei:expansion]">
+               <sch:assert test="descendant::mei:section|descendant::mei:ending|descendant::mei:rdg">A
+              section containing an expansion element must have descendant section, ending, or rdg
+              elements.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -16125,9 +14855,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_series">
       <element name="series">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-            information about the serial publication in which a bibliographic item has
-            appeared.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains information about the serial publication in which a bibliographic item has appeared.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_model.titleLike"/>
@@ -16148,10 +14876,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_space">
       <element name="space">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-            placeholder used to fill an incomplete measure, layer, etc. most often so that the
-            combined duration of the events equals the number of beats in the
-            measure.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A placeholder used to fill an incomplete measure, layer, etc. most often so that the combined duration of the events equals the number of beats in the measure.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
@@ -16164,10 +14889,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_sponsor">
       <element name="sponsor">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Names of
-            sponsoring individuals, organizations or institutions. Sponsors give their intellectual
-            authority to a project; they are to be distinguished from funders, who provide the
-            funding but do not necessarily take intellectual responsibility.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Names of sponsoring individuals, organizations or institutions. Sponsors give their intellectual authority to a project; they are to be distinguished from funders, who provide the funding but do not necessarily take intellectual responsibility.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -16183,8 +14905,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_stack">
       <element name="stack">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(stacked
-            text) – An inline table with a single column.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(stacked text) – An inline table with a single column.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -16196,29 +14917,22 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.lang.attributes"/>
          <optional>
             <attribute name="delim">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Indicates the delimiter used to mark the portions of text that are to be
-                  stacked.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the delimiter used to mark the portions of text that are to be stacked.</a:documentation>
                <data type="string"/>
             </attribute>
          </optional>
          <optional>
             <attribute name="align">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Specifies how the stacked text components should be aligned.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies how the stacked text components should be aligned.</a:documentation>
                <choice>
                   <value>left</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Left justified.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Left justified.</a:documentation>
                   <value>right</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Right justified.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Right justified.</a:documentation>
                   <value>center</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Centered.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Centered.</a:documentation>
                   <value>rightdigit</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Aligned on right-most digit.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Aligned on right-most digit.</a:documentation>
                </choice>
             </attribute>
          </optional>
@@ -16227,11 +14941,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_staff">
       <element name="staff">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A group of
-            equidistant horizontal lines on which notes are placed in order to represent pitch or a
-            grouping element for individual 'strands' of notes, rests, etc. that may or may not
-            actually be rendered on staff lines; that is, both diastematic and non-diastematic
-            signs.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A group of equidistant horizontal lines on which notes are placed in order to represent pitch or a grouping element for individual 'strands' of notes, rests, etc. that may or may not actually be rendered on staff lines; that is, both diastematic and non-diastematic signs.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_model.appLike"/>
@@ -16253,8 +14963,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.staff.anl.attributes"/>
          <optional>
             <attribute name="n">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                  non-negative integer value functioning as a "name".</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A non-negative integer value functioning as a "name".</a:documentation>
                <data type="nonNegativeInteger"/>
             </attribute>
          </optional>
@@ -16263,8 +14972,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_staffDef">
       <element name="staffDef">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(staff
-            definition) – Container for staff meta-information.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(staff definition) – Container for staff meta-information.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.labelLike"/>
          </zeroOrMore>
@@ -16276,126 +14984,125 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </choice>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-staffDef-Check_staffDefn-constraint-38">
+                  id="mei-staffDef-Check_staffDefn-constraint-38">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:staffDef">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:staffDef">
                <sch:let name="thisstaff" value="@n"/>
                <sch:assert test="@n">A staffDef must have an n attribute.</sch:assert>
-               <sch:assert test="@lines or preceding::mei:staffDef[@n=$thisstaff and @lines]">The
-                  first occurrence of a staff must declare the number of staff lines.</sch:assert>
-               <sch:assert test="count(mei:clef) + count(mei:clefGrp) &lt; 2">Only one clef or
-                  clefGrp is permitted.</sch:assert>
+               <sch:assert test="@lines or preceding::mei:staffDef[@n=$thisstaff and @lines]">The first
+              occurrence of a staff must declare the number of staff lines.</sch:assert>
+               <sch:assert test="count(mei:clef) + count(mei:clefGrp) &lt; 2">Only one clef or clefGrp
+              is permitted.</sch:assert>
             </sch:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-staffDef-Check_ancestor_staff-constraint-39">
+                  id="mei-staffDef-Check_ancestor_staff-constraint-39">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:staffDef[ancestor::mei:staff]">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:staffDef[ancestor::mei:staff]">
                <sch:let name="thisstaff" value="@n"/>
                <sch:assert test="ancestor::mei:staff/@n eq $thisstaff">If a staffDef appears in a
-                  staff, it must bear the same @n as this staff.</sch:assert>
+              staff, it must bear the same @n as this staff.</sch:assert>
             </sch:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-staffDef-Check_clef_position_staffDef-constraint-40">
+                  id="mei-staffDef-Check_clef_position_staffDef-constraint-40">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:staffDef[@clef.line and @lines]">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:staffDef[@clef.line and @lines]">
                <sch:assert test="number(@clef.line) &lt;= number(@lines)">The clef position must be
-                  less than or equal to the number of lines on the staff.</sch:assert>
+              less than or equal to the number of lines on the staff.</sch:assert>
             </sch:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-staffDef-Check_clef_position_staffDef_nolines-constraint-41">
+                  id="mei-staffDef-Check_clef_position_staffDef_nolines-constraint-41">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0"
-               context="mei:staffDef[@clef.line and not(@lines)]">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:staffDef[@clef.line and not(@lines)]">
                <sch:let name="thisstaff" value="@n"/>
                <sch:let name="stafflines"
-                  value="preceding::mei:staffDef[@n=$thisstaff and @lines][1]/@lines"/>
-               <sch:assert test="number(@clef.line) &lt;= number($stafflines)">The clef position
-                  must be less than or equal to the number of lines on the staff.</sch:assert>
+                        value="preceding::mei:staffDef[@n=$thisstaff and @lines][1]/@lines"/>
+               <sch:assert test="number(@clef.line) &lt;= number($stafflines)">The clef position must
+              be less than or equal to the number of lines on the staff.</sch:assert>
             </sch:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-staffDef-Check_tab_strings_lines-constraint-42">
+                  id="mei-staffDef-Check_tab_strings_lines-constraint-42">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:staffDef[@tab.strings and @lines]">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:staffDef[@tab.strings and @lines]">
                <sch:let name="countTokens"
-                  value="count(tokenize(normalize-space(@tab.strings), '\s'))"/>
-               <sch:assert test="$countTokens = 1 or $countTokens = @lines">The tab.strings
-                  attribute must have the same number of values as there are staff
-                  lines.</sch:assert>
+                        value="count(tokenize(normalize-space(@tab.strings), '\s'))"/>
+               <sch:assert test="$countTokens = 1 or $countTokens = @lines">The tab.strings attribute
+              must have the same number of values as there are staff lines.</sch:assert>
             </sch:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-staffDef-Check_tab_strings_nolines-constraint-43">
+                  id="mei-staffDef-Check_tab_strings_nolines-constraint-43">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0"
-               context="mei:staffDef[@tab.strings and not(@lines)]">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:staffDef[@tab.strings and not(@lines)]">
                <sch:let name="countTokens"
-                  value="count(tokenize(normalize-space(@tab.strings), '\s'))"/>
+                        value="count(tokenize(normalize-space(@tab.strings), '\s'))"/>
                <sch:let name="thisStaff" value="@n"/>
-               <sch:assert
-                  test="$countTokens = 1 or $countTokens = preceding::mei:staffDef[@n=$thisStaff and @lines][1]/@lines"
-                  >The tab.strings attribute must have the same number of values as there are staff
-                  lines.</sch:assert>
+               <sch:assert test="$countTokens = 1 or $countTokens = preceding::mei:staffDef[@n=$thisStaff and @lines][1]/@lines">The tab.strings attribute must have the same number of values as there are staff
+              lines.</sch:assert>
             </sch:rule>
          </pattern>
          <sch:pattern xmlns:rng="http://relaxng.org/ns/structure/1.0"
-            xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            xmlns="http://www.tei-c.org/ns/1.0">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0">
             <sch:rule context="mei:staffDef[@lines.color and @lines]">
-               <sch:let name="countTokens"
-                  value="count(tokenize(normalize-space(@lines.color), '\s'))"/>
-               <sch:assert test="$countTokens = 1 or $countTokens = @lines">The lines.color
-                  attribute must have either 1) a single value or 2) the same number of values as
-                  there are staff lines.</sch:assert>
+              <sch:let name="countTokens"
+                        value="count(tokenize(normalize-space(@lines.color), '\s'))"/>
+              <sch:assert test="$countTokens = 1 or $countTokens = @lines">The lines.color attribute
+                must have either 1) a single value or 2) the same number of values as there are
+                staff lines.</sch:assert>
             </sch:rule>
             <sch:rule context="mei:staffDef[@lines.color and not(@lines)]">
-               <sch:let name="countTokens"
-                  value="count(tokenize(normalize-space(@lines.color), '\s'))"/>
-               <sch:let name="thisStaff" value="@n"/>
-               <sch:assert
-                  test="$countTokens = 1 or $countTokens = preceding::mei:staffDef[@n=$thisStaff and @lines][1]/@lines"
-                  >The lines.color attribute must have either 1) a single value or 2) the same
-                  number of values as there are staff lines.</sch:assert>
+              <sch:let name="countTokens"
+                        value="count(tokenize(normalize-space(@lines.color), '\s'))"/>
+              <sch:let name="thisStaff" value="@n"/>
+              <sch:assert test="$countTokens = 1 or $countTokens = preceding::mei:staffDef[@n=$thisStaff and @lines][1]/@lines">The lines.color attribute must have either 1) a single value or 2) the same number
+                of values as there are staff lines.</sch:assert>
             </sch:rule>
-         </sch:pattern>
+          </sch:pattern>
          <sch:pattern xmlns:rng="http://relaxng.org/ns/structure/1.0"
-            xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            xmlns="http://www.tei-c.org/ns/1.0">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0">
             <sch:rule context="mei:staffDef[@ppq][ancestor::mei:scoreDef[@ppq]]">
-               <sch:let name="staffPPQ" value="@ppq"/>
-               <sch:let name="scorePPQ" value="ancestor::mei:scoreDef[@ppq][1]/@ppq"/>
-               <sch:assert test="($scorePPQ mod $staffPPQ) = 0">The value of ppq must be a factor of
-                  the value of ppq on an ancestor scoreDef.</sch:assert>
+              <sch:let name="staffPPQ" value="@ppq"/>
+              <sch:let name="scorePPQ" value="ancestor::mei:scoreDef[@ppq][1]/@ppq"/>
+              <sch:assert test="($scorePPQ mod $staffPPQ) = 0">The value of ppq must be a factor of
+                the value of ppq on an ancestor scoreDef.</sch:assert>
             </sch:rule>
-         </sch:pattern>
+          </sch:pattern>
          <sch:pattern xmlns:rng="http://relaxng.org/ns/structure/1.0"
-            xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            xmlns="http://www.tei-c.org/ns/1.0">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0">
             <sch:rule context="mei:staffDef[@ppq][preceding::mei:scoreDef[@ppq]]">
-               <sch:let name="staffPPQ" value="@ppq"/>
-               <sch:let name="scorePPQ" value="preceding::mei:scoreDef[@ppq][1]/@ppq"/>
-               <sch:assert test="($scorePPQ mod $staffPPQ) = 0">The value of ppq must be a factor of
-                  the value of ppq on a preceding scoreDef.</sch:assert>
+              <sch:let name="staffPPQ" value="@ppq"/>
+              <sch:let name="scorePPQ" value="preceding::mei:scoreDef[@ppq][1]/@ppq"/>
+              <sch:assert test="($scorePPQ mod $staffPPQ) = 0">The value of ppq must be a factor of
+                the value of ppq on a preceding scoreDef.</sch:assert>
             </sch:rule>
-         </sch:pattern>
+          </sch:pattern>
          <ref name="mei_att.commonPart.attributes"/>
          <ref name="mei_att.declaring.attributes"/>
          <ref name="mei_att.staffDef.log.attributes"/>
@@ -16404,8 +15111,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.staffDef.anl.attributes"/>
          <optional>
             <attribute name="n">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                  non-negative integer value functioning as a "name".</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A non-negative integer value functioning as a "name".</a:documentation>
                <data type="nonNegativeInteger"/>
             </attribute>
          </optional>
@@ -16414,8 +15120,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_staffGrp">
       <element name="staffGrp">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(staff
-            group) – A group of bracketed or braced staves.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(staff group) – A group of bracketed or braced staves.</a:documentation>
          <zeroOrMore>
             <ref name="mei_grpSym"/>
          </zeroOrMore>
@@ -16435,16 +15140,17 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             <ref name="mei_grpSym"/>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-staffGrp-Check_staffGrp_unique_staff_n_values-constraint-48">
+                  id="mei-staffGrp-Check_staffGrp_unique_staff_n_values-constraint-48">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:staffGrp">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:staffGrp">
                <sch:let name="countstaves" value="count(descendant::mei:staffDef)"/>
                <sch:let name="countuniqstaves"
-                  value="count(distinct-values(descendant::mei:staffDef/@n))"/>
+                        value="count(distinct-values(descendant::mei:staffDef/@n))"/>
                <sch:assert test="$countstaves eq $countuniqstaves">Each staffDef must have a unique
-                  value for the n attribute.</sch:assert>
+              value for the n attribute.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -16459,8 +15165,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_syl">
       <element name="syl">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(syllable) –
-            Individual lyric syllable.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(syllable) – Individual lyric syllable.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -16481,9 +15186,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_tempo">
       <element name="tempo">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Text and
-            symbols descriptive of tempo, mood, or style, e.g., "allarg.", "a tempo", "cantabile",
-            "Moderato", "♩=60", "Moderato ♩ =60").</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Text and symbols descriptive of tempo, mood, or style, e.g., "allarg.", "a tempo", "cantabile", "Moderato", "♩=60", "Moderato ♩ =60").</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -16494,26 +15197,25 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </choice>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-tempo-tempo_in_header_disallow_most_attrs-constraint-49">
+                  id="mei-tempo-tempo_in_header_disallow_most_attrs-constraint-49">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:tempo[ancestor::mei:meiHead]">
-               <sch:assert
-                  test="not(@*[name() != 'label' and name() != 'n' and name() != 'xml:base' and name() != 'xml:id' and name() != 'xml:lang'])"
-                  >Only label, n, xml:base, xml:id, and xml:lang attributes allowed when this
-                  element occurs in the header.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:tempo[ancestor::mei:meiHead]">
+               <sch:assert test="not(@*[name() != 'label' and name() != 'n' and name() != 'xml:base' and name() != 'xml:id' and name() != 'xml:lang'])">Only label, n, xml:base, xml:id, and xml:lang attributes allowed when this element
+              occurs in the header.</sch:assert>
             </sch:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-tempo-tempo_start-type_attributes_required-constraint-50">
+                  id="mei-tempo-tempo_start-type_attributes_required-constraint-50">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0"
-               context="mei:tempo[not(ancestor::mei:syllable) and not(ancestor::mei:work) and not(ancestor::mei:expression) and not(count(ancestor::mei:*) = 0)]">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:tempo[not(ancestor::mei:syllable) and not(ancestor::mei:work) and not(ancestor::mei:expression) and not(count(ancestor::mei:*) = 0)]">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -16530,9 +15232,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_textLang">
       <element name="textLang">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text
-            language) – Identifies the languages and writing systems within the work described by a
-            bibliographic description, not the language of the description.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(text language) – Identifies the languages and writing systems within the work described by a bibliographic description, not the language of the description.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -16545,17 +15245,13 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.lang.attributes"/>
          <optional>
             <attribute name="mainLang">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(main
-                  language) supplies a code which identifies the chief language used in the
-                  bibliographic work.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(main language) supplies a code which identifies the chief language used in the bibliographic work.</a:documentation>
                <data type="language"/>
             </attribute>
          </optional>
          <optional>
             <attribute name="otherLangs">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(other
-                  languages) one or more codes identifying any other languages used in the
-                  bibliographic work.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(other languages) one or more codes identifying any other languages used in the bibliographic work.</a:documentation>
                <list>
                   <oneOrMore>
                      <data type="language"/>
@@ -16568,8 +15264,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_title">
       <element name="title">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Title of a
-            bibliographic entity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Title of a bibliographic entity.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -16587,63 +15282,45 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.lang.attributes"/>
          <optional>
             <attribute name="level">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Indicates the bibliographic level for a title.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the bibliographic level for a title.</a:documentation>
                <choice>
                   <value>a</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Analyzed component, such as an article or chapter, within a larger
-                     bibliographic entity.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Analyzed component, such as an article or chapter, within a larger bibliographic entity.</a:documentation>
                   <value>m</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Monograph.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Monograph.</a:documentation>
                   <value>j</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Journal.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Journal.</a:documentation>
                   <value>s</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Series.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Series.</a:documentation>
                   <value>u</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Unpublished (including theses and dissertations unless published by a
-                     commercial press).</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unpublished (including theses and dissertations unless published by a commercial press).</a:documentation>
                </choice>
             </attribute>
          </optional>
          <optional>
             <attribute name="type">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Characterizes the element in some sense, using any convenient classification
-                  scheme or typology. Suggested values include: 1] main; 2] subordinate; 3]
-                  abbreviated; 4] alternative; 5] translated; 6] uniform</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Characterizes the element in some sense, using any convenient classification scheme or typology.
+Suggested values include: 1] main; 2] subordinate; 3] abbreviated; 4] alternative; 5] translated; 6] uniform</a:documentation>
                <choice>
                   <value>main</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Main title.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Main title.</a:documentation>
                   <value>subordinate</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Subtitle or title of part.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Subtitle or title of part.</a:documentation>
                   <value>abbreviated</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Abbreviated form of title.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Abbreviated form of title.</a:documentation>
                   <value>alternative</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Alternate title by which the item is also known.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Alternate title by which the item is also known.</a:documentation>
                   <value>translated</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Translated form of title.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Translated form of title.</a:documentation>
                   <value>uniform</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Collective title.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Collective title.</a:documentation>
                   <data type="NMTOKEN"/>
                </choice>
             </attribute>
          </optional>
          <optional>
             <attribute name="subtype">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Provide any sub-classification for the element, additional to that given by its
-                  type attribute.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provide any sub-classification for the element, additional to that given by its type attribute.</a:documentation>
                <data type="NMTOKEN"/>
             </attribute>
          </optional>
@@ -16652,8 +15329,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_titlePage">
       <element name="titlePage">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a
-            transcription of the title page of a text.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a transcription of the title page of a text.</a:documentation>
          <oneOrMore>
             <choice>
                <ref name="mei_model.figureLike"/>
@@ -16673,8 +15349,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_width">
       <element name="width">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Description
-            of the horizontal size of an object.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Description of the horizontal size of an object.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -16695,15 +15370,12 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.regularmethod.attribute.method">
       <optional>
          <attribute name="method">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the method employed to mark corrections and normalizations.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the method employed to mark corrections and normalizations.</a:documentation>
             <choice>
                <value>silent</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Corrections and normalizations made silently.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Corrections and normalizations made silently.</a:documentation>
                <value>tags</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Corrections and normalizations indicated using elements.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Corrections and normalizations indicated using elements.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -16786,9 +15458,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_accessRestrict">
       <element name="accessRestrict">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(access
-            restriction) – Describes the conditions that affect the accessibility of
-            material.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(access restriction) – Describes the conditions that affect the accessibility of material.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -16803,10 +15473,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_altId">
       <element name="altId">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(alternative
-            identifier) – May contain a bibliographic identifier that does not fit within the
-            meiHead element's id attribute, for example because the identifier does not fit the
-            definition of an XML id or because multiple identifiers are needed.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(alternative identifier) – May contain a bibliographic identifier that does not fit within the meiHead element's id attribute, for example because the identifier does not fit the definition of an XML id or because multiple identifiers are needed.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -16822,9 +15489,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_appInfo">
       <element name="appInfo">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(application
-            information) – Groups information about applications which have acted upon the MEI
-            file.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(application information) – Groups information about applications which have acted upon the MEI file.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -16837,9 +15502,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_application">
       <element name="application">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-            information about an application which has acted upon the current
-            document.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides information about an application which has acted upon the current document.</a:documentation>
          <oneOrMore>
             <ref name="mei_name"/>
          </oneOrMore>
@@ -16856,9 +15519,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.typed.attributes"/>
          <optional>
             <attribute name="version">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Supplies a version number for an application, independent of its identifier or
-                  display name.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Supplies a version number for an application, independent of its identifier or display name.</a:documentation>
                <data type="NMTOKEN"/>
             </attribute>
          </optional>
@@ -16867,10 +15528,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_audience">
       <element name="audience">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Defines the
-            class of user for which the work is intended, as defined by age group (e.g., children,
-            young adults, adults, etc.), educational level (e.g., primary, secondary, etc.), or
-            other categorization.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Defines the class of user for which the work is intended, as defined by age group (e.g., children, young adults, adults, etc.), educational level (e.g., primary, secondary, etc.), or other categorization.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -16886,9 +15544,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_availability">
       <element name="availability">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Groups
-            elements that describe the availability of and access to a bibliographic item, including
-            an MEI-encoded document.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Groups elements that describe the availability of and access to a bibliographic item, including an MEI-encoded document.</a:documentation>
          <ref name="mei_macro.availabilityPart"/>
          <ref name="mei_att.bibl.attributes"/>
          <ref name="mei_att.common.attributes"/>
@@ -16898,9 +15554,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_byline">
       <element name="byline">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the
-            primary statement of responsibility given for a work on its title
-            page.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the primary statement of responsibility given for a work on its title page.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -16917,10 +15571,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_captureMode">
       <element name="captureMode">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(capture
-            mode) – The means used to record notation, sound, or images in the production of a
-            source/manifestation (e.g., analogue, acoustic, electric, digital, optical
-            etc.).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(capture mode) – The means used to record notation, sound, or images in the production of a source/manifestation (e.g., analogue, acoustic, electric, digital, optical etc.).</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -16936,13 +15587,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_carrierForm">
       <element name="carrierForm">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(carrier
-            form) – The specific class of material to which the physical carrier of the
-            source/manifestation belongs (e.g., sound cassette, videodisc, microfilm cartridge,
-            transparency, etc.). The carrier for a manifestation comprising multiple physical
-            components may include more than one form (e.g., a filmstrip with an accompanying
-            booklet, a separate sound disc carrying the sound track for a film,
-            etc.).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(carrier form) – The specific class of material to which the physical carrier of the source/manifestation belongs (e.g., sound cassette, videodisc, microfilm cartridge, transparency, etc.). The carrier for a manifestation comprising multiple physical components may include more than one form (e.g., a filmstrip with an accompanying booklet, a separate sound disc carrying the sound track for a film, etc.).</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -16958,8 +15603,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_change">
       <element name="change">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Individual
-            change within the revision description.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Individual change within the revision description.</a:documentation>
          <optional>
             <ref name="mei_respStmt"/>
          </optional>
@@ -16968,15 +15612,16 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             <ref name="mei_model.dateLike"/>
          </optional>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-change-change_requirements-constraint-51">
+                  id="mei-change-change_requirements-constraint-51">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:change">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:change">
                <sch:assert test="@isodate or mei:date">The date of the change must be recorded in an
-                  isodate attribute or date element.</sch:assert>
-               <sch:assert test="@resp or mei:respStmt">The person responsible for the change must
-                  be recorded in a resp attribute or respStmt element.</sch:assert>
+              isodate attribute or date element.</sch:assert>
+               <sch:assert test="@resp or mei:respStmt">The person responsible for the change must be
+              recorded in a resp attribute or respStmt element.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -16989,8 +15634,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_changeDesc">
       <element name="changeDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(change
-            description) – Description of a revision of the MEI file.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(change description) – Description of a revision of the MEI file.</a:documentation>
          <oneOrMore>
             <ref name="mei_model.pLike"/>
          </oneOrMore>
@@ -17002,11 +15646,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_classCode">
       <element name="classCode">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >(classification code) – Holds a citation to the source of controlled-vocabulary terms
-            used in the &lt;termList&gt; element; for example, Library of Congress Subject Headings
-            (LCSH), Library of Congress Classification (LCC), Library of Congress Name Authority
-            File (LCNAF), or other thesaurus or ontology.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(classification code) – Holds a citation to the source of controlled-vocabulary terms used in the &lt;termList&gt; element; for example, Library of Congress Subject Headings (LCSH), Library of Congress Classification (LCC), Library of Congress Name Authority File (LCNAF), or other thesaurus or ontology.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -17023,8 +15663,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_classification">
       <element name="classification">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Groups
-            information which describes the nature or topic of an entity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Groups information which describes the nature or topic of an entity.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -17042,10 +15681,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_condition">
       <element name="condition">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The physical
-            condition of an item, particularly any variances between the physical make-up of the
-            item and that of other copies of the same item (e.g., missing pages or plates,
-            brittleness, faded images, etc.).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The physical condition of an item, particularly any variances between the physical make-up of the item and that of other copies of the same item (e.g., missing pages or plates, brittleness, faded images, etc.).</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -17060,8 +15696,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_contentItem">
       <element name="contentItem">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a
-            single entry within a content description element.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a single entry within a content description element.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -17078,8 +15713,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_contents">
       <element name="contents">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Description
-            of the material contained within a resource.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Description of the material contained within a resource.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -17102,12 +15736,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_context">
       <element name="context">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The
-            historical, social, intellectual, artistic, or other context within which the work was
-            originally conceived (e.g., the 17th century restoration of the monarchy in England, the
-            aesthetic movement of the late 19th century, etc.) or the historical, social,
-            intellectual, artistic, or other context within which the expression was
-            realized.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The historical, social, intellectual, artistic, or other context within which the work was originally conceived (e.g., the 17th century restoration of the monarchy in England, the aesthetic movement of the late 19th century, etc.) or the historical, social, intellectual, artistic, or other context within which the expression was realized.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -17123,8 +15752,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_correction">
       <element name="correction">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">States how
-            and under what circumstances corrections have been made in the text.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">States how and under what circumstances corrections have been made in the text.</a:documentation>
          <oneOrMore>
             <ref name="mei_model.pLike"/>
          </oneOrMore>
@@ -17135,21 +15763,16 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.regularmethod.attributes"/>
          <optional>
             <attribute name="corrlevel">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Indicates the degree of correction applied to the text.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the degree of correction applied to the text.</a:documentation>
                <choice>
                   <value>high</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The
-                     text has been thoroughly checked and proofread.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The text has been thoroughly checked and proofread.</a:documentation>
                   <value>medium</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The
-                     text has been checked at least once.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The text has been checked at least once.</a:documentation>
                   <value>low</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The
-                     text has not been checked.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The text has not been checked.</a:documentation>
                   <value>unknown</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The
-                     correction status of the text is unknown.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The correction status of the text is unknown.</a:documentation>
                </choice>
             </attribute>
          </optional>
@@ -17158,9 +15781,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_dimensions">
       <element name="dimensions">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Information
-            about the physical size of a bibliographic source; usually includes numerical
-            data.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Information about the physical size of a bibliographic source; usually includes numerical data.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -17177,9 +15798,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_editionStmt">
       <element name="editionStmt">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(edition
-            statement) – Container for meta-data pertaining to a particular edition of the material
-            being described.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(edition statement) – Container for meta-data pertaining to a particular edition of the material being described.</a:documentation>
          <oneOrMore>
             <ref name="mei_model.editionLike"/>
             <zeroOrMore>
@@ -17194,9 +15813,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_editorialDecl">
       <element name="editorialDecl">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(editorial
-            declaration) – Used to provide details of editorial principles and practices applied
-            during the encoding of musical text.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(editorial declaration) – Used to provide details of editorial principles and practices applied during the encoding of musical text.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -17222,10 +15839,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_encodingDesc">
       <element name="encodingDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(encoding
-            description) – Documents the relationship between an electronic file and the source or
-            sources from which it was derived as well as applications used in the encoding/editing
-            process.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(encoding description) – Documents the relationship between an electronic file and the source or sources from which it was derived as well as applications used in the encoding/editing process.</a:documentation>
          <optional>
             <ref name="mei_appInfo"/>
          </optional>
@@ -17245,9 +15859,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_exhibHist">
       <element name="exhibHist">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(exhibition
-            history) – A record of public exhibitions, including dates, venues,
-            etc.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(exhibition history) – A record of public exhibitions, including dates, venues, etc.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -17262,8 +15874,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_extMeta">
       <element name="extMeta">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(extended
-            metadata) – Provides a container element for non-MEI metadata formats.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(extended metadata) – Provides a container element for non-MEI metadata formats.</a:documentation>
          <zeroOrMore>
             <group>
                <choice>
@@ -17279,11 +15890,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_fileChar">
       <element name="fileChar">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(file
-            characteristics) – Standards or schemes used to encode the file (e.g., ASCII, SGML,
-            etc.), physical characteristics of the file (e.g., recording density, parity, blocking,
-            etc.), and other characteristics that have a bearing on how the file can be
-            processed.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(file characteristics) – Standards or schemes used to encode the file (e.g., ASCII, SGML, etc.), physical characteristics of the file (e.g., recording density, parity, blocking, etc.), and other characteristics that have a bearing on how the file can be processed.</a:documentation>
          <text/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.bibl.attributes"/>
@@ -17293,9 +15900,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_fileDesc">
       <element name="fileDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(file
-            description) – Contains a full bibliographic description of the MEI
-            file.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(file description) – Contains a full bibliographic description of the MEI file.</a:documentation>
          <ref name="mei_titleStmt"/>
          <optional>
             <ref name="mei_editionStmt"/>
@@ -17320,10 +15925,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_fingerprint">
       <element name="fingerprint">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a
-            string that uniquely identifies an item, such as those constructed by combining groups
-            of characters transcribed from specified pages of a printed item or a file's
-            checksum.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a string that uniquely identifies an item, such as those constructed by combining groups of characters transcribed from specified pages of a printed item or a file's checksum.</a:documentation>
          <text/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.authorized.attributes"/>
@@ -17333,8 +15935,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_hand">
       <element name="hand">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Defines a
-            distinct scribe or handwriting style.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Defines a distinct scribe or handwriting style.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -17348,8 +15949,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.responsibility.attributes"/>
          <optional>
             <attribute name="initial">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Marks
-                  this hand as the first one of the document.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Marks this hand as the first one of the document.</a:documentation>
                <ref name="mei_data.BOOLEAN"/>
             </attribute>
          </optional>
@@ -17358,8 +15958,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_handList">
       <element name="handList">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Container
-            for one or more hand elements.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Container for one or more hand elements.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -17377,11 +15976,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_history">
       <element name="history">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a
-            container for information about the history of a resource. To facilitate efficient data
-            interchange, basic information about the circumstances surrounding the creation of
-            bibliographic resources should be recorded within the creation
-            element.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a container for information about the history of a resource. To facilitate efficient data interchange, basic information about the circumstances surrounding the creation of bibliographic resources should be recorded within the creation element.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -17398,18 +15993,17 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_incipCode">
       <element name="incipCode">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Incipit
-            coded in a non-XML, plain text format, such as Plaine &amp; Easie
-            Code.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Incipit coded in a non-XML, plain text format, such as Plaine &amp; Easie Code.</a:documentation>
          <text/>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-incipCode-Check_incipCode_form_mimetype-constraint-52">
+                  id="mei-incipCode-Check_incipCode_form_mimetype-constraint-52">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:incipCode">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:incipCode">
                <sch:assert test="@form or @mimetype">incipCode must have a form or mimetype
-                  attribute.</sch:assert>
+              attribute.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -17419,19 +16013,15 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.whitespace.attributes"/>
          <optional>
             <attribute name="form">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Form
-                  of the encoded incipit. Suggested values include: 1] plaineAndEasie; 2]
-                  humdrumKern; 3] parsons</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Form of the encoded incipit.
+Suggested values include: 1] plaineAndEasie; 2] humdrumKern; 3] parsons</a:documentation>
                <choice>
                   <value>plaineAndEasie</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Plaine &amp; Easie Code.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Plaine &amp; Easie Code.</a:documentation>
                   <value>humdrumKern</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Humdrum Kern format.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Humdrum Kern format.</a:documentation>
                   <value>parsons</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Parsons code.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Parsons code.</a:documentation>
                   <data type="NMTOKEN"/>
                </choice>
             </attribute>
@@ -17441,8 +16031,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_incipText">
       <element name="incipText">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Opening
-            words of a musical composition.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Opening words of a musical composition.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_model.pLike"/>
@@ -17459,9 +16048,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_inscription">
       <element name="inscription">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An
-            inscription added to an item, such as a bookplate, a note designating the item as a
-            gift, and/or the author's signature.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An inscription added to an item, such as a bookplate, a note designating the item as a gift, and/or the author's signature.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -17478,9 +16065,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_interpretation">
       <element name="interpretation">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-            the scope of any analytic or interpretive information added to the transcription of the
-            music.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the scope of any analytic or interpretive information added to the transcription of the music.</a:documentation>
          <oneOrMore>
             <ref name="mei_model.pLike"/>
          </oneOrMore>
@@ -17493,8 +16078,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_key">
       <element name="key">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key captures
-            information about tonal center and mode.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Key captures information about tonal center and mode.</a:documentation>
          <text/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.bibl.attributes"/>
@@ -17504,8 +16088,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_language">
       <element name="language">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Description
-            of a language used in the document.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Description of a language used in the document.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -17521,9 +16104,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_langUsage">
       <element name="langUsage">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(language
-            usage) – Groups elements describing the languages, sub-languages, dialects, etc.,
-            represented within the encoded resource.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(language usage) – Groups elements describing the languages, sub-languages, dialects, etc., represented within the encoded resource.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -17538,9 +16119,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_meiHead">
       <element name="meiHead">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(MEI header)
-            – Supplies the descriptive and declarative metadata prefixed to every MEI-conformant
-            text.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(MEI header) – Supplies the descriptive and declarative metadata prefixed to every MEI-conformant text.</a:documentation>
          <zeroOrMore>
             <ref name="mei_altId"/>
          </zeroOrMore>
@@ -17563,16 +16142,12 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.meiversion.attributes"/>
          <optional>
             <attribute name="type">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Specifies the kind of document to which the header is attached, for example
-                  whether it is a corpus or individual text.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies the kind of document to which the header is attached, for example whether it is a corpus or individual text.</a:documentation>
                <choice>
                   <value>music</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Header is attached to a music document.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Header is attached to a music document.</a:documentation>
                   <value>corpus</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Header is attached to a corpus.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Header is attached to a corpus.</a:documentation>
                </choice>
             </attribute>
          </optional>
@@ -17581,8 +16156,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_mensuration">
       <element name="mensuration">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures
-            information about mensuration within bibliographic descriptions.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures information about mensuration within bibliographic descriptions.</a:documentation>
          <text/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.bibl.attributes"/>
@@ -17593,9 +16167,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_meter">
       <element name="meter">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures
-            information about the time signature within bibliographic
-            descriptions.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures information about the time signature within bibliographic descriptions.</a:documentation>
          <text/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.bibl.attributes"/>
@@ -17606,9 +16178,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_normalization">
       <element name="normalization">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-            the extent of normalization or regularization of the original source carried out in
-            converting it to electronic form.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the extent of normalization or regularization of the original source carried out in converting it to electronic form.</a:documentation>
          <oneOrMore>
             <ref name="mei_model.pLike"/>
          </oneOrMore>
@@ -17622,9 +16192,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_notesStmt">
       <element name="notesStmt">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(notes
-            statement)– Collects any notes providing information about a text additional to that
-            recorded in other parts of the bibliographic description.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(notes statement)– Collects any notes providing information about a text additional to that recorded in other parts of the bibliographic description.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -17638,9 +16206,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_otherChar">
       <element name="otherChar">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(other
-            distinguishing characteristic) – Any characteristic that serves to differentiate a work
-            or expression from another.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(other distinguishing characteristic) – Any characteristic that serves to differentiate a work or expression from another.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -17655,9 +16221,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_perfDuration">
       <element name="perfDuration">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(performance
-            duration) – Used to express the duration of performance of printed or manuscript music
-            or the playing time for a sound recording, videorecording, etc.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(performance duration) – Used to express the duration of performance of printed or manuscript music or the playing time for a sound recording, videorecording, etc.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -17670,8 +16234,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.lang.attributes"/>
          <optional>
             <attribute name="isodur">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds
-                  a W3C duration value, e.g., "PT2H34M45.67S".</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds a W3C duration value, e.g., "PT2H34M45.67S".</a:documentation>
                <data type="duration"/>
             </attribute>
          </optional>
@@ -17680,9 +16243,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_perfMedium">
       <element name="perfMedium">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(performance
-            medium) – Indicates the number and character of the performing forces used in a musical
-            composition.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(performance medium) – Indicates the number and character of the performing forces used in a musical composition.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -17703,9 +16264,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_perfRes">
       <element name="perfRes">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(performance
-            resource) – Name of an instrument on which a performer plays, a performer's voice range,
-            or a standard performing ensemble designation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(performance resource) – Name of an instrument on which a performer plays, a performer's voice range, or a standard performing ensemble designation.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -17720,16 +16279,13 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.lang.attributes"/>
          <optional>
             <attribute name="count">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Indicates the number of performers.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the number of performers.</a:documentation>
                <data type="positiveInteger"/>
             </attribute>
          </optional>
          <optional>
             <attribute name="solo">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Marks
-                  this instrument or vocal part as a soloist. Do not use this attribute for a solo
-                  instrument which is not accompanied.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Marks this instrument or vocal part as a soloist. Do not use this attribute for a solo instrument which is not accompanied.</a:documentation>
                <ref name="mei_data.BOOLEAN"/>
             </attribute>
          </optional>
@@ -17738,8 +16294,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_perfResList">
       <element name="perfResList">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Several
-            instrumental or vocal resources treated as a group.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Several instrumental or vocal resources treated as a group.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -17757,8 +16312,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.lang.attributes"/>
          <optional>
             <attribute name="count">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Indicates the number of performers.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the number of performers.</a:documentation>
                <data type="positiveInteger"/>
             </attribute>
          </optional>
@@ -17767,10 +16321,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_physDesc">
       <element name="physDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(physical
-            description) – Container for information about the appearance, construction, or handling
-            of physical materials, such as their dimension, quantity, color, style, and technique of
-            creation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(physical description) – Container for information about the appearance, construction, or handling of physical materials, such as their dimension, quantity, color, style, and technique of creation.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.pLike"/>
          </zeroOrMore>
@@ -17784,9 +16335,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_physMedium">
       <element name="physMedium">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(physical
-            medium) – Records the physical materials used in the source, such as ink and
-            paper.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(physical medium) – Records the physical materials used in the source, such as ink and paper.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -17802,10 +16351,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_plateNum">
       <element name="plateNum">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(plate
-            number) – Designation assigned to a resource by a music publisher, usually printed at
-            the bottom of each page, and sometimes appearing also on the title
-            page.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(plate number) – Designation assigned to a resource by a music publisher, usually printed at the bottom of each page, and sometimes appearing also on the title page.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -17821,9 +16367,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_playingSpeed">
       <element name="playingSpeed">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Playing
-            speed for a sound recording is the speed at which the carrier must be operated to
-            produce the sound intended (e.g., 33 1/3 rpm, 19 cm/s, etc.).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Playing speed for a sound recording is the speed at which the carrier must be operated to produce the sound intended (e.g., 33 1/3 rpm, 19 cm/s, etc.).</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -17838,8 +16382,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_price">
       <element name="price">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The cost of
-            access to a bibliographic item.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The cost of access to a bibliographic item.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -17851,9 +16394,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.lang.attributes"/>
          <optional>
             <attribute name="amount">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Numeric value capturing a cost. Can only be interpreted in combination with the
-                  currency attribute.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Numeric value capturing a cost. Can only be interpreted in combination with the currency attribute.</a:documentation>
                <data type="decimal">
                   <param name="pattern">[0-9]+\.[0-9]{2}</param>
                </data>
@@ -17861,8 +16402,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute name="currency">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Monetary unit.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Monetary unit.</a:documentation>
                <data type="NMTOKEN"/>
             </attribute>
          </optional>
@@ -17871,11 +16411,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_projectDesc">
       <element name="projectDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(project
-            description) – Project-level meta-data describing the aim or purpose for which the
-            electronic file was encoded, funding agencies, etc. together with any other relevant
-            information concerning the process by which it was assembled or
-            collected.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(project description) – Project-level meta-data describing the aim or purpose for which the electronic file was encoded, funding agencies, etc. together with any other relevant information concerning the process by which it was assembled or collected.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -17891,8 +16427,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_provenance">
       <element name="provenance">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The record
-            of ownership or custodianship of an item.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The record of ownership or custodianship of an item.</a:documentation>
          <choice>
             <optional>
                <ref name="mei_eventList"/>
@@ -17912,10 +16447,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_pubStmt">
       <element name="pubStmt">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(publication
-            statement) – Container for information regarding the publication or distribution of a
-            bibliographic item, including the publisher's name and address, the date of publication,
-            and other relevant details.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(publication statement) – Container for information regarding the publication or distribution of a bibliographic item, including the publisher's name and address, the date of publication, and other relevant details.</a:documentation>
          <choice>
             <optional>
                <ref name="mei_unpub"/>
@@ -17931,9 +16463,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_revisionDesc">
       <element name="revisionDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(revision
-            description) – Container for information about alterations that have been made to an MEI
-            file.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(revision description) – Container for information about alterations that have been made to an MEI file.</a:documentation>
          <oneOrMore>
             <ref name="mei_change"/>
          </oneOrMore>
@@ -17944,9 +16474,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_samplingDecl">
       <element name="samplingDecl">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(sampling
-            declaration) – Contains a prose description of the rationale and methods used in
-            sampling texts in the creation of a corpus or collection.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(sampling declaration) – Contains a prose description of the rationale and methods used in sampling texts in the creation of a corpus or collection.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -17962,9 +16490,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_scoreFormat">
       <element name="scoreFormat">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-            the type of score used to represent a musical composition (e.g., short score, full
-            score, condensed score, close score, etc.).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the type of score used to represent a musical composition (e.g., short score, full score, condensed score, close score, etc.).</a:documentation>
          <text/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.authorized.attributes"/>
@@ -17975,9 +16501,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_segmentation">
       <element name="segmentation">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-            the principles according to which the musical text has been segmented, for example into
-            movements, sections, etc.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the principles according to which the musical text has been segmented, for example into movements, sections, etc.</a:documentation>
          <oneOrMore>
             <ref name="mei_model.pLike"/>
          </oneOrMore>
@@ -17990,9 +16514,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_seriesStmt">
       <element name="seriesStmt">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(series
-            statement) – Groups information about the series, if any, to which a publication
-            belongs.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(series statement) – Groups information about the series, if any, to which a publication belongs.</a:documentation>
          <oneOrMore>
             <ref name="mei_model.titleLike"/>
          </oneOrMore>
@@ -18017,9 +16539,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_soundChan">
       <element name="soundChan">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(sound
-            channels) – Reflects the number of apparent sound channels in the playback of a
-            recording (monaural, stereophonic, quadraphonic, etc.).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(sound channels) – Reflects the number of apparent sound channels in the playback of a recording (monaural, stereophonic, quadraphonic, etc.).</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -18032,8 +16552,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.lang.attributes"/>
          <optional>
             <attribute name="num">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Records the channel configuration in numeric form.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the channel configuration in numeric form.</a:documentation>
                <data type="positiveInteger"/>
             </attribute>
          </optional>
@@ -18042,9 +16561,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_source">
       <element name="source">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-            bibliographic description of a source used in the creation of the electronic
-            file.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A bibliographic description of a source used in the creation of the electronic file.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.identifierLike"/>
          </zeroOrMore>
@@ -18092,9 +16609,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_sourceDesc">
       <element name="sourceDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(source
-            description) – A container for the descriptions of the source(s) used in the creation of
-            the electronic file.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(source description) – A container for the descriptions of the source(s) used in the creation of the electronic file.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -18107,9 +16622,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_specRepro">
       <element name="specRepro">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(special
-            reproduction characteristic) – The equalization system, noise reduction system, etc.
-            used in making the recording (e.g., NAB, DBX, Dolby, etc.).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(special reproduction characteristic) – The equalization system, noise reduction system, etc. used in making the recording (e.g., NAB, DBX, Dolby, etc.).</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -18125,9 +16638,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_stdVals">
       <element name="stdVals">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(standard
-            values) – Specifies the format used when standardized date or number values are
-            supplied.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(standard values) – Specifies the format used when standardized date or number values are supplied.</a:documentation>
          <oneOrMore>
             <ref name="mei_model.pLike"/>
          </oneOrMore>
@@ -18140,8 +16651,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_sysReq">
       <element name="sysReq">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(system
-            requirements) – System requirements for using the electronic item.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(system requirements) – System requirements for using the electronic item.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -18156,8 +16666,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_term">
       <element name="term">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Keyword or
-            phrase which describes a resource.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Keyword or phrase which describes a resource.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -18175,8 +16684,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_termList">
       <element name="termList">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Collection
-            of text phrases which describe a resource.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Collection of text phrases which describe a resource.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -18195,8 +16703,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_titleStmt">
       <element name="titleStmt">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(title
-            statement) – Container for title and responsibility meta-data.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(title statement) – Container for title and responsibility meta-data.</a:documentation>
          <oneOrMore>
             <ref name="mei_model.titleLike"/>
          </oneOrMore>
@@ -18210,9 +16717,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_trackConfig">
       <element name="trackConfig">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(track
-            configuration) – Number of physical/input tracks on a sound medium (e.g., eight track,
-            twelve track).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(track configuration) – Number of physical/input tracks on a sound medium (e.g., eight track, twelve track).</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -18225,8 +16730,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.lang.attributes"/>
          <optional>
             <attribute name="num">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Records the track configuration in numeric form.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the track configuration in numeric form.</a:documentation>
                <data type="positiveInteger"/>
             </attribute>
          </optional>
@@ -18235,9 +16739,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_treatHist">
       <element name="treatHist">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(treatment
-            history) – A record of the treatment the item has undergone (e.g., de-acidification,
-            restoration, etc.).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(treatment history) – A record of the treatment the item has undergone (e.g., de-acidification, restoration, etc.).</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -18252,9 +16754,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_treatSched">
       <element name="treatSched">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(treatment
-            scheduled) – Scheduled treatment, e.g. de-acidification, restoration, etc., for an
-            item.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(treatment scheduled) – Scheduled treatment, e.g. de-acidification, restoration, etc., for an item.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -18269,9 +16769,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_unpub">
       <element name="unpub">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >(unpublished) – Used to explicitly indicate that a bibliographic resource is
-            unpublished.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(unpublished) – Used to explicitly indicate that a bibliographic resource is unpublished.</a:documentation>
          <text/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.bibl.attributes"/>
@@ -18281,9 +16779,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_useRestrict">
       <element name="useRestrict">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(usage
-            restrictions) – Container for information about the conditions that affect use of a
-            bibliographic item after access has been granted.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(usage restrictions) – Container for information about the conditions that affect use of a bibliographic item after access has been granted.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -18298,8 +16794,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_watermark">
       <element name="watermark">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a
-            description of a watermark or similar device.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a description of a watermark or similar device.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -18315,10 +16810,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_work">
       <element name="work">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a
-            detailed description of a work, specifically its history, language use, and high-level
-            musical attributes: key, tempo, meter, medium of performance, and intended
-            duration.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a detailed description of a work, specifically its history, language use, and high-level musical attributes: key, tempo, meter, medium of performance, and intended duration.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.identifierLike"/>
          </zeroOrMore>
@@ -18384,9 +16876,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_workDesc">
       <element name="workDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(work
-            description) – Grouping mechanism for information describing non-bibliographic aspects
-            of a text.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(work description) – Grouping mechanism for information describing non-bibliographic aspects of a text.</a:documentation>
          <oneOrMore>
             <ref name="mei_work"/>
          </oneOrMore>
@@ -18407,19 +16897,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.arpeg.log.attribute.order">
       <optional>
          <attribute name="order">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the direction in which an arpeggio is to be performed.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the direction in which an arpeggio is to be performed.</a:documentation>
             <choice>
                <value>up</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Lowest
-                  to highest pitch.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Lowest to highest pitch.</a:documentation>
                <value>down</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Highest to lowest pitch.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Highest to lowest pitch.</a:documentation>
                <value>nonarp</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Non-arpeggiated style (usually rendered with a preceding bracket instead of a
-                  wavy line).</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Non-arpeggiated style (usually rendered with a preceding bracket instead of a wavy line).</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -18436,8 +16921,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.arpeg.vis.attribute.arrow">
       <optional>
          <attribute name="arrow">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               if an arrowhead is to be drawn as part of the arpeggiation symbol.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates if an arrowhead is to be drawn as part of the arpeggiation symbol.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -18462,8 +16946,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.beamed.attribute.beam">
       <optional>
          <attribute name="beam">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               that this event is "under a beam".</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that this event is "under a beam".</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.BEAM"/>
@@ -18478,10 +16961,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.beamedwith.attribute.beam.with">
       <optional>
          <attribute name="beam.with">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">In the
-               case of cross-staff beams, the beam.with attribute is used to indicate which staff
-               the beam is connected to; that is, the staff above or the staff
-               below.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">In the case of cross-staff beams, the beam.with attribute is used to indicate which staff the beam is connected to; that is, the staff above or the staff below.</a:documentation>
             <ref name="mei_data.OTHERSTAFF"/>
          </attribute>
       </optional>
@@ -18493,9 +16973,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.beaming.log.attribute.beam.group">
       <optional>
          <attribute name="beam.group">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               an example of how automated beaming (including secondary beams) is to be
-               performed.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides an example of how automated beaming (including secondary beams) is to be performed.</a:documentation>
             <data type="string"/>
          </attribute>
       </optional>
@@ -18503,9 +16981,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.beaming.log.attribute.beam.rests">
       <optional>
          <attribute name="beam.rests">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               whether automatically-drawn beams should include rests shorter than a quarter note
-               duration.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates whether automatically-drawn beams should include rests shorter than a quarter note duration.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -18517,24 +16993,16 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.beamrend.attribute.form">
       <optional>
          <attribute name="form">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures
-               whether a beam is "feathered" and in which direction.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures whether a beam is "feathered" and in which direction.</a:documentation>
             <choice>
                <value>acc</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >(accelerando) indicates that the secondary beams get progressively closer
-                  together toward the end of the beam.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(accelerando) indicates that the secondary beams get progressively closer together toward the end of the beam.</a:documentation>
                <value>mixed</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(mixed
-                  acc and rit) for beams that are "feathered" in both directions.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(mixed acc and rit) for beams that are "feathered" in both directions.</a:documentation>
                <value>rit</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >(ritardando) means that the secondary beams become progressively more distant
-                  toward the end of the beam.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(ritardando) means that the secondary beams become progressively more distant toward the end of the beam.</a:documentation>
                <value>norm</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >(normal) indicates that the secondary beams are equidistant along the course of
-                  the beam.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(normal) indicates that the secondary beams are equidistant along the course of the beam.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -18542,8 +17010,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.beamrend.attribute.slope">
       <optional>
          <attribute name="slope">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the slope of the beam.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the slope of the beam.</a:documentation>
             <data type="decimal"/>
          </attribute>
       </optional>
@@ -18554,10 +17021,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.beamsecondary.attribute.breaksec">
       <optional>
          <attribute name="breaksec">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Presence
-               of this attribute indicates that the secondary beam should be broken following this
-               note/chord. The value of the attribute records the number of beams which should
-               remain unbroken.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Presence of this attribute indicates that the secondary beam should be broken following this note/chord. The value of the attribute records the number of beams which should remain unbroken.</a:documentation>
             <data type="positiveInteger"/>
          </attribute>
       </optional>
@@ -18592,8 +17056,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.beatRpt.log.attribute.beatDef">
       <optional>
          <attribute name="beatDef">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the performed duration represented by the beatRpt symbol.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the performed duration represented by the beatRpt symbol.</a:documentation>
             <ref name="mei_data.DURATION.gestural"/>
          </attribute>
       </optional>
@@ -18608,13 +17071,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_att.beatRpt.vis.attribute.form">
       <attribute name="form">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-            the number of slashes required to render the appropriate beat repeat symbol. When a
-            single beat is repeated, consisting of a single note or chord, it is indicated by a
-            single thick, slanting slash; therefore, the value '1' should be used. The following
-            values should be used when the beat is divided into even notes: 4ths or 8ths=1, 16ths=2,
-            32nds=3, 64ths=4, 128ths=5. When the beat is comprised of mixed duration values, the
-            symbol is always rendered as 2 slashes and 2 dots.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the number of slashes required to render the appropriate beat repeat symbol. When a single beat is repeated, consisting of a single note or chord, it is indicated by a single thick, slanting slash; therefore, the value '1' should be used. The following values should be used when the beat is divided into even notes: 4ths or 8ths=1, 16ths=2, 32nds=3, 64ths=4, 128ths=5. When the beat is comprised of mixed duration values, the symbol is always rendered as 2 slashes and 2 dots.</a:documentation>
          <ref name="mei_data.BEATRPT.REND"/>
       </attribute>
    </define>
@@ -18627,9 +17084,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.bend.ges.attribute.amount">
       <optional>
          <attribute name="amount">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the amount of detuning. The decimal values should be rendered as a fraction (or an
-               integer plus a fraction) along with the bend symbol.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the amount of detuning. The decimal values should be rendered as a fraction (or an integer plus a fraction) along with the bend symbol.</a:documentation>
             <ref name="mei_data.BEND.AMOUNT"/>
          </attribute>
       </optional>
@@ -18688,15 +17143,12 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.bTrem.log.attribute.form">
       <optional>
          <attribute name="form">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               whether the tremolo is measured or unmeasured.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates whether the tremolo is measured or unmeasured.</a:documentation>
             <choice>
                <value>meas</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Measured tremolo.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Measured tremolo.</a:documentation>
                <value>unmeas</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Unmeasured tremolo.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unmeasured tremolo.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -18721,12 +17173,10 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.cutout.attribute.cutout">
       <optional>
          <attribute name="cutout">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">"Cut-out"
-               style indicated for this measure.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">"Cut-out" style indicated for this measure.</a:documentation>
             <choice>
                <value>cutout</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The
-                  staff lines should not be drawn.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The staff lines should not be drawn.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -18737,10 +17187,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.expandable.attribute.expand">
       <optional>
          <attribute name="expand">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               whether to render a repeat symbol or the source material to which it refers. A value
-               of 'true' renders the source material, while 'false' displays the repeat
-               symbol.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates whether to render a repeat symbol or the source material to which it refers. A value of 'true' renders the source material, while 'false' displays the repeat symbol.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -18769,16 +17216,12 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.fermata.vis.attribute.form">
       <optional>
          <attribute name="form">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the visual appearance of the fermata; that is, whether it occurs as upright or
-               inverted.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the visual appearance of the fermata; that is, whether it occurs as upright or inverted.</a:documentation>
             <choice>
                <value>inv</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Inverted, i.e., curve or bracket below the dot.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Inverted, i.e., curve or bracket below the dot.</a:documentation>
                <value>norm</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Upright; i.e., curve or bracket above the dot.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Upright; i.e., curve or bracket above the dot.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -18786,19 +17229,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.fermata.vis.attribute.shape">
       <optional>
          <attribute name="shape">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the visual appearance of the fermata; that is, whether it has a curved, square, or
-               angular shape.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the visual appearance of the fermata; that is, whether it has a curved, square, or angular shape.</a:documentation>
             <choice>
                <value>curved</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                  curve above or below the dot.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A curve above or below the dot.</a:documentation>
                <value>square</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                  bracket above or below the dot.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A bracket above or below the dot.</a:documentation>
                <value>angular</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                  triangle above or below the dot.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A triangle above or below the dot.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -18818,15 +17256,12 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.fTrem.log.attribute.form">
       <optional>
          <attribute name="form">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the style of the tremolo.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the style of the tremolo.</a:documentation>
             <choice>
                <value>meas</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Measured tremolo.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Measured tremolo.</a:documentation>
                <value>unmeas</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Unmeasured tremolo.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unmeasured tremolo.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -18865,9 +17300,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.graced.attribute.grace">
       <optional>
          <attribute name="grace">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Marks a
-               note or chord as a "grace" (without a definitive written duration) and records from
-               which other note/chord it should "steal" time.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Marks a note or chord as a "grace" (without a definitive written duration) and records from which other note/chord it should "steal" time.</a:documentation>
             <ref name="mei_data.GRACE"/>
          </attribute>
       </optional>
@@ -18875,8 +17308,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.graced.attribute.grace.time">
       <optional>
          <attribute name="grace.time">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the amount of time to be "stolen" from a non-grace note/chord.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the amount of time to be "stolen" from a non-grace note/chord.</a:documentation>
             <ref name="mei_data.PERCENT"/>
          </attribute>
       </optional>
@@ -18900,25 +17332,19 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_att.hairpin.log.attribute.form">
       <attribute name="form">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures the
-            visual rendition and function of the hairpin; that is, whether it indicates an increase
-            or a decrease in volume.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures the visual rendition and function of the hairpin; that is, whether it indicates an increase or a decrease in volume.</a:documentation>
          <choice>
             <value>cres</value>
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Crescendo; i.e., louder.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Crescendo; i.e., louder.</a:documentation>
             <value>dim</value>
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Diminuendo; i.e., softer.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Diminuendo; i.e., softer.</a:documentation>
          </choice>
       </attribute>
    </define>
    <define name="mei_att.hairpin.log.attribute.niente">
       <optional>
          <attribute name="niente">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               that the hairpin starts from or ends in silence. Often rendered as a small circle
-               attached to the closed end of the hairpin. See Gould, p. 108.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that the hairpin starts from or ends in silence. Often rendered as a small circle attached to the closed end of the hairpin. See Gould, p. 108.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -18936,9 +17362,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.hairpin.vis.attribute.opening">
       <optional>
          <attribute name="opening">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies
-               the distance between the lines at the open end of a hairpin dynamic
-               mark.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies the distance between the lines at the open end of a hairpin dynamic mark.</a:documentation>
             <ref name="mei_data.MEASUREMENTABS"/>
          </attribute>
       </optional>
@@ -18980,8 +17404,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_att.harpPedal.log.attribute.c">
       <optional>
-         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="c"
-            a:defaultValue="n">
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="c"
+                    a:defaultValue="n">
             <a:documentation>Indicates the pedal setting for the harp's C strings.</a:documentation>
             <choice>
                <value>f</value>
@@ -18996,8 +17421,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_att.harpPedal.log.attribute.d">
       <optional>
-         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="d"
-            a:defaultValue="n">
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="d"
+                    a:defaultValue="n">
             <a:documentation>Indicates the pedal setting for the harp's D strings.</a:documentation>
             <choice>
                <value>f</value>
@@ -19012,8 +17438,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_att.harpPedal.log.attribute.e">
       <optional>
-         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="e"
-            a:defaultValue="n">
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="e"
+                    a:defaultValue="n">
             <a:documentation>Indicates the pedal setting for the harp's E strings.</a:documentation>
             <choice>
                <value>f</value>
@@ -19028,8 +17455,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_att.harpPedal.log.attribute.f">
       <optional>
-         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="f"
-            a:defaultValue="n">
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="f"
+                    a:defaultValue="n">
             <a:documentation>Indicates the pedal setting for the harp's F strings.</a:documentation>
             <choice>
                <value>f</value>
@@ -19044,8 +17472,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_att.harpPedal.log.attribute.g">
       <optional>
-         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="g"
-            a:defaultValue="n">
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="g"
+                    a:defaultValue="n">
             <a:documentation>Indicates the pedal setting for the harp's G strings.</a:documentation>
             <choice>
                <value>f</value>
@@ -19060,8 +17489,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_att.harpPedal.log.attribute.a">
       <optional>
-         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="a"
-            a:defaultValue="n">
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="a"
+                    a:defaultValue="n">
             <a:documentation>Indicates the pedal setting for the harp's A strings.</a:documentation>
             <choice>
                <value>f</value>
@@ -19076,8 +17506,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_att.harpPedal.log.attribute.b">
       <optional>
-         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" name="b"
-            a:defaultValue="n">
+         <attribute xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                    name="b"
+                    a:defaultValue="n">
             <a:documentation>Indicates the pedal setting for the harp's B strings.</a:documentation>
             <choice>
                <value>f</value>
@@ -19108,8 +17539,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.lvpresent.attribute.lv">
       <optional>
          <attribute name="lv">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the attachment of an l.v. (laissez vibrer) sign to this element.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the attachment of an l.v. (laissez vibrer) sign to this element.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -19130,19 +17560,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_att.meterSigGrp.log.attribute.func">
       <attribute name="func">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Function of
-            the meter signature group.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Function of the meter signature group.</a:documentation>
          <choice>
             <value>alternating</value>
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Meter
-               signatures appear in alternating measures.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Meter signatures appear in alternating measures.</a:documentation>
             <value>interchanging</value>
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Meter
-               signatures are interchangable, e.g. 3/4 and 6/8.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Meter signatures are interchangable, e.g. 3/4 and 6/8.</a:documentation>
             <value>mixed</value>
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Meter
-               signatures with different unit values are used to express a complex metrical pattern
-               that is not expressable using traditional means, such as 2/4+1/8.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Meter signatures with different unit values are used to express a complex metrical pattern that is not expressable using traditional means, such as 2/4+1/8.</a:documentation>
          </choice>
       </attribute>
    </define>
@@ -19246,10 +17671,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.multiRest.vis.attribute.block">
       <optional>
          <attribute name="block">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">When the
-               block attribute is used, combinations of the 1, 2, and 4 measure rest forms (Read, p.
-               104) should be rendered instead of the modern form or an alternative
-               symbol.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">When the block attribute is used, combinations of the 1, 2, and 4 measure rest forms (Read, p. 104) should be rendered instead of the modern form or an alternative symbol.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -19277,8 +17699,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.note.ges.cmn.attribute.gliss">
       <optional>
          <attribute name="gliss">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               that this element participates in a glissando.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that this element participates in a glissando.</a:documentation>
             <ref name="mei_data.GLISSANDO"/>
          </attribute>
       </optional>
@@ -19297,8 +17718,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.numbered.attribute.num">
       <optional>
          <attribute name="num">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records a
-               number or count accompanying a notational feature.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records a number or count accompanying a notational feature.</a:documentation>
             <data type="positiveInteger"/>
          </attribute>
       </optional>
@@ -19310,9 +17730,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.numberplacement.attribute.num.place">
       <optional>
          <attribute name="num.place">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">States
-               where the tuplet number will be placed in relation to the note
-               heads.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">States where the tuplet number will be placed in relation to the note heads.</a:documentation>
             <ref name="mei_data.PLACE"/>
          </attribute>
       </optional>
@@ -19320,8 +17738,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.numberplacement.attribute.num.visible">
       <optional>
          <attribute name="num.visible">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Determines if the tuplet number is visible.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Determines if the tuplet number is visible.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -19344,15 +17761,10 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.octave.log.attribute.coll">
       <optional>
          <attribute name="coll">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               whether the octave displacement should be performed simultaneously with the written
-               notes, i.e., "coll' ottava". Unlike other octave signs which are indicated by broken
-               lines, coll' ottava typically uses an unbroken line or a series of longer broken
-               lines, ending with a short vertical stroke. See Read, p. 47-48.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates whether the octave displacement should be performed simultaneously with the written notes, i.e., "coll' ottava". Unlike other octave signs which are indicated by broken lines, coll' ottava typically uses an unbroken line or a series of longer broken lines, ending with a short vertical stroke. See Read, p. 47-48.</a:documentation>
             <choice>
                <value>coll</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Coll'
-                  ottava (with the octave).</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Coll' ottava (with the octave).</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -19390,21 +17802,16 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_att.pedal.log.attribute.dir">
       <attribute name="dir">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the
-            position of the piano damper pedal.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the position of the piano damper pedal.</a:documentation>
          <choice>
             <value>down</value>
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Depress
-               the pedal.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Depress the pedal.</a:documentation>
             <value>up</value>
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Release
-               the pedal.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Release the pedal.</a:documentation>
             <value>half</value>
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Half
-               pedal.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Half pedal.</a:documentation>
             <value>bounce</value>
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Release
-               then immediately depress the pedal.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Release then immediately depress the pedal.</a:documentation>
          </choice>
       </attribute>
    </define>
@@ -19422,22 +17829,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.pedal.vis.attribute.form">
       <optional>
          <attribute name="form">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Determines whether piano pedal marks should be rendered as lines or as
-               terms.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Determines whether piano pedal marks should be rendered as lines or as terms.</a:documentation>
             <choice>
                <value>line</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Continuous line with start and end positions rendered by vertical bars and
-                  bounces shown by upward-pointing "blips".</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Continuous line with start and end positions rendered by vertical bars and bounces shown by upward-pointing "blips".</a:documentation>
                <value>pedstar</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Pedal
-                  down and half pedal rendered with "Ped.", pedal up rendered by "*", pedal "bounce"
-                  rendered with "* Ped.".</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Pedal down and half pedal rendered with "Ped.", pedal up rendered by "*", pedal "bounce" rendered with "* Ped.".</a:documentation>
                <value>altpedstar</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Pedal
-                  up and down indications same as with "pedstar", but bounce is rendered with "Ped."
-                  only.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Pedal up and down indications same as with "pedstar", but bounce is rendered with "Ped." only.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -19452,22 +17851,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.pianopedals.attribute.pedal.style">
       <optional>
          <attribute name="pedal.style">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Determines whether piano pedal marks should be rendered as lines or as
-               terms.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Determines whether piano pedal marks should be rendered as lines or as terms.</a:documentation>
             <choice>
                <value>line</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Continuous line with start and end positions rendered by vertical bars and
-                  bounces shown by upward-pointing "blips".</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Continuous line with start and end positions rendered by vertical bars and bounces shown by upward-pointing "blips".</a:documentation>
                <value>pedstar</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Pedal
-                  down and half pedal rendered with "Ped.", pedal up rendered by "*", pedal "bounce"
-                  rendered with "* Ped.".</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Pedal down and half pedal rendered with "Ped.", pedal up rendered by "*", pedal "bounce" rendered with "* Ped.".</a:documentation>
                <value>altpedstar</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Pedal
-                  up and down indications same as with "pedstar", but bounce is rendered with "Ped."
-                  only.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Pedal up and down indications same as with "pedstar", but bounce is rendered with "Ped." only.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -19497,18 +17888,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.rehearsal.attribute.reh.enclose">
       <optional>
          <attribute name="reh.enclose">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the enclosing shape for rehearsal marks.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the enclosing shape for rehearsal marks.</a:documentation>
             <choice>
                <value>box</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Enclosed by box.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosed by box.</a:documentation>
                <value>circle</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Enclosed by circle.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Enclosed by circle.</a:documentation>
                <value>none</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">No
-                  enclosing shape.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">No enclosing shape.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -19533,8 +17920,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.scoreDef.vis.cmn.attribute.grid.show">
       <optional>
          <attribute name="grid.show">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Determines whether to display guitar chord grids.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Determines whether to display guitar chord grids.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -19601,10 +17987,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.stems.cmn.attribute.stem.with">
       <optional>
          <attribute name="stem.with">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               an indication of which staff a note or chord that logically belongs to the current
-               staff should be visually placed on; that is, the one above or the one
-               below.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains an indication of which staff a note or chord that logically belongs to the current staff should be visually placed on; that is, the one above or the one below.</a:documentation>
             <ref name="mei_data.OTHERSTAFF"/>
          </attribute>
       </optional>
@@ -19655,8 +18038,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.tremmeasured.attribute.measperf">
       <optional>
          <attribute name="measperf">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The
-               performed duration of an individual note in a measured tremolo.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The performed duration of an individual note in a measured tremolo.</a:documentation>
             <ref name="mei_data.DURATION.cmn"/>
          </attribute>
       </optional>
@@ -19686,9 +18068,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.tuplet.vis.attribute.bracket.place">
       <optional>
          <attribute name="bracket.place">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to
-               state where a tuplet bracket will be placed in relation to the note
-               heads.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to state where a tuplet bracket will be placed in relation to the note heads.</a:documentation>
             <ref name="mei_data.PLACE"/>
          </attribute>
       </optional>
@@ -19696,8 +18076,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.tuplet.vis.attribute.bracket.visible">
       <optional>
          <attribute name="bracket.visible">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">States
-               whether a bracket should be rendered with a tuplet.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">States whether a bracket should be rendered with a tuplet.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -19705,8 +18084,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.tuplet.vis.attribute.dur.visible">
       <optional>
          <attribute name="dur.visible">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Determines if the tuplet duration is visible.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Determines if the tuplet duration is visible.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -19714,15 +18092,12 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.tuplet.vis.attribute.num.format">
       <optional>
          <attribute name="num.format">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Controls
-               how the num:numbase ratio is to be displayed.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Controls how the num:numbase ratio is to be displayed.</a:documentation>
             <choice>
                <value>count</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Only
-                  the num attribute is displayed, e.g., '7'.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Only the num attribute is displayed, e.g., '7'.</a:documentation>
                <value>ratio</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Both
-                  the num and numbase attributes are displayed, e.g., '7:4'.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Both the num and numbase attributes are displayed, e.g., '7:4'.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -20147,10 +18522,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_arpeg">
       <element name="arpeg">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >(arpeggiation) – Indicates that the notes of a chord are to be performed successively
-            rather than simultaneously, usually from lowest to highest. Sometimes called a
-            "roll".</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(arpeggiation) – Indicates that the notes of a chord are to be performed successively rather than simultaneously, usually from lowest to highest. Sometimes called a "roll".</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
@@ -20164,9 +18536,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_beam">
       <element name="beam">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A container
-            for a series of explicitly beamed events that begins and ends entirely within a
-            measure.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A container for a series of explicitly beamed events that begins and ends entirely within a measure.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_model.eventLike"/>
@@ -20176,15 +18546,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </choice>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-beam-When_not_copyof_beam_content-constraint-53">
+                  id="mei-beam-When_not_copyof_beam_content-constraint-53">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:beam[not(@copyof)]">
-               <sch:assert
-                  test="count(descendant::*[local-name()='note' or local-name()='rest' or               local-name()='chord' or local-name()='space']) &gt; 1"
-                  >A beam without a copyof attribute must have at least 2 note, rest, chord, or
-                  space descendants.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:beam[not(@copyof)]">
+               <sch:assert test="count(descendant::*[local-name()='note' or local-name()='rest' or               local-name()='chord' or local-name()='space']) &gt; 1">A beam without a copyof attribute must have at least 2 note, rest, chord, or space
+              descendants.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -20198,20 +18567,19 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_beamSpan">
       <element name="beamSpan">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(beam span)
-            – Alternative element for explicitly encoding beams, particularly those which extend
-            across bar lines.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(beam span) – Alternative element for explicitly encoding beams, particularly those which extend across bar lines.</a:documentation>
          <empty/>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-beamSpan-beamspan_start-_and_end-type_attributes_required-constraint-54">
+                  id="mei-beamSpan-beamspan_start-_and_end-type_attributes_required-constraint-54">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:beamSpan">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:beamSpan">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
                <sch:assert test="@dur or @dur.ges or @endid or @tstamp2">Must have one of the
-                  attributes: dur, dur.ges, endid, or tstamp2.</sch:assert>
+              attributes: dur, dur.ges, endid, or tstamp2.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -20226,9 +18594,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_beatRpt">
       <element name="beatRpt">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(beat
-            repeat) – An indication that material on a preceding beat should be
-            repeated.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(beat repeat) – An indication that material on a preceding beat should be repeated.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
@@ -20243,20 +18609,19 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_bend">
       <element name="bend">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A variation
-            in pitch (often micro-tonal) upwards or downwards during the course of a
-            note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A variation in pitch (often micro-tonal) upwards or downwards during the course of a note.</a:documentation>
          <empty/>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-bend-bend_start-_and_end-type_attributes_required-constraint-55">
+                  id="mei-bend-bend_start-_and_end-type_attributes_required-constraint-55">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:bend">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:bend">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
                <sch:assert test="@dur or @dur.ges or @endid or @tstamp2">Must have one of the
-                  attributes: dur, dur.ges, endid, or tstamp2.</sch:assert>
+              attributes: dur, dur.ges, endid, or tstamp2.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -20271,18 +18636,17 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_breath">
       <element name="breath">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(breath
-            mark) – A indication of a point at which the performer on an instrument requiring breath
-            (including the voice) may breathe.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(breath mark) – A indication of a point at which the performer on an instrument requiring breath (including the voice) may breathe.</a:documentation>
          <empty/>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-breath-breath_start-type_attributes_required-constraint-56">
+                  id="mei-breath-breath_start-type_attributes_required-constraint-56">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:breath">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:breath">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -20297,8 +18661,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_bTrem">
       <element name="bTrem">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(bowed
-            tremolo) – A rapid alternation on a single pitch or chord.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(bowed tremolo) – A rapid alternation on a single pitch or chord.</a:documentation>
          <choice>
             <ref name="mei_chord"/>
             <ref name="mei_note"/>
@@ -20314,19 +18677,17 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_fermata">
       <element name="fermata">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An
-            indication placed over a note or rest to indicate that it should be held longer than its
-            written value. May also occur over a bar line to indicate the end of a phrase or
-            section. Sometimes called a 'hold' or 'pause'.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An indication placed over a note or rest to indicate that it should be held longer than its written value. May also occur over a bar line to indicate the end of a phrase or section. Sometimes called a 'hold' or 'pause'.</a:documentation>
          <empty/>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-fermata-fermata_start-type_attributes_required-constraint-57">
+                  id="mei-fermata-fermata_start-type_attributes_required-constraint-57">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:fermata">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:fermata">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -20341,10 +18702,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_fTrem">
       <element name="fTrem">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(fingered
-            tremolo) – A rapid alternation between a pair of notes (or chords or perhaps between a
-            note and a chord) that are (usually) farther apart than a major
-            second.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(fingered tremolo) – A rapid alternation between a pair of notes (or chords or perhaps between a note and a chord) that are (usually) farther apart than a major second.</a:documentation>
          <choice>
             <group>
                <ref name="mei_chord"/>
@@ -20372,9 +18730,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_gliss">
       <element name="gliss">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(glissando)
-            – A continuous or sliding movement from one pitch to another, usually indicated by a
-            straight or wavy line.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(glissando) – A continuous or sliding movement from one pitch to another, usually indicated by a straight or wavy line.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -20382,15 +18738,16 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </choice>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-gliss-gliss_start-_and_end-type_attributes_required-constraint-58">
+                  id="mei-gliss-gliss_start-_and_end-type_attributes_required-constraint-58">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:gliss">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:gliss">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
                <sch:assert test="@dur or @dur.ges or @endid or @tstamp2">Must have one of the
-                  attributes: dur, dur.ges, endid, or tstamp2.</sch:assert>
+              attributes: dur, dur.ges, endid, or tstamp2.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -20405,20 +18762,19 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_hairpin">
       <element name="hairpin">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-            continuous dynamics expressed on the score as wedge-shaped graphics, e.g. &lt; and
-            &gt;.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates continuous dynamics expressed on the score as wedge-shaped graphics, e.g. &lt; and &gt;.</a:documentation>
          <empty/>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-hairpin-hairpin_start-_and_end-type_attributes_required-constraint-59">
+                  id="mei-hairpin-hairpin_start-_and_end-type_attributes_required-constraint-59">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:hairpin">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:hairpin">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
                <sch:assert test="@dur or @dur.ges or @endid or @tstamp2">Must have one of the
-                  attributes: dur, dur.ges, endid, or tstamp2.</sch:assert>
+              attributes: dur, dur.ges, endid, or tstamp2.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -20433,8 +18789,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_halfmRpt">
       <element name="halfmRpt">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >(half-measure repeat) – A half-measure repeat in any meter.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(half-measure repeat) – A half-measure repeat in any meter.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
@@ -20447,17 +18802,17 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_harpPedal">
       <element name="harpPedal">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(harp pedal)
-            – Harp pedal diagram.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(harp pedal) – Harp pedal diagram.</a:documentation>
          <empty/>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-harpPedal-harpPedal_start-type_attributes_required-constraint-60">
+                  id="mei-harpPedal-harpPedal_start-type_attributes_required-constraint-60">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:harpPedal">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:harpPedal">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -20472,10 +18827,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_measure">
       <element name="measure">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unit of
-            musical time consisting of a fixed number of note-values of a given type, as determined
-            by the prevailing meter, and delimited in musical notation by bar
-            lines.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Unit of musical time consisting of a fixed number of note-values of a given type, as determined by the prevailing meter, and delimited in musical notation by bar lines.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_model.appLike"/>
@@ -20504,8 +18856,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_meterSig">
       <element name="meterSig">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(meter
-            signature) – Written meter signature.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(meter signature) – Written meter signature.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
@@ -20518,9 +18869,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_meterSigGrp">
       <element name="meterSigGrp">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(meter
-            signature group) – Used to capture alternating, interchanging, and mixed meter
-            signatures.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(meter signature group) – Used to capture alternating, interchanging, and mixed meter signatures.</a:documentation>
          <ref name="mei_meterSig"/>
          <oneOrMore>
             <ref name="mei_meterSig"/>
@@ -20536,8 +18885,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_mRest">
       <element name="mRest">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(measure
-            rest) – Complete measure rest in any meter. </a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(measure rest) – Complete measure rest in any meter. </a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
@@ -20550,8 +18898,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_mRpt">
       <element name="mRpt">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(measure
-            repeat) – An indication that the previous measure should be repeated.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(measure repeat) – An indication that the previous measure should be repeated.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
@@ -20564,9 +18911,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_mRpt2">
       <element name="mRpt2">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(2-measure
-            repeat) – An indication that the previous two measures should be
-            repeated.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(2-measure repeat) – An indication that the previous two measures should be repeated.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
@@ -20579,8 +18924,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_mSpace">
       <element name="mSpace">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(measure
-            space) – A measure containing only empty space in any meter.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(measure space) – A measure containing only empty space in any meter.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
@@ -20593,9 +18937,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_multiRest">
       <element name="multiRest">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(multiple
-            rest) – Multiple measures of rest compressed into a single symbol, frequently found in
-            performer parts.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(multiple rest) – Multiple measures of rest compressed into a single symbol, frequently found in performer parts.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
@@ -20608,8 +18950,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_multiRpt">
       <element name="multiRpt">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(multiple
-            repeat) – Multiple repeated measures.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(multiple repeat) – Multiple repeated measures.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
@@ -20622,9 +18963,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_octave">
       <element name="octave">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An
-            indication that a passage should be performed one or more octaves above or below its
-            written pitch.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An indication that a passage should be performed one or more octaves above or below its written pitch.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -20632,15 +18971,16 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </choice>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-octave-octave_start-_and_end-type_attributes_required-constraint-61">
+                  id="mei-octave-octave_start-_and_end-type_attributes_required-constraint-61">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:octave">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:octave">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
                <sch:assert test="@dur or @dur.ges or @endid or @tstamp2">Must have one of the
-                  attributes: dur, dur.ges, endid, or tstamp2.</sch:assert>
+              attributes: dur, dur.ges, endid, or tstamp2.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -20655,8 +18995,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_ossia">
       <element name="ossia">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An alternate
-            notational version *present in the source being transcribed*.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An alternate notational version *present in the source being transcribed*.</a:documentation>
          <choice>
             <group>
                <ref name="mei_model.staffLike"/>
@@ -20672,18 +19011,18 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </group>
          </choice>
          <sch:pattern xmlns:rng="http://relaxng.org/ns/structure/1.0"
-            xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            xmlns="http://www.tei-c.org/ns/1.0">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0">
             <sch:rule context="mei:measure/mei:ossia">
-               <sch:assert test="count(mei:*) = count(mei:staff)">In a measure, ossia may only
-                  contain staff elements.</sch:assert>
+              <sch:assert test="count(mei:*) = count(mei:staff)">In a measure, ossia may only
+                contain staff elements.</sch:assert>
             </sch:rule>
             <sch:rule context="mei:staff/mei:ossia">
-               <sch:assert test="count(mei:*) = count(mei:layer)">In a staff, ossia may only contain
-                  layer elements.</sch:assert>
+              <sch:assert test="count(mei:*) = count(mei:layer)">In a staff, ossia may only contain
+                layer elements.</sch:assert>
             </sch:rule>
-         </sch:pattern>
+          </sch:pattern>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
          <ref name="mei_att.ossia.log.attributes"/>
@@ -20695,17 +19034,17 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_pedal">
       <element name="pedal">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Piano pedal
-            mark.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Piano pedal mark.</a:documentation>
          <empty/>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-pedal-pedal_start-type_attributes_required-constraint-64">
+                  id="mei-pedal-pedal_start-type_attributes_required-constraint-64">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:pedal">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:pedal">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -20720,9 +19059,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_reh">
       <element name="reh">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(rehearsal
-            mark) – In an orchestral score and its corresponding parts, a mark indicating a
-            convenient point from which to resume rehearsal after a break.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(rehearsal mark) – In an orchestral score and its corresponding parts, a mark indicating a convenient point from which to resume rehearsal after a break.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -20743,36 +19080,35 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_slur">
       <element name="slur">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indication
-            of 1) a "unified melodic idea" or 2) performance technique.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indication of 1) a "unified melodic idea" or 2) performance technique.</a:documentation>
          <zeroOrMore>
             <ref name="mei_curve"/>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-slur-slur_start-_and_end-type_attributes_required-constraint-65">
+                  id="mei-slur-slur_start-_and_end-type_attributes_required-constraint-65">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:slur">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:slur">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
                <sch:assert test="@dur or @dur.ges or @endid or @tstamp2">Must have one of the
-                  attributes: dur, dur.ges, endid, or tstamp2.</sch:assert>
+              attributes: dur, dur.ges, endid, or tstamp2.</sch:assert>
             </sch:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-slur-slur_containing_curve-constraint-66">
+                  id="mei-slur-slur_containing_curve-constraint-66">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0"
-               context="mei:slur[mei:curve[@bezier or @bulge or @curvedir or @lform or @lwidth or              @ho or @startho or @endho or @to or @startto or @endto or @vo or @startvo or @endvo or              @x or @y or @x2 or @y2]]">
-               <sch:assert
-                  test="not(@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or @startho or                @endho or @to or @startto or @endto or @vo or @startvo or @endvo or @x or @y or @x2 or @y2)"
-                  role="warning">The visual attributes of the slur (@bezier, @bulge, @curvedir,
-                  @lform, @lwidth, @ho, @startho, @endho, @to, @startto, @endto, @vo, @startvo,
-                  @endvo, @x, @y, @x2, and @y2) will be overridden by visual attributes of the
-                  contained curve elements.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:slur[mei:curve[@bezier or @bulge or @curvedir or @lform or @lwidth or              @ho or @startho or @endho or @to or @startto or @endto or @vo or @startvo or @endvo or              @x or @y or @x2 or @y2]]">
+               <sch:assert test="not(@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or @startho or                @endho or @to or @startto or @endto or @vo or @startvo or @endvo or @x or @y or @x2 or @y2)"
+                           role="warning">The visual attributes of the slur (@bezier, @bulge, @curvedir, @lform,
+              @lwidth, @ho, @startho, @endho, @to, @startto, @endto, @vo, @startvo, @endvo, @x, @y,
+              @x2, and @y2) will be overridden by visual attributes of the contained curve
+              elements.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -20787,37 +19123,35 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_tie">
       <element name="tie">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An
-            indication that two notes of the same pitch form a single note with their combined
-            rhythmic values.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An indication that two notes of the same pitch form a single note with their combined rhythmic values.</a:documentation>
          <zeroOrMore>
             <ref name="mei_curve"/>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-tie-tie_start-_and_end-type_attributes_required-constraint-67">
+                  id="mei-tie-tie_start-_and_end-type_attributes_required-constraint-67">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:tie">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:tie">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
                <sch:assert test="@dur or @dur.ges or @endid or @tstamp2">Must have one of the
-                  attributes: dur, dur.ges, endid, or tstamp2.</sch:assert>
+              attributes: dur, dur.ges, endid, or tstamp2.</sch:assert>
             </sch:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-tie-tie_containing_curve-constraint-68">
+                  id="mei-tie-tie_containing_curve-constraint-68">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0"
-               context="mei:tie[mei:curve[@bezier or @bulge or @curvedir or @lform or @lwidth or              @ho or @startho or @endho or @to or @startto or @endto or @vo or @startvo or              @endvo or @x or @y or @x2 or @y2]]">
-               <sch:assert
-                  test="not(@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or @startho or                @endho or @to or @startto or @endto or @vo or @startvo or @endvo or @x or @y or @x2 or @y2)"
-                  role="warning">The visual attributes of the tie (@bezier, @bulge, @curvedir,
-                  @lform, @lwidth, @ho, @startho, @endho, @to, @startto, @endto, @vo, @startvo,
-                  @endvo, @x, @y, @x2, and @y2) will be overridden by visual attributes of the
-                  contained curve elements.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:tie[mei:curve[@bezier or @bulge or @curvedir or @lform or @lwidth or              @ho or @startho or @endho or @to or @startto or @endto or @vo or @startvo or              @endvo or @x or @y or @x2 or @y2]]">
+               <sch:assert test="not(@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or @startho or                @endho or @to or @startto or @endto or @vo or @startvo or @endvo or @x or @y or @x2 or @y2)"
+                           role="warning">The visual attributes of the tie (@bezier, @bulge, @curvedir, @lform,
+              @lwidth, @ho, @startho, @endho, @to, @startto, @endto, @vo, @startvo, @endvo, @x, @y,
+              @x2, and @y2) will be overridden by visual attributes of the contained curve
+              elements.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -20832,10 +19166,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_tuplet">
       <element name="tuplet">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A group of
-            notes with "irregular" (sometimes called "irrational") rhythmic values, for example,
-            three notes in the time normally occupied by two or nine in the time of
-            five.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A group of notes with "irregular" (sometimes called "irrational") rhythmic values, for example, three notes in the time normally occupied by two or nine in the time of five.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_model.eventLike"/>
@@ -20845,15 +19176,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </choice>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-tuplet-When_not_copyof_tuplet_content-constraint-69">
+                  id="mei-tuplet-When_not_copyof_tuplet_content-constraint-69">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:tuplet[not(@copyof)]">
-               <sch:assert
-                  test="count(descendant::*[local-name()='note' or local-name()='rest' or               local-name()='chord']) &gt; 1"
-                  >A tuplet without a copyof attribute must have at least 2 note, rest, or chord
-                  descendants.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:tuplet[not(@copyof)]">
+               <sch:assert test="count(descendant::*[local-name()='note' or local-name()='rest' or               local-name()='chord']) &gt; 1">A tuplet without a copyof attribute must have at least 2 note, rest, or chord
+              descendants.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -20867,20 +19197,19 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_tupletSpan">
       <element name="tupletSpan">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(tuplet
-            span) – Alternative element for encoding tuplets, especially useful for tuplets that
-            extend across bar lines.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(tuplet span) – Alternative element for encoding tuplets, especially useful for tuplets that extend across bar lines.</a:documentation>
          <empty/>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-tupletSpan-tupletSpan_start-_and_end-type_attributes_required-constraint-70">
+                  id="mei-tupletSpan-tupletSpan_start-_and_end-type_attributes_required-constraint-70">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:tupletSpan">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:tupletSpan">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
                <sch:assert test="@dur or @dur.ges or @endid or @tstamp2">Must have one of the
-                  attributes: dur, dur.ges, endid, or tstamp2.</sch:assert>
+              attributes: dur, dur.ges, endid, or tstamp2.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -20911,8 +19240,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.ligature.log.attribute.form">
       <optional>
          <attribute name="form">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               an indication of the function of the ligature.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides an indication of the function of the ligature.</a:documentation>
             <ref name="mei_data.LIGATUREFORM"/>
          </attribute>
       </optional>
@@ -20939,8 +19267,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mensur.vis.attribute.form">
       <optional>
          <attribute name="form">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               whether the base symbol is written vertically or horizontally.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates whether the base symbol is written vertically or horizontally.</a:documentation>
             <choice>
                <value>horizontal</value>
                <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
@@ -20953,8 +19280,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mensur.vis.attribute.orient">
       <optional>
          <attribute name="orient">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the rotation or reflection of the base symbol.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the rotation or reflection of the base symbol.</a:documentation>
             <ref name="mei_data.ORIENTATION"/>
          </attribute>
       </optional>
@@ -20970,8 +19296,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mensural.log.attribute.mensur.dot">
       <optional>
          <attribute name="mensur.dot">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Determines if a dot is to be added to the base symbol.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Determines if a dot is to be added to the base symbol.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -20979,8 +19304,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mensural.log.attribute.mensur.sign">
       <optional>
          <attribute name="mensur.sign">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The base
-               symbol in the mensuration sign/time signature of mensural notation.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The base symbol in the mensuration sign/time signature of mensural notation.</a:documentation>
             <ref name="mei_data.MENSURATIONSIGN"/>
          </attribute>
       </optional>
@@ -20988,9 +19312,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mensural.log.attribute.mensur.slash">
       <optional>
          <attribute name="mensur.slash">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the number lines added to the mensuration sign. For example, one slash is added for
-               what we now call 'alla breve'.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the number lines added to the mensuration sign. For example, one slash is added for what we now call 'alla breve'.</a:documentation>
             <data type="positiveInteger"/>
          </attribute>
       </optional>
@@ -20998,9 +19320,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mensural.log.attribute.proport.num">
       <optional>
          <attribute name="proport.num">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Together,
-               proport.num and proport.numbase specify a proportional change as a ratio, e.g., 1:3.
-               Proport.num is for the first value in the ratio.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Together, proport.num and proport.numbase specify a proportional change as a ratio, e.g., 1:3. Proport.num is for the first value in the ratio.</a:documentation>
             <data type="positiveInteger"/>
          </attribute>
       </optional>
@@ -21008,9 +19328,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mensural.log.attribute.proport.numbase">
       <optional>
          <attribute name="proport.numbase">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Together,
-               proport.num and proport.numbase specify a proportional change as a ratio, e.g., 1:3.
-               Proport.numbase is for the second value in the ratio.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Together, proport.num and proport.numbase specify a proportional change as a ratio, e.g., 1:3. Proport.numbase is for the second value in the ratio.</a:documentation>
             <data type="positiveInteger"/>
          </attribute>
       </optional>
@@ -21024,8 +19342,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mensural.shared.attribute.modusmaior">
       <optional>
          <attribute name="modusmaior">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the maxima-long relationship.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the maxima-long relationship.</a:documentation>
             <ref name="mei_data.MODUSMAIOR"/>
          </attribute>
       </optional>
@@ -21033,8 +19350,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mensural.shared.attribute.modusminor">
       <optional>
          <attribute name="modusminor">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the long-breve relationship.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the long-breve relationship.</a:documentation>
             <ref name="mei_data.MODUSMINOR"/>
          </attribute>
       </optional>
@@ -21042,8 +19358,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mensural.shared.attribute.prolatio">
       <optional>
          <attribute name="prolatio">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the semibreve-minim relationship.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the semibreve-minim relationship.</a:documentation>
             <ref name="mei_data.PROLATIO"/>
          </attribute>
       </optional>
@@ -21051,8 +19366,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mensural.shared.attribute.tempus">
       <optional>
          <attribute name="tempus">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the breve-semibreve relationship.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the breve-semibreve relationship.</a:documentation>
             <ref name="mei_data.TEMPUS"/>
          </attribute>
       </optional>
@@ -21067,9 +19381,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mensural.vis.attribute.mensur.color">
       <optional>
          <attribute name="mensur.color">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the color of the mensuration sign. Do not confuse this with the musical term 'color'
-               as used in pre-CMN notation.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the color of the mensuration sign. Do not confuse this with the musical term 'color' as used in pre-CMN notation.</a:documentation>
             <ref name="mei_data.COLOR"/>
          </attribute>
       </optional>
@@ -21077,8 +19389,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mensural.vis.attribute.mensur.form">
       <optional>
          <attribute name="mensur.form">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               whether the base symbol is written vertically or horizontally.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates whether the base symbol is written vertically or horizontally.</a:documentation>
             <choice>
                <value>horizontal</value>
                <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
@@ -21091,8 +19402,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mensural.vis.attribute.mensur.loc">
       <optional>
          <attribute name="mensur.loc">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the
-               staff location of the mensuration sign.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds the staff location of the mensuration sign.</a:documentation>
             <ref name="mei_data.STAFFLOC"/>
          </attribute>
       </optional>
@@ -21100,8 +19410,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mensural.vis.attribute.mensur.orient">
       <optional>
          <attribute name="mensur.orient">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the rotation or reflection of the base symbol.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the rotation or reflection of the base symbol.</a:documentation>
             <ref name="mei_data.ORIENTATION"/>
          </attribute>
       </optional>
@@ -21109,8 +19418,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mensural.vis.attribute.mensur.size">
       <optional>
          <attribute name="mensur.size">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               the relative size of the mensuration sign.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the relative size of the mensuration sign.</a:documentation>
             <ref name="mei_data.SIZE"/>
          </attribute>
       </optional>
@@ -21124,8 +19432,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.note.log.mensural.attribute.lig">
       <optional>
          <attribute name="lig">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               this element's participation in a ligature.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates this element's participation in a ligature.</a:documentation>
             <choice>
                <value>recta</value>
                <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
@@ -21158,8 +19465,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.rest.vis.mensural.attribute.spaces">
       <optional>
          <attribute name="spaces">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">States
-               how many spaces are covered by the rest.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">States how many spaces are covered by the rest.</a:documentation>
             <data type="positiveInteger"/>
          </attribute>
       </optional>
@@ -21324,8 +19630,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_ligature">
       <element name="ligature">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A mensural
-            notation symbol that combines two or more notes into a single sign.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A mensural notation symbol that combines two or more notes into a single sign.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.layerPart"/>
          </zeroOrMore>
@@ -21340,9 +19645,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_mensur">
       <element name="mensur">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >(mensuration) – Collects information about the metrical relationship between a note
-            value and the next smaller value; that is, either triple or duple.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(mensuration) – Collects information about the metrical relationship between a note value and the next smaller value; that is, either triple or duple.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
@@ -21355,8 +19658,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_proport">
       <element name="proport">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(proportion)
-            – Description of note duration as arithmetic ratio.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(proportion) – Description of note duration as arithmetic ratio.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
@@ -21380,8 +19682,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.ineume.log.attribute.form">
       <optional>
          <attribute name="form">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               a subclass or functional label for the neume.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a subclass or functional label for the neume.</a:documentation>
             <ref name="mei_data.INEUMEFORM"/>
          </attribute>
       </optional>
@@ -21389,8 +19690,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.ineume.log.attribute.name">
       <optional>
          <attribute name="name">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the name of the neume.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the name of the neume.</a:documentation>
             <ref name="mei_data.INEUMENAME"/>
          </attribute>
       </optional>
@@ -21421,8 +19721,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.uneume.log.attribute.form">
       <optional>
          <attribute name="form">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               a subclass or functional label for the neume.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a subclass or functional label for the neume.</a:documentation>
             <ref name="mei_data.UNEUMEFORM"/>
          </attribute>
       </optional>
@@ -21430,8 +19729,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.uneume.log.attribute.name">
       <optional>
          <attribute name="name">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the name of the neume.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the name of the neume.</a:documentation>
             <ref name="mei_data.UNEUMENAME"/>
          </attribute>
       </optional>
@@ -21605,9 +19903,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_ineume">
       <element name="ineume">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(interrupted
-            neume) – A graphically interrupted neume; that is, a neume which is logically a single
-            entity but is written using multiple signs.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(interrupted neume) – A graphically interrupted neume; that is, a neume which is logically a single entity but is written using multiple signs.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_model.eventLike"/>
@@ -21631,9 +19927,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_syllable">
       <element name="syllable">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Neume
-            notation can be thought of as "neumed text". Therefore, the syllable element provides
-            high-level organization in this repertoire.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Neume notation can be thought of as "neumed text". Therefore, the syllable element provides high-level organization in this repertoire.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_model.appLike"/>
@@ -21655,8 +19949,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_uneume">
       <element name="uneume">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >(uninterrupted neume) – A graphically-uninterrupted neume sign.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(uninterrupted neume) – A graphically-uninterrupted neume sign.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_model.eventLike"/>
@@ -21689,41 +19982,40 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.common.anl.attribute.copyof">
       <optional>
          <attribute name="copyof">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Points to
-               an element of which the current element is a copy.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Points to an element of which the current element is a copy.</a:documentation>
             <ref name="mei_data.URI"/>
          </attribute>
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.common.anl-copyof-When_copyof_element_empty-constraint-71">
+            id="mei-att.common.anl-copyof-When_copyof_element_empty-constraint-71">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="mei:*[@copyof]">
-         <sch:assert test="count(child::node()) = 0">An element with a copyof attribute cannot have
-            content.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="mei:*[@copyof]">
+                <sch:assert test="count(child::node()) = 0">An element with a copyof attribute
+                  cannot have content.</sch:assert>
+              </sch:rule>
    </pattern>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.common.anl-copyof-check_copyofTarget-constraint-72">
+            id="mei-att.common.anl-copyof-check_copyofTarget-constraint-72">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@copyof">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@copyof attribute should
-            have content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">The
-            value in @copyof should correspond to the @xml:id attribute of an element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@copyof">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@copyof attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">The value in @copyof should correspond to the @xml:id attribute of an
+                  element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.common.anl.attribute.corresp">
       <optional>
          <attribute name="corresp">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to
-               point to other elements that correspond to this one in a generic
-               fashion.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to point to other elements that correspond to this one in a generic fashion.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.URI"/>
@@ -21733,23 +20025,23 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.common.anl-corresp-check_correspTarget-constraint-73">
+            id="mei-att.common.anl-corresp-check_correspTarget-constraint-73">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@corresp">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@corresp attribute should
-            have content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">Each
-            value in @corresp should correspond to the @xml:id attribute of an element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@corresp">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@corresp attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">Each value in @corresp should correspond to the @xml:id attribute of an
+                  element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.common.anl.attribute.next">
       <optional>
          <attribute name="next">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to
-               point to the next event(s) in a user-defined collection.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to point to the next event(s) in a user-defined collection.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.URI"/>
@@ -21759,23 +20051,23 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.common.anl-next-check_nextTarget-constraint-74">
+            id="mei-att.common.anl-next-check_nextTarget-constraint-74">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@next">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@next attribute should have
-            content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">Each
-            value in @next should correspond to the @xml:id attribute of an element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@next">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@next attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">Each value in @next should correspond to the @xml:id attribute of an
+                  element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.common.anl.attribute.prev">
       <optional>
          <attribute name="prev">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Points to
-               the previous event(s) in a user-defined collection.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Points to the previous event(s) in a user-defined collection.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.URI"/>
@@ -21785,24 +20077,23 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.common.anl-prev-check_prevTarget-constraint-75">
+            id="mei-att.common.anl-prev-check_prevTarget-constraint-75">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@prev">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@prev attribute should have
-            content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">Each
-            value in @prev should correspond to the @xml:id attribute of an element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@prev">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@prev attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">Each value in @prev should correspond to the @xml:id attribute of an
+                  element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.common.anl.attribute.sameas">
       <optional>
          <attribute name="sameas">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Points to
-               an element that is the same as the current element but is not a literal copy of the
-               current element.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Points to an element that is the same as the current element but is not a literal copy of the current element.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.URI"/>
@@ -21812,23 +20103,23 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.common.anl-sameas-check_sameasTarget-constraint-76">
+            id="mei-att.common.anl-sameas-check_sameasTarget-constraint-76">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@sameas">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@sameas attribute should
-            have content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">Each
-            value in @sameas should correspond to the @xml:id attribute of an element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@sameas">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@sameas attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">Each value in @sameas should correspond to the @xml:id attribute of an
+                  element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.common.anl.attribute.synch">
       <optional>
          <attribute name="synch">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Points to
-               elements that are synchronous with the current element.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Points to elements that are synchronous with the current element.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.URI"/>
@@ -21838,17 +20129,18 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.common.anl-synch-check_synchTarget-constraint-77">
+            id="mei-att.common.anl-synch-check_synchTarget-constraint-77">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@synch">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@synch attribute should
-            have content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">Each
-            value in @synch should correspond to the @xml:id attribute of an element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@synch">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@synch attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*/@xml:id">Each value in @synch should correspond to the @xml:id attribute of an
+                  element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.harmonicfunction.attributes">
       <ref name="mei_att.harmonicfunction.attribute.deg"/>
@@ -21856,11 +20148,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.harmonicfunction.attribute.deg">
       <optional>
          <attribute name="deg">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures
-               relative scale degree information using Humdrum **deg syntax -- an optional indicator
-               of melodic approach (^ = ascending approach, v = descending approach), a scale degree
-               value (1 = tonic ... 7 = leading tone), and an optional indication of chromatic
-               alteration. The amount of chromatic alternation is not indicated.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures relative scale degree information using Humdrum **deg syntax -- an optional indicator of melodic approach (^ = ascending approach, v = descending approach), a scale degree value (1 = tonic ... 7 = leading tone), and an optional indication of chromatic alteration. The amount of chromatic alternation is not indicated.</a:documentation>
             <ref name="mei_data.SCALEDEGREE"/>
          </attribute>
       </optional>
@@ -21871,8 +20159,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.intervalharmonic.attribute.inth">
       <optional>
          <attribute name="inth">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes
-               the harmonic interval between pitches occurring at the same time.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes the harmonic interval between pitches occurring at the same time.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.INTERVAL.HARMONIC"/>
@@ -21887,10 +20174,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.intervalmelodic.attribute.intm">
       <optional>
          <attribute name="intm">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes
-               the melodic interval from the previous pitch. The value may be a general directional
-               indication (u, d, s), an indication of diatonic interval direction, quality, and
-               size, or a precise numeric value in half steps.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Encodes the melodic interval from the previous pitch. The value may be a general directional indication (u, d, s), an indication of diatonic interval direction, quality, and size, or a precise numeric value in half steps.</a:documentation>
             <ref name="mei_data.INTERVAL.MELODIC"/>
          </attribute>
       </optional>
@@ -21901,8 +20185,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.melodicfunction.attribute.mfunc">
       <optional>
          <attribute name="mfunc">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               melodic function using Humdrum **embel syntax.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes melodic function using Humdrum **embel syntax.</a:documentation>
             <ref name="mei_data.MELODICFUNCTION"/>
          </attribute>
       </optional>
@@ -21913,8 +20196,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.pitchclass.attribute.pclass">
       <optional>
          <attribute name="pclass">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds
-               pitch class information.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds pitch class information.</a:documentation>
             <ref name="mei_data.PITCHCLASS"/>
          </attribute>
       </optional>
@@ -21925,9 +20207,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.solfa.attribute.psolfa">
       <optional>
          <attribute name="psolfa">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               sol-fa designation, e.g., do, re, mi, etc., in either a fixed or movable Do
-               system.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains sol-fa designation, e.g., do, re, mi, etc., in either a fixed or movable Do system.</a:documentation>
             <data type="NMTOKEN"/>
          </attribute>
       </optional>
@@ -21948,21 +20228,12 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mordent.log.attribute.form">
       <optional>
          <attribute name="form">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Traditionally, the 'normal' mordent is written as a short wavy line with a vertical
-               line through it and the inverted mordent is written without the vertical line.
-               However, the meaning of these signs is sometimes reversed. See Read, p. 245-246.
-               Another attribute in the visual domain would be necessary in order to be completely
-               explicit about which visual symbol is actually to be rendered.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Traditionally, the 'normal' mordent is written as a short wavy line with a vertical line through it and the inverted mordent is written without the vertical line. However, the meaning of these signs is sometimes reversed. See Read, p. 245-246. Another attribute in the visual domain would be necessary in order to be completely explicit about which visual symbol is actually to be rendered.</a:documentation>
             <choice>
                <value>inv</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Inverted mordent, e.g., performed as the principal note, followed by its upper
-                  neighbor, with a return to the principal note.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Inverted mordent, e.g., performed as the principal note, followed by its upper neighbor, with a return to the principal note.</a:documentation>
                <value>norm</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >"normal" mordent, e.g., performed as the written note, followed by its lower
-                  neighbor, with a return to the written note.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">"normal" mordent, e.g., performed as the written note, followed by its lower neighbor, with a return to the written note.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -21970,9 +20241,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.mordent.log.attribute.long">
       <optional>
          <attribute name="long">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">When the
-               long attribute is set to 'yes', a double or long mordent, consisting of 5 notes, is
-               indicated.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">When the long attribute is set to 'yes', a double or long mordent, consisting of 5 notes, is indicated.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -21991,10 +20260,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.ornam.attribute.ornam">
       <optional>
          <attribute name="ornam">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               that this element has an attached ornament. If visual information about the ornament
-               is needed, then one of the elements that represents an ornament (mordent, trill, or
-               turn) should be employed.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates that this element has an attached ornament. If visual information about the ornament is needed, then one of the elements that represents an ornament (mordent, trill, or turn) should be employed.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.ORNAM.cmn"/>
@@ -22010,8 +20276,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.ornamentaccid.attribute.accidupper">
       <optional>
          <attribute name="accidupper">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the written accidental associated with an upper neighboring note.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the written accidental associated with an upper neighboring note.</a:documentation>
             <ref name="mei_data.ACCIDENTAL.EXPLICIT"/>
          </attribute>
       </optional>
@@ -22019,8 +20284,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.ornamentaccid.attribute.accidlower">
       <optional>
          <attribute name="accidlower">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the written accidental associated with a lower neighboring note.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the written accidental associated with a lower neighboring note.</a:documentation>
             <ref name="mei_data.ACCIDENTAL.EXPLICIT"/>
          </attribute>
       </optional>
@@ -22067,9 +20331,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.turn.log.attribute.delayed">
       <optional>
          <attribute name="delayed">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">When the
-               delayed attribute is set to 'true', the turn begins on the second half of the beat.
-               See Read, p. 246.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">When the delayed attribute is set to 'true', the turn begins on the second half of the beat. See Read, p. 246.</a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -22077,15 +20339,12 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.turn.log.attribute.form">
       <optional>
          <attribute name="form">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the style of the turn.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the style of the turn.</a:documentation>
             <choice>
                <value>inv</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Inverted turn, e.g., begins on the note below the written note.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Inverted turn, e.g., begins on the note below the written note.</a:documentation>
                <value>norm</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >"normal" turn, e.g., begins on the note above the written note.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">"normal" turn, e.g., begins on the note above the written note.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -22153,18 +20412,17 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_mordent">
       <element name="mordent">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An ornament
-            indicating rapid alternation of the main note with a secondary note, usually a step
-            below, but sometimes a step above. </a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An ornament indicating rapid alternation of the main note with a secondary note, usually a step below, but sometimes a step above. </a:documentation>
          <empty/>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-mordent-mordent_start-type_attributes_required-constraint-78">
+                  id="mei-mordent-mordent_start-type_attributes_required-constraint-78">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:mordent">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:mordent">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -22179,18 +20437,17 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_trill">
       <element name="trill">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Rapid
-            alternation of a note with another (usually at the interval of a second
-            above).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Rapid alternation of a note with another (usually at the interval of a second above).</a:documentation>
          <empty/>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-trill-trill_start-type_attributes_required-constraint-79">
+                  id="mei-trill-trill_start-type_attributes_required-constraint-79">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:trill">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:trill">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -22205,18 +20462,17 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_turn">
       <element name="turn">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An ornament
-            consisting of four notes — the upper neighbor of the written note, the written note, the
-            lower neighbor, and the written note.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An ornament consisting of four notes — the upper neighbor of the written note, the written note, the lower neighbor, and the written note.</a:documentation>
          <empty/>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-turn-turn_start-type_attributes_required-constraint-80">
+                  id="mei-turn-turn_start-type_attributes_required-constraint-80">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:turn">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:turn">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -22231,9 +20487,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_meiCorpus">
       <element name="meiCorpus">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(MEI corpus)
-            – A group of related MEI documents, consisting of a header for the group, and one or
-            more &lt;mei&gt; elements, each with its own complete header.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(MEI corpus) – A group of related MEI documents, consisting of a header for the group, and one or more &lt;mei&gt; elements, each with its own complete header.</a:documentation>
          <ref name="mei_meiHead"/>
          <zeroOrMore>
             <ref name="mei_mei"/>
@@ -22253,9 +20507,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.crit.attribute.cause">
       <optional>
          <attribute name="cause">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Classifies the cause for the variant reading, according to any appropriate typology
-               of possible origins.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Classifies the cause for the variant reading, according to any appropriate typology of possible origins.</a:documentation>
             <data type="NMTOKEN"/>
          </attribute>
       </optional>
@@ -22278,10 +20530,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.source.attribute.source">
       <optional>
          <attribute name="source">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               a list of one or more pointers indicating the sources which attest to a given
-               reading. Each value should correspond to the ID of a &lt;source&gt; element located
-               in the document header.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a list of one or more pointers indicating the sources which attest to a given reading. Each value should correspond to the ID of a &lt;source&gt; element located in the document header.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.URI"/>
@@ -22291,18 +20540,18 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.source-source-check_sourceTarget-constraint-81">
+            id="mei-att.source-source-check_sourceTarget-constraint-81">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@source">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@source attribute should
-            have content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:source/@xml:id"
-            >Each value in @source should correspond to the @xml:id attribute of a source
-            element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@source">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@source attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:source/@xml:id">Each value in @source should correspond to the @xml:id attribute of a source
+                  element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_model.appLike">
       <choice>
@@ -22326,8 +20575,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_app">
       <element name="app">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(apparatus)
-            – Contains one or more alternative encodings.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(apparatus) – Contains one or more alternative encodings.</a:documentation>
          <optional>
             <ref name="mei_lem"/>
          </optional>
@@ -22342,8 +20590,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_lem">
       <element name="lem">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(lemma) –
-            Contains the lemma, or base text, of a textual variation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(lemma) – Contains the lemma, or base text, of a textual variation.</a:documentation>
          <zeroOrMore>
             <ref name="mei_expansion"/>
          </zeroOrMore>
@@ -22375,8 +20622,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_rdg">
       <element name="rdg">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(reading) –
-            Contains a single reading within a textual variation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(reading) – Contains a single reading within a textual variation.</a:documentation>
          <zeroOrMore>
             <ref name="mei_expansion"/>
          </zeroOrMore>
@@ -22412,9 +20658,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.agentident.attribute.agent">
       <optional>
          <attribute name="agent">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Signifies
-               the causative agent of damage, illegibility, or other loss of original
-               text.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Signifies the causative agent of damage, illegibility, or other loss of original text.</a:documentation>
             <data type="string"/>
          </attribute>
       </optional>
@@ -22431,8 +20675,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.evidence.attribute.cert">
       <optional>
          <attribute name="cert">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Signifies
-               the degree of certainty or precision associated with a feature.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Signifies the degree of certainty or precision associated with a feature.</a:documentation>
             <ref name="mei_data.CERTAINTY"/>
          </attribute>
       </optional>
@@ -22440,10 +20683,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.evidence.attribute.evidence">
       <optional>
          <attribute name="evidence">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the nature of the evidence supporting the reliability or accuracy of the intervention
-               or interpretation. Suggested values include: 'internal', 'external',
-               'conjecture'.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the nature of the evidence supporting the reliability or accuracy of the intervention or interpretation. Suggested values include: 'internal', 'external', 'conjecture'.</a:documentation>
             <data type="NMTOKEN"/>
          </attribute>
       </optional>
@@ -22454,8 +20694,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.extent.attribute.extent">
       <optional>
          <attribute name="extent">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the extent of damage or omission.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the extent of damage or omission.</a:documentation>
             <data type="string"/>
          </attribute>
       </optional>
@@ -22466,10 +20705,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.reasonident.attribute.reason">
       <optional>
          <attribute name="reason">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds a
-               short phrase describing the reason for missing textual material (gap), why material
-               is supplied (supplied), or why transcription is difficult
-               (unclear).</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Holds a short phrase describing the reason for missing textual material (gap), why material is supplied (supplied), or why transcription is difficult (unclear).</a:documentation>
             <data type="string"/>
          </attribute>
       </optional>
@@ -22513,9 +20749,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_abbr">
       <element name="abbr" ns="http://www.music-encoding.org/ns/mei">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >(abbreviation) – A generic element for 1) a shortened form of a word, including an
-            acronym or 2) a shorthand notation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(abbreviation) – A generic element for 1) a shortened form of a word, including an acronym or 2) a shorthand notation.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -22545,8 +20779,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.typed.attributes"/>
          <optional>
             <attribute name="expan">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Records the expansion of a text abbreviation.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the expansion of a text abbreviation.</a:documentation>
                <data type="string"/>
             </attribute>
          </optional>
@@ -22555,8 +20788,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_add">
       <element name="add">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(addition) –
-            Marks an addition to the text.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(addition) – Marks an addition to the text.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -22586,19 +20818,15 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.typed.attributes"/>
          <optional>
             <attribute name="method">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Contains an indication of how the addition was accomplished. Suggested values
-                  include: 1] interline; 2] intraline; 3] overstrike</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains an indication of how the addition was accomplished.
+Suggested values include: 1] interline; 2] intraline; 3] overstrike</a:documentation>
                <choice>
                   <value>interline</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">New
-                     material added to the existing text.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">New material added to the existing text.</a:documentation>
                   <value>intraline</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">New
-                     material added above or below original text.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">New material added above or below original text.</a:documentation>
                   <value>overstrike</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">New
-                     text obscures original.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">New text obscures original.</a:documentation>
                   <data type="NMTOKEN"/>
                </choice>
             </attribute>
@@ -22608,8 +20836,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_choice">
       <element name="choice">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Groups a
-            number of alternative encodings for the same point in a text.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Groups a number of alternative encodings for the same point in a text.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.choicePart"/>
          </zeroOrMore>
@@ -22619,8 +20846,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_corr">
       <element name="corr">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(correction)
-            – Contains the correct form of an apparent erroneous passage.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(correction) – Contains the correct form of an apparent erroneous passage.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -22652,8 +20878,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_damage">
       <element name="damage">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains an
-            area of damage to the physical medium.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains an area of damage to the physical medium.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -22684,8 +20909,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.typed.attributes"/>
          <optional>
             <attribute name="degree">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Records the degree of damage.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the degree of damage.</a:documentation>
                <data type="string"/>
             </attribute>
          </optional>
@@ -22694,10 +20918,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_del">
       <element name="del">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(deletion) –
-            Contains information deleted, marked as deleted, or otherwise indicated as superfluous
-            or spurious in the copy text by an author, scribe, annotator, or
-            corrector.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(deletion) – Contains information deleted, marked as deleted, or otherwise indicated as superfluous or spurious in the copy text by an author, scribe, annotator, or corrector.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -22726,9 +20947,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.typed.attributes"/>
          <optional>
             <attribute name="rend">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Captures the appearance of the source material using MEI-defined
-                  descriptors.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures the appearance of the source material using MEI-defined descriptors.</a:documentation>
                <list>
                   <oneOrMore>
                      <ref name="mei_data.TEXTRENDITION"/>
@@ -22741,8 +20960,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_expan">
       <element name="expan">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(expansion)
-            – Contains the expansion of an abbreviation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(expansion) – Contains the expansion of an abbreviation.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -22772,8 +20990,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.typed.attributes"/>
          <optional>
             <attribute name="abbr">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Captures the abbreviated form of the text.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures the abbreviated form of the text.</a:documentation>
                <data type="string"/>
             </attribute>
          </optional>
@@ -22782,9 +20999,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_gap">
       <element name="gap">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates a
-            point where material has been omitted in a transcription, whether as part of sampling
-            practice or for editorial reasons described in the MEI header.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates a point where material has been omitted in a transcription, whether as part of sampling practice or for editorial reasons described in the MEI header.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.edit.attributes"/>
@@ -22797,9 +21012,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_handShift">
       <element name="handShift">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Marks the
-            beginning of a passage written in a new hand, or of a change in the scribe, writing
-            style, ink or character of the document hand.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Marks the beginning of a passage written in a new hand, or of a change in the scribe, writing style, ink or character of the document hand.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.edit.attributes"/>
@@ -22807,63 +21020,56 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.medium.attributes"/>
          <optional>
             <attribute name="character">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Describes the character of the new hand.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the character of the new hand.</a:documentation>
                <text/>
             </attribute>
          </optional>
          <optional>
             <attribute name="new">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Identifies the new hand. The value must contain the ID of a hand element given
-                  elsewhere in the document.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the new hand. The value must contain the ID of a hand element given elsewhere in the document.</a:documentation>
                <ref name="mei_data.URI"/>
             </attribute>
          </optional>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-handShift-new-check_newTarget-constraint-82">
+                  id="mei-handShift-new-check_newTarget-constraint-82">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="@new">
-               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@new attribute should
-                  have content.</sch:assert>
-               <sch:assert role="warning"
-                  test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:hand/@xml:id"
-                  >The value in @new should correspond to the @xml:id attribute of a hand
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="@new">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@new attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                           test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:hand/@xml:id">The value in @new should correspond to the @xml:id attribute of a hand
                   element.</sch:assert>
-            </sch:rule>
+              </sch:rule>
          </pattern>
          <optional>
             <attribute name="old">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Identifies the old hand. The value must contain the ID of a hand element given
-                  elsewhere in the document.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the old hand. The value must contain the ID of a hand element given elsewhere in the document.</a:documentation>
                <ref name="mei_data.URI"/>
             </attribute>
          </optional>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-handShift-old-check_oldTarget-constraint-83">
+                  id="mei-handShift-old-check_oldTarget-constraint-83">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="@old">
-               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@old attribute should
-                  have content.</sch:assert>
-               <sch:assert role="warning"
-                  test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:hand/@xml:id"
-                  >The value in @old should correspond to the @xml:id attribute of a hand
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="@old">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@old attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                           test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:hand/@xml:id">The value in @old should correspond to the @xml:id attribute of a hand
                   element.</sch:assert>
-            </sch:rule>
+              </sch:rule>
          </pattern>
          <empty/>
       </element>
    </define>
    <define name="mei_orig">
       <element name="orig">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(original) –
-            Contains material which is marked as following the original, rather than being
-            normalized or corrected.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(original) – Contains material which is marked as following the original, rather than being normalized or corrected.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -22895,9 +21101,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_reg">
       <element name="reg">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >(regularization) – Contains material which has been regularized or normalized in some
-            sense.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(regularization) – Contains material which has been regularized or normalized in some sense.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -22928,9 +21132,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_restore">
       <element name="restore">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-            restoration of material to an earlier state by cancellation of an editorial or authorial
-            marking or instruction.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates restoration of material to an earlier state by cancellation of an editorial or authorial marking or instruction.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -22960,9 +21162,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.typed.attributes"/>
          <optional>
             <attribute name="desc">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Provides a description of the means of restoration, 'stet' or 'strike-down', for
-                  example.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a description of the means of restoration, 'stet' or 'strike-down', for example.</a:documentation>
                <data type="string"/>
             </attribute>
          </optional>
@@ -22971,8 +21171,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_sic">
       <element name="sic">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-            apparently incorrect or inaccurate material.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains apparently incorrect or inaccurate material.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -23002,9 +21201,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_subst">
       <element name="subst">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >(substitution) – Groups transcriptional elements when the combination is to be regarded
-            as a single intervention in the text.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(substitution) – Groups transcriptional elements when the combination is to be regarded as a single intervention in the text.</a:documentation>
          <ref name="mei_model.transcriptionLike"/>
          <oneOrMore>
             <ref name="mei_model.transcriptionLike"/>
@@ -23017,8 +21214,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_supplied">
       <element name="supplied">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-            material supplied by the transcriber or editor for any reason.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains material supplied by the transcriber or editor for any reason.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -23052,9 +21248,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_unclear">
       <element name="unclear">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-            material that cannot be transcribed with certainty because it is illegible or inaudible
-            in the source.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains material that cannot be transcribed with certainty because it is illegible or inaudible in the source.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -23093,28 +21287,26 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.extsym.attribute.glyphname">
       <optional>
          <attribute name="glyphname">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Glyph
-               name.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Glyph name.</a:documentation>
             <data type="string"/>
          </attribute>
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.extsym-glyphname-check_glyphnameTarget-constraint-84">
+            id="mei-att.extsym-glyphname-check_glyphnameTarget-constraint-84">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@glyphname">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@glyphname attribute should
-            have content.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@glyphname">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@glyphname attribute
+                  should have content.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.extsym.attribute.glyphnum">
       <optional>
          <attribute name="glyphnum">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Numeric
-               glyph reference in hexadecimal notation, e.g. "#xE000" or "U+E000". N.B. SMuFL
-               version 1.18 uses the range U+E000 - U+ECBF.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Numeric glyph reference in hexadecimal notation, e.g. "#xE000" or "U+E000". N.B. SMuFL version 1.18 uses the range U+E000 - U+ECBF.</a:documentation>
             <data type="string">
                <param name="pattern">(#x|U\+)[A-F0-9]+</param>
             </data>
@@ -23122,14 +21314,15 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.extsym-glyphnum-check_glyphnum-constraint-85">
+            id="mei-att.extsym-glyphnum-check_glyphnum-constraint-85">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="mei:*[starts-with(@glyphnum, 'U+')]">
-         <sch:assert role="warning" test="string-length(@glyphnum) = 6">SMuFL version 1.18 uses the
-            range U+E000 - U+ECBF.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="mei:*[starts-with(@glyphnum, 'U+')]">
+                <sch:assert role="warning" test="string-length(@glyphnum) = 6">SMuFL version 1.18
+                  uses the range U+E000 - U+ECBF.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.facsimile.attributes">
       <ref name="mei_att.facsimile.attribute.facs"/>
@@ -23137,9 +21330,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.facsimile.attribute.facs">
       <optional>
          <attribute name="facs">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Permits
-               the current element to reference a facsimile surface or image zone which corresponds
-               to it.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Permits the current element to reference a facsimile surface or image zone which corresponds to it.</a:documentation>
             <list>
                <oneOrMore>
                   <ref name="mei_data.URI"/>
@@ -23149,24 +21340,22 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.facsimile-facs-check_facsTarget-constraint-86">
+            id="mei-att.facsimile-facs-check_facsTarget-constraint-86">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@facs">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@facs attribute should have
-            content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*[local-name() eq 'surface' or local-name() eq 'zone']/@xml:id"
-            >Each value in @facs should correspond to the @xml:id attribute of a surface or zone
-            element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@facs">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@facs attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:*[local-name() eq 'surface' or local-name() eq 'zone']/@xml:id">Each value in @facs should correspond to the @xml:id attribute of a surface or
+                  zone element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_facsimile">
       <element name="facsimile">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a
-            representation of some written source in the form of a set of images rather than as
-            transcribed or encoded text.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a representation of some written source in the form of a set of images rather than as transcribed or encoded text.</a:documentation>
          <zeroOrMore>
             <ref name="mei_surface"/>
          </zeroOrMore>
@@ -23177,10 +21366,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_surface">
       <element name="surface">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Defines a
-            writing surface in terms of a rectangular coordinate space, optionally grouping one or
-            more graphic representations of that space, and rectangular zones of interest within
-            it.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Defines a writing surface in terms of a rectangular coordinate space, optionally grouping one or more graphic representations of that space, and rectangular zones of interest within it.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.figDescLike"/>
          </zeroOrMore>
@@ -23201,8 +21387,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_zone">
       <element name="zone">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Defines an
-            area of interest within a surface or graphic file.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Defines an area of interest within a surface or graphic file.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.figDescLike"/>
          </zeroOrMore>
@@ -23223,8 +21408,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.tabular.attribute.colspan">
       <optional>
          <attribute name="colspan">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The
-               number of columns spanned by this cell.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The number of columns spanned by this cell.</a:documentation>
             <data type="positiveInteger"/>
          </attribute>
       </optional>
@@ -23232,8 +21416,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.tabular.attribute.rowspan">
       <optional>
          <attribute name="rowspan">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The
-               number of rows spanned by this cell.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">The number of rows spanned by this cell.</a:documentation>
             <data type="positiveInteger"/>
          </attribute>
       </optional>
@@ -23283,9 +21466,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_fig">
       <element name="fig">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(figure) –
-            Groups elements representing or containing graphic information such as an illustration
-            or figure.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(figure) – Groups elements representing or containing graphic information such as an illustration or figure.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_model.captionLike"/>
@@ -23302,10 +21483,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_figDesc">
       <element name="figDesc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(figure
-            description) – Contains a brief prose description of the appearance or content of a
-            graphic figure, for use when documenting an image without displaying
-            it.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(figure description) – Contains a brief prose description of the appearance or content of a graphic figure, for use when documenting an image without displaying it.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -23314,18 +21492,16 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </choice>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-figDesc-figDesc_content_constraint-constraint-87">
+                  id="mei-figDesc-figDesc_content_constraint-constraint-87">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0"
-               context="mei:figDesc[mei:lg or mei:p or mei:quote or mei:table]">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:figDesc[mei:lg or mei:p or mei:quote or mei:table]">
                <sch:assert test="not(*[../text()[normalize-space()]])">Mixed content is not allowed
-                  when lg, p, quote, or table is used.</sch:assert>
-               <sch:assert
-                  test="not(*[not(local-name() eq 'biblList' or local-name() eq 'castList' or                local-name() eq 'lg' or local-name() eq 'list' or local-name() eq 'p' or                local-name() eq 'quote' or local-name() eq 'table')])"
-                  >Unstructured text not allowed when lg, p, quote, or table elements are
-                  used.</sch:assert>
+              when lg, p, quote, or table is used.</sch:assert>
+               <sch:assert test="not(*[not(local-name() eq 'biblList' or local-name() eq 'castList' or                local-name() eq 'lg' or local-name() eq 'list' or local-name() eq 'p' or                local-name() eq 'quote' or local-name() eq 'table')])">Unstructured text not allowed when lg, p, quote, or table elements are
+              used.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -23335,42 +21511,43 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_graphic">
       <element name="graphic">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-            the location of an inline graphic.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the location of an inline graphic.</a:documentation>
          <zeroOrMore>
             <ref name="mei_zone"/>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-graphic-graphic_attributes-constraint-88">
+                  id="mei-graphic-graphic_attributes-constraint-88">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:zone/mei:graphic">
-               <sch:assert role="warning" test="count(mei:*) = 0">Graphic child of zone should not
-                  have children.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:zone/mei:graphic">
+               <sch:assert role="warning" test="count(mei:*) = 0">Graphic child of zone should not have
+              children.</sch:assert>
             </sch:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-graphic-graphic_attributes-constraint-89">
+                  id="mei-graphic-graphic_attributes-constraint-89">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:symbolDef/mei:graphic">
-               <sch:assert role="warning" test="@startid or (@ulx and @uly)">Graphic should have
-                  either a startid attribute or ulx and uly attributes.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:symbolDef/mei:graphic">
+               <sch:assert role="warning" test="@startid or (@ulx and @uly)">Graphic should have either
+              a startid attribute or ulx and uly attributes.</sch:assert>
             </sch:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-graphic-graphic_attributes-constraint-90">
+                  id="mei-graphic-graphic_attributes-constraint-90">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0"
-               context="mei:graphic[not(ancestor::mei:symbolDef or ancestor::mei:zone)]">
-               <sch:assert role="warning" test="not(@ulx or @uly)">Graphic should not have @ulx or
-                  @uly attributes.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:graphic[not(ancestor::mei:symbolDef or ancestor::mei:zone)]">
+               <sch:assert role="warning" test="not(@ulx or @uly)">Graphic should not have @ulx or @uly
+              attributes.</sch:assert>
                <sch:assert role="warning" test="not(@ho or @vo)">Graphic should not have @ho or @vo
-                  attributes.</sch:assert>
+              attributes.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -23385,15 +21562,13 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.visualoffset.attributes"/>
          <optional>
             <attribute name="ulx">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Indicates the upper-left corner x coordinate.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the upper-left corner x coordinate.</a:documentation>
                <data type="nonNegativeInteger"/>
             </attribute>
          </optional>
          <optional>
             <attribute name="uly">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Indicates the upper-left corner y coordinate.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the upper-left corner y coordinate.</a:documentation>
                <data type="nonNegativeInteger"/>
             </attribute>
          </optional>
@@ -23402,8 +21577,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_table">
       <element name="table">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-            text displayed in tabular form.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains text displayed in tabular form.</a:documentation>
          <optional>
             <ref name="mei_model.captionLike"/>
          </optional>
@@ -23422,9 +21596,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_td">
       <element name="td">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(table data)
-            – Designates a table cell that contains data as opposed to a cell that contains column
-            or row heading information.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(table data) – Designates a table cell that contains data as opposed to a cell that contains column or row heading information.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -23444,9 +21616,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_th">
       <element name="th">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(table
-            header) – Designates a table cell containing column or row heading information as
-            opposed to one containing data.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(table header) – Designates a table cell containing column or row heading information as opposed to one containing data.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -23466,9 +21636,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_tr">
       <element name="tr">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(table row)
-            – A formatting element that contains one or more cells (intersection of a row and a
-            column) in a &lt;table&gt;.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(table row) – A formatting element that contains one or more cells (intersection of a row and a column) in a &lt;table&gt;.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_th"/>
@@ -23522,14 +21690,11 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
             <choice>
                <value>alter</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >alternation of fingers.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">alternation of fingers.</a:documentation>
                <value>combi</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >combination of fingers.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">combination of fingers.</a:documentation>
                <value>subst</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >substitution of fingers.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">substitution of fingers.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -23548,12 +21713,9 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
             <choice>
                <value>horiz</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Combination expressed horizontally, as for brass instruments.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Combination expressed horizontally, as for brass instruments.</a:documentation>
                <value>vert</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Combination expressed vertically, as for woodwind instruments or
-                  piano.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Combination expressed vertically, as for woodwind instruments or piano.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -23600,8 +21762,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_fing">
       <element name="fing">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">finger – An
-            individual finger in a fingering indication.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">finger – An individual finger in a fingering indication.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -23611,13 +21772,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </choice>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-fing-stack_exclusion-constraint-91">
+                  id="mei-fing-stack_exclusion-constraint-91">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:fing">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:fing">
                <sch:assert test="not(descendant::mei:stack)">The stack element is not allowed as a
-                  descendant of fing.</sch:assert>
+              descendant of fing.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -23632,8 +21794,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_fingGrp">
       <element name="fingGrp">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(finger
-            group)– A group of individual fingers in a fingering indication.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(finger group)– A group of individual fingers in a fingering indication.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_model.fingeringLike"/>
@@ -23642,31 +21803,30 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </choice>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-fingGrp-require_fingeringLike_children-constraint-92">
+                  id="mei-fingGrp-require_fingeringLike_children-constraint-92">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:fingGrp">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:fingGrp">
                <sch:assert test="count(mei:fing) + count(mei:fingGrp) &gt; 1">At least 2 fing or
-                  fingGrp elements are required.</sch:assert>
+              fingGrp elements are required.</sch:assert>
             </sch:rule>
          </pattern>
          <sch:pattern xmlns:rng="http://relaxng.org/ns/structure/1.0"
-            xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-            xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            xmlns="http://www.tei-c.org/ns/1.0">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0">
             <sch:rule context="mei:fingGrp[not(ancestor::mei:fingGrp)][@tstamp or @startid]">
-               <sch:assert test="not(child::mei:*[@tstamp or @startid])">When @tstamp or @startid is
-                  present on fingGrp, its child elements cannot have a @tstamp or @startid
-                  attribute.</sch:assert>
+              <sch:assert test="not(child::mei:*[@tstamp or @startid])">When @tstamp or @startid is
+                present on fingGrp, its child elements cannot have a @tstamp or @startid
+                attribute.</sch:assert>
             </sch:rule>
             <sch:rule context="mei:fingGrp[not(ancestor::mei:fingGrp)][not(@tstamp or @startid)]">
-               <sch:assert
-                  test="count(descendant::mei:*[@tstamp or @startid]) = count(child::mei:*[local-name()='fing' or local-name()='fingGrp'])"
-                  >When @tstamp or @startid is not present on fingGrp, each of its child elements
-                  must have a @tstamp or @startid attribute.</sch:assert>
+              <sch:assert test="count(descendant::mei:*[@tstamp or @startid]) = count(child::mei:*[local-name()='fing' or local-name()='fingGrp'])">When @tstamp or @startid is not present on fingGrp, each of its child elements must
+                have a @tstamp or @startid attribute.</sch:assert>
             </sch:rule>
-         </sch:pattern>
+          </sch:pattern>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.facsimile.attributes"/>
          <ref name="mei_att.fingGrp.anl.attributes"/>
@@ -23682,10 +21842,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_att.rel.attribute.rel">
       <attribute name="rel">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-            the relationship between the current entity and the target entity. The values follow
-            FRBR (see
-            http://www.ifla.org/files/assets/cataloguing/frbr/frbr_2008.pdf).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes the relationship between the current entity and the target entity. The values follow FRBR (see http://www.ifla.org/files/assets/cataloguing/frbr/frbr_2008.pdf).</a:documentation>
          <ref name="mei_data.FRBRRELATIONSHIP"/>
       </attribute>
    </define>
@@ -23711,8 +21868,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_componentGrp">
       <element name="componentGrp">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(component
-            group) – Container for components of a bibliographic entity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(component group) – Container for components of a bibliographic entity.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -23731,15 +21887,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </zeroOrMore>
          </choice>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-componentGrp-checkComponentGrp-constraint-95">
+                  id="mei-componentGrp-checkComponentGrp-constraint-95">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:componentGrp">
-               <sch:assert
-                  test="every $i in ./child::mei:*[not(local-name()='head')] satisfies $i/local-name() eq ./parent::mei:*/local-name()"
-                  >Only child elements of the same name as the parent of the componentGrp are
-                  allowed.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:componentGrp">
+               <sch:assert test="every $i in ./child::mei:*[not(local-name()='head')] satisfies $i/local-name() eq ./parent::mei:*/local-name()">Only child elements of the same name as the parent of the componentGrp are
+              allowed.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -23748,8 +21903,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_expression">
       <element name="expression">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Intellectual
-            or artistic realization of a work.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Intellectual or artistic realization of a work.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.identifierLike"/>
          </zeroOrMore>
@@ -23815,8 +21969,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_expressionList">
       <element name="expressionList">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Gathers
-            bibliographic expression entities.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Gathers bibliographic expression entities.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -23829,8 +21982,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_item">
       <element name="item">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Single
-            instance or exemplar of a source/manifestation.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Single instance or exemplar of a source/manifestation.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.identifierLike"/>
          </zeroOrMore>
@@ -23871,8 +22023,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_itemList">
       <element name="itemList">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Gathers
-            bibliographic item entities.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Gathers bibliographic item entities.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -23886,9 +22037,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_relation">
       <element name="relation">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A relation
-            element describes the relationship between its parent and the object referenced by the
-            relation element's target attribute.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A relation element describes the relationship between its parent and the object referenced by the relation element's target attribute.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.bibl.attributes"/>
@@ -23901,8 +22050,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_relationList">
       <element name="relationList">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Gathers
-            bibliographic relation elements.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Gathers bibliographic relation elements.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -23919,8 +22067,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.fretlocation.attribute.fret">
       <optional>
          <attribute name="fret">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the location at which a string should be stopped against a fret.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the location at which a string should be stopped against a fret.</a:documentation>
             <ref name="mei_data.FRET"/>
          </attribute>
       </optional>
@@ -23943,26 +22090,24 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.harm.log.attribute.chordref">
       <optional>
          <attribute name="chordref">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains
-               a reference to a &lt;chordDef&gt; element elsewhere in the
-               document.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a reference to a &lt;chordDef&gt; element elsewhere in the document.</a:documentation>
             <ref name="mei_data.URI"/>
          </attribute>
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.harm.log-chordref-check_chordrefTarget-constraint-96">
+            id="mei-att.harm.log-chordref-check_chordrefTarget-constraint-96">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@chordref">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@chordref attribute should
-            have content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:chordDef/@xml:id"
-            >The value in @chordref should correspond to the @xml:id attribute of a chordDef
-            element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@chordref">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@chordref attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:chordDef/@xml:id">The value in @chordref should correspond to the @xml:id attribute of a chordDef
+                  element.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_att.harm.vis.attributes">
       <ref name="mei_att.extender.attributes"/>
@@ -23976,18 +22121,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.harm.vis.attribute.rendgrid">
       <optional>
          <attribute name="rendgrid">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes
-               how the harmonic indication should be rendered.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Describes how the harmonic indication should be rendered.</a:documentation>
             <choice>
                <value>grid</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Chord
-                  tablature grid.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Chord tablature grid.</a:documentation>
                <value>gridtext</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Chord
-                  tablature grid and the element's textual content.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Chord tablature grid and the element's textual content.</a:documentation>
                <value>text</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Textual content of the element.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Textual content of the element.</a:documentation>
             </choice>
          </attribute>
       </optional>
@@ -24065,8 +22206,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_barre">
       <element name="barre">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An
-            indication of fingering in a chord tablature grid.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An indication of fingering in a chord tablature grid.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.fretlocation.attributes"/>
@@ -24076,8 +22216,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_chordDef">
       <element name="chordDef">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(chord
-            definition) – Chord tablature definition.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(chord definition) – Chord tablature definition.</a:documentation>
          <zeroOrMore>
             <ref name="mei_chordMember"/>
          </zeroOrMore>
@@ -24087,9 +22226,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.common.attributes"/>
          <optional>
             <attribute name="pos">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Records the fret position at which the chord tablature is to be
-                  played.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the fret position at which the chord tablature is to be played.</a:documentation>
                <data type="positiveInteger"/>
             </attribute>
          </optional>
@@ -24098,8 +22235,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_chordMember">
       <element name="chordMember">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An
-            individual pitch in a chord defined by a &lt;chordDef&gt; element.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">An individual pitch in a chord defined by a &lt;chordDef&gt; element.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.accidental.performed.attributes"/>
@@ -24108,11 +22244,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.pitched.attributes"/>
          <optional>
             <attribute name="fing">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Indicates which finger, if any, should be used to play an individual string. The
-                  index, middle, ring, and little fingers are represented by the values 1-4, while
-                  't' is for the thumb. The values 'x' and 'o' indicate muffled and open strings,
-                  respectively.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates which finger, if any, should be used to play an individual string. The index, middle, ring, and little fingers are represented by the values 1-4, while 't' is for the thumb. The values 'x' and 'o' indicate muffled and open strings, respectively.</a:documentation>
                <ref name="mei_data.FINGER.FRET"/>
             </attribute>
          </optional>
@@ -24121,8 +22253,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_chordTable">
       <element name="chordTable">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >Chord/tablature look-up table.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Chord/tablature look-up table.</a:documentation>
          <oneOrMore>
             <ref name="mei_chordDef"/>
          </oneOrMore>
@@ -24132,8 +22263,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_f">
       <element name="f">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(figure) –
-            Single element of a figured bass indication.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(figure) – Single element of a figured bass indication.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -24153,10 +22283,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_fb">
       <element name="fb">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(figured
-            bass) – Symbols added to a bass line that indicate harmony. Used to improvise a chordal
-            accompaniment. Sometimes called Generalbass, thoroughbass, or basso
-            continuo.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(figured bass) – Symbols added to a bass line that indicate harmony. Used to improvise a chordal accompaniment. Sometimes called Generalbass, thoroughbass, or basso continuo.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_model.fLike"/>
@@ -24172,9 +22299,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_harm">
       <element name="harm">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(harmony) –
-            An indication of harmony, e.g., chord names, tablature grids, harmonic analysis, figured
-            bass.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(harmony) – An indication of harmony, e.g., chord names, tablature grids, harmonic analysis, figured bass.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -24186,13 +22311,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </choice>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-harm-harm_start-type_attributes_required-constraint-97">
+                  id="mei-harm-harm_start-type_attributes_required-constraint-97">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:harm">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one
-                  of the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:harm">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
+              the attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -24232,8 +22358,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.verse.log.attribute.refrain">
       <optional>
          <attribute name="refrain">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to
-               indicate a common, usually centered, refrain. </a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to indicate a common, usually centered, refrain. </a:documentation>
             <ref name="mei_data.BOOLEAN"/>
          </attribute>
       </optional>
@@ -24241,9 +22366,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.verse.log.attribute.rhythm">
       <optional>
          <attribute name="rhythm">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to
-               specify a rhythm for the lyric syllables that differs from that of the notes on the
-               staff, e.g. '4,4,4,4' when the rhythm of the notes is '4.,8,4.,8'.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to specify a rhythm for the lyric syllables that differs from that of the notes on the staff, e.g. '4,4,4,4' when the rhythm of the notes is '4.,8,4.,8'.</a:documentation>
             <data type="string"/>
          </attribute>
       </optional>
@@ -24295,8 +22418,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_lyrics">
       <element name="lyrics">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Vocally
-            performed 'text' of a musical composition, such as a song or opera.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Vocally performed 'text' of a musical composition, such as a song or opera.</a:documentation>
          <oneOrMore>
             <ref name="mei_model.verseLike"/>
          </oneOrMore>
@@ -24312,8 +22434,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_verse">
       <element name="verse">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Lyric
-            verse.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Lyric verse.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_dir"/>
@@ -24350,8 +22471,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.channelized.attribute.midi.channel">
       <optional>
          <attribute name="midi.channel">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records a
-               MIDI channel value.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records a MIDI channel value.</a:documentation>
             <ref name="mei_data.MIDICHANNEL"/>
          </attribute>
       </optional>
@@ -24359,9 +22479,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.channelized.attribute.midi.duty">
       <optional>
          <attribute name="midi.duty">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies
-               the 'on' part of the duty cycle as a percentage of a note's
-               duration.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies the 'on' part of the duty cycle as a percentage of a note's duration.</a:documentation>
             <ref name="mei_data.PERCENT"/>
          </attribute>
       </optional>
@@ -24369,8 +22487,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.channelized.attribute.midi.port">
       <optional>
          <attribute name="midi.port">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the
-               MIDI port value.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the MIDI port value.</a:documentation>
             <ref name="mei_data.MIDIVALUE"/>
          </attribute>
       </optional>
@@ -24378,8 +22495,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.channelized.attribute.midi.track">
       <optional>
          <attribute name="midi.track">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the
-               MIDI track.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the MIDI track.</a:documentation>
             <data type="positiveInteger"/>
          </attribute>
       </optional>
@@ -24411,8 +22527,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.midiinstrument.attribute.midi.instrnum">
       <optional>
          <attribute name="midi.instrnum">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the
-               MIDI instrument number.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the MIDI instrument number.</a:documentation>
             <ref name="mei_data.MIDIVALUE"/>
          </attribute>
       </optional>
@@ -24420,8 +22535,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.midiinstrument.attribute.midi.instrname">
       <optional>
          <attribute name="midi.instrname">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               a General MIDI label for the MIDI instrument.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a General MIDI label for the MIDI instrument.</a:documentation>
             <ref name="mei_data.MIDINAMES"/>
          </attribute>
       </optional>
@@ -24429,9 +22543,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.midiinstrument.attribute.midi.pan">
       <optional>
          <attribute name="midi.pan">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the
-               instrument's position in a stereo field. Values of 0 and 1 both pan left, 127 pans
-               right, and 64 pans to the center.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the instrument's position in a stereo field. Values of 0 and 1 both pan left, 127 pans right, and 64 pans to the center.</a:documentation>
             <ref name="mei_data.MIDIVALUE"/>
          </attribute>
       </optional>
@@ -24439,8 +22551,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.midiinstrument.attribute.midi.volume">
       <optional>
          <attribute name="midi.volume">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the
-               instrument's volume.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Sets the instrument's volume.</a:documentation>
             <ref name="mei_data.MIDIVALUE"/>
          </attribute>
       </optional>
@@ -24450,8 +22561,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_att.midinumber.attribute.num">
       <attribute name="num">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI number
-            in the range set by data.MIDIVALUE.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI number in the range set by data.MIDIVALUE.</a:documentation>
          <ref name="mei_data.MIDIVALUE"/>
       </attribute>
    </define>
@@ -24462,10 +22572,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.miditempo.attribute.midi.bpm">
       <optional>
          <attribute name="midi.bpm">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures
-               the number of *quarter notes* per minute. In MIDI, a beat is always defined as a
-               quarter note, *not the numerator of the time signature or the metronomic
-               indication*.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures the number of *quarter notes* per minute. In MIDI, a beat is always defined as a quarter note, *not the numerator of the time signature or the metronomic indication*.</a:documentation>
             <ref name="mei_data.MIDIBPM"/>
          </attribute>
       </optional>
@@ -24473,11 +22580,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.miditempo.attribute.midi.mspb">
       <optional>
          <attribute name="midi.mspb">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the number of microseconds per *quarter note*. In MIDI, a beat is always defined as a
-               quarter note, *not the numerator of the time signature or the metronomic indication*.
-               At 120 quarter notes per minute, each quarter note will last 500,000
-               microseconds.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the number of microseconds per *quarter note*. In MIDI, a beat is always defined as a quarter note, *not the numerator of the time signature or the metronomic indication*. At 120 quarter notes per minute, each quarter note will last 500,000 microseconds.</a:documentation>
             <ref name="mei_data.MIDIMSPB"/>
          </attribute>
       </optional>
@@ -24488,8 +22591,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.midivalue.attribute.val">
       <optional>
          <attribute name="val">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI
-               number.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI number.</a:documentation>
             <ref name="mei_data.MIDIVALUE"/>
          </attribute>
       </optional>
@@ -24500,8 +22602,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.midivalue2.attribute.val2">
       <optional>
          <attribute name="val2">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI
-               number.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI number.</a:documentation>
             <ref name="mei_data.MIDIVALUE"/>
          </attribute>
       </optional>
@@ -24512,8 +22613,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.midivelocity.attribute.vel">
       <optional>
          <attribute name="vel">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI
-               Note-on/off velocity.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI Note-on/off velocity.</a:documentation>
             <ref name="mei_data.MIDIVALUE"/>
          </attribute>
       </optional>
@@ -24524,10 +22624,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.timebase.attribute.ppq">
       <optional>
          <attribute name="ppq">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the number of pulses (sometimes referred to as ticks or divisions) per quarter note.
-               Unlike MIDI, MEI permits different values for a score and individual
-               staves.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the number of pulses (sometimes referred to as ticks or divisions) per quarter note. Unlike MIDI, MEI permits different values for a score and individual staves.</a:documentation>
             <data type="positiveInteger"/>
          </attribute>
       </optional>
@@ -24562,8 +22659,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_cc">
       <element name="cc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(control
-            change) – MIDI parameter/control change.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(control change) – MIDI parameter/control change.</a:documentation>
          <empty/>
          <ref name="mei_att.common.anl.attributes"/>
          <ref name="mei_att.common.attributes"/>
@@ -24575,15 +22671,13 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_chan">
       <element name="chan">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(channel) –
-            MIDI channel assignment.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(channel) – MIDI channel assignment.</a:documentation>
          <empty/>
          <ref name="mei_att.common.anl.attributes"/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.midi.event.attributes"/>
          <attribute name="num">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI
-               number in the range set by data.MIDICHANNEL.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI number in the range set by data.MIDICHANNEL.</a:documentation>
             <ref name="mei_data.MIDICHANNEL"/>
          </attribute>
          <empty/>
@@ -24591,8 +22685,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_chanPr">
       <element name="chanPr">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(channel
-            pressure) – MIDI channel pressure/after touch.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(channel pressure) – MIDI channel pressure/after touch.</a:documentation>
          <empty/>
          <ref name="mei_att.common.anl.attributes"/>
          <ref name="mei_att.common.attributes"/>
@@ -24603,8 +22696,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_cue">
       <element name="cue">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI cue
-            point.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI cue point.</a:documentation>
          <text/>
          <ref name="mei_att.common.anl.attributes"/>
          <ref name="mei_att.common.attributes"/>
@@ -24615,8 +22707,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_hex">
       <element name="hex">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Arbitrary
-            MIDI data in hexadecimal form.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Arbitrary MIDI data in hexadecimal form.</a:documentation>
          <text/>
          <ref name="mei_att.common.anl.attributes"/>
          <ref name="mei_att.common.attributes"/>
@@ -24626,8 +22717,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_instrDef">
       <element name="instrDef">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(instrument
-            definition) – MIDI instrument declaration.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(instrument definition) – MIDI instrument declaration.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.channelized.attributes"/>
@@ -24637,8 +22727,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_instrGrp">
       <element name="instrGrp">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(instrument
-            group) – Collects MIDI instrument definitions.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(instrument group) – Collects MIDI instrument definitions.</a:documentation>
          <oneOrMore>
             <ref name="mei_model.instrDefLike"/>
          </oneOrMore>
@@ -24648,8 +22737,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_marker">
       <element name="marker">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI marker
-            meta-event.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI marker meta-event.</a:documentation>
          <text/>
          <ref name="mei_att.common.anl.attributes"/>
          <ref name="mei_att.common.attributes"/>
@@ -24660,8 +22748,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_metaText">
       <element name="metaText">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI text
-            meta-event.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI text meta-event.</a:documentation>
          <text/>
          <ref name="mei_att.common.anl.attributes"/>
          <ref name="mei_att.common.attributes"/>
@@ -24672,9 +22759,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_midi">
       <element name="midi">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Container
-            for elements that contain information useful when generating MIDI
-            output.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Container for elements that contain information useful when generating MIDI output.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_cc"/>
@@ -24703,8 +22788,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_noteOff">
       <element name="noteOff">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI
-            note-off event.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI note-off event.</a:documentation>
          <empty/>
          <ref name="mei_att.common.anl.attributes"/>
          <ref name="mei_att.common.attributes"/>
@@ -24715,8 +22799,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_noteOn">
       <element name="noteOn">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI note-on
-            event.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI note-on event.</a:documentation>
          <empty/>
          <ref name="mei_att.common.anl.attributes"/>
          <ref name="mei_att.common.attributes"/>
@@ -24727,8 +22810,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_port">
       <element name="port">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI
-            port.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">MIDI port.</a:documentation>
          <empty/>
          <ref name="mei_att.common.anl.attributes"/>
          <ref name="mei_att.common.attributes"/>
@@ -24739,8 +22821,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_prog">
       <element name="prog">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(program) –
-            MIDI program change.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(program) – MIDI program change.</a:documentation>
          <empty/>
          <ref name="mei_att.common.anl.attributes"/>
          <ref name="mei_att.common.attributes"/>
@@ -24751,15 +22832,13 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_seqNum">
       <element name="seqNum">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(sequence
-            number) – MIDI sequence number.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(sequence number) – MIDI sequence number.</a:documentation>
          <empty/>
          <ref name="mei_att.common.anl.attributes"/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.midi.event.attributes"/>
          <attribute name="num">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Number in
-               the range 0-65535.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Number in the range 0-65535.</a:documentation>
             <data type="nonNegativeInteger">
                <param name="maxInclusive">65535</param>
             </data>
@@ -24769,8 +22848,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_trkName">
       <element name="trkName">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(track name)
-            – MIDI track/sequence name.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(track name) – MIDI track/sequence name.</a:documentation>
          <text/>
          <ref name="mei_att.common.anl.attributes"/>
          <ref name="mei_att.common.attributes"/>
@@ -24781,16 +22859,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_vel">
       <element name="vel">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(velocity) –
-            MIDI Note-on/off velocity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(velocity) – MIDI Note-on/off velocity.</a:documentation>
          <empty/>
          <ref name="mei_att.common.anl.attributes"/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.midi.event.attributes"/>
          <ref name="mei_att.midinumber.attributes"/>
          <attribute name="form">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               whether this is note-on or note-off velocity data.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates whether this is note-on or note-off velocity data.</a:documentation>
             <choice>
                <value>on</value>
                <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"/>
@@ -25113,9 +23189,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_addName">
       <element name="addName">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(additional
-            name) – Contains an additional name component, such as a nickname, epithet, or alias, or
-            any other descriptive phrase used within a personal name.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(additional name) – Contains an additional name component, such as a nickname, epithet, or alias, or any other descriptive phrase used within a personal name.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25136,9 +23210,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_bloc">
       <element name="bloc">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the
-            name of a geo-political unit consisting of two or more nation states or
-            countries.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the name of a geo-political unit consisting of two or more nation states or countries.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25159,9 +23231,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_corpName">
       <element name="corpName">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(corporate
-            name) – Identifies an organization or group of people that acts as a single
-            entity.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(corporate name) – Identifies an organization or group of people that acts as a single entity.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25182,9 +23252,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_country">
       <element name="country">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the
-            name of a geo-political unit, such as a nation, country, colony, or commonwealth, larger
-            than or administratively superior to a region and smaller than a bloc.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the name of a geo-political unit, such as a nation, country, colony, or commonwealth, larger than or administratively superior to a region and smaller than a bloc.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25205,9 +23273,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_district">
       <element name="district">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the
-            name of any kind of subdivision of a settlement, such as a parish, ward, or other
-            administrative or geographic unit.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the name of any kind of subdivision of a settlement, such as a parish, ward, or other administrative or geographic unit.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25228,9 +23294,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_famName">
       <element name="famName">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(family
-            name) – Contains a family (inherited) name, as opposed to a given, baptismal, or nick
-            name.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(family name) – Contains a family (inherited) name, as opposed to a given, baptismal, or nick name.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25251,8 +23315,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_foreName">
       <element name="foreName">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a
-            forename, given or baptismal name.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a forename, given or baptismal name.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25273,10 +23336,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_genName">
       <element name="genName">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >(generational name component) – Contains a name component used to distinguish otherwise
-            similar names on the basis of the relative ages or generations of the persons
-            named.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(generational name component) – Contains a name component used to distinguish otherwise similar names on the basis of the relative ages or generations of the persons named.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25297,9 +23357,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_geogFeat">
       <element name="geogFeat">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-            >(geographical feature name) – Contains a common noun identifying a geographical
-            feature.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(geographical feature name) – Contains a common noun identifying a geographical feature.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25320,9 +23378,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_geogName">
       <element name="geogName">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(geographic
-            name) – The proper noun designation for a place, natural feature, or political
-            jurisdiction.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(geographic name) – The proper noun designation for a place, natural feature, or political jurisdiction.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25343,9 +23399,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_nameLink">
       <element name="nameLink">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(name link)
-            – Contains a connecting phrase or link used within a name but not regarded as part of
-            it, such as "van der" or "of", "from", etc.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(name link) – Contains a connecting phrase or link used within a name but not regarded as part of it, such as "van der" or "of", "from", etc.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25366,9 +23420,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_periodName">
       <element name="periodName">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(period
-            name) – A label that describes a period of time, such as 'Baroque' or '3rd Style
-            period'.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(period name) – A label that describes a period of time, such as 'Baroque' or '3rd Style period'.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25389,9 +23441,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_persName">
       <element name="persName">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(personal
-            name) – Designation for an individual, including any or all of that individual's
-            forenames, surnames, honorific titles, and added names.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(personal name) – Designation for an individual, including any or all of that individual's forenames, surnames, honorific titles, and added names.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25413,9 +23463,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_postBox">
       <element name="postBox">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(postal box
-            or post office box) contains a number or other identifier for some postal delivery point
-            other than a street address.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(postal box or post office box) contains a number or other identifier for some postal delivery point other than a street address.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25431,9 +23479,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_postCode">
       <element name="postCode">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(postal
-            code) contains a numerical or alphanumeric code used as part of a postal address to
-            simplify sorting or delivery of mail.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(postal code) contains a numerical or alphanumeric code used as part of a postal address to simplify sorting or delivery of mail.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25449,9 +23495,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_region">
       <element name="region">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the
-            name of an administrative unit such as a state, province, or county, larger than a
-            settlement, but smaller than a country.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the name of an administrative unit such as a state, province, or county, larger than a settlement, but smaller than a country.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25472,9 +23516,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_roleName">
       <element name="roleName">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(role name)
-            – Contains a name component which indicates that the referent has a particular role or
-            position in society, such as an official title or rank.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(role name) – Contains a name component which indicates that the referent has a particular role or position in society, such as an official title or rank.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25495,9 +23537,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_settlement">
       <element name="settlement">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the
-            name of a settlement such as a city, town, or village identified as a single
-            geo-political or administrative unit.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains the name of a settlement such as a city, town, or village identified as a single geo-political or administrative unit.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25518,9 +23558,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_street">
       <element name="street">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">full street
-            address including any name or number identifying a building as well as the name of the
-            street or route on which it is located.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">full street address including any name or number identifying a building as well as the name of the street or route on which it is located.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25537,9 +23575,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_styleName">
       <element name="styleName">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(style name)
-            – A label for a characteristic style of writing or performance, such as 'bebop' or
-            'rock-n-roll'.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(style name) – A label for a characteristic style of writing or performance, such as 'bebop' or 'rock-n-roll'.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25564,42 +23600,41 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.alignment.attribute.when">
       <optional>
          <attribute name="when">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates
-               the point of occurrence of this feature along a time line. Its value must be the ID
-               of a when element elsewhere in the document.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates the point of occurrence of this feature along a time line. Its value must be the ID of a when element elsewhere in the document.</a:documentation>
             <ref name="mei_data.URI"/>
          </attribute>
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.alignment-check_whenTarget-constraint-98">
+            id="mei-att.alignment-check_whenTarget-constraint-98">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@when">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@when attribute should have
-            content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:when/@xml:id">A
-            value in @when should correspond to the @xml:id attribute of a when
-            element.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@when">
+            <sch:assert role="warning" test="not(normalize-space(.) eq '')">@when attribute should
+              have content.</sch:assert>
+            <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:when/@xml:id">A
+              value in @when should correspond to the @xml:id attribute of a when
+              element.</sch:assert>
+          </sch:rule>
    </pattern>
    <define name="mei_avFile">
       <element name="avFile">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(audio/video
-            file) – References an external digital audio or video file.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(audio/video file) – References an external digital audio or video file.</a:documentation>
          <zeroOrMore>
             <ref name="mei_clip"/>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-avFile-avFile_child_of_clip-constraint-99">
+                  id="mei-avFile-avFile_child_of_clip-constraint-99">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:clip/mei:avFile">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:clip/mei:avFile">
                <sch:assert test="count(mei:*) = 0">An avFile child of clip cannot have
-                  children.</sch:assert>
+              children.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.bibl.attributes"/>
@@ -25614,9 +23649,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_clip">
       <element name="clip">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Defines a
-            time segment of interest within a recording or within a digital audio or video
-            file.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Defines a time segment of interest within a recording or within a digital audio or video file.</a:documentation>
          <zeroOrMore>
             <ref name="mei_avFile"/>
          </zeroOrMore>
@@ -25624,13 +23657,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             <ref name="mei_when"/>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-clip-betype_required_when_begin_or_end-constraint-100">
+                  id="mei-clip-betype_required_when_begin_or_end-constraint-100">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:clip[@begin or @end]">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:clip[@begin or @end]">
                <sch:assert role="warning" test="@betype or ancestor::mei:*[@betype]">When @begin or
-                  @end is used, @betype should appear on clip or one of its ancestors.</sch:assert>
+              @end is used, @betype should appear on clip or one of its ancestors.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -25643,8 +23677,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_performance">
       <element name="performance">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-            presentation of one or more musical works.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A presentation of one or more musical works.</a:documentation>
          <zeroOrMore>
             <ref name="mei_recording"/>
          </zeroOrMore>
@@ -25655,8 +23688,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_recording">
       <element name="recording">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A recorded
-            performance.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A recorded performance.</a:documentation>
          <zeroOrMore>
             <ref name="mei_avFile"/>
          </zeroOrMore>
@@ -25667,13 +23699,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             <ref name="mei_clip"/>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-recording-betype_required_when_begin_or_end-constraint-101">
+                  id="mei-recording-betype_required_when_begin_or_end-constraint-101">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:recording[@begin or @end]">
-               <sch:assert role="warning" test="@betype">When @begin or @end is used, @betype should
-                  be present.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:recording[@begin or @end]">
+               <sch:assert role="warning" test="@betype">When @begin or @end is used, @betype should be
+              present.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -25686,73 +23719,69 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_when">
       <element name="when">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates a
-            point in time either absolutely (using the absolute attribute), or relative to another
-            when element (using the since, interval and inttype attributes).</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Indicates a point in time either absolutely (using the absolute attribute), or relative to another when element (using the since, interval and inttype attributes).</a:documentation>
          <empty/>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-when-check_when_interval-constraint-102">
+                  id="mei-when-check_when_interval-constraint-102">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:when[@interval]">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:when[@interval]">
                <sch:assert role="warning" test="@since">@since should be present when @interval is
-                  used.</sch:assert>
+              used.</sch:assert>
                <sch:assert role="warning"
-                  test="every $i in tokenize(@since, '\s+') satisfies substring($i,2)=//mei:when/@xml:id"
-                  >The value in @since should correspond to the @xml:id attribute of a when
-                  element.</sch:assert>
-               <sch:assert role="warning" test="@inttype">@inttype should be present when @interval
-                  is used.</sch:assert>
+                           test="every $i in tokenize(@since, '\s+') satisfies substring($i,2)=//mei:when/@xml:id">The value in @since should correspond to the @xml:id attribute of a when
+              element.</sch:assert>
+               <sch:assert role="warning" test="@inttype">@inttype should be present when @interval is
+              used.</sch:assert>
             </sch:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-when-check_when_interval-constraint-103">
+                  id="mei-when-check_when_interval-constraint-103">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0"
-               context="mei:when[matches(@interval, '^[0-9]+$')]">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:when[matches(@interval, '^[0-9]+$')]">
                <sch:assert test="not(@inttype eq 'time')">When @interval contains an integer value,
-                  @inttype cannot be 'time'.</sch:assert>
+              @inttype cannot be 'time'.</sch:assert>
             </sch:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-when-check_when_interval-constraint-104">
+                  id="mei-when-check_when_interval-constraint-104">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:when[matches(@interval, ':')]">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:when[matches(@interval, ':')]">
                <sch:assert test="@inttype eq 'time'">When @interval contains a time value, @inttype
-                  must be 'time'.</sch:assert>
+              must be 'time'.</sch:assert>
             </sch:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-when-check_when_absolute-constraint-105">
+                  id="mei-when-check_when_absolute-constraint-105">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:when[@absolute]">
-               <sch:assert role="warning" test="@abstype or ancestor::mei:*[@betype]">When @absolute
-                  is present, @abstype should be present or @betype should be present on an
-                  ancestor.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:when[@absolute]">
+               <sch:assert role="warning" test="@abstype or ancestor::mei:*[@betype]">When @absolute is
+              present, @abstype should be present or @betype should be present on an
+              ancestor.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.datapointing.attributes"/>
          <optional>
             <attribute name="absolute">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Provides an absolute value for the time point.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides an absolute value for the time point.</a:documentation>
                <text/>
             </attribute>
          </optional>
          <optional>
             <attribute name="interval">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Specifies the time interval between this time point and the one designated by the
-                  since attribute. This attribute can only be interpreted meaningfully in
-                  conjunction with the inttype attribute.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies the time interval between this time point and the one designated by the since attribute. This attribute can only be interpreted meaningfully in conjunction with the inttype attribute.</a:documentation>
                <choice>
                   <data type="decimal">
                      <param name="minInclusive">1</param>
@@ -25763,43 +23792,35 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          </optional>
          <optional>
             <attribute name="abstype">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Specifies the kind of values used in the absolute attribute.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies the kind of values used in the absolute attribute.</a:documentation>
                <ref name="mei_data.BETYPE"/>
             </attribute>
          </optional>
          <optional>
             <attribute name="inttype">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Specifies the kind of values used in the interval attribute.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Specifies the kind of values used in the interval attribute.</a:documentation>
                <ref name="mei_data.BETYPE"/>
             </attribute>
          </optional>
          <optional>
             <attribute name="since">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Identifies the reference point for determining the time of the current when
-                  element, which is obtained by adding the interval to the time of the reference
-                  point. The value should be the ID of another when element within the same parent
-                  element. If the since attribute is omitted and the absolute attribute is not
-                  specified, then the reference point is understood to be the immediately preceding
-                  when element.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Identifies the reference point for determining the time of the current when element, which is obtained by adding the interval to the time of the reference point. The value should be the ID of another when element within the same parent element. If the since attribute is omitted and the absolute attribute is not specified, then the reference point is understood to be the immediately preceding when element.</a:documentation>
                <ref name="mei_data.URI"/>
             </attribute>
          </optional>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-when-since-check_sinceTarget-constraint-106">
+                  id="mei-when-since-check_sinceTarget-constraint-106">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="@since">
-               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@since attribute
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="@since">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@since attribute
                   should have content.</sch:assert>
-               <sch:assert role="warning"
-                  test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:when/@xml:id"
-                  >The value in @since should correspond to the @xml:id attribute of a when
+                <sch:assert role="warning"
+                           test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:when/@xml:id">The value in @since should correspond to the @xml:id attribute of a when
                   element.</sch:assert>
-            </sch:rule>
+              </sch:rule>
          </pattern>
          <empty/>
       </element>
@@ -25846,9 +23867,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_ptr">
       <element name="ptr">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(pointer) –
-            Defines a pointer to another location, using only attributes to describe the
-            destination.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(pointer) – Defines a pointer to another location, using only attributes to describe the destination.</a:documentation>
          <empty/>
          <ref name="mei_att.common.attributes"/>
          <ref name="mei_att.internetmedia.attributes"/>
@@ -25860,9 +23879,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_ref">
       <element name="ref">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(reference)
-            – Defines a reference to another location that may contain text and sub-elements to
-            describe the destination.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(reference) – Defines a reference to another location that may contain text and sub-elements to describe the destination.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -25885,8 +23902,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.note.ges.tablature.attribute.tab.fret">
       <optional>
          <attribute name="tab.fret">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               the fret at which a string should be stopped.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records the fret at which a string should be stopped.</a:documentation>
             <ref name="mei_data.FRETNUMBER"/>
          </attribute>
       </optional>
@@ -25894,8 +23910,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.note.ges.tablature.attribute.tab.string">
       <optional>
          <attribute name="tab.string">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records
-               which string is to be played.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Records which string is to be played.</a:documentation>
             <ref name="mei_data.STRINGNUMBER"/>
          </attribute>
       </optional>
@@ -25906,14 +23921,11 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.staffDef.ges.tablature.attribute.tab.strings">
       <optional>
          <attribute name="tab.strings">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               a *written* pitch and octave for each open string or course of
-               strings.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a *written* pitch and octave for each open string or course of strings.</a:documentation>
             <list>
                <oneOrMore>
                   <data type="token">
-                     <param name="pattern"
-                        >[a-g][0-9](s|f|ss|x|ff|xs|sx|ts|tf|n|nf|ns|su|sd|fu|fd|nu|nd|1qf|3qf|1qs|3qs)?([a-g][0-9](s|f|ss|x|ff|xs|sx|ts|tf|n|nf|ns|su|sd|fu|fd|nu|nd|1qf|3qf|1qs|3qs)?)*</param>
+                     <param name="pattern">[a-g][0-9](s|f|ss|x|ff|xs|sx|ts|tf|n|nf|ns|su|sd|fu|fd|nu|nd|1qf|3qf|1qs|3qs)?([a-g][0-9](s|f|ss|x|ff|xs|sx|ts|tf|n|nf|ns|su|sd|fu|fd|nu|nd|1qf|3qf|1qs|3qs)?)*</param>
                   </data>
                </oneOrMore>
             </list>
@@ -25960,9 +23972,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_back">
       <element name="back">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(back
-            matter) – Contains any appendixes, advertisements, indexes, etc. following the main body
-            of a musical text.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(back matter) – Contains any appendixes, advertisements, indexes, etc. following the main body of a musical text.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_model.divLike"/>
@@ -25979,9 +23989,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_front">
       <element name="front">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(front
-            matter) – Bundles prefatory text found before the start of the musical
-            text.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(front matter) – Bundles prefatory text found before the start of the musical text.</a:documentation>
          <zeroOrMore>
             <choice>
                <ref name="mei_model.divLike"/>
@@ -25998,8 +24006,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_l">
       <element name="l">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(line of
-            text) – Contains a single line of text within a line group.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(line of text) – Contains a single line of text within a line group.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -26016,10 +24023,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_lg">
       <element name="lg">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(line group)
-            – May be used for any section of text that is organized as a group of lines; however, it
-            is most often used for a group of verse lines functioning as a formal unit, e.g. a
-            stanza, refrain, verse paragraph, etc.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(line group) – May be used for any section of text that is organized as a group of lines; however, it is most often used for a group of verse lines functioning as a formal unit, e.g. a stanza, refrain, verse paragraph, etc.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -26044,8 +24048,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_li">
       <element name="li">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(list item)
-            – Single item in a &lt;list&gt;.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(list item) – Single item in a &lt;list&gt;.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -26063,9 +24066,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_list">
       <element name="list">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A formatting
-            element that contains a series of items separated from one another and arranged in a
-            linear, often vertical, sequence.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A formatting element that contains a series of items separated from one another and arranged in a linear, often vertical, sequence.</a:documentation>
          <zeroOrMore>
             <ref name="mei_model.headLike"/>
          </zeroOrMore>
@@ -26076,13 +24077,14 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             <ref name="mei_li"/>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-list-list_type_constraint-constraint-107">
+                  id="mei-list-list_type_constraint-constraint-107">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:list[@type='gloss']">
-               <sch:assert test="count(mei:label) = count(mei:li)">In a list of type "gloss" all
-                  items must be immediately preceded by a label.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:list[@type='gloss']">
+               <sch:assert test="count(mei:label) = count(mei:li)">In a list of type "gloss" all items
+              must be immediately preceded by a label.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -26091,53 +24093,32 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_att.xy.attributes"/>
          <optional>
             <attribute name="form">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used
-                  to indicate the format of a list. In a "simple" list, li elements are not numbered
-                  or bulleted. In a "marked" list, the sequence of the list items is not critical,
-                  and a bullet, box, dash, or other character is displayed at the start of each
-                  item. In an "ordered" list, the sequence of the items is important, and each li is
-                  lettered or numbered. Style sheet functions should be used to specify the mark or
-                  numeration system for each li.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Used to indicate the format of a list. In a "simple" list, li elements are not numbered or bulleted. In a "marked" list, the sequence of the list items is not critical, and a bullet, box, dash, or other character is displayed at the start of each item. In an "ordered" list, the sequence of the items is important, and each li is lettered or numbered. Style sheet functions should be used to specify the mark or numeration system for each li.</a:documentation>
                <choice>
                   <value>simple</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Items are not numbered or bulleted.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Items are not numbered or bulleted.</a:documentation>
                   <value>marked</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Bullet, box, dash, or other character is displayed before each
-                     item.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Bullet, box, dash, or other character is displayed before each item.</a:documentation>
                   <value>ordered</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Each item is numbered or lettered.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Each item is numbered or lettered.</a:documentation>
                </choice>
             </attribute>
          </optional>
          <optional>
             <attribute name="type">
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                  >Captures the nature of the content of a list. Suggested values include: 1] gloss;
-                  2] index; 3] instructions; 4] litany; 5] syllogism</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Captures the nature of the content of a list.
+Suggested values include: 1] gloss; 2] index; 3] instructions; 4] litany; 5] syllogism</a:documentation>
                <choice>
                   <value>gloss</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Each list item glosses some term or concept, which is given by a label element
-                     preceding the list item.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Each list item glosses some term or concept, which is given by a label element preceding the list item.</a:documentation>
                   <value>index</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Each list item is an entry in an index such as the alphabetical topical index
-                     at the back of a print volume.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Each list item is an entry in an index such as the alphabetical topical index at the back of a print volume.</a:documentation>
                   <value>instructions</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Each list item is a step in a sequence of instructions, as in a
-                     recipe.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Each list item is a step in a sequence of instructions, as in a recipe.</a:documentation>
                   <value>litany</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Each list item is one of a sequence of petitions, supplications or
-                     invocations, typically in a religious ritual.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Each list item is one of a sequence of petitions, supplications or invocations, typically in a religious ritual.</a:documentation>
                   <value>syllogism</value>
-                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-                     >Each list item is part of an argument consisting of two or more propositions
-                     and a final conclusion derived from them.</a:documentation>
+                  <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Each list item is part of an argument consisting of two or more propositions and a final conclusion derived from them.</a:documentation>
                   <data type="NMTOKEN"/>
                </choice>
             </attribute>
@@ -26147,10 +24128,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_quote">
       <element name="quote">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(block
-            quote) – A formatting element that designates an extended quotation; that is, a passage
-            attributed to a source external to the text and normally set off from the text by
-            spacing or other typographic distinction.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(block quote) – A formatting element that designates an extended quotation; that is, a passage attributed to a source external to the text and normally set off from the text by spacing or other typographic distinction.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -26172,29 +24150,27 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    <define name="mei_att.altsym.attribute.altsym">
       <optional>
          <attribute name="altsym">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides
-               a way of pointing to a user-defined symbol. It must contain an ID of a
-               &lt;symbolDef&gt; element elsewhere in the document.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Provides a way of pointing to a user-defined symbol. It must contain an ID of a &lt;symbolDef&gt; element elsewhere in the document.</a:documentation>
             <ref name="mei_data.URI"/>
          </attribute>
       </optional>
    </define>
    <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-      id="mei-att.altsym-altsym-check_altsymTarget-constraint-108">
+            id="mei-att.altsym-altsym-check_altsymTarget-constraint-108">
       <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-         xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-         xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-         xmlns="http://www.tei-c.org/ns/1.0" context="@altsym">
-         <sch:assert role="warning" test="not(normalize-space(.) eq '')">@altsym attribute should
-            have content.</sch:assert>
-         <sch:assert role="warning"
-            test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:symbolDef/@xml:id"
-            >The value in @altsym should correspond to the @xml:id attribute of a symbolDef
-            element.</sch:assert>
-         <sch:assert test="not(substring(., 2) eq ancestor::mei:symbolDef/@xml:id)">The value in
-            @altsym must not correspond to the @xml:id attribute of a symbolDef
-            ancestor.</sch:assert>
-      </sch:rule>
+                xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                xmlns="http://www.tei-c.org/ns/1.0"
+                context="@altsym">
+                <sch:assert role="warning" test="not(normalize-space(.) eq '')">@altsym attribute
+                  should have content.</sch:assert>
+                <sch:assert role="warning"
+                     test="every $i in tokenize(., '\s+') satisfies substring($i,2)=//mei:symbolDef/@xml:id">The value in @altsym should correspond to the @xml:id attribute of a symbolDef
+                  element.</sch:assert>
+                <sch:assert test="not(substring(., 2) eq ancestor::mei:symbolDef/@xml:id)">The value
+                  in @altsym must not correspond to the @xml:id attribute of a symbolDef
+                  ancestor.</sch:assert>
+              </sch:rule>
    </pattern>
    <define name="mei_model.graphicprimitiveLike">
       <choice>
@@ -26210,9 +24186,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_anchoredText">
       <element name="anchoredText">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Container
-            for text that is fixed to a particular page location, regardless of changes made to the
-            layout of the measures around it.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Container for text that is fixed to a particular page location, regardless of changes made to the layout of the measures around it.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -26234,22 +24208,21 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_curve">
       <element name="curve">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A curved
-            line that cannot be represented by a more specific element, such as a
-            slur.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A curved line that cannot be represented by a more specific element, such as a slur.</a:documentation>
          <empty/>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-curve-symbolDef_curve_attributes_required-constraint-109">
+                  id="mei-curve-symbolDef_curve_attributes_required-constraint-109">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:curve[ancestor::mei:symbolDef]">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:curve[ancestor::mei:symbolDef]">
                <sch:assert test="@startid or (@x and @y)">In the symbolDef context, curve must have
-                  either a startid attribute or x and y attributes.</sch:assert>
+              either a startid attribute or x and y attributes.</sch:assert>
                <sch:assert test="@endid or (@x2 and @y2)">In the symbolDef context, curve must have
-                  either an endid attribute or both x2 and y2 attributes.</sch:assert>
-               <sch:assert test="@bezier or @bulge">In the symbolDef context, curve must have either
-                  a bezier or bulge attribute.</sch:assert>
+              either an endid attribute or both x2 and y2 attributes.</sch:assert>
+               <sch:assert test="@bezier or @bulge">In the symbolDef context, curve must have either a
+              bezier or bulge attribute.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.anl.attributes"/>
@@ -26269,9 +24242,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_line">
       <element name="line">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A visual
-            line that cannot be represented by a more specific; i.e., semantic,
-            element.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A visual line that cannot be represented by a more specific; i.e., semantic, element.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -26279,29 +24250,30 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
             </choice>
          </zeroOrMore>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-line-line_start-_and_end-type_attributes_required-constraint-110">
+                  id="mei-line-line_start-_and_end-type_attributes_required-constraint-110">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:line[ancestor::mei:symbolDef]">
-               <sch:assert test="@startid or (@x and @y)">When used in the symbolDef context, must
-                  have either a startid attribute or x and y attributes.</sch:assert>
-               <sch:assert test="@endid or (@x2 and @y2)">When used in the symbolDef context, must
-                  have either an endid attribute or both x2 and y2 attributes.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:line[ancestor::mei:symbolDef]">
+               <sch:assert test="@startid or (@x and @y)">When used in the symbolDef context, must have
+              either a startid attribute or x and y attributes.</sch:assert>
+               <sch:assert test="@endid or (@x2 and @y2)">When used in the symbolDef context, must have
+              either an endid attribute or both x2 and y2 attributes.</sch:assert>
             </sch:rule>
          </pattern>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-line-line_start-_and_end-type_attributes_required-constraint-111">
+                  id="mei-line-line_start-_and_end-type_attributes_required-constraint-111">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:line[not(ancestor::mei:symbolDef)]">
-               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real or (@x and @y)"
-                  >When used in the score context, must have a startid, tstamp, tstamp.ges or
-                  tstamp.real attribute or both x and y attributes.</sch:assert>
-               <sch:assert test="@dur or @dur.ges or @endid or @tstamp2 or (@x2 and @y2)">When used
-                  in the score context, must have an endid, dur, dur.ges, or tstamp2 attribute or
-                  both x2 and y2 attributes.</sch:assert>
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:line[not(ancestor::mei:symbolDef)]">
+               <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real or (@x and @y)">When used in the score context, must have a startid, tstamp, tstamp.ges or
+              tstamp.real attribute or both x and y attributes.</sch:assert>
+               <sch:assert test="@dur or @dur.ges or @endid or @tstamp2 or (@x2 and @y2)">When used in
+              the score context, must have an endid, dur, dur.ges, or tstamp2 attribute or both x2
+              and y2 attributes.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.common.attributes"/>
@@ -26316,9 +24288,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_mapping">
       <element name="mapping">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">One or more
-            characters which are related to the parent symbol in some respect, as specified by the
-            type attribute.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">One or more characters which are related to the parent symbol in some respect, as specified by the type attribute.</a:documentation>
          <zeroOrMore>
             <choice>
                <text/>
@@ -26333,20 +24303,16 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_propName">
       <element name="propName">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(property
-            name) – Name of a property of the symbol.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(property name) – Name of a property of the symbol.</a:documentation>
          <text/>
          <ref name="mei_att.common.attributes"/>
          <attribute name="type">
-            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               >Characterizes the property name.</a:documentation>
+            <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Characterizes the property name.</a:documentation>
             <choice>
                <value>unicode</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                  registered Unicode normative or informative property name.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A registered Unicode normative or informative property name.</a:documentation>
                <value>local</value>
-               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A
-                  locally defined name.</a:documentation>
+               <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A locally defined name.</a:documentation>
             </choice>
          </attribute>
          <empty/>
@@ -26354,8 +24320,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_propValue">
       <element name="propValue">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(property
-            value) – A single property value.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(property value) – A single property value.</a:documentation>
          <text/>
          <ref name="mei_att.common.attributes"/>
          <empty/>
@@ -26363,20 +24328,20 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_symbol">
       <element name="symbol">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A reference
-            to a previously defined symbol.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">A reference to a previously defined symbol.</a:documentation>
          <empty/>
          <pattern xmlns="http://purl.oclc.org/dsdl/schematron"
-            id="mei-symbol-symbolDef_symbol_attributes_required-constraint-112">
+                  id="mei-symbol-symbolDef_symbol_attributes_required-constraint-112">
             <sch:rule xmlns:rng="http://relaxng.org/ns/structure/1.0"
-               xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-               xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
-               xmlns="http://www.tei-c.org/ns/1.0" context="mei:symbol[ancestor::mei:symbolDef]">
+                      xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+                      xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0"
+                      xmlns="http://www.tei-c.org/ns/1.0"
+                      context="mei:symbol[ancestor::mei:symbolDef]">
                <sch:assert test="@startid or (@x and @y)">In the symbolDef context, symbol must have
-                  either a startid attribute or x and y attributes.</sch:assert>
-               <sch:assert test="@altsym or @glyphname or @glyphnum">In the symbolDef context,
-                  symbol must have one of the following attributes: altsym, glyphname, or
-                  glyphnum.</sch:assert>
+              either a startid attribute or x and y attributes.</sch:assert>
+               <sch:assert test="@altsym or @glyphname or @glyphnum">In the symbolDef context, symbol
+              must have one of the following attributes: altsym, glyphname, or
+              glyphnum.</sch:assert>
             </sch:rule>
          </pattern>
          <ref name="mei_att.altsym.attributes"/>
@@ -26397,8 +24362,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_symbolDef">
       <element name="symbolDef">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(symbol
-            definition) – Declaration of an individual symbol in a symbolTable.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(symbol definition) – Declaration of an individual symbol in a symbolTable.</a:documentation>
          <optional>
             <ref name="mei_symName"/>
          </optional>
@@ -26427,9 +24391,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_symName">
       <element name="symName">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(symbol
-            name) – Contains the name of a symbol, expressed following Unicode
-            conventions.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(symbol name) – Contains the name of a symbol, expressed following Unicode conventions.</a:documentation>
          <text/>
          <ref name="mei_att.common.attributes"/>
          <empty/>
@@ -26437,9 +24399,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_symProp">
       <element name="symProp">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(symbol
-            property) – Provides a name and value for some property of the parent
-            symbol.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">(symbol property) – Provides a name and value for some property of the parent symbol.</a:documentation>
          <ref name="mei_propName"/>
          <ref name="mei_propValue"/>
          <ref name="mei_att.common.attributes"/>
@@ -26448,8 +24408,7 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
    </define>
    <define name="mei_symbolTable">
       <element name="symbolTable">
-         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a
-            set of user-defined symbols.</a:documentation>
+         <a:documentation xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0">Contains a set of user-defined symbols.</a:documentation>
          <oneOrMore>
             <ref name="mei_symbolDef"/>
          </oneOrMore>
@@ -26465,8 +24424,10 @@ TEI Edition Location: http://www.tei-c.org/Vault/P5//
          <ref name="mei_music"/>
       </choice>
    </start>
-   <ns xmlns="http://purl.oclc.org/dsdl/schematron" prefix="mei"
-      uri="http://www.music-encoding.org/ns/mei"/>
-   <ns xmlns="http://purl.oclc.org/dsdl/schematron" prefix="xlink"
-      uri="http://www.w3.org/1999/xlink"/>
+   <ns xmlns="http://purl.oclc.org/dsdl/schematron"
+       prefix="mei"
+       uri="http://www.music-encoding.org/ns/mei"/> 
+   <ns xmlns="http://purl.oclc.org/dsdl/schematron"
+       prefix="xlink"
+       uri="http://www.w3.org/1999/xlink"/>
 </grammar>

--- a/source/specs/mei-source.xml
+++ b/source/specs/mei-source.xml
@@ -1262,56 +1262,59 @@
     <macroSpec ident="data.HEADSHAPE" module="MEI" type="dt">
       <desc>Note head shapes.</desc>
       <content>
-        <valList type="semi">
-          <valItem ident="quarter">
-            <desc>Filled, rotated oval (Unicode 1D158).</desc>
-          </valItem>
-          <valItem ident="half">
-            <desc>Unfilled, rotated oval (Unicode 1D157).</desc>
-          </valItem>
-          <valItem ident="whole">
-            <desc>Unfilled, rotated oval (Unicode 1D15D).</desc>
-          </valItem>
-          <valItem ident="backslash">
-            <desc>Unfilled backslash (~ reflection of Unicode 1D10D).</desc>
-          </valItem>
-          <valItem ident="circle">
-            <desc>Unfilled circle (Unicode 25CB).</desc>
-          </valItem>
-          <valItem ident="+">
-            <desc>Plus sign (Unicode 1D144).</desc>
-          </valItem>
-          <valItem ident="diamond">
-            <desc>Unfilled diamond (Unicode 1D1B9).</desc>
-          </valItem>
-          <valItem ident="isotriangle">
-            <desc>Unfilled isosceles triangle (Unicode 1D148).</desc>
-          </valItem>
-          <valItem ident="oval">
-            <desc>Unfilled, unrotated oval (Unicode 2B2D).</desc>
-          </valItem>
-          <valItem ident="piewedge">
-            <desc>Unfilled downward-pointing wedge (Unicode 1D154).</desc>
-          </valItem>
-          <valItem ident="rectangle">
-            <desc>Unfilled rectangle (Unicode 25AD).</desc>
-          </valItem>
-          <valItem ident="rtriangle">
-            <desc>Unfilled right triangle (Unicode 1D14A).</desc>
-          </valItem>
-          <valItem ident="semicircle">
-            <desc>Unfilled semi-circle (Unicode 1D152).</desc>
-          </valItem>
-          <valItem ident="slash">
-            <desc>Unfilled slash (~ Unicode 1D10D).</desc>
-          </valItem>
-          <valItem ident="square">
-            <desc>Unfilled square (Unicode 1D146).</desc>
-          </valItem>
-          <valItem ident="x">
-            <desc>X (Unicode 1D143).</desc>
-          </valItem>
-        </valList>
+        <alternate>
+          <valList type="semi">
+            <valItem ident="quarter">
+              <desc>Filled, rotated oval (Unicode 1D158).</desc>
+            </valItem>
+            <valItem ident="half">
+              <desc>Unfilled, rotated oval (Unicode 1D157).</desc>
+            </valItem>
+            <valItem ident="whole">
+              <desc>Unfilled, rotated oval (Unicode 1D15D).</desc>
+            </valItem>
+            <valItem ident="backslash">
+              <desc>Unfilled backslash (~ reflection of Unicode 1D10D).</desc>
+            </valItem>
+            <valItem ident="circle">
+              <desc>Unfilled circle (Unicode 25CB).</desc>
+            </valItem>
+            <valItem ident="+">
+              <desc>Plus sign (Unicode 1D144).</desc>
+            </valItem>
+            <valItem ident="diamond">
+              <desc>Unfilled diamond (Unicode 1D1B9).</desc>
+            </valItem>
+            <valItem ident="isotriangle">
+              <desc>Unfilled isosceles triangle (Unicode 1D148).</desc>
+            </valItem>
+            <valItem ident="oval">
+              <desc>Unfilled, unrotated oval (Unicode 2B2D).</desc>
+            </valItem>
+            <valItem ident="piewedge">
+              <desc>Unfilled downward-pointing wedge (Unicode 1D154).</desc>
+            </valItem>
+            <valItem ident="rectangle">
+              <desc>Unfilled rectangle (Unicode 25AD).</desc>
+            </valItem>
+            <valItem ident="rtriangle">
+              <desc>Unfilled right triangle (Unicode 1D14A).</desc>
+            </valItem>
+            <valItem ident="semicircle">
+              <desc>Unfilled semi-circle (Unicode 1D152).</desc>
+            </valItem>
+            <valItem ident="slash">
+              <desc>Unfilled slash (~ Unicode 1D10D).</desc>
+            </valItem>
+            <valItem ident="square">
+              <desc>Unfilled square (Unicode 1D146).</desc>
+            </valItem>
+            <valItem ident="x">
+              <desc>X (Unicode 1D143).</desc>
+            </valItem>
+          </valList>
+          <dataRef name="string"/>
+        </alternate>
       </content>
     </macroSpec>
     <macroSpec ident="data.HORIZONTALALIGNMENT" module="MEI" type="dt">


### PR DESCRIPTION
This was added to make explicit that the `<valList type='semi'>` should accept other string values for the note.head attribute.

I'm using two "pure ODD" recently added elements to solve this problem: `<alternate>`and `<dataRef>`.
This allows me to indicate that the datatype should either allow the list of attribute values or string. 

Caveat: the current TEI schema doesn't validate this yet, but it's correctly processed by the latest release of TEI XSLTs.
