### PR TITLE
remove MIDI attributes from silent elements

### DIFF
--- a/source/modules/MEI.gestural.xml
+++ b/source/modules/MEI.gestural.xml
@@ -399,7 +399,6 @@
     <desc>Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.instrumentIdent"/>
     </classes>
   </classSpec>
   <classSpec ident="att.mRpt.ges" module="MEI.gestural" type="atts">
@@ -412,14 +411,12 @@
     <desc>Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.instrumentIdent"/>
     </classes>
   </classSpec>
   <classSpec ident="att.multiRest.ges" module="MEI.gestural" type="atts">
     <desc>Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.instrumentIdent"/>
     </classes>
   </classSpec>
   <classSpec ident="att.multiRpt.ges" module="MEI.gestural" type="atts">
@@ -590,7 +587,6 @@
     <desc>Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
-      <memberOf key="att.instrumentIdent"/>
       <memberOf key="att.rest.ges.mensural"/>
     </classes>
   </classSpec>


### PR DESCRIPTION
This removes `att.instrumentIdent` from the _non-sounding_ layer elements `mSpace`, `rest`, `mRest`, and `multiRest`, and thus brings them in line with `space`.