### PR TITLE
Fix fermata issue

### DIFF
--- a/source/modules/MEI.analytical.xml
+++ b/source/modules/MEI.analytical.xml
@@ -352,6 +352,7 @@
       <memberOf key="att.melodicFunction"/>
       <memberOf key="att.note.anl.cmn"/>
       <memberOf key="att.note.anl.mensural"/>
+      <memberOf key="att.fermataPresent"/>
       <memberOf key="att.pitchClass"/>
       <memberOf key="att.solfa"/>
     </classes>

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -823,7 +823,6 @@
     <desc>Analytical domain attributes in the CMN repertoire.</desc>
     <classes>
       <memberOf key="att.beamPresent"/>
-      <memberOf key="att.fermataPresent"/>
       <memberOf key="att.glissPresent"/>
       <memberOf key="att.lvPresent"/>
       <memberOf key="att.ornamPresent"/>

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -268,9 +268,6 @@
   </classSpec>
   <classSpec ident="att.note.anl.mensural" module="MEI.mensural" type="atts">
     <desc>Analytical domain attributes in the Mensural repertoire.</desc>
-    <classes>
-      <memberOf key="att.fermataPresent"/>
-    </classes>
   </classSpec>
   <classSpec ident="att.note.ges.mensural" module="MEI.mensural" type="atts">
     <desc>Gestural domain attributes in the Mensural repertoire.</desc>


### PR DESCRIPTION
Due to a previous pull request, there was a 'duplicate attribute fermata validation issue when using the mei-all customization. Now this doesn't happen anymore, and still the attribute is available in both mensural and cmn modules.