### PR TITLE
add single value

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -3163,6 +3163,9 @@
           <valItem ident="m">
             <desc>(medial) neither first nor last syllable.</desc>
           </valItem>
+          <valItem ident="s">
+            <desc>(single) single syllable.</desc>
+          </valItem>
           <valItem ident="t">
             <desc>(terminal) last syllable.</desc>
           </valItem>


### PR DESCRIPTION
This adds a missing "single" value to `@wordpos`.
Shouldn't this be a datatype, too?