### PR TITLE
Updated url to ECL License.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-© 2015 by the Encoding Initiative (MEI).
+© 2015-2016 by the Encoding Initiative (MEI).
 Licensed under the Educational Community License, Version 2.0 (the "License"); you may
 not use this file except in compliance with the License. You may obtain a copy of the License
 at https://opensource.org/licenses/ECL-2.0.

--- a/LICENSE
+++ b/LICENSE
@@ -1,14 +1,14 @@
-© 2015 by the Encoding Initiative (MEI).
+Â© 2015 by the Encoding Initiative (MEI).
 Licensed under the Educational Community License, Version 2.0 (the "License"); you may
-not use this file except in compliance with the License. You may obtain a copy of the License 
-at http://www.osedu.org/licenses/ECL-2.0.
+not use this file except in compliance with the License. You may obtain a copy of the License
+at https://opensource.org/licenses/ECL-2.0.
 
 Unless required by applicable law or agreed to in writing, software distributed under the
 License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
 OF ANY KIND, either express or implied. See the License for the specific language
 governing permissions and limitations under the License.
 
-This is a derivative work based on earlier versions of the schema © 2001-2006 Perry Roland 
+This is a derivative work based on earlier versions of the schema Â© 2001-2006 Perry Roland
 and the Rector and Visitors of the University of Virginia; licensed under the Educational
 Community License version 1.0.
 


### PR DESCRIPTION
Fix: URL to ECL License.
Fix: character encoding of @.

The osedu.org URL to the link seems to be out of date. 

Additionally, there was something funky going on with the © signs: oxygen could not open the file, saying "UTF8 does not support all characters from the file". 
