### PR TITLE
Move staffDef attributes related to mensuration sign into visual domain

### DIFF
--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -196,25 +196,6 @@
       <memberOf key="att.mensural.shared"/>
     </classes>
     <attList>
-      <attDef ident="mensur.dot" usage="opt">
-        <desc>Determines if a dot is to be added to the base symbol.</desc>
-        <datatype>
-          <rng:ref name="data.BOOLEAN"/>
-        </datatype>
-      </attDef>
-      <attDef ident="mensur.sign" usage="opt">
-        <desc>The base symbol in the mensuration sign/time signature of mensural notation.</desc>
-        <datatype>
-          <rng:ref name="data.MENSURATIONSIGN"/>
-        </datatype>
-      </attDef>
-      <attDef ident="mensur.slash" usage="opt">
-        <desc>Indicates the number lines added to the mensuration sign. For example, one slash is
-          added for what we now call 'alla breve'.</desc>
-        <datatype>
-          <rng:data type="positiveInteger"/>
-        </datatype>
-      </attDef>
       <attDef ident="proport.num" usage="opt">
         <desc>Together, proport.num and proport.numbase specify a proportional change as a ratio,
           e.g., 1:3. Proport.num is for the first value in the ratio.</desc>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -961,6 +961,12 @@
       <memberOf key="att.slashCount"/>
     </classes>
     <attList>
+      <attDef ident="dot" usage="opt">
+        <desc>Specifies whether a dot is to be added to the base symbol.</desc>
+        <datatype>
+          <rng:ref name="data.BOOLEAN"/>
+        </datatype>
+      </attDef>
       <attDef ident="form" usage="opt">
         <desc>Indicates whether the base symbol is written vertically or horizontally.</desc>
         <valList type="closed">
@@ -976,12 +982,6 @@
         <desc>Describes the rotation or reflection of the base symbol.</desc>
         <datatype>
           <rng:ref name="data.ORIENTATION"/>
-        </datatype>
-      </attDef>
-      <attDef ident="dot" usage="opt">
-        <desc>Specifies whether a dot is to be added to the base symbol.</desc>
-        <datatype>
-          <rng:ref name="data.BOOLEAN"/>
         </datatype>
       </attDef>
       <attDef ident="sign" usage="opt">

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1003,6 +1003,12 @@
           <rng:ref name="data.COLOR"/>
         </datatype>
       </attDef>
+      <attDef ident="mensur.dot" usage="opt">
+        <desc>Determines if a dot is to be added to the base symbol.</desc>
+        <datatype>
+          <rng:ref name="data.BOOLEAN"/>
+        </datatype>
+      </attDef>
       <attDef ident="mensur.form" usage="opt">
         <desc>Indicates whether the base symbol is written vertically or horizontally.</desc>
         <valList type="closed">
@@ -1026,10 +1032,23 @@
           <rng:ref name="data.ORIENTATION"/>
         </datatype>
       </attDef>
+      <attDef ident="mensur.sign" usage="opt">
+        <desc>The base symbol in the mensuration sign/time signature of mensural notation.</desc>
+        <datatype>
+          <rng:ref name="data.MENSURATIONSIGN"/>
+        </datatype>
+      </attDef>
       <attDef ident="mensur.size" usage="opt">
         <desc>Describes the relative size of the mensuration sign.</desc>
         <datatype>
           <rng:ref name="data.FONTSIZE"/>
+        </datatype>
+      </attDef>
+      <attDef ident="mensur.slash" usage="opt">
+        <desc>Indicates the number lines added to the mensuration sign. For example, one slash is
+          added for what we now call 'alla breve'.</desc>
+        <datatype>
+          <rng:data type="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>


### PR DESCRIPTION
Due to this revert commit 2a58dfbfd13c19dc2be0000349f70d3111f8b0ec, `<staffDef>` elements contain once again mensuration-related attributes. Some of these attributes, the ones encoding the **mensuration sign**, should be moved from the logical to the visual domain. These attributes are `@mensur.sign`, `@mensur.dot`, and `@mensur.slash`.

(Something similar was done in commit 9999f894d922fe89d1d09c7929c50d846baef935 for the corresponding attributes in `<mensur>`: `@sign`, `@dot`, and `@slash`.) 