### PR TITLE
Improve multiRest

### DIFF
--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1125,6 +1125,7 @@
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.staffLoc.pitched"/>
       <memberOf key="att.typography"/>
+      <memberOf key="att.width"/>
     </classes>
     <attList>
       <attDef ident="block" usage="opt">

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1121,6 +1121,7 @@
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.extSym"/>
+      <memberOf key="att.numberPlacement"/>
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.staffLoc.pitched"/>
       <memberOf key="att.typography"/>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1128,9 +1128,8 @@
     </classes>
     <attList>
       <attDef ident="block" usage="opt">
-        <desc>When the block attribute is used, combinations of the 1, 2, and 4 measure rest forms
-          (Read, p. 104) should be rendered instead of the modern form or an alternative
-          symbol.</desc>
+        <desc>The block attribute controls, whether the multimeasure rest should be rendered as a block rest 
+          or as church rests ("Kirchenpause"), that are combinations of longa, breve and semibreve rests.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1128,8 +1128,8 @@
     </classes>
     <attList>
       <attDef ident="block" usage="opt">
-        <desc>The block attribute controls, whether the multimeasure rest should be rendered as a block rest 
-          or as church rests ("Kirchenpause"), that are combinations of longa, breve and semibreve rests.</desc>
+        <desc>The block attribute controls whether the multimeasure rest should be rendered as a block rest 
+          or as church rests ("Kirchenpausen"), that are combinations of longa, breve and semibreve rests.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>


### PR DESCRIPTION
Working on the guidelines I noticed, that the description of the `@block` attribute on `multiRest` is a bit unclear (and contained an outdated reference). I tried to clear it up. 

Additionally (to the `@block` attribute) it seems to be missing the `@num.visible` attribute to control whether the number above is shown or not. 

Also it was missing a way to control the color (refers to #524).