### PR TITLE
Use proper node name markup inside <desc> and <remarks>

### DIFF
--- a/source/specs/mei-source.xml
+++ b/source/specs/mei-source.xml
@@ -3637,7 +3637,7 @@
       <attList>
         <attDef ident="altsym" usage="opt">
           <desc>Provides a way of pointing to a user-defined symbol. It must contain a reference to
-            an ID of a &lt;symbolDef&gt; element elsewhere in the document.</desc>
+            an ID of a <gi scheme="MEI">symbolDef</gi> element elsewhere in the document.</desc>
           <datatype>
             <rng:ref name="data.URI"/>
           </datatype>
@@ -3847,7 +3847,7 @@
           <desc>Encodes the written articulation(s). Articulations are normally encoded in order
             from the note head outward; that is, away from the stem. See additional notes at
             att.vis.note. Only articulations should be encoded in the artic attribute; for example,
-            fingerings should be encoded using the &lt;fingering&gt; element.</desc>
+            fingerings should be encoded using the <gi scheme="MEIT">fing</gi> element.</desc>
           <datatype maxOccurs="unbounded">
             <rng:ref name="data.ARTICULATION"/>
           </datatype>
@@ -3884,7 +3884,7 @@
         </attDef>
       </attList>
       <remarks>
-        <p>The @dots attribute records the number of augmentation dots necessary to represent a
+        <p>The <att>dots</att> attribute records the number of augmentation dots necessary to represent a
           non-power-of-two duration. This is usually, but not always, the number of dots displayed.
           For example, a note with this attribute will result in displayed dots, while a glissando
           will not.</p>
@@ -4302,7 +4302,7 @@
         </attDef>
       </attList>
       <remarks>
-        <p>Mapping elements from one system to another via @analog may help a repository harvest
+        <p>Mapping elements from one system to another via <att>analog</att> may help a repository harvest
           selected data from the MEI file to build a basic catalog record. The encoding system from
           which fields are taken must be specified. When possible, subfields as well as fields
           should be specified, e.g., subfields within MARC fields.</p>
@@ -5640,8 +5640,8 @@
         <memberOf key="att.xy"/>
       </classes>
       <remarks>
-        <p>If @tstamp2 is not provided, then the extender should be drawn based on the value of
-          @tstamp2 on the harm ancestor.</p>
+        <p>If <att>tstamp2</att> is not provided, then the extender should be drawn based on the value of
+          <att>tstamp2</att> on the harm ancestor.</p>
       </remarks>
     </classSpec>
     <classSpec ident="att.facsimile" module="MEI.facsimile" type="atts">
@@ -5733,7 +5733,7 @@
       <attList>
         <attDef ident="fermata" usage="opt">
           <desc>Indicates the attachment of a fermata to this element. If visual information about
-            the fermata needs to be recorded, then a &lt;fermata&gt; element should be employed
+            the fermata needs to be recorded, then a <gi scheme="MEI">fermata</gi> element should be employed
             instead.</desc>
           <datatype>
             <rng:ref name="data.PLACE"/>
@@ -5785,8 +5785,8 @@
         <memberOf key="att.xy"/>
       </classes>
       <remarks>
-        <p>If @tstamp2 is not provided, then the extender should be drawn based on the value of
-          @tstamp2 on a fingering ancestor.</p>
+        <p>If <att>tstamp2</att> is not provided, then the extender should be drawn based on the value of
+          <att>tstamp2</att> on a fingering ancestor.</p>
       </remarks>
     </classSpec>
     <classSpec ident="att.fingGrp.anl" module="MEI.fingering" type="atts">
@@ -6110,7 +6110,7 @@
       <attList>
         <attDef ident="hand" usage="opt">
           <desc>Signifies the hand responsible for an action. The value must be the ID of a
-            &lt;hand&gt; element declared in the header.</desc>
+            <gi scheme="MEI">hand</gi> element declared in the header.</desc>
           <datatype>
             <rng:ref name="data.URI"/>
           </datatype>
@@ -6169,7 +6169,7 @@
       </classes>
       <attList>
         <attDef ident="chordref" usage="opt">
-          <desc>Contains a reference to a &lt;chordDef&gt; element elsewhere in the document.</desc>
+          <desc>Contains a reference to a <gi scheme="MEI">chordDef</gi> element elsewhere in the document.</desc>
           <datatype>
             <rng:ref name="data.URI"/>
           </datatype>
@@ -6446,7 +6446,7 @@
       <attList>
         <attDef ident="instr" usage="opt">
           <desc>Provides a way of pointing to a MIDI instrument definition. It must contain the ID
