### PR TITLE
Add 'dur.quality' attribute to 'space' element

### DIFF
--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -179,10 +179,24 @@
           </sch:assert>
         </sch:rule>
       </constraint>
+      <constraint>
+        <sch:rule context="mei:space[@dur.quality='duplex']">
+          <sch:assert test="@dur='longa'">
+            Duplex quality can only be used with longas (in Ars antiqua).
+          </sch:assert>
+        </sch:rule>
+      </constraint>
     </constraintSpec>
     <constraintSpec ident="check_maiorminor_quality" scheme="isoschematron">
       <constraint>
         <sch:rule context="mei:note[@dur.quality='maior' or @dur.quality='minor']">
+          <sch:assert test="@dur='semibrevis'">
+            Maior / minor quality can only be used with semibreves (in Ars antiqua).
+          </sch:assert>
+        </sch:rule>
+      </constraint>
+      <constraint>
+        <sch:rule context="mei:space[@dur.quality='maior' or @dur.quality='minor']">
           <sch:assert test="@dur='semibrevis'">
             Maior / minor quality can only be used with semibreves (in Ars antiqua).
           </sch:assert>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -7607,6 +7607,7 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
+      <memberOf key="att.duration.quality"/>
       <memberOf key="att.space.log"/>
       <memberOf key="att.space.vis"/>
       <memberOf key="att.space.ges"/>


### PR DESCRIPTION
The space element is a placeholder that uses duration values to fill an incomplete layer. Because of this, for mensural notation, it should also include the 'dur.quality' attribute (since both 'dur' and 'dur.quality' are needed to convey duration of mensural notes).