### PR TITLE
Allowing the use of bracketSpan in mensural notation within the section element

### DIFF
--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -170,6 +170,66 @@
         <!-- Remove them as attributes of <note> and <rest> -->
         <classSpec ident="att.augmentDots" module="MEI.shared" type="atts" mode="delete"/>
 
+        <elementSpec ident="bracketSpan" module="MEI.shared" mode="change">
+          <desc>Marks a sequence of notational events grouped by a bracket.</desc>
+          <classes>
+            <memberOf key="att.common"/>
+            <memberOf key="att.bracketSpan.log"/>
+            <memberOf key="att.bracketSpan.vis"/>
+            <memberOf key="att.bracketSpan.ges"/>
+            <memberOf key="att.bracketSpan.anl"/>
+            <memberOf key="att.facsimile"/>
+            <memberOf key="model.controlEventLike.cmn" mode="delete"/>
+            <memberOf key="model.sectionLike" mode="add"></memberOf>
+          </classes>
+          <content>
+            <rng:zeroOrMore>
+              <rng:choice>
+                <rng:text/>
+                <rng:ref name="model.textPhraseLike.limited"/>
+              </rng:choice>
+            </rng:zeroOrMore>
+          </content>
+          <constraintSpec ident="bracketSpan_start-_and_end-type_attributes_required"
+            scheme="isoschematron">
+            <constraint>
+              <sch:rule context="mei:bracketSpan">
+                <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
+                  attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                <sch:assert test="@dur or @dur.ges or @endid or @tstamp2">Must have one of the attributes:
+                  dur, dur.ges, endid, or tstamp2.</sch:assert>
+              </sch:rule>
+            </constraint>
+          </constraintSpec>
+          <attList>
+            <attDef ident="func" usage="req">
+              <desc>Describes the function of the bracketed event sequence.</desc>
+              <datatype>
+                <rng:data type="NMTOKENS"/>
+              </datatype>
+              <valList type="semi">
+                <valItem ident="coloration">
+                  <desc>Represents coloration in the mensural notation source material.</desc>
+                </valItem>
+                <valItem ident="cross-rhythm">
+                  <desc>Marks a sequence which does not match the current meter.</desc>
+                </valItem>
+                <valItem ident="ligature">
+                  <desc>Represents a ligature in the mensural notation source material.</desc>
+                </valItem>
+              </valList>
+            </attDef>
+          </attList>
+          <remarks>
+            <p>Text that interrupts the bracket used to mark the event group may be captured as the
+              content of <gi scheme="MEI">bracketSpan</gi>. The starting point of the group/bracket may be
+              indicated by either a <att>startid</att>, <att>tstamp</att>, <att>tstamp.ges</att>, or
+              <att>tstamp.real</att> attribute, while the ending point may be recorded by either a
+              <att>dur</att>, <att>dur.ges</att>, <att>endid</att>, or <att>tstamp2</att> attribute. It is
+              a semantic error not to specify one starting and one ending type of attribute.</p>
+          </remarks>
+        </elementSpec>
+
       </schemaSpec>
     </body>
   </text>

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -170,12 +170,64 @@
         <!-- Remove them as attributes of <note> and <rest> -->
         <classSpec ident="att.augmentDots" module="MEI.shared" type="atts" mode="delete"/>
 
-        <elementSpec ident="bracketSpan" module="MEI.shared" mode="change">
+        <elementSpec ident="bracketSpan" module="MEI.shared" mode="replace">
           <desc>Marks a sequence of notational events grouped by a bracket.</desc>
           <classes>
-            <memberOf key="model.controlEventLike.cmn" mode="delete"/>
-            <memberOf key="model.sectionLike" mode="add"></memberOf>
+            <memberOf key="att.common"/>
+            <memberOf key="att.bracketSpan.log"/>
+            <memberOf key="att.bracketSpan.vis"/>
+            <memberOf key="att.bracketSpan.ges"/>
+            <memberOf key="att.bracketSpan.anl"/>
+            <memberOf key="att.facsimile"/>
+            <!--<memberOf key="model.controlEventLike.cmn"/>-->
+            <memberOf key="model.sectionLike" mode="add"/>
           </classes>