-            of an &lt;instrDef&gt; element elsewhere in the document.</desc>
+            of an <gi scheme="MEI">instrDef</gi> element elsewhere in the document.</desc>
           <datatype>
             <rng:ref name="data.URI"/>
           </datatype>
@@ -6592,7 +6592,7 @@
             p. 143, ex. 9-39), and key signatures with unorthodox placement of the accidentals
             (Read, p. 141) must be indicated by setting the key.sig attribute to 'mixed' and
             providing explicit key signature information in the key.sig.mixed attribute or in the
-            &lt;keySig&gt; element. It is intended that key.sig.mixed contain a series of tokens
+            <gi scheme="MEI">keySig</gi> element. It is intended that key.sig.mixed contain a series of tokens
             with each token containing pitch name, accidental, and octave, such as 'a4 c5s e5f' that
             indicate what key accidentals should be rendered and where they should be placed.</desc>
           <datatype maxOccurs="unbounded">
@@ -6656,7 +6656,7 @@
             p. 143, ex. 9-39), and key signatures with unorthodox placement of the accidentals
             (Read, p. 141) must be indicated by setting the key.sig attribute to 'mixed' and
             providing explicit key signature information in the key.sig.mixed attribute or in the
-            &lt;keySig&gt; element. It is intended that key.sig.mixed contain a series of tokens
+            <gi scheme="MEI">keySig</gi> element. It is intended that key.sig.mixed contain a series of tokens
             with each token containing pitch name, accidental, and octave, such as 'a4 c5s e5f' that
             indicate what key accidentals should be rendered and where they should be placed.</desc>
           <datatype maxOccurs="unbounded">
@@ -7508,7 +7508,7 @@
           <desc>Indicates whether or not a bar line is "controlling"; that is, if it indicates a
             point of alignment across all the parts. Bar lines within a score are usually
             controlling; that is, they "line up". Bar lines within parts may or may not be
-            controlling. When applied to &lt;measure&gt;, this attribute indicates the nature of the
+            controlling. When applied to <gi scheme="MEI">measure</gi>, this attribute indicates the nature of the
             right barline but not the left.</desc>
           <datatype>
             <rng:ref name="data.BOOLEAN"/>
@@ -7993,7 +7993,7 @@
     </classSpec>
     <classSpec ident="att.mSpace.anl" module="MEI.cmn" type="atts">
       <desc>Analytical domain attributes. Use the n attribute to explicitly encode this measure's
-        position in a string of measures containing only &lt;mRest&gt; elements.</desc>
+        position in a string of measures containing only <gi scheme="MEI">mRest</gi> elements.</desc>
       <classes>
         <memberOf key="att.common.anl"/>
       </classes>
@@ -8139,7 +8139,7 @@
                 >http://www.loc.gov/marc/relators/relaterm.html</ref>) or code list (<ref
                 target="http://www.loc.gov/marc/relators/relacode.html"
                 >http://www.loc.gov/marc/relators/relacode.html</ref>) are recommended for
-              @role.</p>
+              <att>role</att>.</p>
           </remarks>
         </attDef>
       </attList>
@@ -8641,7 +8641,7 @@
         <attDef ident="origin.tstamp2" usage="rec">
           <desc>encodes the ending point of musical material in terms of musical time, i.e., a count
             of measures plus a beat location. The values are relative to the measure identified by
-            @origin.tstamp.</desc>
+            <att>origin.tstamp</att>.</desc>
           <datatype>
             <rng:ref name="data.MEASUREBEAT"/>
           </datatype>
@@ -8854,7 +8854,7 @@
       <attList>
         <attDef ident="folium" usage="opt">
           <desc>States the side of a leaf (as in a manuscript) on which the content following the
-            &lt;pb&gt; element occurs.</desc>
+            <gi scheme="MEI">pb</gi> element occurs.</desc>
           <valList type="closed">
             <valItem ident="verso"/>
             <valItem ident="recto"/>
@@ -9551,7 +9551,7 @@
       <desc>Gestural domain attributes for scoreDef. The values set in these attributes act as
         score-wide defaults for attributes that are not set in descendant elements. For example, the
         grace attribute value here applies to all the grace attribute values in the score (or, more
-        accurately, until the next &lt;scoreDef&gt; element) without having to individually set each
+        accurately, until the next <gi scheme="MEI">scoreDef</gi> element) without having to individually set each
         note's grace attribute value. The midi.* attributes function as default values when creating
         sounding output. The tune.* attributes provide the capability of recording a tuning
         reference pitch.</desc>
@@ -9759,7 +9759,7 @@
       <attList>
         <attDef ident="slur" usage="opt">
           <desc>Indicates that this element participates in a slur. If visual information about the
