### PR TITLE
Renaming att.verticalAlignment and changing type for vgrp

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -3392,13 +3392,13 @@
       </attDef>
     </attList>
   </classSpec>
-  <classSpec ident="att.verticalAlignment" module="MEI.shared" type="atts">
-    <desc>Attributes that describe visual alignment in the vertical dimension.</desc>
+  <classSpec ident="att.verticalGroup" module="MEI.shared" type="atts">
+    <desc>Attributes that record grouping of vertically aligned elements.</desc>
     <attList>
       <attDef ident="vgrp" usage="opt">
         <desc>Provides a label for members of a vertically aligned group.</desc>
         <datatype>
-          <rng:data type="integer"/>
+          <rng:data type="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -120,7 +120,7 @@
     <classes>
       <memberOf key="att.extender"/>
       <memberOf key="att.placement"/>
-      <memberOf key="att.verticalAlignment"/>
+      <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
       <memberOf key="att.visualOffset2.to"/>
@@ -380,7 +380,7 @@
     <classes>
       <memberOf key="att.extender"/>
       <memberOf key="att.placement"/>
-      <memberOf key="att.verticalAlignment"/>
+      <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
       <memberOf key="att.visualOffset2.to"/>
@@ -405,7 +405,7 @@
     <desc>Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.placement"/>
-      <memberOf key="att.verticalAlignment"/>
+      <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
       <memberOf key="att.visualOffset2.to"/>
@@ -580,7 +580,7 @@
       <memberOf key="att.color"/>
       <memberOf key="att.lineRend.base"/>
       <memberOf key="att.placement"/>
-      <memberOf key="att.verticalAlignment"/>
+      <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2"/>
       <memberOf key="att.xy"/>
@@ -1607,7 +1607,7 @@
     <desc>Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.placement"/>
-      <memberOf key="att.verticalAlignment"/>
+      <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
       <memberOf key="att.visualOffset2.to"/>


### PR DESCRIPTION
This is a cosmetic change that renames the classSpec name `att.verticalAlignment` to `att.verticalGroup` in order to avoid confusion with `att.verticalAlign` and also because it is not related to `data.VERTICALALIGNMENT`. Also the type was changed to `positiveInteger`