### PR TITLE
Allow ossia staves below the regular staves

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -2113,22 +2113,22 @@
     </classes>
     <content>
       <rng:choice>
-        <rng:group>
+        <rng:interleave>
           <rng:oneOrMore>
             <rng:ref name="oStaff"/>
           </rng:oneOrMore>
           <rng:oneOrMore>
             <rng:ref name="model.staffLike"/>
           </rng:oneOrMore>
-        </rng:group>
-        <rng:group>
+        </rng:interleave>
+        <rng:interleave>
           <rng:oneOrMore>
             <rng:ref name="oLayer"/>
           </rng:oneOrMore>
           <rng:oneOrMore>
             <rng:ref name="model.layerLike"/>
           </rng:oneOrMore>
-        </rng:group>
+        </rng:interleave>
       </rng:choice>
     </content>
     <constraintSpec ident="Check_ossia" scheme="isoschematron">


### PR DESCRIPTION
We should allow `<staff>` and `<oStaff>` to be in any order because ossia staves can appear below their "parent" staves.

![grafik](https://user-images.githubusercontent.com/1147152/88521830-0a91a900-cfe5-11ea-9d83-be9bbb428aa1.png)