### PR TITLE
remove unnecessary comment

### DIFF
--- a/utils/guidelines_xslt/odd2html/htmlFile.xsl
+++ b/utils/guidelines_xslt/odd2html/htmlFile.xsl
@@ -262,8 +262,6 @@
                                 const storageName = 'meiSpecs_' + facetId + '_display';
                                 localStorage.setItem(storageName,style);
                                 
-                                //console.log('setting tabs, storageName: ' + storageName + ', facetId: ' + facetId + ', style: ' + style)
-                                
                                 const facetElem = document.getElementById(facetId);
                                 
                                 //console.log(facetElem)


### PR DESCRIPTION
fixes https://github.com/music-encoding/guidelines/issues/197

the comment in question is too long for one line, and apparently something in the pipeline inserts a line break, which has led to partial re-insertion of the commented code. The result was invalid JS code, which could not be parsed and thus stopped browsers. As the comment is just for debugging, it can safely go away.