### PR TITLE
Support for encoding Italian Trecento Notation (Mensural Module)

### DIFF
--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -134,6 +134,12 @@
           <rng:ref name="data.TEMPUS"/>
         </datatype>
       </attDef>
+      <attDef ident="divisio" usage="opt">
+        <desc>Describes the divisions of the breve in use in 14th-century Italy.</desc>
+        <datatype>
+          <rng:ref name="data.DIVISIO"/>
+        </datatype>
+      </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.note.anl.mensural" module="MEI.mensural" type="atts">

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -109,6 +109,15 @@
   </classSpec>
   <classSpec ident="att.mensural.shared" module="MEI.mensural" type="atts">
     <desc>Shared attributes in the mensural repertoire.</desc>
+    <constraintSpec ident="mensuration_conflicting_attributes" scheme="isoschematron">
+      <constraint>
+        <sch:rule context="mei:mensur[@divisio]">
+          <sch:assert test="not(@tempus) and not(@prolatio)">
+            When the @divisio attribute is used, the @tempus and @prolatio attributes are not allowed.
+          </sch:assert>
+        </sch:rule>
+      </constraint>
+    </constraintSpec>
     <attList>
       <attDef ident="modusmaior" usage="opt">
         <desc>Describes the maxima-long relationship.</desc>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1857,22 +1857,7 @@
     <classes>
       <memberOf key="att.duration.ratio"/>
       <memberOf key="att.mensural.shared"/>
-      <memberOf key="att.slashCount"/>
     </classes>
-    <attList>
-      <attDef ident="dot" usage="opt">
-        <desc>Specifies whether a dot is to be added to the base symbol.</desc>
-        <datatype>
-          <rng:ref name="data.BOOLEAN"/>
-        </datatype>
-      </attDef>
-      <attDef ident="sign" usage="opt">
-        <desc>The base symbol in the mensuration sign/time signature of mensural notation.</desc>
-        <datatype>
-          <rng:ref name="data.MENSURATIONSIGN"/>
-        </datatype>
-      </attDef>
-    </attList>
   </classSpec>
   <classSpec ident="att.meterConformance" module="MEI.shared" type="atts">
     <desc>Attributes that provide information about a structure's conformance to the prevailing

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -958,6 +958,7 @@
       <memberOf key="att.extSym"/>
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.typography"/>
+      <memberOf key="att.slashCount"/>
     </classes>
     <attList>
       <attDef ident="form" usage="opt">
@@ -975,6 +976,18 @@
         <desc>Describes the rotation or reflection of the base symbol.</desc>
         <datatype>
           <rng:ref name="data.ORIENTATION"/>
+        </datatype>
+      </attDef>
+      <attDef ident="dot" usage="opt">
+        <desc>Specifies whether a dot is to be added to the base symbol.</desc>
+        <datatype>
+          <rng:ref name="data.BOOLEAN"/>
+        </datatype>
+      </attDef>
+      <attDef ident="sign" usage="opt">
+        <desc>The base symbol in the mensuration sign/time signature of mensural notation.</desc>
+        <datatype>
+          <rng:ref name="data.MENSURATIONSIGN"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -1031,6 +1031,34 @@
       </rng:data>
     </content>
   </macroSpec>
