### PR TITLE
split and extend modes

### DIFF
--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -2619,6 +2619,16 @@
   <macroSpec ident="data.MODE" module="MEI" type="dt">
     <desc>Modes.</desc>
     <content>
+      <rng:choice>
+        <rng:ref name="data.MODE.cmn"/>
+        <rng:ref name="data.MODE.gregorian"/>
+        <rng:ref name="data.MODE.extended"/>
+      </rng:choice>
+    </content>
+  </macroSpec>
+  <macroSpec ident="data.MODE.cmn" module="MEI" type="dt">
+    <desc>Common modes.</desc>
+    <content>
       <valList type="closed">
         <valItem ident="major">
           <desc>Major mode.</desc>
@@ -2626,23 +2636,64 @@
         <valItem ident="minor">
           <desc>Minor mode.</desc>
         </valItem>
+      </valList>
+    </content>
+  </macroSpec>
+  <macroSpec ident="data.MODE.gregorian" module="MEI" type="dt">
+    <desc>Gregorian modes.</desc>
+    <content>
+      <valList type="closed">
         <valItem ident="dorian">
-          <desc>Dorian mode.</desc>
+          <desc>Dorian mode (the first mode).</desc>
+        </valItem>
+        <valItem ident="hypodorian">
+          <desc>Hypodorian mode (the second mode).</desc>
         </valItem>
         <valItem ident="phrygian">
-          <desc>Phrygian mode.</desc>
+          <desc>Phrygian mode (the third mode).</desc>
+        </valItem>
+        <valItem ident="hypophrygian">
+          <desc>Hypophrygian mode (the fourth mode).</desc>
         </valItem>
         <valItem ident="lydian">
-          <desc>Lydian mode.</desc>
+          <desc>Hypolydian mode (the fifth mode).</desc>
+        </valItem>
+        <valItem ident="hypolydian">
+          <desc>Lydian mode (the sixth mode).</desc>
         </valItem>
         <valItem ident="mixolydian">
-          <desc>Mixolydian mode.</desc>
+          <desc>Mixolydian mode (the seventh mode).</desc>
+        </valItem>
+        <valItem ident="hypomixolydian">
+          <desc>Hypomixolydian mode (the eighth mode).</desc>
+        </valItem>
+        <valItem ident="peregrinus">
+          <desc>Tonus peregrinus (the ninth mode).</desc>
+        </valItem>
+      </valList>
+    </content>
+  </macroSpec>
+  <macroSpec ident="data.MODE.extended" module="MEI" type="dt">
+    <desc>Modern modes.</desc>
+    <content>
+      <valList type="semi">
+        <valItem ident="ionian">
+          <desc>Ionian mode.</desc>
+        </valItem>
+        <valItem ident="hypoionian">
+          <desc>Hypoionian mode.</desc>
         </valItem>
         <valItem ident="aeolian">
           <desc>Aeolian mode.</desc>
         </valItem>
+        <valItem ident="hypoaeolian">
+          <desc>Hypoaeolian mode.</desc>
+        </valItem>
         <valItem ident="locrian">
           <desc>Locrian mode.</desc>
+        </valItem>
+        <valItem ident="hypolocrian">
+          <desc>Hypolocrian mode.</desc>
         </valItem>
       </valList>
     </content>


### PR DESCRIPTION
This PR adds missing values in `data.MODE` and splits them up into `data.MODE.cmn`, `data.MODE.gregorian`, and `data.MODE.extended`, of which the last one is a semi-open list.
closes #627