-            slur needs to be recorded, then a &lt;slur&gt; element should be employed.</desc>
+            slur needs to be recorded, then a <gi scheme="MEI">slur</gi> element should be employed.</desc>
           <datatype maxOccurs="unbounded">
             <rng:ref name="data.SLUR"/>
           </datatype>
@@ -9798,7 +9798,7 @@
       <attList>
         <attDef ident="source" usage="opt">
           <desc>Contains a list of one or more pointers indicating the sources which attest to a
-            given reading. Each value should correspond to the ID of a &lt;source&gt; element
+            given reading. Each value should correspond to the ID of a <gi scheme="MEI">source</gi> element
             located in the document header.</desc>
           <datatype maxOccurs="unbounded">
             <rng:ref name="data.URI"/>
@@ -10069,7 +10069,7 @@
         </attDef>
         <attDef ident="spacing" usage="opt">
           <desc>Records the absolute distance (as opposed to the relative distances recorded in
-            &lt;scoreDef&gt; elements) between this staff and the preceding one in the same system.
+            <gi scheme="MEI">scoreDef</gi> elements) between this staff and the preceding one in the same system.
             This value is meaningless for the first staff in a system since the spacing.system
             attribute indicates the spacing between systems.</desc>
           <datatype>
@@ -10654,7 +10654,7 @@
       <attList>
         <attDef ident="tie" usage="opt">
           <desc>Indicates that this element participates in a tie. If visual information about the
-            tie needs to be recorded, then a &lt;tie&gt; element should be employed.</desc>
+            tie needs to be recorded, then a <gi scheme="MEI">tie</gi> element should be employed.</desc>
           <datatype maxOccurs="unbounded">
             <rng:ref name="data.TIE"/>
           </datatype>
@@ -10882,7 +10882,7 @@
       <attList>
         <attDef ident="tuplet" usage="opt">
           <desc>Indicates that this feature participates in a tuplet. If visual information about
-            the tuplet needs to be recorded, then a &lt;tuplet&gt; element should be
+            the tuplet needs to be recorded, then a <gi scheme="MEI">tuplet</gi> element should be
             employed.</desc>
           <datatype maxOccurs="unbounded">
             <rng:ref name="data.TUPLET"/>
@@ -13607,7 +13607,7 @@
       </remarks>
     </elementSpec>
     <elementSpec ident="chordMember" module="MEI.harmony">
-      <desc>An individual pitch in a chord defined by a &lt;chordDef&gt; element.</desc>
+      <desc>An individual pitch in a chord defined by a <gi scheme="MEI">chordDef</gi> element.</desc>
       <classes>
         <memberOf key="att.accidental.gestural"/>
         <memberOf key="att.common"/>
@@ -13666,7 +13666,7 @@
     </elementSpec>
     <elementSpec ident="classCode" module="MEI.header">
       <desc>(classification code) – Holds a citation to the source of controlled-vocabulary terms
-        used in the &lt;termList&gt; element; for example, Library of Congress Subject Headings
+        used in the <gi scheme="MEI">termList</gi> element; for example, Library of Congress Subject Headings
         (LCSH), Library of Congress Classification (LCC), Library of Congress Name Authority File
         (LCNAF), or other thesaurus or ontology.</desc>
       <classes>
@@ -14195,18 +14195,18 @@
         <p>Typical examples are <foreign>colla parte</foreign> instructions (such as "col Basso") or
           other indications intended to result in filling gaps in the score with material written
           elsewhere. It is recommended to capture the position of the indication itself with the
-          attributes @tstamp and @staff. The area to be filled should contain <gi scheme="MEI"
+          attributes <att>tstamp</att> and <att>staff</att>. The area to be filled should contain <gi scheme="MEI"
             >space</gi> or <gi scheme="MEI">mSpace</gi> elements. The material to be used to fill
-          the gap can be identified by the attributes @origin.tstamp, @origin.tstamp2,
-          @origin.staff, and @origin.layer. If @origin.tstamp2 is not provided, a duration similar
-          to that of the local omission (as encoded in the combination of @tstamp and @tstamp2) is
+          the gap can be identified by the attributes <att>origin.tstamp</att>, <att>origin.tstamp2</att>,
+          <att>origin.staff</att>, and <att>origin.layer</att>. If <att>origin.tstamp2</att> is not provided, a duration similar
+          to that of the local omission (as encoded in the combination of <att>tstamp</att> and <att>tstamp2</att>) is
           assumed. Any missing @origin.* attributes are assumed to take the same values as
-          information associated with the cpMark. For example, when only the @origin.staff attribute
+          information associated with the cpMark. For example, when only the <att>origin.staff</att> attribute
           is provided, it is assumed that the referenced part comes from a different staff in the
