### PR TITLE
Introduce <smufl> element for multi-character smufl strings

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -3436,6 +3436,13 @@
   </classSpec>
   <classSpec ident="att.typography" module="MEI.shared" type="atts">
     <desc>Typographical attributes.</desc>
+    <classes>
+      <memberOf key="att.typography.font"/>
+      <memberOf key="att.typography.style"/>
+    </classes>
+  </classSpec>
+  <classSpec ident="att.typography.font" module="MEI.shared" type="atts">
+    <desc>Attributes for fonts and font sizes</desc>
     <attList>
       <attDef ident="fontfam" usage="opt">
         <desc>Contains the name of a font-family.</desc>
@@ -3449,6 +3456,11 @@
           <rng:ref name="data.FONTNAME"/>
         </datatype>
       </attDef>
+    </attList>
+  </classSpec>
+  <classSpec ident="att.typography.style" module="MEI.shared" type="atts">
+    <desc>Attributes for font style and weight</desc>
+    <attList>
       <attDef ident="fontsize" usage="opt">
         <desc>Indicates the size of a font expressed in printers' points, i.e., 1/72nd of an inch,
           relative terms, e.g., "small", "larger", etc., or percentage values relative to "normal"

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -7217,6 +7217,44 @@
         be used instead of the <gi scheme="MEI">rend</gi> element.</p>
     </remarks>
   </elementSpec>
+  <elementSpec ident="smufl" module="MEI.shared">
+    <desc>Contains music text characters in SMuFL encoding.</desc>
+    <classes>
+      <memberOf key="att.color"/>
+      <memberOf key="att.common"/>
+      <memberOf key="att.horizontalAlign"/>
+      <memberOf key="att.typography.font"/>
+      <memberOf key="att.verticalAlign"/>
+      <memberOf key="model.rendLike"/>
+    </classes>
+    <content>
+      <rng:text/>
+    </content>
+    <constraintSpec ident="check_smufl" scheme="isoschematron">
+      <constraint>
+        <sch:rule context="mei:smufl">
+          <sch:assert
+            test="matches(., '[&#x266D;-&#x266F;&#x1D100;-&#x1D126;&#x1D129;-&#x1D1BE;&#x1D1C1;-&#x1D1D4;&#x1D1DE;-&#x1D1E8;&#xE000;-&#xF8FF;]+')"
+            role="warning">May only contain codepoints from the Basic Multilingual Plane Private Use
+            Area as well as musical symbols from Unicode.</sch:assert>
+        </sch:rule>
+      </constraint>
+    </constraintSpec>
+    <attList>
+      <attDef ident="rotation" usage="opt">
+        <desc>A positive value for rotation rotates the text in a counter-clockwise fashion, while
+          negative values produce clockwise rotation.</desc>
+        <datatype>
+          <rng:ref name="data.DEGREES"/>
+        </datatype>
+      </attDef>
+    </attList>
+    <remarks>
+      <p>Similar to <gi scheme="MEI">symbol</gi> elements with <att>auth</att> set to "smufl", but
+      for a string of multiple characters. Typical use-case are dynamics for which there is no
+      dedicated SMuFL glyph that have to be composed of multiple SMuFL glyphs, like "fzp".</p>
+    </remarks>
+  </elementSpec>
   <elementSpec ident="repository" module="MEI.shared">
     <desc>Institution, agency, or individual which holds a bibliographic item.</desc>
     <classes>


### PR DESCRIPTION
As per [a suggestion](https://github.com/music-encoding/guidelines/pull/145#issuecomment-591927828)  by @kepper, this introduces a way of encoding SMuFL strings like:

```xml
<!-- "fzp" -->
<dynam><smufl>&#xE522;&#xE525;&#xE520;</smufl></dynam>
```

I split [att.typography](https://music-encoding.org/guidelines/v4/attribute-classes/att.typography.html) for this as `@fontstyle` and `@fontweight` are not applicable to SMuFL text (there is no non-italic variant of a forte, no oblique variant of a time signature numeral, and no bold variant of quarter note).

Concerning `@fontfam` and `@fontname`, I do not understand the difference between the two and we have to either deprecate one or document clearly what the difference is.  If I interpret [this](https://github.com/music-encoding/music-encoding/issues/140#issue-82036031) correctly then the origin seems to be historic and `@fontname` was originally intended for mup-specific purposes that are now covered by `@fontweight` and `@fontstyle`. @pe-ro already [stated in 2012](https://github.com/music-encoding/music-encoding/issues/140#issuecomment-106500294) that `@fontname` is "not useful anymore".

I can't find much other discussion about those attributes. (Is that because there is none or is that because the GitHub issue search possibly ignores code blocks, things with `@` or in backticks?)