### PR TITLE
Support tempo text with extension lines

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -3256,7 +3256,8 @@
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.mmTempo"/>
-      <memberOf key="att.startId"/>
+      <memberOf key="att.startEndId"/>
+      <memberOf key="att.timestamp2.logical"/>
     </classes>
     <attList>
       <attDef ident="func">


### PR DESCRIPTION
Analogously to `<dynam>` with extension lines, supports this:

![grafik](https://user-images.githubusercontent.com/1147152/74953774-0049fe00-53fa-11ea-83f3-ce599924ecb9.png)

(Gould, p. 184)