### PR TITLE
Changes in the mei-Mensural.xml customization to make it compliant with the decisions made by the mensural-ig

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - git clone https://github.com/TEIC/Stylesheets.git
   - cd Stylesheets && git checkout c5d26c36f5beb01688c75591e8cc1c9c7e34b039 && git reset --hard
   - cd ../
-  - curl -O http://central.maven.org/maven2/net/sf/saxon/Saxon-HE/9.8.0-5/Saxon-HE-9.8.0-5.jar
+  - curl -O https://repo1.maven.org/maven2/net/sf/saxon/Saxon-HE/9.8.0-5/Saxon-HE-9.8.0-5.jar
 
 before_script:
  - ./build.sh build

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -106,8 +106,44 @@
         <classSpec ident="model.layerPart.cmn" module="MEI.shared" type="model" mode="delete"/>
 
         <!-- Martha's changes -->
+        
+        <!-- (0) Modification of the description of 'data.DURATION.mensural' -->
+        <!-- I changed the general description, and also the description of four value items (brevis, semiminima, fusa, and semifusa). -->
+        <macroSpec ident="data.DURATION.mensural" module="MEI.mensural" type="dt" mode="change">
+          <desc>Logical, that is, written, note-shape (or note symbol) attribute values for the mensural repertoire.</desc>
+          <content>
+            <valList type="closed">
+              <valItem ident="maxima">
+                <desc>Two or three times as long as a longa.</desc>
+              </valItem>
+              <valItem ident="longa">
+                <desc>Two or three times as long as a brevis.</desc>
+              </valItem>
+              <valItem ident="brevis">
+                <desc>Two or three times as long as a semibrevis.</desc>
+              </valItem>
+              <valItem ident="semibrevis">
+                <desc>Half or one-third as long as a breve/brevis.</desc>
+              </valItem>
+              <valItem ident="minima">
+                <desc>Half or one-third as long as a semibreve/semibrevis.</desc>
+              </valItem>
+              <valItem ident="semiminima">
+                <desc>Half as long as a minima.</desc>
+              </valItem>
+              <valItem ident="fusa">
+                <desc>Half as long as a semiminima.</desc>
+              </valItem>
+              <valItem ident="semifusa">
+                <desc>Half as long as a fusa.</desc>
+              </valItem>
+            </valList>
+          </content>
+        </macroSpec>
+        
+        <!-- (1) The @dur.quality attribute of the <note> element in Mensural MEI -->
         <macroSpec ident="data.DURQUALITY.mensural" module="MEI.mensural" type="dt" mode="add">
-          <desc></desc>
+          <desc>Duration attribute values of a given note symbol for the mensural repertoire.</desc>
           <content>
             <valList type="closed">
               <valItem ident="perfecta">
@@ -117,26 +153,26 @@
                 <desc>Two times the duration of the note in the next smaller degree.</desc>
               </valItem>
               <valItem ident="altera">
-                <desc>Twice the original duration of the note.</desc>
-              </valItem>
-              <valItem ident="maior">
-                <desc>The duration of two minor semibreves (Ars antiqua).</desc>
+                <desc>Twice the original duration of the note (only usable in perfect mensurations).</desc>
               </valItem>
               <valItem ident="minor">
-                <desc>Regular duration of a semibreve (for Ars antiqua).</desc>
+                <desc>Category of a regular semibrevis in Ars antiqua, equivalent to a third of a brevis.</desc>
+              </valItem>
+              <valItem ident="maior">
+                <desc>Category of an altered semibrevis in Ars antiqua, equivalent to two minor semibrevis.</desc>
               </valItem>
               <valItem ident="duplex">
-                <desc>A duplex long, with the duration of two breves.</desc>
+                <desc>One of the three categories of a longa in Ars antiqua ('duplex', 'perfecta', and 'imperfecta'). A duplex longa is twice as long as a regular longa.</desc>
               </valItem>
             </valList>
           </content>
         </macroSpec>
-
+        
         <classSpec ident="att.duration.quality" module="MEI.mensural" type="atts" mode="add">
-          <desc></desc>
+          <desc>Attribute that expresses duration for a given mensural note symbol.</desc>
           <attList>
             <attDef ident="dur.quality" usage="rec" mode="add">
-              <desc>Encode the durational quality of a note (i.e., its perfect / imperfect / altered/ major / minor / duplex nature)</desc>
+              <desc>Encodes the durational quality of a mensural note using the values provided by the data.DURQUALITY.mensural datatype (i.e., the perfect / imperfect / altered / major / minor / duplex quality of a note).</desc>
               <datatype>
                 <rng:ref name="data.DURQUALITY.mensural"/>
               </datatype>

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -105,10 +105,6 @@
         <classSpec ident="model.sectionPart.cmn" module="MEI.shared" type="model" mode="delete"/>
         <classSpec ident="model.layerPart.cmn" module="MEI.shared" type="model" mode="delete"/>
 
