### PR TITLE
Allow tuplets with one note

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -2371,16 +2371,6 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="When_not_copyof_tuplet_content" scheme="isoschematron">
-      <constraint>
-        <sch:rule context="mei:tuplet[not(@copyof)]">
-          <sch:assert
-            test="count(descendant::*[local-name()='note' or local-name()='rest' or               local-name()='chord']) &gt; 1"
-            >A tuplet without a copyof attribute must have at least 2 note, rest, or chord
-            descendants.</sch:assert>
-        </sch:rule>
-      </constraint>
-    </constraintSpec>
     <remarks>
       <p>The <gi scheme="MEI">beam</gi> sub-element is allowed so that custom beaming may be
         indicated, e.g., a septuplet may be divided into a group of three plus a group of four


### PR DESCRIPTION
There are real-life situations where single-note tuplets occur – I just stumbled upon one:

There are 6-tuplets where the number becomes implicit:

![grafik](https://user-images.githubusercontent.com/1147152/63803340-35224000-c904-11e9-9056-1c7edd01d89e.png)

Later on, we have a 6-tuplet without number in one voice and in the other voice we have a dotted quarter:

![grafik](https://user-images.githubusercontent.com/1147152/63803353-3b182100-c904-11e9-945a-9359a92aca0a.png)

This use of a single-note tuplet is legitimate and sensible. Another (constructed) example to demonstrate that single-note tupets can be reasonable:

![grafik](https://user-images.githubusercontent.com/1147152/63804548-f477f600-c906-11e9-956b-2c8955ea1215.png)
