### PR TITLE
Update documentation generation

### DIFF
--- a/utils/guidelines_xslt/generateGuidelines.xsl
+++ b/utils/guidelines_xslt/generateGuidelines.xsl
@@ -1052,15 +1052,15 @@
                 <tr>
                     <td class="wovenodd-col1"><span class="label" lang="en">May contain</span></td>
                     <td class="wovenodd-col2">
-                        <xsl:variable name="direct.childs" select="$elements/descendant-or-self::tei:elementSpec[@ident = $elementSpec//tei:content//rng:ref[not(starts-with(@name,'model.'))]/@name]" as="node()*"/>
-                        <xsl:variable name="class.childs" as="node()*">
+                        <xsl:variable name="direct.children" select="$elements/descendant-or-self::tei:elementSpec[@ident = $elementSpec//tei:content//rng:ref[not(starts-with(@name,'model.'))]/@name]" as="node()*"/>
+                        <xsl:variable name="class.children" as="node()*">
                             
                             <xsl:for-each select="$elementSpec//tei:content//rng:ref[starts-with(@name,'model.')]">
                                 <xsl:variable name="modelClass.name" select="@name" as="xs:string"/>
-                                <xsl:sequence select="local:getChilds($modelClass.name)"/>
+                                <xsl:sequence select="local:getChildren($modelClass.name)"/>
                             </xsl:for-each>
                         </xsl:variable>
-                        <xsl:variable name="macro.childs" as="node()*">
+                        <xsl:variable name="macro.children" as="node()*">
                             <xsl:for-each select="$elementSpec//tei:content//rng:ref[starts-with(@name,'macro.')]">
                                 <xsl:variable name="macroSpec.name" select="@name" as="xs:string"/>
                                 <xsl:variable name="macroSpec" select="$data.types/descendant-or-self::tei:macroSpec[@ident = $macroSpec.name]" as="node()"/>
@@ -1068,10 +1068,10 @@
                             </xsl:for-each>
                         </xsl:variable>
                         
-                        <xsl:variable name="childs" select="$direct.childs | $class.childs | $macro.childs" as="node()*"/>
-                        <!--<xsl:message select="'INFO: ' || $elementSpec/@ident || ' has ' || count($direct.childs) || ' direct and ' || count($class.childs) ||' class childs.'"/>-->
+                        <xsl:variable name="children" select="$direct.children | $class.children | $macro.children" as="node()*"/>
+                        <!--<xsl:message select="'INFO: ' || $elementSpec/@ident || ' has ' || count($direct.children) || ' direct and ' || count($class.children) ||' class children.'"/>-->
                         <xsl:choose>
-                            <xsl:when test="(count($childs) gt 0) or $elementSpec//tei:content//rng:text">
+                            <xsl:when test="(count($children) gt 0) or $elementSpec//tei:content//rng:text">
                                 <div class="specChildren">
                                     <xsl:if test="$elementSpec//tei:content//rng:text">
                                         <div class="specChild">
@@ -1079,10 +1079,10 @@
                                             <span class="specChildElements"></span>
                                         </div>
                                     </xsl:if>
-                                    <xsl:for-each select="distinct-values($childs/descendant-or-self::tei:elementSpec/@module)">
+                                    <xsl:for-each select="distinct-values($children/descendant-or-self::tei:elementSpec/@module)">
                                         <xsl:sort select="count($mei.source//tei:moduleSpec[@ident = current()]/preceding::tei:moduleSpec)" data-type="number"/>
                                         <xsl:variable name="current.module" select="." as="xs:string"/>
-                                        <xsl:variable name="relevant.element.names" select="distinct-values($childs/descendant-or-self::tei:elementSpec[@module = $current.module]/@ident)" as="xs:string*"/>
+                                        <xsl:variable name="relevant.element.names" select="distinct-values($children/descendant-or-self::tei:elementSpec[@module = $current.module]/@ident)" as="xs:string*"/>
                                         <div class="specChild">
                                             <span class="specChildModule"><xsl:value-of select="$current.module"/></span>
                                             <span class="specChildElements">
@@ -1396,13 +1396,13 @@
         </xsl:for-each>
     </xsl:function>
     
-    <xsl:function name="local:getChilds" as="node()*">
+    <xsl:function name="local:getChildren" as="node()*">
         <xsl:param name="className" as="xs:string"/>
         <xsl:sequence select="$elements/descendant-or-self::tei:elementSpec[.//tei:memberOf[@key = $className]]"/>
         
         <xsl:variable name="inheriting.models" select="$model.classes/descendant-or-self::tei:classSpec[.//tei:memberOf/@key = $className]/@ident" as="xs:string*"/>
         <xsl:for-each select="$inheriting.models">
-            <xsl:sequence select="local:getChilds(.)"/>    
+            <xsl:sequence select="local:getChildren(.)"/>    
         </xsl:for-each>
         
     </xsl:function>

