### PR TITLE
Rename break elements

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -3807,7 +3807,7 @@
     </classes>
   </classSpec>
   <classSpec ident="model.lbLike" module="MEI.shared" type="model">
-    <desc>Groups elements that function like line breaks.</desc>
+    <desc>Groups elements that function like line beginnings.</desc>
     <classes>
       <memberOf key="model.milestoneLike.text"/>
       <memberOf key="model.textPhraseLike.limited"/>
@@ -3864,7 +3864,7 @@
     <desc>Groups elements that collect separate performer parts.</desc>
   </classSpec>
   <classSpec ident="model.pbLike" module="MEI.shared" type="model">
-    <desc>Groups page break-like elements.</desc>
+    <desc>Groups page beginning-like elements.</desc>
     <classes>
       <memberOf key="model.milestoneLike.music"/>
       <memberOf key="model.milestoneLike.text"/>
@@ -4588,7 +4588,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="cb" module="MEI.shared">
-    <desc>(column break) – An empty formatting element that forces text to begin in a new
+    <desc>(column beginning) – An empty formatting element that forces text to begin in a new
       column.</desc>
     <classes>
       <memberOf key="att.basic"/>
@@ -4613,7 +4613,7 @@
           <constraint>
             <sch:rule context="mei:cb">
               <sch:let name="totalColumns" value="preceding::mei:colLayout[1]/@cols"/>
-              <sch:assert test="preceding::mei:colLayout">Column break must be preceded by a
+              <sch:assert test="preceding::mei:colLayout">Column beginning must be preceded by a
                 colLayout element.</sch:assert>
               <sch:assert test="@n &lt;= $totalColumns">The value of @n should be less than or equal
                 to the value of @cols (<sch:value-of select="$totalColumns"/>) of the preceding
@@ -5992,7 +5992,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="lb" module="MEI.shared">
-    <desc>(line break) – An empty formatting element that forces text to begin on a new line.</desc>
+    <desc>(line beginning) – An empty formatting element that forces text to begin on a new line.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6481,7 +6481,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="pb" module="MEI.shared">
-    <desc>(page break) – An empty formatting element that forces text to begin on a new page.</desc>
+    <desc>(page beginning) – An empty formatting element that forces text to begin on a new page.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6500,7 +6500,7 @@
       <p>The <att>n</att> attribute should be used to record the page number displayed in the
         source. It need not be an integer, e.g., 'iv', or 'p17-3'. The logical page number can be
         calculated by counting previous <gi scheme="MEI">pb</gi> ancestor elements. When used in a
-        score context, a page break implies an accompanying system break.</p>
+        score context, a page beginning implies an accompanying system beginning.</p>
     </remarks>
     <remarks>
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
@@ -7183,7 +7183,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="sb" module="MEI.shared">
-    <desc>(system break) – An empty formatting element that forces musical notation to begin on a
+    <desc>(system beginning) – An empty formatting element that forces musical notation to begin on a
       new line.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -7235,7 +7235,7 @@
     </content>
     <remarks>
       <p>Since the <gi scheme="MEI">measure</gi> element is optional, a score may consist entirely
-        of page breaks, each of which points to a page image. <gi scheme="MEI">div</gi> elements are
+        of page beginnings, each of which points to a page image. <gi scheme="MEI">div</gi> elements are
         allowed preceding and following sections of music data in order to accommodate blocks of
         explanatory text.</p>
     </remarks>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -6002,19 +6002,6 @@
     <content>
       <rng:empty/>
     </content>
-    <attList>
-      <attDef ident="func" usage="opt">
-        <desc>States whether the line break follows a single line or a line group.</desc>
-        <valList type="closed">
-          <valItem ident="line">
-            <desc>Follows a verse line.</desc>
-          </valItem>
-          <valItem ident="group">
-            <desc>Follows a group of verse lines.</desc>
-          </valItem>
-        </valList>
-      </attDef>
-    </attList>
     <remarks>
       <p>The <att>n</att> attribute should be used to record a number associated with this textual
         line. See comment on <gi scheme="MEI">verse</gi> element for description of <att>func</att>


### PR DESCRIPTION
This PR renames break elements to underline their expected position in the encoding. 

Fix for #521