### PR TITLE
Modifying Schmatron rule for keyAccid in order not to require oct

### DIFF
--- a/source/specs/mei-source.xml
+++ b/source/specs/mei-source.xml
@@ -17655,9 +17655,9 @@
       <constraintSpec ident="Check_keyAccidPlacement" scheme="isoschematron">
         <constraint>
           <sch:rule context="mei:keyAccid">
-            <sch:assert test="(@x and @y) or (@pname and @oct) or @loc">One of the following is
-              required: @x and @y attribute pair, @pname and @oct attribute pair, or @loc
-              attribute.</sch:assert>
+            <sch:assert test="(@x and @y) or @pname or @loc">One of the following is
+              required: @x and @y attribute pair, @pname attribute, or @loc attribute.
+            </sch:assert>
           </sch:rule>
         </constraint>
       </constraintSpec>


### PR DESCRIPTION
In some cases it can be useful to have `<keyAccid`> specifying only the `@pname` and not the `@oct`. That way, the octave can be left undetermined and calculated according to the clef and the standard practice for key signatures. 

With the requested change, the following will be valid:
```xml
<keySig>
   <keyAccid accid="s" pname="f"/>
   <keyAccid accid="s" pname="c" enclose="brack"/>
</keySig>
```