### PR TITLE
Add fermata attribute for mensural notes

### DIFF
--- a/source/modules/MEI.analytical.xml
+++ b/source/modules/MEI.analytical.xml
@@ -351,6 +351,7 @@
       <memberOf key="att.intervalMelodic"/>
       <memberOf key="att.melodicFunction"/>
       <memberOf key="att.note.anl.cmn"/>
+      <memberOf key="att.note.anl.mensural"/>
       <memberOf key="att.pitchClass"/>
       <memberOf key="att.solfa"/>
     </classes>

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -254,6 +254,15 @@
       <memberOf key="att.fermataPresent"/>
     </classes>
   </classSpec>
+  <classSpec ident="att.note.ges.mensural" module="MEI.mensural" type="atts">
+    <desc>Gestural domain attributes in the Mensural repertoire.</desc>
+    <classes>
+      <memberOf key="att.duration.ratio"/>
+    </classes>
+  </classSpec>
+  <classSpec ident="att.note.log.mensural" module="MEI.mensural" type="atts">
+    <desc>Logical domain attributes in the Mensural repertoire.</desc>
+  </classSpec>
   <classSpec ident="att.note.vis.mensural" module="MEI.mensural" type="atts">
     <desc>Visual domain attributes in the Mensural repertoire.</desc>
     <attList>
@@ -264,15 +273,6 @@
         </datatype>
       </attDef>
     </attList>
-  </classSpec>
-  <classSpec ident="att.note.ges.mensural" module="MEI.mensural" type="atts">
-    <desc>Gestural domain attributes in the Mensural repertoire.</desc>
-    <classes>
-      <memberOf key="att.duration.ratio"/>
-    </classes>
-  </classSpec>
-  <classSpec ident="att.note.log.mensural" module="MEI.mensural" type="atts">
-    <desc>Logical domain attributes in the Mensural repertoire.</desc>
   </classSpec>
   <classSpec ident="att.proport.log" module="MEI.mensural" type="atts">
     <desc>Logical domain attributes. These attributes describe augmentation or diminution of the

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -266,7 +266,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.note.ges.mensural" module="MEI.mensural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc>Gestural domain attributes in the Mensural repertoire.</desc>
     <classes>
       <memberOf key="att.duration.ratio"/>
     </classes>

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -248,6 +248,12 @@
       </attDef>
     </attList>
   </classSpec>
+  <classSpec ident="att.note.anl.mensural" module="MEI.mensural" type="atts">
+    <desc>Analytical domain attributes in the Mensural repertoire.</desc>
+    <classes>
+      <memberOf key="att.fermataPresent"/>
+    </classes>
+  </classSpec>
   <classSpec ident="att.note.vis.mensural" module="MEI.mensural" type="atts">
     <desc>Visual domain attributes in the Mensural repertoire.</desc>
     <attList>


### PR DESCRIPTION
The fermata attribute (found in the `att.fermataPresent` class) is only available for notes in CMN.

In this PR, I add the missing class `att.note.anl.mensural` (the logical, gestural, and visual corresponding classes already exist), and make it a member of `att.fermataPresent`, similar to how `att.note.anl.cmn` is a member of `att.fermataPresent`. Then include the newly introduced `att.note.anl.mensural` class in the classes of `att.note.anl`.