### PR TITLE
Add plica element & fix stem element

### DIFF
--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -510,7 +510,7 @@
     <constraintSpec ident="Check_plica" scheme="isoschematron">
       <constraint>
         <sch:rule context="mei:plica">
-          <sch:assert test="count(../mei:plica) &lt;= 1)">Only one plica is allowed.</sch:assert>
+          <sch:assert test="count(../mei:plica) &lt;= 1">Only one plica is allowed.</sch:assert>
         </sch:rule>
       </constraint>
     </constraintSpec>

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -357,6 +357,7 @@
     <desc>Visual domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
     <classes>
         <memberOf key="att.xy"/>
+        <memberOf key="att.color"/>
     </classes>
     <attList>
       <attDef ident="pos" usage="opt">

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -268,6 +268,28 @@
   <classSpec ident="att.note.log.mensural" module="MEI.mensural" type="atts">
     <desc>Logical domain attributes in the Mensural repertoire.</desc>
   </classSpec>
+  <classSpec ident="att.plica" module="MEI.mensural" type="atts">
+    <desc>Attributes that describe the properties of a plica stem in the mensural repertoire.</desc>
+    <attList>
+      <attDef ident="dir" usage="opt">
+        <desc>Plica's direction.</desc>
+        <valList type="closed">
+          <valItem ident="down">
+            <desc>Plica stem pointing down.</desc>
+          </valItem>
+          <valItem ident="up">
+            <desc>Plica stem pointing up.</desc>
+          </valItem>
+        </valList>
+      </attDef>
+      <attDef ident="len" usage="opt">
+        <desc>Records the length of plica stem.</desc>
+        <datatype>
+          <rng:data type="positiveInteger"/>
+        </datatype>
+      </attDef>
+    </attList>
+  </classSpec>
   <classSpec ident="att.proport.log" module="MEI.mensural" type="atts">
     <desc>Logical domain attributes. These attributes describe augmentation or diminution of the
       normal value of the notes in mensural notation as a ratio.</desc>
@@ -460,6 +482,14 @@
         The <att>slash</att> attribute indicates the number lines added to the mensuration sign. For
         example, one slash is added for what we now call 'alla breve'.</p>
     </remarks>
+  </elementSpec>
+  <elementSpec ident="plica" module="MEI.mensural">
+    <desc>plica</desc>
+    <classes>
+      <memberOf key="att.common"/>
+      <memberOf key="att.plica"/>
+      <memberOf key="model.noteModifierLike"/>
+    </classes>
   </elementSpec>
   <elementSpec ident="proport" module="MEI.mensural">
     <desc>(proportion) – Description of note duration as arithmetic ratio.</desc>

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -286,10 +286,10 @@
           <rng:ref name="data.STEMDIRECTION.basic"/>
         </datatype>
       </attDef>
-      <attDef ident="length" usage="opt">
+      <attDef ident="len" usage="opt">
         <desc>Encodes the stem length.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <rng:ref name="data.MEASUREMENTABS"/>
         </datatype>
       </attDef>
     </attList>
@@ -365,10 +365,10 @@
           <rng:ref name="data.STEMPOSITION"/>
         </datatype>
       </attDef>
-      <attDef ident="length" usage="opt">
+      <attDef ident="len" usage="opt">
         <desc>Encodes the stem length.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <rng:ref name="data.MEASUREMENTABS"/>
         </datatype>
       </attDef>
       <attDef ident="form" usage="opt">

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -281,18 +281,13 @@
     <desc>Visual domain attributes that describe the properties of a plica stem in the mensural repertoire.</desc>
     <attList>
       <attDef ident="dir" usage="opt">
-        <desc>Plica's direction.</desc>
-        <valList type="closed">
-          <valItem ident="down">
-            <desc>Plica stem pointing down.</desc>
-          </valItem>
-          <valItem ident="up">
-            <desc>Plica stem pointing up.</desc>
-          </valItem>
-        </valList>
+        <desc>Describes the direction of a stem.</desc>
+        <datatype>
+          <rng:ref name="data.STEMDIRECTION.basic"/>
+        </datatype>
       </attDef>
-      <attDef ident="len" usage="opt">
-        <desc>Records the length of plica stem.</desc>
+      <attDef ident="length" usage="opt">
+        <desc>Encodes the stem length.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
@@ -349,8 +344,17 @@
       <memberOf key="att.mensural.vis"/>
     </classes>
   </classSpec>
-  <classSpec ident="att.STEMPROPERTIES.mensural" module="MEI.mensural" type="atts">
-    <desc>Attributes that describe the properties of stems in the mensural repertoire.</desc>
+  <classSpec ident="att.stem.anl" module="MEI.mensural" type="atts">
+    <desc>Analytical domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
+  </classSpec>
+  <classSpec ident="att.stem.ges" module="MEI.mensural" type="atts">
+    <desc>Gestural domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
+  </classSpec>
+  <classSpec ident="att.stem.log" module="MEI.mensural" type="atts">
+    <desc>Logical domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
+  </classSpec>
+  <classSpec ident="att.stem.vis" module="MEI.mensural" type="atts">
+    <desc>Visual domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
     <classes>
         <memberOf key="att.xy"/>
     </classes>
