### PR TITLE
Text instruct elem spec

### DIFF
--- a/source/specs/mei-source.xml
+++ b/source/specs/mei-source.xml
@@ -20207,6 +20207,31 @@
         </rng:zeroOrMore>
       </content>
     </elementSpec>
+    <elementSpec ident="textInstruct" module="MEI.shared">
+      <desc>(text instruction) Encodes a playing or performance
+      direction which is given in prose text and which cannot be
+      captured by more specific elements such as &lt;tempo&gt;.</desc>
+      <classes>
+        <memberOf key="att.common"/>
+        <memberOf key="att.bibl"/>
+        <memberOf key="att.facsimile"/>
+        <memberOf key="att.lang"/>
+        <memberOf key="model.sectionPart"/>
+        <memberOf key="model.staffPart"/>
+        <memberOf key="model.layerPart"/>
+        <memberOf key="model.measurePart"/>
+        <memberOf key="model.rdgPart.text"/>
+      </classes>
+      <content>
+        <rng:zeroOrMore>
+          <rng:choice>
+            <rng:text />
+            <rng:ref name="model.annotLike"/>
+            <rng:ref name="model.transcriptionLike"/>
+          </rng:choice>
+        </rng:zeroOrMore>
+      </content>
+    </elementSpec>
     <elementSpec ident="textLang" module="MEI.shared">
       <desc>(text language) – Identifies the languages and writing systems within the work described
         by a bibliographic description, not the language of the description.</desc>

--- a/source/specs/mei-source.xml
+++ b/source/specs/mei-source.xml
@@ -15821,6 +15821,7 @@
             <rng:ref name="model.editLike"/>
             <rng:ref name="model.transcriptionLike"/>
             <rng:ref name="model.rdgPart.critapp"/>
+            <rng:ref name="model.rdgPart.text"/>
             <rng:ref name="model.sectionPart"/>
           </rng:choice>
         </rng:zeroOrMore>
@@ -18185,6 +18186,7 @@
             <rng:ref name="model.editLike"/>
             <rng:ref name="model.transcriptionLike"/>
             <rng:ref name="model.rdgPart.critapp"/>
+            <rng:ref name="model.rdgPart.text"/>
             <rng:ref name="model.sectionPart"/>
           </rng:choice>
         </rng:zeroOrMore>


### PR DESCRIPTION
This pull request implements the element `<textInstruct>` which encodes a textual instruction in music notation. These are portions of text written on the score which give instructions to the performer. Such text plays a similar role to features such as dynamic markings and tempo markings, but the composers (or transcribers or editors) felt that a non-standard instruction was necessary.

`<textInstruct>` can appear in a `<section>`, `<layer>`, `<staff>`, or `<measure>` and may also be part of a `<lem>` or `<rdg>`. It may contain any of the `model.transcriptionLike` or `model.annotLike` elements.

It's also in the `model.rdgPart.text` class. Another commit alters this class adding it to the content model of `<lem>` and `<rdg>`.
