### PR TITLE
remove empty att.midi.vis

### DIFF
--- a/source/modules/MEI.midi.xml
+++ b/source/modules/MEI.midi.xml
@@ -357,7 +357,6 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.midi.log"/>
-      <memberOf key="att.midi.vis"/>
       <memberOf key="att.midi.ges"/>
       <memberOf key="att.midi.anl"/>
       <memberOf key="model.midiLike"/>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1102,9 +1102,6 @@
   <classSpec ident="att.meterSigGrp.vis" module="MEI.visual" type="atts">
     <desc>Visual domain attributes.</desc>
   </classSpec>
-  <classSpec ident="att.midi.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
-  </classSpec>
   <classSpec ident="att.mordent.vis" module="MEI.visual" type="atts">
     <desc>Visual domain attributes.</desc>
     <classes>


### PR DESCRIPTION
This PR removes the `midi.vis` attribute class, because it is empty and not clear what should be _visual_ about midi information.