-        <!-- Martha's changes -->
-        
-        <!-- (0) Modification of the description of 'data.DURATION.mensural' -->
-        <!-- I changed the general description, and also the description of four value items (brevis, semiminima, fusa, and semifusa). -->
         <macroSpec ident="data.DURATION.mensural" module="MEI.mensural" type="dt" mode="change">
           <desc>Logical, that is, written, note-shape (or note symbol) attribute values for the mensural repertoire.</desc>
           <content>
@@ -141,7 +137,6 @@
           </content>
         </macroSpec>
         
-        <!-- (1) The @dur.quality attribute of the <note> element in Mensural MEI -->
         <macroSpec ident="data.DURQUALITY.mensural" module="MEI.mensural" type="dt" mode="add">
           <desc>Duration attribute values of a given note symbol for the mensural repertoire.</desc>
           <content>
@@ -195,7 +190,6 @@
           </classes>
         </classSpec>
         
-        <!-- (2) Adding values to the @dur attribute for mensural <rest> elements -->
         <macroSpec ident="data.multibreverests.mensural" module="MEI.mensural" type="dt" mode="add">
           <desc>Logical, that is, written, duration attribute values for multi-breve rests in the mensural repertoire.</desc>
           <content>
@@ -242,10 +236,7 @@
             <memberOf key="att.rest.log.cmn"/>
           </classes>
         </classSpec>
-        
-        <!-- (3a) Adding the <stem> element as the child of the <note> element -->
-        
-        <!-- Form: data values -->
+                
         <macroSpec ident="data.FORM.mensural" module="MEI.mensural" type="dt" mode="add">
           <desc>Form of the stem attached to the note.</desc>
           <content>
@@ -265,7 +256,6 @@
             </valList>
           </content>
         </macroSpec>
-        <!-- Flag position: data values -->
         <macroSpec ident="data.FLAGPOS.mensural" module="MEI.mensural" type="dt" mode="add">
           <desc>Position of the flag relative to the stem.</desc>
           <content>
@@ -282,7 +272,6 @@
             </valList>
           </content>
         </macroSpec>
-        <!-- Flag form: data values -->
         <macroSpec ident="data.FLAGFORM.mensural" module="MEI.mensural" type="dt" mode="add">
           <desc>Form of the flag.</desc>
           <content>
@@ -309,7 +298,6 @@
           </content>
         </macroSpec>
         
-        <!-- Attributes for stem -->
         <classSpec ident="att.STEMproperties.mensural" module="MEI.mensural" type="atts">
           <desc>Attributes that describe the properties of stems in the mensural repertoire.</desc>
           <attList>
@@ -364,11 +352,6 @@
           </attList>
         </classSpec>
         
