### PR TITLE
fix missing extSym on rest

### DIFF
--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1428,6 +1428,7 @@
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
       <memberOf key="att.enclosingChars"/>
+      <memberOf key="att.extSym"/>
       <memberOf key="att.rest.vis.cmn"/>
       <memberOf key="att.rest.vis.mensural"/>
       <memberOf key="att.staffLoc"/>


### PR DESCRIPTION
Basically every other element (especially `note`, `mRest`, `multiRest`) are part of `att.extSym`, so this missing on `rest` seems to be a bug. 