### PR TITLE
Ligature-related attributes moved into the visual domain

### DIFF
--- a/source/modules/MEI.analytical.xml
+++ b/source/modules/MEI.analytical.xml
@@ -351,7 +351,6 @@
       <memberOf key="att.intervalMelodic"/>
       <memberOf key="att.melodicFunction"/>
       <memberOf key="att.note.anl.cmn"/>
-      <memberOf key="att.note.anl.mensural"/>
       <memberOf key="att.pitchClass"/>
       <memberOf key="att.solfa"/>
     </classes>

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -174,14 +174,6 @@
   </classSpec>
   <classSpec ident="att.ligature.log" module="MEI.mensural" type="atts">
     <desc>Logical domain attributes.</desc>
-    <attList>
-      <attDef ident="form" usage="opt">
-        <desc>Provides an indication of the function of the ligature.</desc>
-        <datatype>
-          <rng:ref name="data.LIGATUREFORM"/>
-        </datatype>
-      </attDef>
-    </attList>
   </classSpec>
   <classSpec ident="att.mensural.log" module="MEI.mensural" type="atts">
     <desc>Used by staffDef and scoreDef to provide default values for attributes in the logical
@@ -275,8 +267,8 @@
       </attDef>
     </attList>
   </classSpec>
-  <classSpec ident="att.note.anl.mensural" module="MEI.mensural" type="atts">
-    <desc>Analytical domain attributes in the Mensural repertoire.</desc>
+  <classSpec ident="att.note.vis.mensural" module="MEI.mensural" type="atts">
+    <desc>Visual domain attributes in the Mensural repertoire.</desc>
     <attList>
       <attDef ident="lig" usage="opt">
         <desc>Indicates this element's participation in a ligature.</desc>

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -272,10 +272,9 @@
     <attList>
       <attDef ident="lig" usage="opt">
         <desc>Indicates this element's participation in a ligature.</desc>
-        <valList type="closed">
-          <valItem ident="recta"/>
-          <valItem ident="obliqua"/>
-        </valList>
+        <datatype>
+          <rng:ref name="data.LIGATUREFORM"/>
+        </datatype>
       </attDef>
     </attList>
   </classSpec>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -812,6 +812,14 @@
     <classes>
       <memberOf key="att.color"/>
     </classes>
+    <attList>
+      <attDef ident="form" usage="opt">
+        <desc>Provides an indication of the function of the ligature.</desc>
+        <datatype>
+          <rng:ref name="data.LIGATUREFORM"/>
+        </datatype>
+      </attDef>
+    </attList>
   </classSpec>
   <classSpec ident="att.line.vis" module="MEI.visual" type="atts">
     <desc>Attributes for describing the visual appearance of a line.</desc>
@@ -1213,6 +1221,7 @@
       <memberOf key="att.visualOffset.to"/>
       <memberOf key="att.xy"/>
       <memberOf key="att.note.vis.cmn"/>
+      <memberOf key="att.note.vis.mensural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.octave.vis" module="MEI.visual" type="atts">


### PR DESCRIPTION
In this pull request, the attributes `@form` and `@lig` (used within the `<ligature>` and `<note>` element, respectively) are moved into the visual domain. These two attributes indicate whether the ligature (`@form`) or the individual notes of the ligature (`@lig`) have a `"recta"` or `"obliqua"` shape. Because they deal with the shape of ligatures, the attributes have been moved into the visual domain.

This answers to the issue brought up in https://github.com/music-encoding/mensural-ig/issues/5