-        <!-- New element: stem -->
-        <!-- This element inherits the attributes of 'att.common' (such as @xml:id) 
-          and the attributes of 'att.STEMproperties.mensural'. 
-          The new element acts as a noteModifier (being used as a children of the 
-          <note> element -->
         <elementSpec ident="stem" module="MEI.mensural" mode="add">
           <desc>A stem element.</desc>
           <classes>
@@ -385,7 +368,6 @@
           </remarks>
         </elementSpec>
         
-        <!-- (3b) Adding the attribute @stem.form into "att.stems"-->
         <classSpec ident="att.stems" module="MEI.shared" type="atts" mode="replace">
           <desc>Attributes that describe the properties of stemmed features; that is, chords and notes.</desc>
           <classes>
@@ -416,14 +398,12 @@
                 <rng:ref name="data.STEMPOSITION" />
               </datatype>
             </attDef>
-            <!-- Added attribute -->
             <attDef ident="stem.form" usage="opt">
               <desc>Records the form of the stem.</desc>
               <datatype maxOccurs="1" minOccurs="1">
                 <rng:ref name="data.FORM.mensural"/>
               </datatype>
             </attDef>
-            <!-- End of added attribute -->
             <attDef ident="stem.visible" usage="opt">
               <desc>Determines whether a stem should be displayed.</desc>
               <datatype maxOccurs="1" minOccurs="1">

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -133,23 +133,9 @@
               <valItem ident="semifusa">
                 <desc>Half as long as a fusa.</desc>
               </valItem>
-              <valItem ident="2B" mode="add">
-                <desc>Two-breve rest.</desc>
-              </valItem>
-              <valItem ident="3B" mode="add">
-                <desc>Three-breve rest.</desc>
-              </valItem>
             </valList>
           </content>
         </macroSpec>
-        
-        <constraintSpec ident="multibreve_rests_only" scheme="isoschematron" mode="add">
-          <constraint>
-            <sch:rule context="mei:note">
-              <sch:assert test="not(@dur='2B' or @dur='3B')">Values 2B and 3B are to be used only with rest elements.</sch:assert>
-            </sch:rule>
-          </constraint>
-        </constraintSpec>
         
         <macroSpec ident="data.DURQUALITY.mensural" module="MEI.mensural" type="dt" mode="add">
           <desc>Duration attribute values of a given note symbol for the mensural repertoire.</desc>
@@ -203,7 +189,63 @@
             <memberOf key="att.duration.quality" mode="add"/>
           </classes>
         </classSpec>
-                
+
+        <macroSpec ident="data.MULTIBREVERESTS.mensural" module="MEI.mensural" type="dt" mode="add">
+          <desc>Logical, that is, written, duration attribute values for multi-breve rests in the mensural repertoire.</desc>
+          <content>
+            <valList type="closed">
+              <valItem ident="2B">
+                <desc>A two-breve rest.</desc>
+              </valItem>
+              <valItem ident="3B">
+                <desc>A three-breve rest.</desc>
+              </valItem>
+            </valList>
+          </content>
+        </macroSpec>
+        <macroSpec ident="data.DURATIONRESTS.mensural" module="MEI.mensural" type="dt" mode="add">
+          <desc>Logical, that is, written, duration attribute values for mensural rests.</desc>
+          <content>
+            <rng:choice>
+              <rng:ref name="data.MULTIBREVERESTS.mensural"/>
+              <rng:ref name="data.DURATION.mensural"/>
+            </rng:choice>
+          </content>
+        </macroSpec>
+
+        <macroSpec ident="data.DURATIONRESTS" module="MEI" type="dt" mode="add">
+          <desc>Logical, that is, written, duration attribute values for rests.</desc>
+          <content>
+            <rng:choice>
+              <rng:ref name="data.DURATION.cmn"/>
+              <rng:ref name="data.DURATIONRESTS.mensural"/>
+            </rng:choice>
+          </content>
+        </macroSpec>
+        <classSpec ident="att.restduration.logical" module="MEI.shared" type="atts" mode="add">
+          <desc>Attributes that express duration of rests in musical terms.</desc>
+          <attList>
+            <attDef ident="dur" usage="opt" mode="change">
+              <desc>Records the duration of a rest using the relative durational values provided by the
+                data.DURATIONRESTS datatype.</desc>
+              <datatype>
+                <rng:ref name="data.DURATIONRESTS"/>
+              </datatype>
+            </attDef>
+          </attList>
+        </classSpec>
+        <classSpec ident="att.rest.log" module="MEI.shared" type="atts" mode="change">
+          <desc>Logical domain attributes.</desc>
+          <classes mode="change">
+            <memberOf key="att.augmentDots"/>
+            <memberOf key="att.cue"/>
+            <memberOf key="att.duration.logical" mode="delete"/>
+            <memberOf key="att.restduration.logical" mode="add"/>
+            <memberOf key="att.event"/>
+            <memberOf key="att.rest.log.cmn"/>
+          </classes>
+        </classSpec>
+
         <macroSpec ident="data.STEMFORM.mensural" module="MEI.mensural" type="dt" mode="add">
           <desc>Form of the stem attached to the note.</desc>
           <content>

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -105,6 +105,60 @@
         <classSpec ident="model.sectionPart.cmn" module="MEI.shared" type="model" mode="delete"/>
         <classSpec ident="model.layerPart.cmn" module="MEI.shared" type="model" mode="delete"/>
 
+        <!-- Martha's changes -->
+        <macroSpec ident="data.DURQUALITY.mensural" module="MEI.mensural" type="dt" mode="add">
+          <desc></desc>
+          <content>
+            <valList type="closed">
+              <valItem ident="perfecta">
+                <desc>Three times the duration of the note in the next smaller degree.</desc>
+              </valItem>
+              <valItem ident="imperfecta">
+                <desc>Two times the duration of the note in the next smaller degree.</desc>
+              </valItem>
+              <valItem ident="altera">
+                <desc>Twice the original duration of the note.</desc>
+              </valItem>
+              <valItem ident="maior">
+                <desc>The duration of two minor semibreves (Ars antiqua).</desc>
+              </valItem>
+              <valItem ident="minor">
+                <desc>Regular duration of a semibreve (for Ars antiqua).</desc>
+              </valItem>
+              <valItem ident="duplex">
+                <desc>A duplex long, with the duration of two breves.</desc>
+              </valItem>
+            </valList>
+          </content>
+        </macroSpec>
+
+        <classSpec ident="att.duration.quality" module="MEI.mensural" type="atts" mode="add">
+          <desc></desc>
+          <attList>
+            <attDef ident="dur.quality" usage="rec" mode="add">
+              <desc>Encode the durational quality of a note (i.e., its perfect / imperfect / altered/ major / minor / duplex nature)</desc>
+              <datatype>
+                <rng:ref name="data.DURQUALITY.mensural"/>
+              </datatype>
+            </attDef>
+          </attList>
+        </classSpec>
+        
+        <classSpec ident="att.note.log" module="MEI.shared" type="atts" mode="change">
+          <desc>Logical domain attributes.</desc>
+          <classes mode="replace">
+            <memberOf key="att.augmentDots"/>
+            <memberOf key="att.coloration"/>
+            <memberOf key="att.cue"/>
+            <memberOf key="att.duration.logical"/>
+            <memberOf key="att.event"/>
+            <memberOf key="att.note.log.cmn"/>
+            <memberOf key="att.note.log.mensural"/>
+            <memberOf key="att.pitched"/>
+            <memberOf key="att.duration.quality"/>
+          </classes>
+        </classSpec>
+
       </schemaSpec>
     </body>
   </text>

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -133,9 +133,23 @@
               <valItem ident="semifusa">
                 <desc>Half as long as a fusa.</desc>
               </valItem>
+              <valItem ident="2B" mode="add">
+                <desc>Two-breve rest.</desc>
+              </valItem>
+              <valItem ident="3B" mode="add">
+                <desc>Three-breve rest.</desc>
+              </valItem>
             </valList>
           </content>
         </macroSpec>
+        
+        <constraintSpec ident="multibreve_rests_only" scheme="isoschematron" mode="add">
+          <constraint>
+            <sch:rule context="mei:note">
+              <sch:assert test="not(@dur='2B' or @dur='3B')">Values 2B and 3B are to be used only with rest elements.</sch:assert>
+            </sch:rule>
+          </constraint>
+        </constraintSpec>
         
         <macroSpec ident="data.DURQUALITY.mensural" module="MEI.mensural" type="dt" mode="add">
           <desc>Duration attribute values of a given note symbol for the mensural repertoire.</desc>
@@ -187,54 +201,6 @@
             <memberOf key="att.note.log.mensural"/>
             <memberOf key="att.pitched"/>
             <memberOf key="att.duration.quality" mode="add"/>
-          </classes>
-        </classSpec>
-        
-        <macroSpec ident="data.multibreverests.mensural" module="MEI.mensural" type="dt" mode="add">
-          <desc>Logical, that is, written, duration attribute values for multi-breve rests in the mensural repertoire.</desc>
-          <content>
-            <valList type="closed">
-              <valItem ident="2B">
-                <desc>A two-breve rest.</desc>
-              </valItem>
-              <valItem ident="3B">
-                <desc>A three-breve rest.</desc>
-              </valItem>
-            </valList>
-          </content>
-        </macroSpec>
-        
-        <macroSpec ident="data.DURATIONrests.mensural" module="MEI.mensural" type="dt" mode="add">
-          <desc>Logical, that is, written, duration attribute values for mensural rests.</desc>
-          <content>
-            <rng:choice>
-              <rng:ref name="data.multibreverests.mensural"/>
-              <rng:ref name="data.DURATION.mensural"/>
-            </rng:choice>
-          </content>
-        </macroSpec>
-        
-        <classSpec ident="att.restduration" module="MEI.mensural" type="atts" mode="add">
-          <desc>Attribute that expresses duration of mensural rests.</desc>
-          <attList>
-            <attDef ident="dur" usage="opt" mode="change">
-              <desc>Records the duration of a rest using the relative durational values provided by the data.DURATIONrests.mensural datatype.</desc>
-              <datatype>
-                <rng:ref name="data.DURATIONrests.mensural"/>
-              </datatype>
-            </attDef>
-          </attList>
-        </classSpec>
-        
-        <classSpec ident="att.rest.log" module="MEI.shared" type="atts" mode="change">
-          <desc>Logical domain attributes.</desc>
-          <classes mode="change">
-            <memberOf key="att.augmentDots"/>
-            <memberOf key="att.cue"/>
-            <memberOf key="att.duration.logical" mode="delete"/>
-            <memberOf key="att.restduration" mode="add"/>
-            <memberOf key="att.event"/>
-            <memberOf key="att.rest.log.cmn"/>
           </classes>
         </classSpec>
                 

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -186,7 +186,7 @@
             <memberOf key="att.note.log.cmn"/>
             <memberOf key="att.note.log.mensural"/>
             <memberOf key="att.pitched"/>
-            <memberOf key="att.duration.quality"/>
+            <memberOf key="att.duration.quality" mode="add"/>
           </classes>
         </classSpec>
         
@@ -228,10 +228,11 @@
         
         <classSpec ident="att.rest.log" module="MEI.shared" type="atts" mode="change">
           <desc>Logical domain attributes.</desc>
-          <classes mode="replace">
+          <classes mode="change">
             <memberOf key="att.augmentDots"/>
             <memberOf key="att.cue"/>
-            <memberOf key="att.restduration"/>
+            <memberOf key="att.duration.logical" mode="delete"/>
+            <memberOf key="att.restduration" mode="add"/>
             <memberOf key="att.event"/>
             <memberOf key="att.rest.log.cmn"/>
           </classes>
@@ -298,7 +299,7 @@
           </content>
         </macroSpec>
         
-        <classSpec ident="att.STEMproperties.mensural" module="MEI.mensural" type="atts">
+        <classSpec ident="att.STEMproperties.mensural" module="MEI.mensural" type="atts" mode="add">
           <desc>Attributes that describe the properties of stems in the mensural repertoire.</desc>
           <attList>
             <attDef ident="pos" usage="opt">
@@ -398,7 +399,7 @@
                 <rng:ref name="data.STEMPOSITION" />
               </datatype>
             </attDef>
-            <attDef ident="stem.form" usage="opt">
+            <attDef ident="stem.form" usage="opt" mode="add">
               <desc>Records the form of the stem.</desc>
               <datatype maxOccurs="1" minOccurs="1">
                 <rng:ref name="data.FORM.mensural"/>

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -242,6 +242,208 @@
             <memberOf key="att.rest.log.cmn"/>
           </classes>
         </classSpec>
+        
+        <!-- (3a) Adding the <stem> element as the child of the <note> element -->
+        
+        <!-- Form: data values -->
+        <macroSpec ident="data.FORM.mensural" module="MEI.mensural" type="dt" mode="add">
+          <desc>Form of the stem attached to the note.</desc>
+          <content>
+            <valList type="closed">
+              <valItem ident="circle">
+                <desc>Stem has a circular form.</desc>
+              </valItem>
+              <valItem ident="oblique">
+                <desc>Stem has an oblique form.</desc>
+              </valItem>
+              <valItem ident="swallowtail">
+                <desc>Stem has a swallowtail form.</desc>
+              </valItem>
+              <valItem ident="virgula">
+                <desc>Stem has a virgula-like form.</desc>
+              </valItem>
+            </valList>
+          </content>
+        </macroSpec>
+        <!-- Flag position: data values -->
+        <macroSpec ident="data.FLAGPOS.mensural" module="MEI.mensural" type="dt" mode="add">
+          <desc>Position of the flag relative to the stem.</desc>
+          <content>
+            <valList type="closed">
+              <valItem ident="left">
+                <desc>Flag lies at the left side of the stem.</desc>
+              </valItem>
+              <valItem ident="right">
+                <desc>Flag lies at the right side of the stem.</desc>
+              </valItem>
+              <valItem ident="center">
+                <desc>Flag is centered in the stem.</desc>
+              </valItem>
+            </valList>
+          </content>
+        </macroSpec>
+        <!-- Flag form: data values -->
+        <macroSpec ident="data.FLAGFORM.mensural" module="MEI.mensural" type="dt" mode="add">
+          <desc>Form of the flag.</desc>
+          <content>
+            <valList type="closed">
+              <valItem ident="straight">
+                <desc>Flag is a straight horizontal line.</desc>
+              </valItem>
+              <valItem ident="angled">
+                <desc>Flag is a straight line at an angle.</desc>
+              </valItem>
+              <valItem ident="curled">
+                <desc>Flag is curled.</desc>
+              </valItem>
+              <valItem ident="flared">
+                <desc>Flag is flared.</desc>
+              </valItem>
+              <valItem ident="extended">
+                <desc>Flag looks extended.</desc>
+              </valItem>
+              <valItem ident="hooked">
+                <desc>Flag is hooked-form.</desc>
+              </valItem>
+            </valList>
+          </content>
+        </macroSpec>
+        
+        <!-- Attributes for stem -->
+        <classSpec ident="att.STEMproperties.mensural" module="MEI.mensural" type="atts">
+          <desc>Attributes that describe the properties of stems in the mensural repertoire.</desc>
+          <attList>
+            <attDef ident="pos" usage="opt">
+              <desc>Records the position of the stem in relation to the note head(s).</desc>
+              <datatype>
+                <rng:ref name="data.STEMPOSITION"/>
+              </datatype>
+            </attDef>
+            <attDef ident="length" usage="opt">
+              <desc>Encodes the stem length.</desc>
+              <datatype>
+                <rng:ref name="data.MEASUREMENTABS"/>
+              </datatype>
+            </attDef>
+            <attDef ident="form" usage="opt">
+              <desc>Encodes the form of the stem using the values provided by the data.FORM.mensural datatype.</desc>
+              <datatype>
+                <rng:ref name="data.FORM.mensural"/>
+              </datatype>
+            </attDef>
+            <attDef ident="dir" usage="opt">
+              <desc>Describes the direction of a stem.</desc>
+              <datatype>
+                <rng:ref name="data.STEMDIRECTION"/>
+              </datatype>
+            </attDef>
+            <attDef ident="flag.pos" usage="opt">
+              <desc>Records the position of the flag using the values provided by the data.FLAGPOS.mensural datatype.</desc>
+              <datatype>
+                <rng:ref name="data.FLAGPOS.mensural"/>
+              </datatype>
+            </attDef>
+            <attDef ident="flag.form" usage="opt">
+              <desc>Encodes the form of the flag using the values provided by the data.FLAGFORM.mensural datatype.</desc>
+              <datatype>
+                <rng:ref name="data.FLAGFORM.mensural"/>
+              </datatype>
+            </attDef>
+            <attDef ident="x" usage="opt">
+              <desc>Records the output x coordinate of the stem's attachment point.</desc>
+              <datatype maxOccurs="1" minOccurs="1">
+                <rng:data type="decimal"/>
+              </datatype>
+            </attDef>
+            <attDef ident="y" usage="opt">
+              <desc>Records the output y coordinate of the stem's attachment point.</desc>
+              <datatype maxOccurs="1" minOccurs="1">
+                <rng:data type="decimal"/>
+              </datatype>
+            </attDef>
+          </attList>
+        </classSpec>
+        
+        <!-- New element: stem -->
+        <!-- This element inherits the attributes of 'att.common' (such as @xml:id) 
+          and the attributes of 'att.STEMproperties.mensural'. 
+          The new element acts as a noteModifier (being used as a children of the 
+          <note> element -->
+        <elementSpec ident="stem" module="MEI.mensural" mode="add">
+          <desc>A stem element.</desc>
+          <classes>
+            <memberOf key="att.common"/>
+            <memberOf key="att.STEMproperties.mensural"/>
+            <memberOf key="model.noteModifierLike"/>
+          </classes>
+          <remarks>
+            <p>Mensural notes can have multiple stems and these may have various forms, directions, and types of flags.
+              Multiple stem elements can be encoded as children of a single note. The attributes <att>pos</att>,
+              <att>length</att>, <att>form</att>, and <att>dir</att> allow to encode different positions, lengths,
+              forms, and directions for each these stems. The attributes <att>flag.pos</att> and <att>flag.form</att> 
+              also allow to encode different types of flags for each of the stems.</p>
+          </remarks>
+        </elementSpec>
+        
+        <!-- (3b) Adding the attribute @stem.form into "att.stems"-->
+        <classSpec ident="att.stems" module="MEI.shared" type="atts" mode="replace">
+          <desc>Attributes that describe the properties of stemmed features; that is, chords and notes.</desc>
+          <classes>
+            <memberOf key="att.stems.cmn"/>
+          </classes>
+          <attList org="group">
+            <attDef ident="stem.dir" usage="opt">
+              <desc>Describes the direction of a stem.</desc>
+              <datatype maxOccurs="1" minOccurs="1">
+                <rng:ref name="data.STEMDIRECTION" />
+              </datatype>
+            </attDef>
+            <attDef ident="stem.len" usage="opt">
+              <desc>Encodes the stem length.</desc>
+              <datatype maxOccurs="1" minOccurs="1">
+                <rng:ref name="data.MEASUREMENTABS" />
+              </datatype>
+            </attDef>
+            <attDef ident="stem.mod" usage="opt">
+              <desc>Encodes any stem "modifiers"; that is, symbols rendered on the stem, such as tremolo or Sprechstimme indicators.</desc>
+              <datatype maxOccurs="1" minOccurs="1">
+                <rng:ref name="data.STEMMODIFIER" />
+              </datatype>
+            </attDef>
+            <attDef ident="stem.pos" usage="opt">
+              <desc>Records the position of the stem in relation to the note head(s).</desc>
+              <datatype maxOccurs="1" minOccurs="1">
+                <rng:ref name="data.STEMPOSITION" />
+              </datatype>
+            </attDef>
+            <!-- Added attribute -->
+            <attDef ident="stem.form" usage="opt">
+              <desc>Records the form of the stem.</desc>
+              <datatype maxOccurs="1" minOccurs="1">
+                <rng:ref name="data.FORM.mensural"/>
+              </datatype>
+            </attDef>
+            <!-- End of added attribute -->
+            <attDef ident="stem.visible" usage="opt">
+              <desc>Determines whether a stem should be displayed.</desc>
+              <datatype maxOccurs="1" minOccurs="1">
+                <rng:ref name="data.BOOLEAN" />
+              </datatype>
+            </attDef>
+            <attDef ident="stem.x" usage="opt">
+              <desc>Records the output x coordinate of the stem's attachment point.</desc>
+              <datatype maxOccurs="1" minOccurs="1">
+                <rng:data type="decimal"/>
+              </datatype>
+            </attDef>
+            <attDef ident="stem.y" usage="opt">
+              <desc>Records the output y coordinate of the stem's attachment point.</desc>
+              <datatype maxOccurs="1" minOccurs="1">
+                <rng:data type="decimal"/>
+              </datatype>
+            </attDef>
+          </attList>
+        </classSpec>
 
       </schemaSpec>
     </body>

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -194,6 +194,54 @@
             <memberOf key="att.duration.quality"/>
           </classes>
         </classSpec>
+        
+        <!-- (2) Adding values to the @dur attribute for mensural <rest> elements -->
+        <macroSpec ident="data.multibreverests.mensural" module="MEI.mensural" type="dt" mode="add">
+          <desc>Logical, that is, written, duration attribute values for multi-breve rests in the mensural repertoire.</desc>
+          <content>
+            <valList type="closed">
+              <valItem ident="2B">
+                <desc>A two-breve rest.</desc>
+              </valItem>
+              <valItem ident="3B">
+                <desc>A three-breve rest.</desc>
+              </valItem>
+            </valList>
+          </content>
+        </macroSpec>
+        
+        <macroSpec ident="data.DURATIONrests.mensural" module="MEI.mensural" type="dt" mode="add">
+          <desc>Logical, that is, written, duration attribute values for mensural rests.</desc>
+          <content>
+            <rng:choice>
+              <rng:ref name="data.multibreverests.mensural"/>
+              <rng:ref name="data.DURATION.mensural"/>
+            </rng:choice>
+          </content>
+        </macroSpec>
+        
+        <classSpec ident="att.restduration" module="MEI.mensural" type="atts" mode="add">
+          <desc>Attribute that expresses duration of mensural rests.</desc>
+          <attList>
+            <attDef ident="dur" usage="opt" mode="change">
+              <desc>Records the duration of a rest using the relative durational values provided by the data.DURATIONrests.mensural datatype.</desc>
+              <datatype>
+                <rng:ref name="data.DURATIONrests.mensural"/>
+              </datatype>
+            </attDef>
+          </attList>
+        </classSpec>
+        
+        <classSpec ident="att.rest.log" module="MEI.shared" type="atts" mode="change">
+          <desc>Logical domain attributes.</desc>
+          <classes mode="replace">
+            <memberOf key="att.augmentDots"/>
+            <memberOf key="att.cue"/>
+            <memberOf key="att.restduration"/>
+            <memberOf key="att.event"/>
+            <memberOf key="att.rest.log.cmn"/>
+          </classes>
+        </classSpec>
 
       </schemaSpec>
     </body>

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -204,7 +204,7 @@
           </classes>
         </classSpec>
                 
-        <macroSpec ident="data.FORM.mensural" module="MEI.mensural" type="dt" mode="add">
+        <macroSpec ident="data.STEMFORM.mensural" module="MEI.mensural" type="dt" mode="add">
           <desc>Form of the stem attached to the note.</desc>
           <content>
             <valList type="closed">
@@ -263,11 +263,20 @@
               </valItem>
             </valList>
           </content>
+            <remarks>
+                <p>
+                    <!-- TODO: Add samples for all values here  -->
+                    <!--<graphic url="ExampleImages/accid-20100510.png" height="50%" width="50%"/>-->
+                </p>
+            </remarks>
         </macroSpec>
         
-        <classSpec ident="att.STEMproperties.mensural" module="MEI.mensural" type="atts" mode="add">
+        <classSpec ident="att.STEMPROPERTIES.mensural" module="MEI.mensural" type="atts" mode="add">
           <desc>Attributes that describe the properties of stems in the mensural repertoire.</desc>
-          <attList>
+            <classes>
+                <memberOf key="att.xy"/>
+            </classes>
+            <attList>
             <attDef ident="pos" usage="opt">
               <desc>Records the position of the stem in relation to the note head(s).</desc>
               <datatype>
@@ -281,9 +290,9 @@
               </datatype>
             </attDef>
             <attDef ident="form" usage="opt">
-              <desc>Encodes the form of the stem using the values provided by the data.FORM.mensural datatype.</desc>
+              <desc>Encodes the form of the stem using the values provided by the data.STEMFORM.mensural datatype.</desc>
               <datatype>
-                <rng:ref name="data.FORM.mensural"/>
+                <rng:ref name="data.STEMFORM.mensural"/>
               </datatype>
             </attDef>
             <attDef ident="dir" usage="opt">
@@ -304,18 +313,6 @@
                 <rng:ref name="data.FLAGFORM.mensural"/>
               </datatype>
             </attDef>
-            <attDef ident="x" usage="opt">
-              <desc>Records the output x coordinate of the stem's attachment point.</desc>
-              <datatype maxOccurs="1" minOccurs="1">
-                <rng:data type="decimal"/>
-              </datatype>
-            </attDef>
-            <attDef ident="y" usage="opt">
-              <desc>Records the output y coordinate of the stem's attachment point.</desc>
-              <datatype maxOccurs="1" minOccurs="1">
-                <rng:data type="decimal"/>
-              </datatype>
-            </attDef>
           </attList>
         </classSpec>
         
@@ -323,9 +320,19 @@
           <desc>A stem element.</desc>
           <classes>
             <memberOf key="att.common"/>
-            <memberOf key="att.STEMproperties.mensural"/>
+            <memberOf key="att.STEMPROPERTIES.mensural"/>
             <memberOf key="model.noteModifierLike"/>
           </classes>
+          <content>
+            <rng:empty/>
+          </content>
+          <constraintSpec ident="Check_stem" scheme="isoschematron">
+            <constraint>
+              <sch:rule context="mei:stem">
+                <sch:assert test="not(ancestor::mei:note/@*[starts-with(local-name(),'stem.')])">A note with nested stem elements must not have @stem.* attributes.</sch:assert>
+              </sch:rule>
+            </constraint>
+          </constraintSpec>
           <remarks>
             <p>Mensural notes can have multiple stems and these may have various forms, directions, and types of flags.
               Multiple stem elements can be encoded as children of a single note. The attributes <att>pos</att>,
@@ -339,6 +346,7 @@
           <desc>Attributes that describe the properties of stemmed features; that is, chords and notes.</desc>
           <classes>
             <memberOf key="att.stems.cmn"/>
+            <memberOf key="att.stems.mensural"/>
           </classes>
           <attList org="group">
             <attDef ident="stem.dir" usage="opt">
@@ -365,12 +373,6 @@
                 <rng:ref name="data.STEMPOSITION" />
               </datatype>
             </attDef>
-            <attDef ident="stem.form" usage="opt" mode="add">
-              <desc>Records the form of the stem.</desc>
-              <datatype maxOccurs="1" minOccurs="1">
-                <rng:ref name="data.FORM.mensural"/>
-              </datatype>
-            </attDef>
             <attDef ident="stem.visible" usage="opt">
               <desc>Determines whether a stem should be displayed.</desc>
               <datatype maxOccurs="1" minOccurs="1">
@@ -391,6 +393,18 @@
             </attDef>
           </attList>
         </classSpec>
+          
+          <classSpec ident="att.stems.mensural" module="MEI.mensural" type="atts">
+              <desc>Attributes that describe the properties of stemmed features specific to mensural repertoires.</desc>
+              <attList>
+                  <attDef ident="stem.form" usage="opt" mode="add">
+                      <desc>Records the form of the stem.</desc>
+                      <datatype maxOccurs="1" minOccurs="1">
+                          <rng:ref name="data.STEMFORM.mensural"/>
+                      </datatype>
+                  </attDef>
+              </attList>
+          </classSpec>
 
       </schemaSpec>
     </body>


### PR DESCRIPTION
Three main changes:

1. New attribute `@dur.quality` for `<note>` elements to indicate whether the note is perfect / imperfect / altered / etc. and, therefore, be comprehensive in the durational information of the note (given that in mensural notation, the note shape is not enough to indicate the length of a note). The new attribute can have the following six values: `perfecta`, `imperfecta`, `altera`, `maior`, `minor`, and `duplex`. The last three are used in Ars antiqua: `maior` and `minor` are used for semibreves and `duplex` is used for longae.

2. New values for the attribute `@dur` for the `<rest>` elements: two-breve rests ("2B") and three-breve rests ("3B"). 

3. New `<stem>` element to be used as children of the `<note>` element. Notes can have more than one stem. Therefore the introduction of the `<stem>` element as a children of `<note>`, allowing to associate multiple stem elements to a single note, each stem with its own form, direction, etc. Attributes of `<stem>`: `pos`, `length`, `form`, `dir`, `flag.pos`, `flag.form`, `x`, and `y`.


Two small changes:

4. Change in the description of the `@dur` attribute

5. Added a new stem-related attribute `@stem.form` to be encoded within the `<note>` element.

These are all (but one) of the changes that were discussed and approved by the mensural-ig in the 2018 meeting. The one change I did not include has to do with the encoding of the mensuration sign, because (based on the notes) further discussion is needed. 
**[The discussion can be seen in the attached file.]**
[MEI-Mensural IG - Approved MEC 2018 Pending Implementation.pdf](https://github.com/music-encoding/music-encoding/files/3853621/MEI-Mensural.IG.-.Approved.MEC.2018.Pending.Implementation.pdf)

