### PR TITLE
Fixed: Globs on PR configuration

### DIFF
--- a/.github/pr-labeler_config.yml
+++ b/.github/pr-labeler_config.yml
@@ -1,11 +1,11 @@
 "Component: Core Schema":
-- source/modules/*
+- source/modules/**/*
 
 "Component: Workflows":
-- .github/workflows/*
+- .github/workflows/**/*
 
 "Component: Guidelines & Documentation":
-- source/docs/*
+- source/docs/**/*
 
 "Component: Utils":
 - utils/**/*


### PR DESCRIPTION
The PR labeller seems to produce an error, and this may be because the glob in the label config is not permissive enough to capture changes in any subdirectories.

This changes the glob to cover all subdirectories in the paths.