### PR TITLE
bump meiversion to 5.0.0-dev

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1855,13 +1855,10 @@
     <attList>
       <attDef ident="meiversion" usage="opt">
         <desc>Specifies a generic MEI version label.</desc>
-        <defaultVal>4.0.1</defaultVal>
+        <defaultVal>5.0.0-dev</defaultVal>
         <valList type="closed">
-          <valItem ident="4.0.0">
-            <desc>First release of MEI 4</desc>
-          </valItem>
-          <valItem ident="4.0.1">
-            <desc>Bugfix Release 4.0.1</desc>
+          <valItem ident="5.0.0-dev">
+            <desc>Development version of MEI 5.0.0</desc>
           </valItem>
         </valList>
       </attDef>


### PR DESCRIPTION
bump default and allowed values of `@meiversion` to 5.0.0-dev