### PR TITLE
Fixed: Update address for TEI schema

### DIFF
--- a/customizations/mei-CMN.xml
+++ b/customizations/mei-CMN.xml
@@ -92,7 +92,7 @@
         <moduleRef key="MEI.visual"/>
 
         <!-- Include SVG -->
-        <moduleRef url="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/svg11.rng"
+        <moduleRef url="https://www.tei-c.org/release/xml/tei/custom/schema/relaxng/svg11.rng"
           prefix="svg_">
           <content>
             <rng:define name="mei_model.graphicLike" combine="choice">

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -92,7 +92,7 @@
         <moduleRef key="MEI.visual"/>
 
         <!-- Include SVG -->
-        <moduleRef url="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/svg11.rng"
+        <moduleRef url="https://www.tei-c.org/release/xml/tei/custom/schema/relaxng/svg11.rng"
           prefix="svg_">
           <content>
             <rng:define name="mei_model.graphicLike" combine="choice">

--- a/customizations/mei-Neumes.xml
+++ b/customizations/mei-Neumes.xml
@@ -92,7 +92,7 @@
         <moduleRef key="MEI.visual"/>
 
         <!-- Include SVG -->
-        <moduleRef url="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/svg11.rng"
+        <moduleRef url="https://www.tei-c.org/release/xml/tei/custom/schema/relaxng/svg11.rng"
           prefix="svg_">
           <content>
             <rng:define name="mei_model.graphicLike" combine="choice">

--- a/customizations/mei-all.xml
+++ b/customizations/mei-all.xml
@@ -97,7 +97,7 @@
         <moduleRef key="MEI.visual"/>
 
         <!-- Include SVG -->
-        <moduleRef url="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/svg11.rng"
+        <moduleRef url="https://www.tei-c.org/release/xml/tei/custom/schema/relaxng/svg11.rng"
           prefix="svg_">
           <content>
             <rng:define name="mei_model.graphicLike" combine="choice">

--- a/customizations/mei-all_anyStart.xml
+++ b/customizations/mei-all_anyStart.xml
@@ -133,7 +133,7 @@
         <moduleRef key="MEI.visual"/>
 
         <!-- Include SVG -->
-        <moduleRef url="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/svg11.rng"
+        <moduleRef url="https://www.tei-c.org/release/xml/tei/custom/schema/relaxng/svg11.rng"
           prefix="svg_">
           <content>
             <rng:define name="mei_model.graphicLike" combine="choice">


### PR DESCRIPTION
Updates the address for the SVG RNG on the TEI site. The build process now runs without error.

Fixes #581
