### PR TITLE
Remove explicit mei_ prefix so elements get listed in HTML documentation

### DIFF
--- a/source/modules/MEI.midi.xml
+++ b/source/modules/MEI.midi.xml
@@ -370,7 +370,7 @@
           <rng:ref name="chanPr"/>
           <rng:ref name="cue"/>
           <rng:ref name="hex"/>
-          <rng:ref name="mei_marker"/>
+          <rng:ref name="marker"/>
           <rng:ref name="metaText"/>
           <rng:ref name="noteOff"/>
           <rng:ref name="noteOn"/>

--- a/source/modules/MEI.usersymbols.xml
+++ b/source/modules/MEI.usersymbols.xml
@@ -243,7 +243,7 @@
       <rng:zeroOrMore>
         <rng:choice>
           <rng:text/>
-          <rng:ref name="mei_symbol"/>
+          <rng:ref name="symbol"/>
         </rng:choice>
       </rng:zeroOrMore>
     </content>
@@ -307,7 +307,7 @@
         <rng:zeroOrMore>
           <rng:choice>
             <rng:ref name="model.graphicPrimitiveLike"/>
-            <rng:ref name="mei_symbol"/>
+            <rng:ref name="symbol"/>
             <rng:ref name="graphic"/>
           </rng:choice>
         </rng:zeroOrMore>


### PR DESCRIPTION
I found that [`<symbol>`](https://music-encoding.org/guidelines/v4/elements/symbol.html) is allowed in both [`<mapping>`](https://music-encoding.org/guidelines/v4/elements/mapping.html) and [`<symbolDef>`](https://music-encoding.org/guidelines/v4/elements/symboldef.html), but they are not listed in the HTML documentation. I assume this is because of the `mei_` prefix that was added explicitly here, but the HTML generation can't handle it. Same thing happens for [`<marker>`](https://music-encoding.org/guidelines/v4/elements/marker.html) inside [`<midi>`](https://music-encoding.org/guidelines/v4/elements/midi.html)

As far as I see, it makes no difference to not add the prefix explicitly. I assume it was originally added because of SVG elements with the same names (`<symbol>` and `<marker>`). However, I don't really see how that could cause a conflict because the prefix `svg_` is used for those.