### PR TITLE
Guidelines chapter05

### DIFF
--- a/source/docs/05-mensural.xml
+++ b/source/docs/05-mensural.xml
@@ -225,12 +225,32 @@
                <head>Mensuration</head>
                <p>Using the mensural module, mensuration signs can be indicated with the attributes available on the <gi scheme="MEI">scoreDef</gi> and <gi scheme="MEI">staffDef</gi> elements. Mensuration signs encoded using attributes on <gi scheme="MEI">scoreDef</gi> are regarded as default values which may be overridden by values attached to individual <gi scheme="MEI">staffDef</gi> elements.</p>
                <p>The division levels corresponding to <hi rend="italic">modus maior</hi>, <hi rend="italic">modus minor</hi>, <hi rend="italic">tempus</hi>, and <hi rend="italic">prolatio</hi> can be encoded in the <att>modusmaior</att>, <att>modusminor</att>, <att>tempus</att>, and <att>prolatio</att> attributes respectively. Their value must be 3 (perfect) or 2 (imperfect).</p>
+               <p>
+                  <specList>
+                     <specDesc key="att.mensural.shared" atts="modusmaior modusminor tempus prolatio"/>
+                  </specList>
+               </p>
                <p>The mensur signs themselves can be encoded in the <att>mensur.sign</att> attribute with a possible value of "C" or "O". Its orientation can be encoded in the <att>mensur.orient</att> attribute, for example, with the value "reversed" for a flipped C sign. The number of slashes (up to 6) can be given in the <att>mensur.slash</att> attribute. There is also a <att>mensur.dot</att> attribute for indicating the presence of a dot through the boolean values "true" or "false".</p>
+               <p>
+                  <specList>
+                     <specDesc key="att.mensural.vis" atts="mensur.sign mensur.dot mensur.slash mensur.orient"/>
+                  </specList>
+               </p>
                <p>
                   <gi scheme="MEI">mensur</gi> elements can also be used instead of <gi scheme="MEI">staffDef</gi> and its attributes. In <gi scheme="MEI">mensur</gi>, the division levels are encoded with the previously mentioned <att>modusmaior</att>, <att>modusminor</att>, <att>tempus</att>, and <att>prolatio</att> attributes, while the attributes to indicate the mensur signs are: <att>sign</att>, <att>orient</att>, <att>slash</att>, and <att>dot</att>. <gi scheme="MEI">mensur</gi> can be a child of the <gi scheme="MEI">staffDef</gi> and <gi scheme="MEI">layer</gi> elements.</p>
                <p>
                   <specList>
                      <specDesc key="mensur"/>
+                  </specList>
+               </p>
+               <p>
+                  <specList>
+                     <specDesc key="att.mensur.log" atts="modusmaior mdousminor tempus prolatio"/>
+                  </specList>
+               </p>
+               <p>
+                  <specList>
+                     <specDesc key="att.mensur.vis" atts="sign dot slash orient"/>
                   </specList>
                </p>
                <div xml:id="changeinmensuration" type="div3">
@@ -344,7 +364,17 @@
                      </specList>
                   </p>
                   <p>PLACE-HOLDER FOR EXAMPLE OF ONE NOTE WITH ONE STEM: IMAGE &amp; ITS ENCODING</p>
-                  <p>Sometimes notes have two stems. In this case, the <gi scheme="MEI">stem</gi> element can be used as a child of <gi scheme="MEI">note</gi> to define the individual characteristics of each stem.</p>
+                  <p>Sometimes notes have two stems. In this case, the <gi scheme="MEI">stem</gi> element can be used as a child of <gi scheme="MEI">note</gi> to define the individual characteristics of each stem with the following attributes:</p>
+                  <p>
+                     <specList>
+                        <specDesc key="stem"/>
+                     </specList>
+                  </p>
+                  <p>
+                     <specList>
+                        <specDesc key="att.stem.vis" atts="dir form len pos x y flag.form flag.pos"/>
+                     </specList>
+                  </p>
                   <p>PLACE-HOLDER FOR EXAMPLE OF A NOTE WITH TWO STEMS: IMAGE &amp; ITS ENCODING</p>
                </div>
             </div>

