### PR TITLE
Mensural source

### DIFF
--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -38,6 +38,31 @@
       </valList>
     </content>
   </macroSpec>
+  <macroSpec ident="data.DURQUALITY.mensural" module="MEI.mensural" type="dt">
+    <desc>Duration attribute values of a given note symbol for the mensural repertoire.</desc>
+    <content>
+      <valList type="closed">
+        <valItem ident="perfecta">
+          <desc>Three times the duration of the note in the next smaller degree.</desc>
+        </valItem>
+        <valItem ident="imperfecta">
+          <desc>Two times the duration of the note in the next smaller degree.</desc>
+        </valItem>
+        <valItem ident="altera">
+          <desc>Twice the original duration of the note (only usable in perfect mensurations).</desc>
+        </valItem>
+        <valItem ident="minor">
+          <desc>Category of a regular semibrevis in Ars antiqua, equivalent to a third of a brevis.</desc>
+        </valItem>
+        <valItem ident="maior">
+          <desc>Category of an altered semibrevis in Ars antiqua, equivalent to two minor semibrevis.</desc>
+        </valItem>
+        <valItem ident="duplex">
+          <desc>One of the three categories of a longa in Ars antiqua ('duplex', 'perfecta', and 'imperfecta'). A duplex longa is twice as long as a regular longa.</desc>
+        </valItem>
+      </valList>
+    </content>
+  </macroSpec>
   <macroSpec ident="data.STAFFITEM.mensural" module="MEI.mensural" type="dt">
     <desc>Items in the Mensural repertoire that may be printed near a staff.</desc>
     <content>
@@ -48,6 +73,17 @@
       </valList>
     </content>
   </macroSpec>
+  <classSpec ident="att.duration.quality" module="MEI.mensural" type="atts">
+    <desc>Attribute that expresses duration for a given mensural note symbol.</desc>
+    <attList>
+      <attDef ident="dur.quality" usage="rec" mode="add">
+        <desc>Encodes the durational quality of a mensural note using the values provided by the data.DURQUALITY.mensural datatype (i.e., the perfect / imperfect / altered / major / minor / duplex quality of a note).</desc>
+        <datatype>
+          <rng:ref name="data.DURQUALITY.mensural"/>
+        </datatype>
+      </attDef>
+    </attList>
+  </classSpec>
   <classSpec ident="att.ligature.log" module="MEI.mensural" type="atts">
     <desc>Logical domain attributes.</desc>
     <attList>

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -142,7 +142,7 @@
   <classSpec ident="att.duration.quality" module="MEI.mensural" type="atts">
     <desc>Attribute that expresses duration for a given mensural note symbol.</desc>
     <attList>
-      <attDef ident="dur.quality" usage="rec" mode="add">
+      <attDef ident="dur.quality" usage="rec">
         <desc>Encodes the durational quality of a mensural note using the values provided by the data.DURQUALITY.mensural datatype (i.e., the perfect / imperfect / altered / major / minor / duplex quality of a note).</desc>
         <datatype>
           <rng:ref name="data.DURQUALITY.mensural"/>

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -8,7 +8,7 @@
     <desc>Mensural repertoire component declarations.</desc>
   </moduleSpec>
   <macroSpec ident="data.DURATION.mensural" module="MEI.mensural" type="dt">
-    <desc>Logical, that is, written, duration attribute values for the mensural repertoire.</desc>
+    <desc>Logical, that is, written, note-shape (or note symbol) attribute values for the mensural repertoire.</desc>
     <content>
       <valList type="closed">
         <valItem ident="maxima">
@@ -18,7 +18,7 @@
           <desc>Two or three times as long as a brevis.</desc>
         </valItem>
         <valItem ident="brevis">
-          <desc>Two times as long as a semibreve.</desc>
+          <desc>Two or three times as long as a semibreve.</desc>
         </valItem>
         <valItem ident="semibrevis">
           <desc>Half or one-third as long as a breve/brevis.</desc>
@@ -27,13 +27,13 @@
           <desc>Half or one-third as long as a semibreve/semibrevis.</desc>
         </valItem>
         <valItem ident="semiminima">
-          <desc>Half or one-third as long as a minima.</desc>
+          <desc>Half as long as a minima.</desc>
         </valItem>
         <valItem ident="fusa">
-          <desc>Half or one-third as long as a semiminima.</desc>
+          <desc>Half as long as a semiminima.</desc>
         </valItem>
         <valItem ident="semifusa">
-          <desc>Half or one-third as long as a fusa.</desc>
+          <desc>Half as long as a fusa.</desc>
         </valItem>
       </valList>
     </content>

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -63,12 +63,78 @@
       </valList>
     </content>
   </macroSpec>
