### PR TITLE
Allow 100% with trailing fractional zeroes

### DIFF
--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3000,7 +3000,7 @@
     <desc>Positive decimal number between 0 and 100, followed by a percent sign "%".</desc>
     <content>
       <rng:data type="token">
-        <rng:param name="pattern">(([0-9]|[1-9][0-9])(\.[0-9]+)?|100)%</rng:param>
+        <rng:param name="pattern">(([0-9]|[1-9][0-9])(\.[0-9]+)?|100(\.0+)?)%</rng:param>
       </rng:data>
     </content>
   </macroSpec>
@@ -3008,7 +3008,7 @@
     <desc>Positive decimal number between -100 and 100, followed by a percent sign "%".</desc>
     <content>
       <rng:data type="token">
-        <rng:param name="pattern">(\+|-)?(([0-9]|[1-9][0-9])(\.[0-9]+)?|100)%</rng:param>
+        <rng:param name="pattern">(\+|-)?(([0-9]|[1-9][0-9])(\.[0-9]+)?|100(\.0+)?)%</rng:param>
       </rng:data>
     </content>
   </macroSpec>


### PR DESCRIPTION
Values like "100.00%" were not accepted, but values like "90.00%" were. So let's make it consistent. Verovio sometimes generates these values when converting from MusicXML.