-          same measure. If a different measure is provided by @origin.tstamp, but no @origin.staff
+          same measure. If a different measure is provided by <att>origin.tstamp</att>, but no <att>origin.staff</att>
           is given, then it is assumed that the material is to be taken from the same staff.</p>
         <p>Textual instructions are encoded as text content of the cpMark, while graphical
-          instructions may use the @altsym, @facs, or @extsym attributes.</p>
+          instructions may use the <att>altsym</att>, <att>facs</att>, or <att>extsym</att> attributes.</p>
       </remarks>
     </elementSpec>
     <elementSpec ident="creation" module="MEI.shared">
@@ -14544,7 +14544,7 @@
       <desc>(directive) – An instruction expressed as a combination of text and symbols — such as
         segno and coda symbols, fermatas over a bar line, etc., typically above, below, or between
         staves, but not on the staff — that is not encoded elsewhere in more specific elements, like
-        &lt;tempo&gt; or &lt;dynam&gt;.</desc>
+        <gi scheme="MEI">tempo</gi> or <gi scheme="MEI">dynam</gi>.</desc>
       <classes>
         <memberOf key="att.common"/>
         <memberOf key="att.facsimile"/>
@@ -17103,7 +17103,7 @@
       </remarks>
     </elementSpec>
     <elementSpec ident="li" module="MEI.text">
-      <desc>(list item) – Single item in a &lt;list&gt;.</desc>
+      <desc>(list item) – Single item in a <gi scheme="MEI">list</gi>.</desc>
       <classes>
         <memberOf key="att.common"/>
         <memberOf key="att.facsimile"/>
@@ -17534,7 +17534,7 @@
     </elementSpec>
     <elementSpec ident="meiCorpus" module="MEI.corpus">
       <desc>(MEI corpus) – A group of related MEI documents, consisting of a header for the group,
-        and one or more &lt;mei&gt; elements, each with its own complete header.</desc>
+        and one or more <gi scheme="MEI">mei</gi> elements, each with its own complete header.</desc>
       <classes>
         <memberOf key="att.common"/>
         <memberOf key="att.meiVersion"/>
@@ -19782,9 +19782,9 @@
       </content>
       <attList>
         <attDef ident="rel" usage="req">
-          <desc>Describes the relationship between the entity identified by the &lt;relatedItem&gt;
-            element and the resource described in the parent element, i.e., &lt;bibl&gt;,
-            &lt;source&gt; or &lt;relatedItem&gt;.</desc>
+          <desc>Describes the relationship between the entity identified by the <gi scheme="MEI">relatedItem</gi>
+            element and the resource described in the parent element, i.e., <gi scheme="MEI">bibl</gi>,
+            <gi scheme="MEI">source</gi> or <gi scheme="MEI">relatedItem</gi>.</desc>
           <datatype>
             <rng:ref name="data.MODSRELATIONSHIP"/>
           </datatype>
@@ -21726,7 +21726,7 @@
           </datatype>
         </attDef>
         <attDef ident="withid" usage="opt">
-          <desc>Number of occurrences in the defined context that have an @xml:id attribute.</desc>
+          <desc>Number of occurrences in the defined context that have an <att>xml:id</att> attribute.</desc>
           <datatype>
             <rng:data type="nonNegativeInteger"/>
           </datatype>
@@ -22199,7 +22199,7 @@
     </elementSpec>
     <elementSpec ident="tr" module="MEI.figtable">
       <desc>(table row) – A formatting element that contains one or more cells (intersection of a
-        row and a column) in a &lt;table&gt;.</desc>
+        row and a column) in a <gi scheme="MEI">table</gi>.</desc>
       <classes>
         <memberOf key="att.common"/>
         <memberOf key="att.facsimile"/>

--- a/source/specs/mei-source.xml
+++ b/source/specs/mei-source.xml
@@ -3847,7 +3847,7 @@
           <desc>Encodes the written articulation(s). Articulations are normally encoded in order
             from the note head outward; that is, away from the stem. See additional notes at
             att.vis.note. Only articulations should be encoded in the artic attribute; for example,
-            fingerings should be encoded using the <gi scheme="MEIT">fing</gi> element.</desc>
+            fingerings should be encoded using the <gi scheme="MEI">fing</gi> element.</desc>
           <datatype maxOccurs="unbounded">
             <rng:ref name="data.ARTICULATION"/>
           </datatype>


### PR DESCRIPTION
Replaces literal "`<>`" with `<gi>` and literal "`@`" with `<att>`.
Also corrects `<gi>fingering</gi>` to `<gi>fing</gi>`.