### PR TITLE
lv ties don't need duration information

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -1782,8 +1782,6 @@
         <sch:rule context="mei:lv">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
             attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
-          <sch:assert test="@dur or @dur.ges or @endid or @tstamp2">Must have one of the attributes:
-            dur, dur.ges, endid, or tstamp2.</sch:assert>
         </sch:rule>
       </constraint>
     </constraintSpec>


### PR DESCRIPTION
`@dur` and `@dur.ges` are not even allowed on `<lv>`, so don't enforce them.