### PR TITLE
New: Add division element to neumes module

### DIFF
--- a/source/modules/MEI.neumes.xml
+++ b/source/modules/MEI.neumes.xml
@@ -514,4 +514,38 @@
       </rng:zeroOrMore>
     </content>
   </elementSpec>
+  <elementSpec ident="division" module="MEI.neumes">
+    <desc>Represents a division in neume notation. Divisions indicate short, medium, or long pauses
+    similar to breath marks in modern notation.</desc>
+    <classes>
+      <memberOf key="att.basic"/>
+      <memberOf key="att.classed"/>
+      <memberOf key="att.facsimile"/>
+      <memberOf key="att.labelled"/>
+      <memberOf key="att.linking"/>
+      <memberOf key="att.nNumberLike"/>
+      <memberOf key="att.responsibility"/>
+      <memberOf key="att.extSym" />
+      <memberOf key="att.staffLoc" />
+      <memberOf key="att.visibility" />
+      <memberOf key="att.xy" />
+      <memberOf key="att.visualOffset.ho" />
+    </classes>
+    <attList>
+      <attDef ident="type" usage="opt">
+        <desc>Identifies the type of division.</desc>
+        <datatype maxOccurs="unbounded">
+          <rng:data type="NMTOKEN"/>
+        </datatype>
+        <valList type="semi">
+          <valItem ident="minima"/>
+          <valItem ident="maior"/>
+          <valItem ident="maxima"/>
+          <valItem ident="finalis"/>
+          <valItem ident="virgula"/>
+          <valItem ident="caesura"/>
+        </valList>
+      </attDef>
+    </attList>
+  </elementSpec>
 </specGrp>

--- a/source/modules/MEI.neumes.xml
+++ b/source/modules/MEI.neumes.xml
@@ -520,6 +520,7 @@
     <classes>
       <memberOf key="att.basic"/>
       <memberOf key="att.classed"/>
+      <memberOf key="att.color" />
       <memberOf key="att.facsimile"/>
       <memberOf key="att.labelled"/>
       <memberOf key="att.linking"/>
@@ -530,7 +531,6 @@
       <memberOf key="att.visibility" />
       <memberOf key="att.xy" />
       <memberOf key="att.visualOffset.ho" />
-      <memberOf key="att.color" />
     </classes>
     <attList>
       <attDef ident="form" usage="opt">
@@ -539,12 +539,12 @@
           <rng:data type="NMTOKEN"/>
         </datatype>
         <valList type="semi">
-          <valItem ident="minima"/>
+          <valItem ident="caesura"/>
+          <valItem ident="finalis"/>
           <valItem ident="maior"/>
           <valItem ident="maxima"/>
-          <valItem ident="finalis"/>
+          <valItem ident="minima"/>
           <valItem ident="virgula"/>
-          <valItem ident="caesura"/>
         </valList>
       </attDef>
     </attList>

--- a/source/modules/MEI.neumes.xml
+++ b/source/modules/MEI.neumes.xml
@@ -514,8 +514,8 @@
       </rng:zeroOrMore>
     </content>
   </elementSpec>
-  <elementSpec ident="division" module="MEI.neumes">
-    <desc>Represents a division in neume notation. Divisions indicate short, medium, or long pauses
+  <elementSpec ident="divLine" module="MEI.neumes">
+    <desc>Represents a division (divisio) in neume notation. Divisions indicate short, medium, or long pauses
     similar to breath marks in modern notation.</desc>
     <classes>
       <memberOf key="att.basic"/>
@@ -530,10 +530,11 @@
       <memberOf key="att.visibility" />
       <memberOf key="att.xy" />
       <memberOf key="att.visualOffset.ho" />
+      <memberOf key="att.color" />
     </classes>
     <attList>
-      <attDef ident="type" usage="opt">
-        <desc>Identifies the type of division.</desc>
+      <attDef ident="form" usage="opt">
+        <desc>Identifies the different kinds of division.</desc>
         <datatype maxOccurs="unbounded">
           <rng:data type="NMTOKEN"/>
         </datatype>


### PR DESCRIPTION
The division element is currently missing from the neumes module. These symbols look like barlines but have a function similar to breath marks and rests, with no specific duration.

The lilypond documentation gives some examples of divisions: http://lilypond.org/doc/v2.18/Documentation/notation/typesetting-gregorian-chant#divisiones

They are also available as SMuFL symbols here: https://w3c.github.io/smufl/gitbook/tables/medieval-and-renaissance-staves.html