+          <content>
+            <rng:zeroOrMore>
+              <rng:choice>
+                <rng:text/>
+                <rng:ref name="model.textPhraseLike.limited"/>
+              </rng:choice>
+            </rng:zeroOrMore>
+          </content>
+          <constraintSpec ident="bracketSpan_start-_and_end-type_attributes_required"
+            scheme="isoschematron">
+            <constraint>
+              <sch:rule context="mei:bracketSpan">
+                <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
+                  attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+                <sch:assert test="@dur or @dur.ges or @endid or @tstamp2">Must have one of the attributes:
+                  dur, dur.ges, endid, or tstamp2.</sch:assert>
+              </sch:rule>
+            </constraint>
+          </constraintSpec>
+          <attList>
+            <attDef ident="func" usage="req">
+              <desc>Describes the function of the bracketed event sequence.</desc>
+              <datatype>
+                <rng:data type="NMTOKENS"/>
+              </datatype>
+              <valList type="semi">
+                <valItem ident="coloration">
+                  <desc>Represents coloration in the mensural notation source material.</desc>
+                </valItem>
+                <valItem ident="cross-rhythm">
+                  <desc>Marks a sequence which does not match the current meter.</desc>
+                </valItem>
+                <valItem ident="ligature">
+                  <desc>Represents a ligature in the mensural notation source material.</desc>
+                </valItem>
+              </valList>
+            </attDef>
+          </attList>
+          <remarks>
+            <p>Text that interrupts the bracket used to mark the event group may be captured as the
+              content of <gi scheme="MEI">bracketSpan</gi>. The starting point of the group/bracket may be
+              indicated by either a <att>startid</att>, <att>tstamp</att>, <att>tstamp.ges</att>, or
+              <att>tstamp.real</att> attribute, while the ending point may be recorded by either a
+              <att>dur</att>, <att>dur.ges</att>, <att>endid</att>, or <att>tstamp2</att> attribute. It is
+              a semantic error not to specify one starting and one ending type of attribute.</p>
+          </remarks>
         </elementSpec>
 
       </schemaSpec>

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -173,61 +173,9 @@
         <elementSpec ident="bracketSpan" module="MEI.shared" mode="change">
           <desc>Marks a sequence of notational events grouped by a bracket.</desc>
           <classes>
-            <memberOf key="att.common"/>
-            <memberOf key="att.bracketSpan.log"/>
-            <memberOf key="att.bracketSpan.vis"/>
-            <memberOf key="att.bracketSpan.ges"/>
-            <memberOf key="att.bracketSpan.anl"/>
-            <memberOf key="att.facsimile"/>
             <memberOf key="model.controlEventLike.cmn" mode="delete"/>
             <memberOf key="model.sectionLike" mode="add"></memberOf>
           </classes>
-          <content>
-            <rng:zeroOrMore>
-              <rng:choice>
-                <rng:text/>
-                <rng:ref name="model.textPhraseLike.limited"/>
-              </rng:choice>
-            </rng:zeroOrMore>
-          </content>
-          <constraintSpec ident="bracketSpan_start-_and_end-type_attributes_required"
-            scheme="isoschematron">
-            <constraint>
-              <sch:rule context="mei:bracketSpan">
-                <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
-                  attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
-                <sch:assert test="@dur or @dur.ges or @endid or @tstamp2">Must have one of the attributes:
-                  dur, dur.ges, endid, or tstamp2.</sch:assert>
-              </sch:rule>
-            </constraint>
-          </constraintSpec>
-          <attList>
-            <attDef ident="func" usage="req">
-              <desc>Describes the function of the bracketed event sequence.</desc>
-              <datatype>
-                <rng:data type="NMTOKENS"/>
-              </datatype>
-              <valList type="semi">
-                <valItem ident="coloration">
-                  <desc>Represents coloration in the mensural notation source material.</desc>
-                </valItem>
-                <valItem ident="cross-rhythm">
-                  <desc>Marks a sequence which does not match the current meter.</desc>
-                </valItem>
-                <valItem ident="ligature">
-                  <desc>Represents a ligature in the mensural notation source material.</desc>
-                </valItem>
-              </valList>
-            </attDef>
-          </attList>
-          <remarks>
-            <p>Text that interrupts the bracket used to mark the event group may be captured as the
-              content of <gi scheme="MEI">bracketSpan</gi>. The starting point of the group/bracket may be
-              indicated by either a <att>startid</att>, <att>tstamp</att>, <att>tstamp.ges</att>, or
-              <att>tstamp.real</att> attribute, while the ending point may be recorded by either a
-              <att>dur</att>, <att>dur.ges</att>, <att>endid</att>, or <att>tstamp2</att> attribute. It is
-              a semantic error not to specify one starting and one ending type of attribute.</p>
-          </remarks>
         </elementSpec>
 
       </schemaSpec>

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -1419,64 +1419,6 @@
       </constraint>
     </constraintSpec>
   </elementSpec>
