### PR TITLE
fix removed attribute

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -7985,7 +7985,7 @@
         coordinate terms using the <att>x</att> and <att>y</att> attributes or relative to another
         element using the <att>startid</att> attribute. Attributes in the att.visualOffset class may
         be used to record horizontal, vertical, or time offsets from the absolute coordinates or
-        from the location of the referenced element. The <att>ref</att> attribute must contain the
+        from the location of the referenced element. The <att>altsym</att> attribute must contain the
         id of a <gi scheme="MEI">symbolDef</gi> element. The <att>scale</att> attribute indicates
         that the printed output must be scaled by the specified percentage.</p>
     </remarks>


### PR DESCRIPTION
`@ref` has been replaced by `@altsym`, fixing this in the remarks.

What I'm not sure about is the meaning of `@startid`. How is that supposed to be used, if `<symbol>` cant't be used as a free controlEvent? 