--- a/source/docs/05-mensural.xml
+++ b/source/docs/05-mensural.xml
@@ -245,12 +245,13 @@
                </p>
                <p>
                   <specList>
-                     <specDesc key="att.mensur.log" atts="modusmaior modusminor tempus prolatio"/>
+                     <specDesc key="att.mensural.shared" atts="modusmaior modusminor tempus prolatio"/>
                   </specList>
                </p>
                <p>
                   <specList>
-                     <specDesc key="att.mensur.vis" atts="sign dot slash orient"/>
+                     <specDesc key="att.mensur.vis" atts="sign dot orient"/>
+                     <specDesc key="att.slashCount" atts="slash"/>
                   </specList>
                </p>
                <div xml:id="changeinmensuration" type="div3">
@@ -360,7 +361,8 @@
                   <p>The characteristics of a note's stem can be encoded within the <gi scheme="MEI">note</gi> element, using the attributes:</p>
                   <p>
                      <specList>
-                        <specDesc key="att.stems" atts="stem.dir stem.form stem.len stem.pos stem.x stem.y"/>
+                        <specDesc key="att.stems" atts="stem.dir stem.len stem.pos stem.x stem.y"/>
+                        <specDesc key="att.stems.mensural" atts="stem.form"/>
                      </specList>
                   </p>
                   <p>PLACE-HOLDER FOR EXAMPLE OF ONE NOTE WITH ONE STEM: IMAGE &amp; ITS ENCODING</p>
@@ -372,7 +374,8 @@
                   </p>
                   <p>
                      <specList>
-                        <specDesc key="att.stem.vis" atts="dir form len pos x y flag.form flag.pos"/>
+                        <specDesc key="att.stem.vis" atts="dir form len pos flag.form flag.pos"/>
+                        <specDesc key="att.xy" atts="x y"/>
                      </specList>
                   </p>
                   <p>PLACE-HOLDER FOR EXAMPLE OF A NOTE WITH TWO STEMS: IMAGE &amp; ITS ENCODING</p>

--- a/source/docs/05-mensural.xml
+++ b/source/docs/05-mensural.xml
@@ -245,7 +245,7 @@
                </p>
                <p>
                   <specList>
-                     <specDesc key="att.mensur.log" atts="modusmaior mdousminor tempus prolatio"/>
+                     <specDesc key="att.mensur.log" atts="modusmaior modusminor tempus prolatio"/>
                   </specList>
                </p>
                <p>

--- a/source/docs/05-mensural.xml
+++ b/source/docs/05-mensural.xml
@@ -377,6 +377,20 @@
                   </p>
                   <p>PLACE-HOLDER FOR EXAMPLE OF A NOTE WITH TWO STEMS: IMAGE &amp; ITS ENCODING</p>
                </div>
+               <div xml:id="plicas" type="div3">
+                  <head>Plicas</head>
+                  <p>Plicas can be encoded using the <gi scheme="MEI">plica</gi> element as a child of <gi scheme="MEI">note</gi>. The direction of the plica, as well as its length, can be encoded using the following visual-domain attributes:</p>
+                  <p>
+                     <specList>
+                        <specDesc key="plica"/>
+                     </specList>
+                  </p>
+                  <p>
+                     <specList>
+                        <specDesc key="att.plica.vis" atts="dir len"/>
+                     </specList>
+                  </p>
+               </div>
             </div>
          </div>
       </body>

--- a/source/docs/05-mensural.xml
+++ b/source/docs/05-mensural.xml
@@ -132,10 +132,6 @@
                      <graphic url="../images/modules/mensural/Motet_Fauvel_Fol22r_Triplum_Staves4-5.png"/>
                   </figure>
                </p>
-               <p>&lt;!--<figure>
-                     <head/>
-                     <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="verovio code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/verovio/motet_fauvel_fol22r_triplum.mei" parse="text"/></egXML>
-                  </figure>--&gt;</p>
                <p>
                   <figure>
                      <head/>