-  <elementSpec ident="bracketSpan" module="MEI.cmn">
-    <desc>Marks a sequence of notational events grouped by a bracket.</desc>
-    <classes>
-      <memberOf key="att.common"/>
-      <memberOf key="att.bracketSpan.log"/>
-      <memberOf key="att.bracketSpan.vis"/>
-      <memberOf key="att.bracketSpan.ges"/>
-      <memberOf key="att.bracketSpan.anl"/>
-      <memberOf key="att.facsimile"/>
-      <memberOf key="model.controlEventLike.cmn"/>
-    </classes>
-    <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:text/>
-          <rng:ref name="model.textPhraseLike.limited"/>
-        </rng:choice>
-      </rng:zeroOrMore>
-    </content>
-    <constraintSpec ident="bracketSpan_start-_and_end-type_attributes_required"
-      scheme="isoschematron">
-      <constraint>
-        <sch:rule context="mei:bracketSpan">
-          <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
-            attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
-          <sch:assert test="@dur or @dur.ges or @endid or @tstamp2">Must have one of the attributes:
-            dur, dur.ges, endid, or tstamp2.</sch:assert>
-        </sch:rule>
-      </constraint>
-    </constraintSpec>
-    <attList>
-      <attDef ident="func" usage="req">
-        <desc>Describes the function of the bracketed event sequence.</desc>
-        <datatype>
-          <rng:data type="NMTOKENS"/>
-        </datatype>
-        <valList type="semi">
-          <valItem ident="coloration">
-            <desc>Represents coloration in the mensural notation source material.</desc>
-          </valItem>
-          <valItem ident="cross-rhythm">
-            <desc>Marks a sequence which does not match the current meter.</desc>
-          </valItem>
-          <valItem ident="ligature">
-            <desc>Represents a ligature in the mensural notation source material.</desc>
-          </valItem>
-        </valList>
-      </attDef>
-    </attList>
-    <remarks>
-      <p>Text that interrupts the bracket used to mark the event group may be captured as the
-        content of <gi scheme="MEI">bracketSpan</gi>. The starting point of the group/bracket may be
-        indicated by either a <att>startid</att>, <att>tstamp</att>, <att>tstamp.ges</att>, or
-        <att>tstamp.real</att> attribute, while the ending point may be recorded by either a
-        <att>dur</att>, <att>dur.ges</att>, <att>endid</att>, or <att>tstamp2</att> attribute. It is
-        a semantic error not to specify one starting and one ending type of attribute.</p>
-    </remarks>
-  </elementSpec>
   <elementSpec ident="breath" module="MEI.cmn">
     <desc>(breath mark) – An indication of a point at which the performer on an instrument requiring
       breath (including the voice) may breathe.</desc>

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -325,15 +325,6 @@
       <memberOf key="att.timestamp2.logical"/>
     </classes>
   </classSpec>
-  <classSpec ident="att.bracketSpan.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
-    <classes>
-      <memberOf key="att.controlEvent"/>
-      <memberOf key="att.duration.additive"/>
-      <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.logical"/>
-    </classes>
-  </classSpec>
   <classSpec ident="att.breath.log" module="MEI.cmn" type="atts">
     <desc>Logical domain attributes.</desc>
     <classes>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -4620,6 +4620,64 @@
         those which completely lack music notation.</p>
     </remarks>
   </elementSpec>