+  <macroSpec ident="data.FLAGFORM.mensural" module="MEI.mensural" type="dt">
+    <desc>Form of the flag.</desc>
+    <content>
+      <valList type="closed">
+        <valItem ident="straight">
+          <desc>Flag is a straight horizontal line.</desc>
+        </valItem>
+        <valItem ident="angled">
+          <desc>Flag is a straight line at an angle.</desc>
+        </valItem>
+        <valItem ident="curled">
+          <desc>Flag is curled.</desc>
+        </valItem>
+        <valItem ident="flared">
+          <desc>Flag is flared.</desc>
+        </valItem>
+        <valItem ident="extended">
+          <desc>Flag looks extended.</desc>
+        </valItem>
+        <valItem ident="hooked">
+          <desc>Flag is hooked-form.</desc>
+        </valItem>
+      </valList>
+    </content>
+    <remarks>
+        <p>
+            <!-- TODO: Add samples for all values here  -->
+            <!--<graphic url="ExampleImages/accid-20100510.png" height="50%" width="50%"/>-->
+        </p>
+    </remarks>
+  </macroSpec>
+  <macroSpec ident="data.FLAGPOS.mensural" module="MEI.mensural" type="dt">
+    <desc>Position of the flag relative to the stem.</desc>
+    <content>
+      <valList type="closed">
+        <valItem ident="left">
+          <desc>Flag lies at the left side of the stem.</desc>
+        </valItem>
+        <valItem ident="right">
+          <desc>Flag lies at the right side of the stem.</desc>
+        </valItem>
+        <valItem ident="center">
+          <desc>Flag is centered in the stem.</desc>
+        </valItem>
+      </valList>
+    </content>
+  </macroSpec>
   <macroSpec ident="data.STAFFITEM.mensural" module="MEI.mensural" type="dt">
     <desc>Items in the Mensural repertoire that may be printed near a staff.</desc>
     <content>
       <valList type="closed">
         <valItem ident="ligature">
           <desc>Ligatures.</desc>
+        </valItem>
+      </valList>
+    </content>
+  </macroSpec>
+  <macroSpec ident="data.STEMFORM.mensural" module="MEI.mensural" type="dt">
+    <desc>Form of the stem attached to the note.</desc>
+    <content>
+      <valList type="closed">
+        <valItem ident="circle">
+          <desc>Stem has a circular form.</desc>
+        </valItem>
+        <valItem ident="oblique">
+          <desc>Stem has an oblique form.</desc>
+        </valItem>
+        <valItem ident="swallowtail">
+          <desc>Stem has a swallowtail form.</desc>
+        </valItem>
+        <valItem ident="virgula">
+          <desc>Stem has a virgula-like form.</desc>
         </valItem>
       </valList>
     </content>
@@ -243,6 +309,61 @@
       <memberOf key="att.mensural.vis"/>
     </classes>
   </classSpec>
+  <classSpec ident="att.STEMPROPERTIES.mensural" module="MEI.mensural" type="atts">
+    <desc>Attributes that describe the properties of stems in the mensural repertoire.</desc>
+    <classes>
+        <memberOf key="att.xy"/>
+    </classes>
+    <attList>
+      <attDef ident="pos" usage="opt">
+        <desc>Records the position of the stem in relation to the note head(s).</desc>
+        <datatype>
+          <rng:ref name="data.STEMPOSITION"/>
+        </datatype>
+      </attDef>
+      <attDef ident="length" usage="opt">
+        <desc>Encodes the stem length.</desc>
+        <datatype>
+          <rng:ref name="data.MEASUREMENTABS"/>
+        </datatype>
+      </attDef>
+      <attDef ident="form" usage="opt">
+        <desc>Encodes the form of the stem using the values provided by the data.STEMFORM.mensural datatype.</desc>
+        <datatype>
+          <rng:ref name="data.STEMFORM.mensural"/>
+        </datatype>
+      </attDef>
+      <attDef ident="dir" usage="opt">
+        <desc>Describes the direction of a stem.</desc>
+        <datatype>
+          <rng:ref name="data.STEMDIRECTION"/>
+        </datatype>
+      </attDef>
+      <attDef ident="flag.pos" usage="opt">
+        <desc>Records the position of the flag using the values provided by the data.FLAGPOS.mensural datatype.</desc>
+        <datatype>
+          <rng:ref name="data.FLAGPOS.mensural"/>
+        </datatype>
+      </attDef>
+      <attDef ident="flag.form" usage="opt">
+        <desc>Encodes the form of the flag using the values provided by the data.FLAGFORM.mensural datatype.</desc>
+        <datatype>
+          <rng:ref name="data.FLAGFORM.mensural"/>
+        </datatype>
+      </attDef>
+    </attList>
+  </classSpec>
+  <classSpec ident="att.stems.mensural" module="MEI.mensural" type="atts">
+      <desc>Attributes that describe the properties of stemmed features specific to mensural repertoires.</desc>
+      <attList>
+          <attDef ident="stem.form" usage="opt">
+              <desc>Records the form of the stem.</desc>
+              <datatype maxOccurs="1" minOccurs="1">
+                  <rng:ref name="data.STEMFORM.mensural"/>
+              </datatype>
+          </attDef>
+      </attList>
+  </classSpec>
   <classSpec ident="model.eventLike.mensural" module="MEI.mensural" type="model">
     <desc>Groups event elements that occur in the mensural repertoire.</desc>
     <classes>
@@ -351,6 +472,31 @@
         description of note durations as arithmetic ratios. While mensuration refers to the normal
         relationships between note durations, proportion affects the relations of the note durations
         to the tactus.</p>
