### PR TITLE
allow color on key signatures

### DIFF
--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -752,6 +752,7 @@
     <desc>Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
+      <memberOf key="att.color"/>
       <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extSym"/>
       <memberOf key="att.staffLoc"/>
@@ -762,6 +763,7 @@
   <classSpec ident="att.keySig.vis" module="MEI.visual" type="atts">
     <desc>Visual domain attributes.</desc>
     <classes>
+      <memberOf key="att.color"/>
       <memberOf key="att.visibility"/>
     </classes>
     <attList>


### PR DESCRIPTION
This PR makes  `att.keyAccid.vis` and `att.keySig.vis` member of `att.color`.