### PR TITLE
Add `@rotate` to att.coordinated

### DIFF
--- a/source/modules/MEI.facsimile.xml
+++ b/source/modules/MEI.facsimile.xml
@@ -109,8 +109,10 @@
     </content>
     <attList>
       <attDef ident="rotate">
-        <desc>Indicates the amount by which this zone has been rotated clockwise, with respect
-          to the normal orientation of the parent surface. The orientation is expressed in arc degrees.</desc>
+        <desc>
+          Indicates the amount by which the contents of this zone have been rotated clockwise, with respect
+          to the normal orientation of the parent surface. The orientation is expressed in arc degrees.
+        </desc>
         <datatype minOccurs="1" maxOccurs="1">
           <rng:ref name="data.DEGREES"/>
         </datatype>

--- a/source/modules/MEI.facsimile.xml
+++ b/source/modules/MEI.facsimile.xml
@@ -107,6 +107,16 @@
         <rng:ref name="model.graphicLike"/>
       </rng:zeroOrMore>
     </content>
+    <attList>
+      <attDef ident="rotate">
+        <desc>Indicates the amount by which this zone has been rotated clockwise, with respect
+          to the normal orientation of the parent surface. The orientation is expressed in arc degrees.</desc>
+        <datatype minOccurs="1" maxOccurs="1">
+          <rng:ref name="data.DEGREES"/>
+        </datatype>
+        <defaultVal>0</defaultVal>
+      </attDef>
+    </attList>
     <remarks>
       <p>Scalable Vector Graphics (SVG) markup may be used when allowed by the graphicLike
         model.</p>


### PR DESCRIPTION
This PR is to add [the attribute of the same name from TEI](https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-zone.html) to att.coordinated and is meant to address cases where elements are not aligned to the edges of the page/surface to an extent where it is significant.
This is meant to succeed the similar PR #620 which should be referenced for additional examples and discussion.