--- a/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
@@ -133,7 +133,7 @@
         
         <group ident="{$label}" class="{$additional.class}" module="{$spec/@module}">
             <xsl:choose>
-                <xsl:when test="not($label = 'direct childs') and exists($spec)">
+                <xsl:when test="not($label = 'direct children') and exists($spec)">
                     <xsl:attribute name="module" select="$spec/@module"/>
                 </xsl:when>
                 <xsl:otherwise>
@@ -548,7 +548,7 @@
                     <xsl:sequence select="tools:resolveAttDef($current.att,$current.element/@module)"/>
                 </xsl:for-each>
             </xsl:variable>
-            <xsl:sequence select="tools:getClassBox('direct childs','',$content,'direct')"/>
+            <xsl:sequence select="tools:getClassBox('direct children','',$content,'direct')"/>
         </xsl:if>
         
         <xsl:sequence select="for $attClass in $current.element//tei:memberOf[starts-with(@key,'att.')]/@key return tools:resolveAttClass($attClass, $current.element/@ident)"/>
@@ -1152,13 +1152,13 @@
         <xd:param name="model.classes"></xd:param>
         <xd:return></xd:return>
     </xd:doc>
-    <xsl:function name="tools:getChilds" as="node()*">
+    <xsl:function name="tools:getChildren" as="node()*">
         <xsl:param name="className" as="xs:string"/>
         <xsl:sequence select="$elements/self::tei:elementSpec[.//tei:memberOf[@key = $className]]"/>
         
         <xsl:variable name="inheriting.models" select="$model.classes/self::tei:classSpec[.//tei:memberOf/@key = $className]/@ident" as="xs:string*"/>
         <xsl:for-each select="$inheriting.models">
-            <xsl:sequence select="tools:getChilds(.)"/>    
+            <xsl:sequence select="tools:getChildren(.)"/>    
         </xsl:for-each>
         
     </xsl:function>
@@ -1173,14 +1173,14 @@
     <xsl:function name="tools:getMayContainFacet" as="node()">
         <xsl:param name="object" as="node()"/>
         
-        <xsl:variable name="direct.childs" select="$elements/self::tei:elementSpec[@ident = $object//tei:content//rng:ref[not(starts-with(@name,'model.'))]/@name]" as="node()*"/>
-        <xsl:variable name="class.childs" as="node()*">
+        <xsl:variable name="direct.children" select="$elements/self::tei:elementSpec[@ident = $object//tei:content//rng:ref[not(starts-with(@name,'model.'))]/@name]" as="node()*"/>
+        <xsl:variable name="class.children" as="node()*">
             <xsl:for-each select="$object//tei:content//rng:ref[starts-with(@name,'model.')]">
                 <xsl:variable name="modelClass.name" select="@name" as="xs:string"/>
-                <xsl:sequence select="tools:getChilds($modelClass.name)"/>
+                <xsl:sequence select="tools:getChildren($modelClass.name)"/>
             </xsl:for-each>
         </xsl:variable>
-        <xsl:variable name="macro.childs" as="node()*">
+        <xsl:variable name="macro.children" as="node()*">
             <xsl:for-each select="$object//tei:content//rng:ref[starts-with(@name,'macro.')]">
                 <xsl:variable name="macroSpec.name" select="@name" as="xs:string"/>
                 <xsl:variable name="macroSpec" select="$macro.groups/self::tei:macroSpec[@ident = $macroSpec.name]" as="node()?"/>
@@ -1190,17 +1190,17 @@
                 <xsl:sequence select="$elements/self::tei:elementSpec[@ident = $macroSpec//tei:content//rng:ref/@name]"/>    
             </xsl:for-each>
         </xsl:variable>
-        <xsl:variable name="childs" select="$direct.childs | $class.childs | $macro.childs" as="node()*"/>
+        <xsl:variable name="children" select="$direct.children | $class.children | $macro.children" as="node()*"/>
         <xsl:variable name="allows.anyXML" select="exists($object/tei:content/rng:element[rng:anyName and rng:zeroOrMore/rng:attribute/rng:anyName and rng:zeroOrMore//rng:text and rng:zeroOrMore//rng:ref[@name = $object/@ident]])" as="xs:boolean"/>
         <xsl:variable name="allows.text" select="xs:boolean(not($allows.anyXML) and exists($object/tei:content//rng:text))" as="xs:boolean"/>
         
         <xsl:choose>
-            <xsl:when test="count($childs) gt 0 or $allows.text">
-                <!--<xsl:variable name="childs.compact" as="node()*">
+            <xsl:when test="count($children) gt 0 or $allows.text">
+                <!--<xsl:variable name="children.compact" as="node()*">
                     <xsl:if test="$allows.text">
                         <span class="ident textualContent" title="textual content">textual content</span>
                     </xsl:if>
