### PR TITLE
fix wrong classSpec identifier

### DIFF
--- a/source/modules/MEI.gestural.xml
+++ b/source/modules/MEI.gestural.xml
@@ -267,7 +267,7 @@
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
-  <classSpec ident="att.fing.ges" module="MEI.gestural" type="atts">
+  <classSpec ident="att.fingGrp.ges" module="MEI.gestural" type="atts">
     <desc>Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>


### PR DESCRIPTION
`att.fing.ges` was declared twice while `att.fingGrp.ges` was never declared. This commit resolves that issue and closes #506