### PR TITLE
Fix 'mensuration' missing attributes

### DIFF
--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -1619,6 +1619,7 @@
       <memberOf key="att.bibl"/>
       <memberOf key="att.lang"/>
       <memberOf key="att.mensur.log"/>
+      <memberOf key="att.mensur.vis"/>
       <memberOf key="model.workIdent"/>
     </classes>
     <content>


### PR DESCRIPTION
The header 'mensuration' element was missing some attributes (dot, sign, orient, etc.) that were moved from the logical (att.mensur.log) into the visual domain (att.mensur.vis) in a previous PR. These attributes are now available again.