+  <elementSpec ident="bracketSpan" module="MEI.shared">
+    <desc>Marks a sequence of notational events grouped by a bracket.</desc>
+    <classes>
+      <memberOf key="att.common"/>
+      <memberOf key="att.bracketSpan.log"/>
+      <memberOf key="att.bracketSpan.vis"/>
+      <memberOf key="att.bracketSpan.ges"/>
+      <memberOf key="att.bracketSpan.anl"/>
+      <memberOf key="att.facsimile"/>
+      <memberOf key="model.controlEventLike.cmn"/>
+    </classes>
+    <content>
+      <rng:zeroOrMore>
+        <rng:choice>
+          <rng:text/>
+          <rng:ref name="model.textPhraseLike.limited"/>
+        </rng:choice>
+      </rng:zeroOrMore>
+    </content>
+    <constraintSpec ident="bracketSpan_start-_and_end-type_attributes_required"
+      scheme="isoschematron">
+      <constraint>
+        <sch:rule context="mei:bracketSpan">
+          <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
+            attributes: startid, tstamp, tstamp.ges or tstamp.real.</sch:assert>
+          <sch:assert test="@dur or @dur.ges or @endid or @tstamp2">Must have one of the attributes:
+            dur, dur.ges, endid, or tstamp2.</sch:assert>
+        </sch:rule>
+      </constraint>
+    </constraintSpec>
+    <attList>
+      <attDef ident="func" usage="req">
+        <desc>Describes the function of the bracketed event sequence.</desc>
+        <datatype>
+          <rng:data type="NMTOKENS"/>
+        </datatype>
+        <valList type="semi">
+          <valItem ident="coloration">
+            <desc>Represents coloration in the mensural notation source material.</desc>
+          </valItem>
+          <valItem ident="cross-rhythm">
+            <desc>Marks a sequence which does not match the current meter.</desc>
+          </valItem>
+          <valItem ident="ligature">
+            <desc>Represents a ligature in the mensural notation source material.</desc>
+          </valItem>
+        </valList>
+      </attDef>
+    </attList>
+    <remarks>
+      <p>Text that interrupts the bracket used to mark the event group may be captured as the
+        content of <gi scheme="MEI">bracketSpan</gi>. The starting point of the group/bracket may be
+        indicated by either a <att>startid</att>, <att>tstamp</att>, <att>tstamp.ges</att>, or
+        <att>tstamp.real</att> attribute, while the ending point may be recorded by either a
+        <att>dur</att>, <att>dur.ges</att>, <att>endid</att>, or <att>tstamp2</att> attribute. It is
+        a semantic error not to specify one starting and one ending type of attribute.</p>
+    </remarks>
+  </elementSpec>
   <elementSpec ident="caesura" module="MEI.shared">
     <desc>Break, pause, or interruption in the normal tempo of a composition. Typically indicated by
       "railroad tracks", i.e., two diagonal slashes.</desc>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -449,6 +449,15 @@
         should be specified, e.g., subfields within MARC fields.</p>
     </remarks>
   </classSpec>
+  <classSpec ident="att.bracketSpan.log" module="MEI.shared" type="atts">
+    <desc>Logical domain attributes.</desc>
+    <classes>
+      <memberOf key="att.controlEvent"/>
+      <memberOf key="att.duration.additive"/>
+      <memberOf key="att.startEndId"/>
+      <memberOf key="att.timestamp2.logical"/>
+    </classes>
+  </classSpec>
   <classSpec ident="att.caesura.log" module="MEI.shared" type="atts">
     <desc>Logical domain attributes.</desc>
     <classes>


### PR DESCRIPTION
This PR allows the use of `<bracketSpan>` as a child of `<section>` only for mensural notation (see customization file). Usually, `<bracketSpan>` is used as a child of` <measure>`, but mensural notation doesn't have measures. Therefore, if we wanted to include a bracket in mensural notation, we would try to include it in the next upper level, as a child of `<section>`, but this causes a validation error. 

The need for the use of bracketSpan in mensural notation is explained in issue https://github.com/music-encoding/music-encoding/issues/692.

In addition to allow for `<bracketSpan>` as a child of `<section>` in the Mensural customization file, I moved the definition of the element `<bracketSpan>` and its logical-domain attributes (`att.bracketSpan.log`) from the CMN to the Shared module since now its use is not exclusive of CMN. Without this change in modules, the use of bracketSpan in mensural (using the mensural schema customization) would still be invalid.

This PR fixes music-encoding/music-encoding#692.