### PR TITLE
Making fig member of att.horizontal/verticalAlign

### DIFF
--- a/source/modules/MEI.figtable.xml
+++ b/source/modules/MEI.figtable.xml
@@ -52,6 +52,8 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
+      <memberOf key="att.horizontalAlign"/>
+      <memberOf key="att.verticalAlign"/>
       <memberOf key="att.xy"/>
       <memberOf key="model.figureLike"/>
     </classes>


### PR DESCRIPTION
This PR makes it possible to encode the horizontal and vertical alignment of a `<fig>` without having to in enclose it in a `<rend>`.