+  <macroSpec ident="data.DIVISIO" module="MEI" type="dt">
+    <desc>Divisio values.</desc>
+    <content>
+      <valList type="closed">
+        <valItem ident="ternaria">
+          <desc>Divisio ternaria. Three semibreves in a breve.</desc>
+        </valItem>
+        <valItem ident="quaternaria">
+          <desc>Divisio quaternaria. Foursemibreves in a breve.</desc>
+        </valItem>
+        <valItem ident="senariaimperf">
+          <desc>Divisio senaria imperfecta. Six semibreves in a breve (breve is divided into two, then into three). Aka senaria gallica.</desc>
+        </valItem>
+        <valItem ident="senariaperf">
+          <desc>Divisio senaria perfecta. Six semibreves in a breve (breve is divided into three, then into two). Aka senaria italica.</desc>
+        </valItem>
+        <valItem ident="octonaria">
+          <desc>Divisio octonaria. Eight semibreves in a breve.</desc>
+        </valItem>
+        <valItem ident="novenaria">
+          <desc>Divisio novenaria. Nine semibreves in a breve.</desc>
+        </valItem>
+        <valItem ident="duodenaria">
+          <desc>Divisio duodenaria. Twelve semibreves in a breve.</desc>
+        </valItem>
+      </valList>
+    </content>
+  </macroSpec>
   <macroSpec ident="data.DURATION" module="MEI" type="dt">
     <desc>Logical, that is, written, duration attribute values.</desc>
     <content>
@@ -1849,14 +1877,53 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.MENSURATIONSIGN" module="MEI" type="dt">
-    <desc>Mensuration attribute values.</desc>
+    <desc>Mensuration signs attribute values.</desc>
     <content>
       <valList type="closed">
         <valItem ident="C">
-          <desc>Tempus imperfectum.</desc>
+          <desc>Sign for tempus imperfectum.</desc>
         </valItem>
         <valItem ident="O">
-          <desc>Tempus perfectum.</desc>
+          <desc>Sign for tempus perfectum.</desc>
+        </valItem>
+        <valItem ident="t">
+          <desc>Sign for divisio ternaria.</desc>
+        </valItem>
+        <valItem ident="q">
+          <desc>Sign for divisio quaternaria.</desc>
+        </valItem>
+        <valItem ident="si">
+          <desc>Sign for divisio senaria imperfecta.</desc>
+        </valItem>
+        <valItem ident="i">
+          <desc>Sign for divisio senaria imperfecta.</desc>
+        </valItem>
+        <valItem ident="sg">
+          <desc>Sign for divisio senaria gallica.</desc>
+        </valItem>
+        <valItem ident="g">
+          <desc>Sign for divisio senaria gallica.</desc>
+        </valItem>
+        <valItem ident="sp">
+          <desc>Sign for divisio senaria perfecta.</desc>
+        </valItem>
+        <valItem ident="p">
+          <desc>Sign for divisio senaria perfecta.</desc>
+        </valItem>
+        <valItem ident="sy">
+          <desc>Sign for divisio senaria ytalica.</desc>
+        </valItem>
+        <valItem ident="y">
+          <desc>Sign for divisio senaria ytalica.</desc>
+        </valItem>
+        <valItem ident="n">
+          <desc>Sign for divisio novenaria.</desc>
+        </valItem>
+        <valItem ident="oc">
+          <desc>Sign for divisio octonaria.</desc>
+        </valItem>
+        <valItem ident="d">
+          <desc>Sign for divisio duodenaria.</desc>
         </valItem>
       </valList>
     </content>


### PR DESCRIPTION
The arrival of this pull request was stated in https://github.com/music-encoding/music-encoding/pull/634#issuecomment-585416648, and it is meant to replace **PR #537**
- Add `@divisio` attribute for encoding the different divisions of the breve used in Italian Trecento notation. 
- Add Schematron rule since this attribute substitutes the use of `@tempus` and `@prolatio` (in French notation).
- Add other values into `@sign` for encoding mensuration signs used in Italian Trecento notation.
- Moved attributes related to mensuration signs into the visual domain (these are: `@dot`, `@sign`, and `@slash`). 
Therefore, the attributes that encode the semantics of the mensuration (`@mdousmaior`, `@modusminor`, `@tempus`, `@prolatio`, and `@divisio`, which encode the divisions / relative_values of the notes) are separated from the attributes encoding the mensuration signs (`@dot`, `@sign`, and `@slash`). This is useful because some pieces don't have a mensuration sign, but there is an implied mensuration still. Additionally, the meaning of some mensuration signs varies through time and between geographical regions. And, for Italian Trecento mensuration, multiple symbols can represent the same mensuration (have the same semantics).