### PR TITLE
Revert "Merge pull request #541 from rettinghaus/develop-mensural"

### DIFF
--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -183,6 +183,54 @@
       </attDef>
     </attList>
   </classSpec>
+  <classSpec ident="att.mensural.log" module="MEI.mensural" type="atts">
+    <desc>Used by staffDef and scoreDef to provide default values for attributes in the logical
+      domain related to mensuration. The tempus, prolatio, modusmaior, and modusminor attributes
+      (from the att.mensural.shared class) specify the relationship between the four principle
+      levels of note value, i.e., the long, breve, semibreve and minim, in mensural notation.
+      Modusminor describes the long-breve relationship, while tempus describes the breve-semibreve,
+      and prolatio the semibreve-minim relationship, respectively. Modusmaior is for the maxima-long
+      relationship. The proport.* attributes describe augmentation or diminution of the normal value
+      of the notes in mensural notation.</desc>
+    <classes>
+      <memberOf key="att.mensural.shared"/>
+    </classes>
+    <attList>
+      <attDef ident="mensur.dot" usage="opt">
+        <desc>Determines if a dot is to be added to the base symbol.</desc>
+        <datatype>
+          <rng:ref name="data.BOOLEAN"/>
+        </datatype>
+      </attDef>
+      <attDef ident="mensur.sign" usage="opt">
+        <desc>The base symbol in the mensuration sign/time signature of mensural notation.</desc>
+        <datatype>
+          <rng:ref name="data.MENSURATIONSIGN"/>
+        </datatype>
+      </attDef>
+      <attDef ident="mensur.slash" usage="opt">
+        <desc>Indicates the number lines added to the mensuration sign. For example, one slash is
+          added for what we now call 'alla breve'.</desc>
+        <datatype>
+          <rng:data type="positiveInteger"/>
+        </datatype>
+      </attDef>
+      <attDef ident="proport.num" usage="opt">
+        <desc>Together, proport.num and proport.numbase specify a proportional change as a ratio,
+          e.g., 1:3. Proport.num is for the first value in the ratio.</desc>
+        <datatype>
+          <rng:data type="positiveInteger"/>
+        </datatype>
+      </attDef>
+      <attDef ident="proport.numbase" usage="opt">
+        <desc>Together, proport.num and proport.numbase specify a proportional change as a ratio,
+          e.g., 1:3. Proport.numbase is for the second value in the ratio.</desc>
+        <datatype>
+          <rng:data type="positiveInteger"/>
+        </datatype>
+      </attDef>
+    </attList>
+  </classSpec>
   <classSpec ident="att.mensural.shared" module="MEI.mensural" type="atts">
     <desc>Shared attributes in the mensural repertoire.</desc>
     <constraintSpec ident="mensuration_conflicting_attributes" scheme="isoschematron">
@@ -272,6 +320,32 @@
       </attDef>
     </attList>
   </classSpec>
+  <classSpec ident="att.scoreDef.log.mensural" module="MEI.mensural" type="atts">
+    <desc>Logical domain attributes for a score in the mensural repertoire. The values set in these
+      attributes act as score-wide defaults for attributes that are not set in descendant
+      elements.</desc>
+    <classes>
+      <memberOf key="att.mensural.log"/>
+    </classes>
+  </classSpec>
+  <classSpec ident="att.scoreDef.vis.mensural" module="MEI.mensural" type="atts">
+    <desc>Visual domain attributes for scoreDef in the mensural repertoire.</desc>
+    <classes>
+      <memberOf key="att.mensural.vis"/>
+    </classes>
+  </classSpec>
+  <classSpec ident="att.staffDef.log.mensural" module="MEI.mensural" type="atts">
+    <desc>Logical domain attributes for staffDef in the mensural repertoire.</desc>
+    <classes>
+      <memberOf key="att.mensural.log"/>
+    </classes>
+  </classSpec>
+  <classSpec ident="att.staffDef.vis.mensural" module="MEI.mensural" type="atts">
+    <desc>Visual domain attributes for the mensural repertoire.</desc>
+    <classes>
+      <memberOf key="att.mensural.vis"/>
+    </classes>
+  </classSpec>
   <classSpec ident="att.STEMPROPERTIES.mensural" module="MEI.mensural" type="atts">
     <desc>Attributes that describe the properties of stems in the mensural repertoire.</desc>
     <classes>