@@ -364,7 +368,7 @@
       <attDef ident="length" usage="opt">
         <desc>Encodes the stem length.</desc>
         <datatype>
-          <rng:ref name="data.MEASUREMENTABS"/>
+          <rng:data type="positiveInteger"/>
         </datatype>
       </attDef>
       <attDef ident="form" usage="opt">
@@ -496,7 +500,7 @@
     <desc>Plica</desc>
     <classes>
       <memberOf key="att.common"/>
-      <memberOf key="att.fasimile"/>
+      <memberOf key="att.facsimile"/>
       <memberOf key="att.plica.log"/>
       <memberOf key="att.plica.vis"/>
       <memberOf key="att.plica.ges"/>
@@ -529,8 +533,11 @@
     <desc>A stem element.</desc>
     <classes>
       <memberOf key="att.common"/>
-      <memberOf key="att.STEMPROPERTIES.mensural"/>
-      <memberOf key="model.noteModifierLike"/>
+      <memberOf key="att.facsimile"/>
+      <memberOf key="att.stem.log"/>
+      <memberOf key="att.stem.vis"/>
+      <memberOf key="att.stem.ges"/>
+      <memberOf key="att.stem.anl"/>
     </classes>
     <content>
       <rng:empty/>

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -506,6 +506,13 @@
       <memberOf key="att.plica.ges"/>
       <memberOf key="att.plica.anl"/>
     </classes>
+    <constraintSpec ident="Check_plica" scheme="isoschematron">
+      <constraint>
+        <sch:rule context="mei:plica">
+          <sch:assert test="count(../mei:plica) &lt;= 1)">Only one plica is allowed.</sch:assert>
+        </sch:rule>
+      </constraint>
+    </constraintSpec>
   </elementSpec>
   <elementSpec ident="proport" module="MEI.mensural">
     <desc>(proportion) – Description of note duration as arithmetic ratio.</desc>

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -268,8 +268,17 @@
   <classSpec ident="att.note.log.mensural" module="MEI.mensural" type="atts">
     <desc>Logical domain attributes in the Mensural repertoire.</desc>
   </classSpec>
-  <classSpec ident="att.plica" module="MEI.mensural" type="atts">
-    <desc>Attributes that describe the properties of a plica stem in the mensural repertoire.</desc>
+  <classSpec ident="att.plica.anl" module="MEI.mensural" type="atts">
+    <desc>Analytical domain attributes that describe the properties of a plica in the mensural repertoire.</desc>
+  </classSpec>
+  <classSpec ident="att.plica.ges" module="MEI.mensural" type="atts">
+    <desc>Gestural domain attributes that describe the properties of a plica in the mensural repertoire.</desc>
+  </classSpec>
+  <classSpec ident="att.plica.log" module="MEI.mensural" type="atts">
+    <desc>Logical domain attributes that describe the properties of a plica in the mensural repertoire.</desc>
+  </classSpec>
+  <classSpec ident="att.plica.vis" module="MEI.mensural" type="atts">
+    <desc>Visual domain attributes that describe the properties of a plica stem in the mensural repertoire.</desc>
     <attList>
       <attDef ident="dir" usage="opt">
         <desc>Plica's direction.</desc>
@@ -484,11 +493,14 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="plica" module="MEI.mensural">
-    <desc>plica</desc>
+    <desc>Plica</desc>
     <classes>
       <memberOf key="att.common"/>
-      <memberOf key="att.plica"/>
-      <memberOf key="model.noteModifierLike"/>
+      <memberOf key="att.fasimile"/>
+      <memberOf key="att.plica.log"/>
+      <memberOf key="att.plica.vis"/>
+      <memberOf key="att.plica.ges"/>
+      <memberOf key="att.plica.anl"/>
     </classes>
   </elementSpec>
   <elementSpec ident="proport" module="MEI.mensural">

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -6487,6 +6487,7 @@
           <rng:ref name="model.appLike"/>
           <rng:ref name="model.editLike"/>
           <rng:ref name="model.transcriptionLike"/>
+          <rng:ref name="plica"/>
         </rng:choice>
       </rng:zeroOrMore>
     </content>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -6488,6 +6488,7 @@
           <rng:ref name="model.editLike"/>
           <rng:ref name="model.transcriptionLike"/>
           <rng:ref name="plica"/>
+          <rng:ref name="stem"/>
         </rng:choice>
       </rng:zeroOrMore>
     </content>


### PR DESCRIPTION
This PR adds support for a `<plica>` element to be used as child of `<note>`. The plica element has two attributes (which are shared with the already existing `<stem>` element): `@dir` and `@len`. A `<note>` element can have only one child `<plica>`.

This PR also contains some corrections regarding the `<stem>` element and its attributes:
- Removed the line `<memberOf key="model.noteModifierLike"/>` from the `<stem>` element classes since, in addition to allow `<stem>` as a child of `<note>` (which was the intention), it also allowed `<stem>` to be a direct child of `<layer>`. Instead, I added `<stem>` directly into the content of `<note>`.
- Substitute the `@length` attribute of `<stem>` by `@len` (to be more consistent with MEI).
- Add `@color` attribute.

For both stem and plica, added corresponding `anl`, `log`, `ges`, and `vis` attribute classes.

**Acknowledgement:**
Thanks to @pe-ro for helping me getting this PR ready. He noticed issues with it that are fixed now.