### PR TITLE
move the bracketSpan@func att list to att.bracketSpan.log

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -333,6 +333,25 @@
       <memberOf key="att.startEndId"/>
       <memberOf key="att.timestamp2.logical"/>
     </classes>
+    <attList>
+      <attDef ident="func" usage="req">
+        <desc>Describes the function of the bracketed event sequence.</desc>
+        <datatype>
+          <rng:data type="NMTOKENS"/>
+        </datatype>
+        <valList type="semi">
+          <valItem ident="coloration">
+            <desc>Represents coloration in the mensural notation source material.</desc>
+          </valItem>
+          <valItem ident="cross-rhythm">
+            <desc>Marks a sequence which does not match the current meter.</desc>
+          </valItem>
+          <valItem ident="ligature">
+            <desc>Represents a ligature in the mensural notation source material.</desc>
+          </valItem>
+        </valList>
+      </attDef>
+    </attList>
   </classSpec>
   <classSpec ident="att.breath.log" module="MEI.cmn" type="atts">
     <desc>Logical domain attributes.</desc>
@@ -1449,25 +1468,6 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <attList>
-      <attDef ident="func" usage="req">
-        <desc>Describes the function of the bracketed event sequence.</desc>
-        <datatype>
-          <rng:data type="NMTOKENS"/>
-        </datatype>
-        <valList type="semi">
-          <valItem ident="coloration">
-            <desc>Represents coloration in the mensural notation source material.</desc>
-          </valItem>
-          <valItem ident="cross-rhythm">
-            <desc>Marks a sequence which does not match the current meter.</desc>
-          </valItem>
-          <valItem ident="ligature">
-            <desc>Represents a ligature in the mensural notation source material.</desc>
-          </valItem>
-        </valList>
-      </attDef>
-    </attList>
     <remarks>
       <p>Text that interrupts the bracket used to mark the event group may be captured as the
         content of <gi scheme="MEI">bracketSpan</gi>. The starting point of the group/bracket may be


### PR DESCRIPTION
This simply changes where the attribute list for bracketSpan@func` is defined. Having it in att.bracketSpan log and not directly within bracketSpan makes it processed by libMEI for Verovio. It does not change anything to the resulting schema itself.