### PR TITLE
Add a skew attribute to att.coordinated

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -690,7 +690,10 @@
         </datatype>
       </attDef>
       <attDef ident="skew" usage="opt">
-        <desc>Indicates the skew of the bounding box.</desc>
+        <desc>Indicates the skew of the bounding box. This represents the offset in degrees from
+          a typical 90-degree rectangle. By default the offset is 0-degrees. A positive angle
+          indicates that the upper-right y coordinate is above the upper-left y coordinate while
+          a negative angle indicates the opposite.</desc>
         <datatype>
           <rng:ref name="data.DEGREES"/>
         </datatype>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -2191,7 +2191,7 @@
           notehead in a counter-clockwise fashion, while negative values produce clockwise
           rotation.</desc>
         <datatype>
-          <rng:ref name="data.DEGREES"/>
+          <rng:ref name="data.ROTATION"/>
         </datatype>
       </attDef>
       <attDef ident="head.shape" usage="opt">

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -227,7 +227,7 @@
       convenient typology of annotation suitable to the work in hand; e.g. annotation, gloss,
       citation, digression, preliminary, temporary, etc.</desc>
     <!-- Some attributes defined in att.controlEvent (att.timestamp.logical, att.timestamp.gestural,
-          att.staffIdent, and att.layerIdent) are provided here directly instead of making annot a 
+          att.staffIdent, and att.layerIdent) are provided here directly instead of making annot a
           member of att.controlEvent. -->
     <classes>
       <memberOf key="att.alignment"/>
@@ -687,6 +687,12 @@
         <desc>Indicates the lower-left corner x coordinate.</desc>
         <datatype>
           <rng:data type="nonNegativeInteger"/>
+        </datatype>
+      </attDef>
+      <attDef ident="skew" usage="opt">
+        <desc>Indicates the skew of the bounding box.</desc>
+        <datatype>
+          <rng:ref name="data.DEGREES"/>
         </datatype>
       </attDef>
     </attList>
@@ -1480,7 +1486,7 @@
         </datatype>
       </attDef>
       <!-- @llength not necessary:
-            @llength implies we know the direction of the vector which we 
+            @llength implies we know the direction of the vector which we
             can't know without establishing an end point, which in turn makes
             @llength redundant. -->
       <attDef ident="lsegs" usage="opt">
@@ -2185,7 +2191,7 @@
           notehead in a counter-clockwise fashion, while negative values produce clockwise
           rotation.</desc>
         <datatype>
-          <rng:ref name="data.ROTATION"/>
+          <rng:ref name="data.DEGREES"/>
         </datatype>
       </attDef>
       <attDef ident="head.shape" usage="opt">
@@ -5875,7 +5881,7 @@
       <memberOf key="att.bibl"/>
       <memberOf key="model.incipLike"/>
     </classes>
-    <!-- Can XSLT be used within content to "select" an incipit from the 
+    <!-- Can XSLT be used within content to "select" an incipit from the
         already-encoded MEI transcription in the music element?
         <rng:ref name="macro.XSLT"/> -->
     <content>
@@ -7089,7 +7095,7 @@
       <constraint>
         <!-- See http://vocab.org/frbr/core for more-precise entity-to-entity constraints -->
         <sch:rule
-          context="mei:relationList/mei:relation[parent::mei:work or parent::mei:expression or             
+          context="mei:relationList/mei:relation[parent::mei:work or parent::mei:expression or
           parent::mei:source or parent::mei:item]">
           <sch:assert
             test="matches(@rel, 'hasAbridgement') or
@@ -7297,7 +7303,7 @@
       <constraint>
         <sch:rule context="mei:respStmt[not(ancestor::mei:change)]">
           <sch:assert
-            test="(mei:resp and (mei:name or mei:corpName or mei:persName)) or 
+            test="(mei:resp and (mei:name or mei:corpName or mei:persName)) or
             count(mei:*[@role]) = count(mei:*) and count(mei:*) &gt; 0"
             role="warning">At least one element pair (a resp element and a name-like element) is
             recommended. Alternatively, each name-like element may have a @role


### PR DESCRIPTION
This pull request adds a new optional attribute to `att.coordinated` called skew which takes a value given in degrees. The number of degrees is equivalent to the angle of a vertical shear.

Its purpose is to address issues that arise in encoding handwritten manuscripts. Specifically discrepancies between the specified location in a `<facsimile>` and the calculated location by pitch and octave, line number, etc. The following is an example to illustrate this. With a staff's position defined only using the upper-left and lower-right points, the following can occur.
![image](https://user-images.githubusercontent.com/6963142/66051863-9a69e200-e4fd-11e9-8833-73bcca137af5.png)
Since in the source the staff slants down, lower staff lines near the left and upper staff lines near the right significantly differ in position from the corresponding source staff lines. The problem continues for elements within the staff. Keeping pitch the same as the source results in the positioning like this:
![image](https://user-images.githubusercontent.com/6963142/66052213-3e538d80-e4fe-11e9-8c63-2c0c5a8b4195.png)
Keeping location the same as the source results in the calculated pitch being incorrect. Shifting the neume to the right up to the correct location results in its pitch being E2, not D2.
With this rectangular bounding box for the staff, the location and pitch of elements cannot agree and both be correct encodings of the source.

The following is how the staff looks with the same upper-left and lower-right points with a skew applied:
![image](https://user-images.githubusercontent.com/6963142/66052602-de111b80-e4fe-11e9-9cf1-e604fb8a0b55.png)
The addition of one value for skew allows the location and pitch of elements to both be correct and in agreement.

More examples can be seen using [Neon](http://ddmal.music.mcgill.ca/Neon/). Skewing is available as one of the new experimental features.