### PR TITLE
Fix: Dots valid position within MEI file.

### DIFF
--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -107,7 +107,6 @@
 
         <!-- Change the availability of dots -->
         <!-- Remove them as children of <note> -->
-        <!-- Allow them as children of <ligature> -->
         <elementSpec ident="dot" module="MEI.shared" mode="change">
           <desc>Dot of augmentation or division.</desc>
           <classes>
@@ -118,7 +117,7 @@
             <memberOf key="att.dot.ges"/>
             <memberOf key="att.dot.anl"/>
             <memberOf key="model.noteModifierLike" mode="delete"/>
-            <memberOf key="model.eventLike.mensural" mode="add"/>
+            <memberOf key="model.eventLike.mensural"/>
           </classes>
           <content>
             <rng:empty/>
@@ -130,7 +129,7 @@
               for dots of division in the mensural repertoire.</p>
           </remarks>
         </elementSpec>
-        <!-- Remove them as attributes of <note> -->
+        <!-- Remove them as attributes of <note> and <rest> -->
         <classSpec ident="att.augmentDots" module="MEI.shared" type="atts" mode="delete"/>
 
       </schemaSpec>

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -105,6 +105,9 @@
         <classSpec ident="model.sectionPart.cmn" module="MEI.shared" type="model" mode="delete"/>
         <classSpec ident="model.layerPart.cmn" module="MEI.shared" type="model" mode="delete"/>
 
+        <!-- Change the availability of dots -->
+        <!-- Remove them as children of <note> -->
+        <!-- Allow them as children of <ligature> -->
         <elementSpec ident="dot" module="MEI.shared" mode="change">
           <desc>Dot of augmentation or division.</desc>
           <classes>
@@ -127,6 +130,8 @@
               for dots of division in the mensural repertoire.</p>
           </remarks>
         </elementSpec>
+        <!-- Remove them as attributes of <note> -->
+        <classSpec ident="att.augmentDots" module="MEI.shared" type="atts" mode="delete"/>
 
       </schemaSpec>
     </body>

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -129,6 +129,44 @@
               for dots of division in the mensural repertoire.</p>
           </remarks>
         </elementSpec>
+        <!-- Remove them as children of <rest> -->
+        <elementSpec ident="rest" module="MEI.shared" mode="replace">
+          <desc>A non-sounding event found in the source being transcribed.</desc>
+          <classes>
+            <memberOf key="att.common"/>
+            <memberOf key="att.facsimile"/>
+            <memberOf key="att.rest.log"/>
+            <memberOf key="att.rest.vis"/>
+            <memberOf key="att.rest.ges"/>
+            <memberOf key="att.rest.anl"/>
+            <memberOf key="model.eventLike"/>
+          </classes>
+          <content>
+            <rng:zeroOrMore>
+              <rng:choice>
+                <!--<rng:ref name="dot"/>-->
+                <rng:ref name="model.appLike"/>
+                <rng:ref name="model.editLike"/>
+                <rng:ref name="model.transcriptionLike"/>
+              </rng:choice>
+            </rng:zeroOrMore>
+          </content>
+          <constraintSpec ident="Check_restline" scheme="isoschematron">
+            <constraint>
+              <sch:rule context="mei:rest[@line]">
+                <sch:let name="thisstaff" value="ancestor::mei:staff/@n"/>
+                <sch:assert
+                  test="number(@line) &lt;= number(preceding::mei:staffDef[@n=$thisstaff and @lines][1]/@lines)"
+                  >The value of @line must be less than or equal to the number of lines on the
+                  staff.</sch:assert>
+              </sch:rule>
+            </constraint>
+          </constraintSpec>
+          <remarks>
+            <p>See (Read, p. 96-102). Do not confuse this element with the <gi scheme="MEI">space</gi>
+              element, which is used as an aid for visual alignment.</p>
+          </remarks>
+        </elementSpec>
         <!-- Remove them as attributes of <note> and <rest> -->
         <classSpec ident="att.augmentDots" module="MEI.shared" type="atts" mode="delete"/>
 

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -105,6 +105,29 @@
         <classSpec ident="model.sectionPart.cmn" module="MEI.shared" type="model" mode="delete"/>
         <classSpec ident="model.layerPart.cmn" module="MEI.shared" type="model" mode="delete"/>
 
+        <elementSpec ident="dot" module="MEI.shared" mode="change">
+          <desc>Dot of augmentation or division.</desc>
+          <classes>
+            <memberOf key="att.common"/>
+            <memberOf key="att.facsimile"/>
+            <memberOf key="att.dot.log"/>
+            <memberOf key="att.dot.vis"/>
+            <memberOf key="att.dot.ges"/>
+            <memberOf key="att.dot.anl"/>
+            <memberOf key="model.noteModifierLike" mode="delete"/>
+            <memberOf key="model.eventLike.mensural" mode="add"/>
+          </classes>
+          <content>
+            <rng:empty/>
+          </content>
+          <remarks>
+            <p>This element provides an alternative to the <att>dots</att> attribute on <gi scheme="MEI"
+              >note</gi> and <gi scheme="MEI">rest</gi> elements. It should be used when specific display
+              info, such as size or color, needs to be recorded for the dot. This element may also be used
+              for dots of division in the mensural repertoire.</p>
+          </remarks>
+        </elementSpec>
+
       </schemaSpec>
     </body>
   </text>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -5354,6 +5354,7 @@
       <memberOf key="att.dot.ges"/>
       <memberOf key="att.dot.anl"/>
       <memberOf key="model.noteModifierLike"/>
+      <memberOf key="model.eventLike.mensural"/>
     </classes>
     <content>
       <rng:empty/>


### PR DESCRIPTION
The position of the dots is problematic in mensural notation. Dots are allowed as children of note elements (which shouldn't be the case, they should be siblings). This behaviour is codified in the Shared module. Since we don't want to modify this behaviour for all `<dot>` elements, but only those used in mensural notation, I modified this in the customization rather than the source file. The other issue is that dots have to be allowed within ligatures. This PR solves both issues (which were originally pointed out in https://github.com/music-encoding/music-encoding/issues/691).

- Deleting model.noteModifierLike, made invalid the use of `<dot>` as a child of `<note>`.
- Adding model.eventLike.mensural, made valid the use of `<dot>` within a `<ligature>`.

Please, feel free to modify this PR if the changes are not made in the appropriate place (maybe this change was supposed to be done in the source file rather than the customization?) or if the `@mode` attribute was not used appropriately. 

Right now, the customization works perfectly. It solves the two problems shown in the screenshot, where the original Mensural schema failed.

![dot_placement](https://user-images.githubusercontent.com/13948831/87731392-644dd400-c798-11ea-8b12-99d3de5a38f3.png)

Also, in the second commit, removed the `@dots` attribute from the `<note>` element (this is the usual way of encoding dots of augmentation in CMN). In mensural notation, both dots of augmentation and dots of division are encoded within the stream of notes inside the `<layer>` element.