### PR TITLE
Add schematron rules for dur.quality values.

### DIFF
--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -171,6 +171,24 @@
         </datatype>
       </attDef>
     </attList>
+    <constraintSpec ident="check_duplex_quality" scheme="isoschematron">
+      <constraint>
+        <sch:rule context="mei:note[@dur.quality='duplex']">
+          <sch:assert test="@dur='longa'">
+            Duplex quality can only be used with longas (in Ars antiqua).
+          </sch:assert>
+        </sch:rule>
+      </constraint>
+    </constraintSpec>
+    <constraintSpec ident="check_maiorminor_quality" scheme="isoschematron">
+      <constraint>
+        <sch:rule context="mei:note[@dur.quality='maior' or @dur.quality='minor']">
+          <sch:assert test="@dur='semibrevis'">
+            Maior / minor quality can only be used with semibreves (in Ars antiqua).
+          </sch:assert>
+        </sch:rule>
+      </constraint>
+    </constraintSpec>
   </classSpec>
   <classSpec ident="att.ligature.log" module="MEI.mensural" type="atts">
     <desc>Logical domain attributes.</desc>


### PR DESCRIPTION
- Not allowing `"duplex"` quality to be used in any other note than a `"longa"`.
- Not allowing `"maior"` and `"minor"` quality values to be used in any other note than a `"semibrevis"`.

This would be what I expect with this PR:
![dur_quality](https://user-images.githubusercontent.com/13948831/88721400-66972300-d0f4-11ea-961b-6ea65706a74a.png)