@@ -256,8 +252,12 @@
                <div xml:id="italianMensur" type="div3">
                   <head>Italian Divisiones</head>
                   <p>The division of the breve in Italian trecento notation can be encoded using the <att>divisio</att> attribute, which provides the values: ternaria, quaternaria, senariaimperf, senariaperf, octonaria, novenaria, duodenaria. The <att>divisio</att> attribute would usually replace the use of the <att>tempus</att> and <att>prolatio</att> set of attributes.</p>
-                  <p>&lt;!-- Later on (when approved in the schema) add the bracketed-and-percentage-expression: include desc atts="att.mensural.shared/divisio" --&gt;</p>
-                  <p>The signs for the Italian <hi rend="italic">divisiones</hi> can be encoded in the <att>sign</att> attribute, with the values: "t" for ternaria, "q" for quaternaria, "si" and "i" for senaria imperfecta, "sp" and "p" for senaria perfecta, "oc" for octonaria, "n" for novenaria, and "d" for duodenaria. And the additional values for senaria gallica, "sg" and "g", and senaria ytalica, "sy" and "y".</p>
+                  <p>
+                     <specList>
+                        <specDesc key="att.mensural.shared" atts="divisio"/>
+                     </specList>
+                  </p>
+                  <p>The signs for the Italian <hi rend="italic">divisiones</hi> can be encoded in the <att>sign</att> or <att>mensur.sign</att> attribute (to be used with <att>mensur</att> or <att>staffDef</att> respectively), with the values: "t" for ternaria, "q" for quaternaria, "si" and "i" for senaria imperfecta, "sp" and "p" for senaria perfecta, "oc" for octonaria, "n" for novenaria, and "d" for duodenaria. And the additional values for senaria gallica, "sg" and "g", and senaria ytalica, "sy" and "y".</p>
                </div>
             </div>
             <div xml:id="mensuralProportions" type="div2">
@@ -340,8 +340,9 @@
                   <p>The characteristics of a note's stem can be encoded within the <gi scheme="MEI">note</gi> element, using the attributes:</p>
                   <p>
                      <specList>
-                        <specDesc key="att.stems" atts="stem.dir stem.pos stem.len stem.x stem.y"/>
-                     </specList> &lt;!-- Add att.stems/stem.form as the third one later on when this change gets accepted in the Mensural MEI module --&gt;</p>
+                        <specDesc key="att.stems" atts="stem.dir stem.form stem.len stem.pos stem.x stem.y"/>
+                     </specList>
+                  </p>
                   <p>PLACE-HOLDER FOR EXAMPLE OF ONE NOTE WITH ONE STEM: IMAGE &amp; ITS ENCODING</p>
                   <p>Sometimes notes have two stems. In this case, the <gi scheme="MEI">stem</gi> element can be used as a child of <gi scheme="MEI">note</gi> to define the individual characteristics of each stem.</p>
                   <p>PLACE-HOLDER FOR EXAMPLE OF A NOTE WITH TWO STEMS: IMAGE &amp; ITS ENCODING</p>

--- a/source/examples/mensural/mensural-sample153.txt
+++ b/source/examples/mensural/mensural-sample153.txt
@@ -1,6 +1,6 @@
 <!--With @modusminor equal to "3" in the <staffDef> element--><layer n="1">
     <!--First system in the image-->
-    ...
+    <!-- ... -->
     <rest dur="2B"/>
    <ligature>
       <note dur="semibrevis" oct="4" pname="d"/>
@@ -46,5 +46,5 @@
    </ligature>
    <note dur="longa" oct="4" pname="e"/>
    <rest dur="3B"/>
-    ...
+   <!-- ... -->
 </layer>


### PR DESCRIPTION
This PR updates the content of Chapter 05 by:
* Removing the commented out MEI example (because the comments are actually shown in the website)
* Substitute comments with the appropriate material (in this case, links to the attributes that are now available in the schema: `@divisio` and `@stem.form`)
* Add links to mensuration- and stem-related elements and attributes in the schema
* Add section about the newly introduced plica element
* Fix example mensural-sample153.txt (comment out the ellipsis)

Given the new setup of the music-encoding repository, I wasn't able to visualize the website to see if the changes reflected correctly. I hope we can clarify in the next ODD Meeting (tomorrow) how to visualize the changes in the guidelines in this new configuration.