@@ -349,6 +423,12 @@
       <memberOf key="model.sectionPart.mensuralAndNeumes"/>
     </classes>
   </classSpec>
+  <classSpec ident="model.staffDefPart.mensural" module="MEI.mensural" type="model">
+    <desc>Groups elements that may appear in the declaration of staff features.</desc>
+    <classes>
+      <memberOf key="model.staffDefPart"/>
+    </classes>
+  </classSpec>
   <classSpec ident="model.staffPart.mensural" module="MEI.mensural" type="model">
     <desc>Groups elements that are components of a staff in the mensural repertoire.</desc>
     <classes>
@@ -398,6 +478,7 @@
       <memberOf key="att.mensur.ges"/>
       <memberOf key="att.mensur.anl"/>
       <memberOf key="model.eventLike.mensural"/>
+      <memberOf key="model.staffDefPart.mensural"/>
     </classes>
     <content>
       <rng:empty/>
@@ -418,6 +499,7 @@
       <memberOf key="att.proport.ges"/>
       <memberOf key="att.proport.anl"/>
       <memberOf key="model.eventLike.mensural"/>
+      <memberOf key="model.staffDefPart.mensural"/>
     </classes>
     <content>
       <rng:empty/>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -227,7 +227,7 @@
       convenient typology of annotation suitable to the work in hand; e.g. annotation, gloss,
       citation, digression, preliminary, temporary, etc.</desc>
     <!-- Some attributes defined in att.controlEvent (att.timestamp.logical, att.timestamp.gestural,
-          att.staffIdent, and att.layerIdent) are provided here directly instead of making annot a
+          att.staffIdent, and att.layerIdent) are provided here directly instead of making annot a 
           member of att.controlEvent. -->
     <classes>
       <memberOf key="att.alignment"/>
@@ -1480,7 +1480,7 @@
         </datatype>
       </attDef>
       <!-- @llength not necessary:
-            @llength implies we know the direction of the vector which we
+            @llength implies we know the direction of the vector which we 
             can't know without establishing an end point, which in turn makes
             @llength redundant. -->
       <attDef ident="lsegs" usage="opt">
@@ -2761,6 +2761,7 @@
       <memberOf key="att.octaveDefault"/>
       <memberOf key="att.transposition"/>
       <memberOf key="att.scoreDef.log.cmn"/>
+      <memberOf key="att.scoreDef.log.mensural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.section.log" module="MEI.shared" type="atts">
@@ -2909,6 +2910,7 @@
       <memberOf key="att.octaveDefault"/>
       <memberOf key="att.transposition"/>
       <memberOf key="att.staffDef.log.cmn"/>
+      <memberOf key="att.staffDef.log.mensural"/>
     </classes>
     <attList>
       <attDef ident="lines" usage="opt">
@@ -5862,7 +5864,7 @@
       <memberOf key="att.bibl"/>
       <memberOf key="model.incipLike"/>
     </classes>
-    <!-- Can XSLT be used within content to "select" an incipit from the
+    <!-- Can XSLT be used within content to "select" an incipit from the 
         already-encoded MEI transcription in the music element?
         <rng:ref name="macro.XSLT"/> -->
     <content>
@@ -7076,7 +7078,7 @@
       <constraint>
         <!-- See http://vocab.org/frbr/core for more-precise entity-to-entity constraints -->
         <sch:rule
-          context="mei:relationList/mei:relation[parent::mei:work or parent::mei:expression or
+          context="mei:relationList/mei:relation[parent::mei:work or parent::mei:expression or             
           parent::mei:source or parent::mei:item]">
           <sch:assert
             test="matches(@rel, 'hasAbridgement') or
@@ -7284,7 +7286,7 @@
       <constraint>
         <sch:rule context="mei:respStmt[not(ancestor::mei:change)]">
           <sch:assert
