### PR TITLE
Allow dots to be encoded within ligatures

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -5354,6 +5354,7 @@
       <memberOf key="att.dot.ges"/>
       <memberOf key="att.dot.anl"/>
       <memberOf key="model.noteModifierLike"/>
+      <memberOf key="model.eventLike.mensural"/>
     </classes>
     <content>
       <rng:empty/>


### PR DESCRIPTION
This PR allows for `<dot>` to be a valid child of `<ligature>`. It happens in mensural music that ligatures do contain dots, as can be seen in the images at the end of this comment.

With this change, I expect the following to be valid:

![87810108-6f514480-c82a-11ea-9bd7-ba0ab4e88d22](https://user-images.githubusercontent.com/13948831/89000603-c3960300-d2c5-11ea-8c21-0dd340a9300c.png)

This PR is substituting the closed PR https://github.com/music-encoding/music-encoding/pull/693 (which addressed this and other issues with dots that I want to run first by the IG).

----

### Examples of dots being used within ligatures in mensural notation:

![](https://user-images.githubusercontent.com/13948831/87807292-17b0da00-c826-11ea-8cf7-dd480cd399c9.png)

![](https://user-images.githubusercontent.com/13948831/87807299-197a9d80-c826-11ea-80b7-cc500e2255de.png)

![](https://user-images.githubusercontent.com/13948831/87807304-1bdcf780-c826-11ea-9c06-dbb6de0c89b9.png)
