### PR TITLE
Move rotate attribute to att.coordinated

### DIFF
--- a/source/modules/MEI.facsimile.xml
+++ b/source/modules/MEI.facsimile.xml
@@ -107,18 +107,6 @@
         <rng:ref name="model.graphicLike"/>
       </rng:zeroOrMore>
     </content>
-    <attList>
-      <attDef ident="rotate">
-        <desc>
-          Indicates the amount by which the contents of this zone have been rotated clockwise, with respect
-          to the normal orientation of the parent surface. The orientation is expressed in arc degrees.
-        </desc>
-        <datatype minOccurs="1" maxOccurs="1">
-          <rng:ref name="data.DEGREES"/>
-        </datatype>
-        <defaultVal>0</defaultVal>
-      </attDef>
-    </attList>
     <remarks>
       <p>Scalable Vector Graphics (SVG) markup may be used when allowed by the graphicLike
         model.</p>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -227,7 +227,7 @@
       convenient typology of annotation suitable to the work in hand; e.g. annotation, gloss,
       citation, digression, preliminary, temporary, etc.</desc>
     <!-- Some attributes defined in att.controlEvent (att.timestamp.logical, att.timestamp.gestural,
-          att.staffIdent, and att.layerIdent) are provided here directly instead of making annot a 
+          att.staffIdent, and att.layerIdent) are provided here directly instead of making annot a
           member of att.controlEvent. -->
     <classes>
       <memberOf key="att.alignment"/>
@@ -688,6 +688,19 @@
         <datatype>
           <rng:data type="nonNegativeInteger"/>
         </datatype>
+      </attDef>
+      <attDef ident="rotate">
+        <desc>
+          Indicates the amount by which the contents of this zone have been rotated clockwise, with respect
+          to the normal orientation of the parent surface. The orientation is expressed in arc degrees.
+        </desc>
+        <datatype minOccurs="1" maxOccurs="1">
+          <rng:ref name="data.DEGREES"/>
+        </datatype>
+        <defaultVal>0</defaultVal>
+        <remarks>
+          <p>This attribute is based on the TEI attribute of the same name.</p>
+        </remarks>
       </attDef>
     </attList>
   </classSpec>
@@ -1480,7 +1493,7 @@
         </datatype>
       </attDef>
       <!-- @llength not necessary:
-            @llength implies we know the direction of the vector which we 
+            @llength implies we know the direction of the vector which we
             can't know without establishing an end point, which in turn makes
             @llength redundant. -->
       <attDef ident="lsegs" usage="opt">
@@ -5865,7 +5878,7 @@
       <memberOf key="att.bibl"/>
       <memberOf key="model.incipLike"/>
     </classes>
-    <!-- Can XSLT be used within content to "select" an incipit from the 
+    <!-- Can XSLT be used within content to "select" an incipit from the
         already-encoded MEI transcription in the music element?
         <rng:ref name="macro.XSLT"/> -->
     <content>
@@ -7079,7 +7092,7 @@
       <constraint>
         <!-- See http://vocab.org/frbr/core for more-precise entity-to-entity constraints -->
         <sch:rule
-          context="mei:relationList/mei:relation[parent::mei:work or parent::mei:expression or             
+          context="mei:relationList/mei:relation[parent::mei:work or parent::mei:expression or
           parent::mei:source or parent::mei:item]">
           <sch:assert
             test="matches(@rel, 'hasAbridgement') or
@@ -7287,7 +7300,7 @@
       <constraint>
         <sch:rule context="mei:respStmt[not(ancestor::mei:change)]">
           <sch:assert
-            test="(mei:resp and (mei:name or mei:corpName or mei:persName)) or 
+            test="(mei:resp and (mei:name or mei:corpName or mei:persName)) or
             count(mei:*[@role]) = count(mei:*) and count(mei:*) &gt; 0"
             role="warning">At least one element pair (a resp element and a name-like element) is
             recommended. Alternatively, each name-like element may have a @role

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -691,8 +691,9 @@
       </attDef>
       <attDef ident="rotate">
         <desc>
-          Indicates the amount by which the contents of this zone have been rotated clockwise, with respect
-          to the normal orientation of the parent surface. The orientation is expressed in arc degrees.
+          Indicates the amount by which the contents of this element have been rotated clockwise or, if applicable, how the orientation of
+          the element self should be interpreted, with respect to the normal orientation of the parent surface.
+          The orientation is expressed in arc degrees.
         </desc>
         <datatype minOccurs="1" maxOccurs="1">
           <rng:ref name="data.DEGREES"/>


### PR DESCRIPTION
This makes `@rotate` apply to all elements with the `att.coordinated` class and not just the `zone` element. This expands it to the `surface` and `symbolDef` elements.

See #674 for more information on `@rotate`.