-                    <xsl:for-each select="$childs/self::tei:elementSpec">
+                    <xsl:for-each select="$children/self::tei:elementSpec">
                         <xsl:sort select="@ident" data-type="text"/>
                         <xsl:variable name="current.elem" select="@ident" as="xs:string"/>
                         <xsl:variable name="desc" select="normalize-space(string-join(tei:desc//text(),' '))" as="xs:string"/>
@@ -1212,15 +1212,15 @@
                         </span>
                     </xsl:for-each>
                 </xsl:variable>-->
-                <xsl:variable name="childs.by.class" as="node()*">
+                <xsl:variable name="children.by.class" as="node()*">
                     <xsl:if test="$allows.text">
                         <div class="textualContent" title="textual content">
                             textual content
                         </div>
                     </xsl:if>
-                    <xsl:sequence select="tools:getChildsByModel($object)"/>
+                    <xsl:sequence select="tools:getChildrenByModel($object)"/>
                 </xsl:variable>
-                <!--<xsl:variable name="childs.by.module" as="node()*">
+                <!--<xsl:variable name="children.by.module" as="node()*">
                     
                     <xsl:if test="$allows.text">
                         <div class="textualContent" title="textual content">
@@ -1228,10 +1228,10 @@
                         </div>
                     </xsl:if>
                     
-                    <xsl:for-each select="distinct-values($childs/self::tei:elementSpec/@module)">
+                    <xsl:for-each select="distinct-values($children/self::tei:elementSpec/@module)">
                         <xsl:sort select="." data-type="text"/>
                         <xsl:variable name="current.module" select="." as="xs:string"/>
-                        <xsl:variable name="relevant.element.names" select="distinct-values($childs/self::tei:elementSpec[@module = $current.module]/@ident)" as="xs:string*"/>
+                        <xsl:variable name="relevant.element.names" select="distinct-values($children/self::tei:elementSpec[@module = $current.module]/@ident)" as="xs:string*"/>
                         
                         <xsl:variable name="ident" select="$current.module" as="xs:string"/>
                         <xsl:variable name="desc" select="normalize-space(string-join($mei.source//tei:moduleSpec[@ident = $current.module]/tei:desc/text(),' '))" as="xs:string"/>
@@ -1256,9 +1256,9 @@
                 </xsl:variable>-->
                 
                 <!--<xsl:variable name="contents" as="node()+">
-                    <tab id="compact" label="compact"><xsl:sequence select="$childs.compact"/></tab>
-                    <tab id="class" label="by class"><xsl:sequence select="$childs.by.class"/></tab>
-                    <tab id="module" label="by module"><xsl:sequence select="$childs.by.module"/></tab>
+                    <tab id="compact" label="compact"><xsl:sequence select="$children.compact"/></tab>
+                    <tab id="class" label="by class"><xsl:sequence select="$children.by.class"/></tab>
+                    <tab id="module" label="by module"><xsl:sequence select="$children.by.module"/></tab>
                 </xsl:variable>
                 
                 <xsl:sequence select="tools:getTabbedFacet('mayContain','May Contain',$contents)"/>    -->    
@@ -1266,7 +1266,7 @@
                 <div class="facet mayContain">
                     <div class="label">May Contain</div>
                     <div class="statement classes">
-                        <xsl:sequence select="$childs.by.class"/>
+                        <xsl:sequence select="$children.by.class"/>
                     </div>
                 </div>
             </xsl:when>
@@ -1301,7 +1301,7 @@
         <xd:param name="object"></xd:param>
         <xd:return></xd:return>
     </xd:doc>
-    <xsl:function name="tools:getChildsByModel" as="node()*">
+    <xsl:function name="tools:getChildrenByModel" as="node()*">
         <xsl:param name="object" as="node()"/>
         
         <xsl:variable name="is.element" select="local-name($object) = 'elementSpec'" as="xs:boolean"/>
@@ -1358,7 +1358,7 @@
                         <xsl:sequence select="$macro.groups/self::tei:macroSpec[@ident = $object/tei:content//rng:ref/@name and not(@ident = $object/@ident)]"/>
                     </xsl:variable>
                     <xsl:for-each select="$inheriting.models">
-                        <xsl:sequence select="tools:getChildsByModel(.)"/>    
+                        <xsl:sequence select="tools:getChildrenByModel(.)"/>    
                     </xsl:for-each>
                 </xsl:if>
             </xsl:variable>
@@ -1371,7 +1371,7 @@
                 <xsl:sequence select="$macro.groups/self::tei:macroSpec[@ident = $object/tei:content//rng:ref/@name]"/>
             </xsl:variable>
             <xsl:for-each select="$inheriting.models">
-                <xsl:sequence select="tools:getChildsByModel(.)"/>    
+                <xsl:sequence select="tools:getChildrenByModel(.)"/>    
             </xsl:for-each>
         </xsl:if>
     </xsl:function>


### PR DESCRIPTION
In the documentation the section "direct childs" should be "direct children". This commit updates the genericSpecFunctions.xsl and generateGuidelines.xsl to correct this, as well as renaming 'childs' to 'children' throughout the code. 