### PR TITLE
Fix: custos and clef elements should be within layer

### DIFF
--- a/customizations/mei-Neumes.xml
+++ b/customizations/mei-Neumes.xml
@@ -111,13 +111,13 @@
         <classSpec ident="model.layerPart.cmn" module="MEI.shared" type="model" mode="delete"/>
 
         <!-- Disallow events within layer -->
-        <classSpec ident="model.eventLike" module="MEI.shared" type="model" mode="replace">
+        <!-- <classSpec ident="model.eventLike" module="MEI.shared" type="model" mode="replace">
           <desc>groups event elements that occur in all notational repertoires.</desc>
           <classes>
             <memberOf key="model.syllablePart"/>
             <memberOf key="model.rdgPart.critapp"/>
           </classes>
-        </classSpec>
+        </classSpec> -->
 
         <!-- Disallow neume events within layer; only permitted in mei-all customization -->
         <classSpec ident="model.eventLike.neumes" module="MEI.neumes" type="model" mode="replace">

--- a/customizations/mei-Neumes.xml
+++ b/customizations/mei-Neumes.xml
@@ -127,6 +127,18 @@
             <memberOf key="model.rdgPart.critapp"/>
           </classes>
         </classSpec>
+        
+        <!-- Allow custos and clef to appear within layer; compensate side effect of removing membership in model.layerPart from model.eventLike -->
+        <elementSpec ident="custos" module="MEI.shared" mode="change">
+          <classes mode="change">
+            <memberOf key="model.layerPart.neumes" mode="add"/>
+          </classes>
+        </elementSpec>
+        <elementSpec ident="clef" module="MEI.shared" mode="change">
+          <classes mode="change">
+            <memberOf key="model.layerPart.neumes" mode="add"/>
+          </classes>
+        </elementSpec>
 
       </schemaSpec>
     </body>

--- a/customizations/mei-Neumes.xml
+++ b/customizations/mei-Neumes.xml
@@ -139,6 +139,14 @@
             <memberOf key="model.layerPart.neumes" mode="add"/>
           </classes>
         </elementSpec>
+        
+        <!-- remove custos and clef (among others) from within syllable -->
+        <classSpec ident="model.eventLike" module="MEI.shared" type="model" mode="change">
+          <classes mode="change">
+            <memberOf key="model.syllablePart" mode="delete"/>
+          </classes>
+        </classSpec>
+        
 
       </schemaSpec>
     </body>


### PR DESCRIPTION
With the current MEI Neume schema, custos and clef elements are expected 
to be within syllable. I asked MEI Neume IG and this seems to be an unintended 
mistake in the schema rather than something they need.

When trying to validate a basic MEI neume file, a few warnings are returned in 
regard to clef and custos elements not allowed as children of syllable.

```
jing mei-Neumes.rng example-neume.mei
```

```
example-neume.mei:14:35: error: element "clef" not allowed here;
expected the element end-tag or element "add", "anchoredText",
"annot", "app", "cb", "choice", "colLayout", "corr", "curve",
"damage", "del", "gap", "handShift", "line", "midi", "orig", "pb",
"reg", "restore", "sb", "sic", "subst", "supplied", "syllable" or
"unclear"

example-neume.mei:24:36: error: element "custos" not allowed here;
expected the element end-tag or element "add", "anchoredText",
"annot", "app", "cb", "choice", "colLayout", "corr", "curve",
"damage", "del", "gap", "handShift", "line", "midi", "orig", "pb",
"reg", "restore", "sb", "sic", "subst", "supplied", "syllable" or
"unclear"
```

If, on the contrary, custos and clefs are children of syllable, validation passes.

This issue is related to the replace happening on https://github.com/music-encoding/music-encoding/blob/develop/customizations/mei-Neumes.xml#L113-L120, which this PR fixes.