-            test="(mei:resp and (mei:name or mei:corpName or mei:persName)) or
+            test="(mei:resp and (mei:name or mei:corpName or mei:persName)) or 
             count(mei:*[@role]) = count(mei:*) and count(mei:*) &gt; 0"
             role="warning">At least one element pair (a resp element and a name-like element) is
             recommended. Alternatively, each name-like element may have a @role

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -830,8 +830,8 @@
           <rng:ref name="data.LINEFORM"/>
         </datatype>
       </attDef>
-      <!-- @length not necessary:
-          @length implies we know the direction of the vector which we
+      <!-- @length not necessary: 
+          @length implies we know the direction of the vector which we 
           can't know without establishing an end point, which in turn makes
           @length redundant.
         -->
@@ -988,6 +988,48 @@
         <desc>The base symbol in the mensuration sign/time signature of mensural notation.</desc>
         <datatype>
           <rng:ref name="data.MENSURATIONSIGN"/>
+        </datatype>
+      </attDef>
+    </attList>
+  </classSpec>
+  <classSpec ident="att.mensural.vis" module="MEI.visual" type="atts">
+    <desc>Used by staffDef and scoreDef to provide default values for attributes in the visual
+      domain related to mensuration.</desc>
+    <attList>
+      <attDef ident="mensur.color" usage="opt">
+        <desc>Records the color of the mensuration sign. Do not confuse this with the musical term
+          'color' as used in pre-CMN notation.</desc>
+        <datatype>
+          <rng:ref name="data.COLOR"/>
+        </datatype>
+      </attDef>
+      <attDef ident="mensur.form" usage="opt">
+        <desc>Indicates whether the base symbol is written vertically or horizontally.</desc>
+        <valList type="closed">
+          <valItem ident="horizontal">
+            <desc>Horizontally oriented.</desc>
+          </valItem>
+          <valItem ident="vertical">
+            <desc>Vertically oriented.</desc>
+          </valItem>
+        </valList>
+      </attDef>
+      <attDef ident="mensur.loc" usage="opt">
+        <desc>Holds the staff location of the mensuration sign.</desc>
+        <datatype>
+          <rng:ref name="data.STAFFLOC"/>
+        </datatype>
+      </attDef>
+      <attDef ident="mensur.orient" usage="opt">
+        <desc>Describes the rotation or reflection of the base symbol.</desc>
+        <datatype>
+          <rng:ref name="data.ORIENTATION"/>
+        </datatype>
+      </attDef>
+      <attDef ident="mensur.size" usage="opt">
+        <desc>Describes the relative size of the mensuration sign.</desc>
+        <datatype>
+          <rng:ref name="data.FONTSIZE"/>
         </datatype>
       </attDef>
     </attList>
@@ -1403,6 +1445,7 @@
       <memberOf key="att.systems"/>
       <memberOf key="att.textStyle"/>
       <memberOf key="att.scoreDef.vis.cmn"/>
+      <memberOf key="att.scoreDef.vis.mensural"/>
     </classes>
     <attList>
       <attDef ident="vu.height" usage="opt">
@@ -1513,6 +1556,7 @@
       <memberOf key="att.textStyle"/>
       <memberOf key="att.visibility"/>
       <memberOf key="att.staffDef.vis.cmn"/>
+      <memberOf key="att.staffDef.vis.mensural"/>
     </classes>
     <attList>
       <attDef ident="grid.show" usage="opt">
@@ -1608,7 +1652,7 @@
       <memberOf key="att.horizontalAlign"/>
     </classes>
     <!-- Is this constraint true in all cases? -->
-    <!--
+    <!-- 
       <constraintSpec ident="check_sylAncestor" scheme="isoschematron">
         <constraint>
           <sch:rule context="mei:syl[@place]">


### PR DESCRIPTION
This reverts commit 03e9478e6194984efd2422c06336fc80b43c49b4, reversing
changes made to c6faac8e132d296f2e13c9be3847c3d5b23ce992.

It reverts the removal of mensuration- and proportion-related attributes from `<staffDef>` and `<scoreDef>`, keeping the consistency with how meter and clefs are encoded in MEI.