+    </remarks>
+  </elementSpec>
+  <elementSpec ident="stem" module="MEI.mensural">
+    <desc>A stem element.</desc>
+    <classes>
+      <memberOf key="att.common"/>
+      <memberOf key="att.STEMPROPERTIES.mensural"/>
+      <memberOf key="model.noteModifierLike"/>
+    </classes>
+    <content>
+      <rng:empty/>
+    </content>
+    <constraintSpec ident="Check_stem" scheme="isoschematron">
+      <constraint>
+        <sch:rule context="mei:stem">
+          <sch:assert test="not(ancestor::mei:note/@*[starts-with(local-name(),'stem.')])">A note with nested stem elements must not have @stem.* attributes.</sch:assert>
+        </sch:rule>
+      </constraint>
+    </constraintSpec>
+    <remarks>
+      <p>Mensural notes can have multiple stems and these may have various forms, directions, and types of flags.
+        Multiple stem elements can be encoded as children of a single note. The attributes <att>pos</att>,
+        <att>length</att>, <att>form</att>, and <att>dir</att> allow to encode different positions, lengths,
+        forms, and directions for each these stems. The attributes <att>flag.pos</att> and <att>flag.form</att> 
+        also allow to encode different types of flags for each of the stems.</p>
     </remarks>
   </elementSpec>
 </specGrp>

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -38,6 +38,28 @@
       </valList>
     </content>
   </macroSpec>
+  <macroSpec ident="data.MULTIBREVERESTS.mensural" module="MEI.mensural" type="dt">
+    <desc>Logical, that is, written, duration attribute values for multi-breve rests in the mensural repertoire.</desc>
+    <content>
+      <valList type="closed">
+        <valItem ident="2B">
+          <desc>A two-breve rest.</desc>
+        </valItem>
+        <valItem ident="3B">
+          <desc>A three-breve rest.</desc>
+        </valItem>
+      </valList>
+    </content>
+  </macroSpec>
+  <macroSpec ident="data.DURATIONRESTS.mensural" module="MEI.mensural" type="dt">
+    <desc>Logical, that is, written, duration attribute values for mensural rests.</desc>
+    <content>
+      <rng:choice>
+        <rng:ref name="data.MULTIBREVERESTS.mensural"/>
+        <rng:ref name="data.DURATION.mensural"/>
+      </rng:choice>
+    </content>
+  </macroSpec>
   <macroSpec ident="data.DURQUALITY.mensural" module="MEI.mensural" type="dt">
     <desc>Duration attribute values of a given note symbol for the mensural repertoire.</desc>
     <content>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -2727,10 +2727,22 @@
     <classes>
       <memberOf key="att.augmentDots"/>
       <memberOf key="att.cue"/>
-      <memberOf key="att.duration.logical"/>
+      <memberOf key="att.restduration.logical"/>
       <memberOf key="att.event"/>
       <memberOf key="att.rest.log.cmn"/>
     </classes>
+  </classSpec>
+  <classSpec ident="att.restduration.logical" module="MEI.shared" type="atts">
+    <desc>Attributes that express duration of rests in musical terms.</desc>
+    <attList>
+      <attDef ident="dur" usage="opt">
+        <desc>Records the duration of a rest using the relative durational values provided by the
+          data.DURATIONRESTS datatype.</desc>
+        <datatype>
+          <rng:ref name="data.DURATIONRESTS"/>
+        </datatype>
+      </attDef>
+    </attList>
   </classSpec>
   <classSpec ident="att.sb.log" module="MEI.shared" type="atts">
     <desc>Logical domain attributes.</desc>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -2111,6 +2111,7 @@
       <memberOf key="att.note.log.cmn"/>
       <memberOf key="att.note.log.mensural"/>
       <memberOf key="att.pitched"/>
+      <memberOf key="att.duration.quality"/>
     </classes>
   </classSpec>
   <classSpec ident="att.noteHeads" module="MEI.shared" type="atts">

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -3075,6 +3075,7 @@
       notes.</desc>
     <classes>
       <memberOf key="att.stems.cmn"/>
+      <memberOf key="att.stems.mensural"/>
     </classes>
     <attList>
       <attDef ident="stem.dir" usage="opt">

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -1040,6 +1040,15 @@
       </rng:choice>
     </content>
   </macroSpec>
+  <macroSpec ident="data.DURATIONRESTS" module="MEI" type="dt">
+    <desc>Logical, that is, written, duration attribute values for rests.</desc>
+    <content>
+      <rng:choice>
+        <rng:ref name="data.DURATION.cmn"/>
+        <rng:ref name="data.DURATIONRESTS.mensural"/>
+      </rng:choice>
+    </content>
+  </macroSpec>
   <macroSpec ident="data.DURATION.gestural" module="MEI" type="dt">
     <desc>Performed duration attribute values.</desc>
     <content>


### PR DESCRIPTION
This PR replaces https://github.com/music-encoding/music-encoding/pull/634. It includes the exact same changes, but the changes are done in the source files (rather than in the customization file as in https://github.com/music-encoding/music-encoding/pull/634).