### PR TITLE
make non-textual elements part of att.enclosingChars

### DIFF
--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -348,6 +348,7 @@
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
+      <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extSym"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.visibility"/>
@@ -510,6 +511,7 @@
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
+      <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extSym"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.typography"/>
@@ -1070,6 +1072,7 @@
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
+      <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extSym"/>
       <memberOf key="att.typography"/>
     </classes>
@@ -1109,6 +1112,7 @@
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
+      <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extSym"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.typography"/>
@@ -1278,6 +1282,7 @@
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
+      <memberOf key="att.enclosingChars"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
@@ -1746,6 +1751,7 @@
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
+      <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.extSym"/>
@@ -1806,6 +1812,7 @@
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
+      <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extSym"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.typography"/>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -1157,7 +1157,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.ENCLOSURE" module="MEI" type="dt">
-    <desc>Enclosures for editorial notes, accidentals, erticulations, etc.</desc>
+    <desc>Enclosures for editorial notes, accidentals, articulations, etc.</desc>
     <content>
       <valList type="closed">
         <valItem ident="paren">

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -1157,7 +1157,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.ENCLOSURE" module="MEI" type="dt">
-    <desc>Enclosures for editorial notes and accidentals.</desc>
+    <desc>Enclosures for editorial notes, accidentals, erticulations, etc.</desc>
     <content>
       <valList type="closed">
         <valItem ident="paren">
@@ -1165,6 +1165,12 @@
         </valItem>
         <valItem ident="brack">
           <desc>Square brackets: [ and ].</desc>
+        </valItem>
+        <valItem ident="box">
+          <desc>Box.</desc>
+        </valItem>
+        <valItem ident="none">
+          <desc>None.</desc>
         </valItem>
       </valList>
     </content>


### PR DESCRIPTION
This PR adds the ability to encode parentheses and brackets around non-textual glyphs in MEI, as seen in the following examples:
![image](https://user-images.githubusercontent.com/7693447/98655511-da75d800-233f-11eb-93f7-b552879ebb5d.png)
![image](https://user-images.githubusercontent.com/7693447/98655528-dfd32280-233f-11eb-9f22-aa5234c610ee.png)
![image](https://user-images.githubusercontent.com/7693447/98655561-e5c90380-233f-11eb-91a5-ab97c7c9f1e5.png)
![image](https://user-images.githubusercontent.com/7693447/98655611-f11c2f00-233f-11eb-909a-ee274c471d07.png)
![image](https://user-images.githubusercontent.com/7693447/98655646-fbd6c400-233f-11eb-866b-c02c97c321cd.png)

Closes #473