### PR TITLE
allow decimal values for midibpm

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1962,7 +1962,9 @@
         <desc>Contains the number indicating the beat unit, that is, the bottom number of the meter
           signature.</desc>
         <datatype>
-          <rng:data type="decimal"/>
+          <rng:data type="decimal">
+            <rng:param name="minExclusive">0</rng:param>
+          </rng:data>
         </datatype>
       </attDef>
       <attDef ident="meter.sym" usage="opt">

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -2061,7 +2061,7 @@
       *not the numerator of the time signature or the metronomic indication*.</desc>
     <content>
       <rng:data type="decimal">
-        <rng:param name="minInclusive">0</rng:param>
+        <rng:param name="minExclusive">0</rng:param>
       </rng:data>
     </content>
   </macroSpec>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -2059,10 +2059,12 @@
   <macroSpec ident="data.MIDIBPM" module="MEI" type="dt">
     <desc>Tempo expressed as "beats" per minute, where "beat" is always defined as a quarter note,
       *not the numerator of the time signature or the metronomic indication*.</desc>
-    <content>
-      <rng:data type="positiveInteger"/>
-    </content>
-  </macroSpec>
+      <content>
+        <rng:data type="decimal">
+          <rng:param name="minInclusive">0</rng:param>
+        </rng:data>
+      </content>
+    </macroSpec>
   <macroSpec ident="data.MIDIMSPB" module="MEI" type="dt">
     <desc>Tempo expressed as microseconds per "beat", where "beat" is always defined as a quarter
       note, *not the numerator of the time signature or the metronomic indication*.</desc>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -2059,12 +2059,12 @@
   <macroSpec ident="data.MIDIBPM" module="MEI" type="dt">
     <desc>Tempo expressed as "beats" per minute, where "beat" is always defined as a quarter note,
       *not the numerator of the time signature or the metronomic indication*.</desc>
-      <content>
-        <rng:data type="decimal">
-          <rng:param name="minInclusive">0</rng:param>
-        </rng:data>
-      </content>
-    </macroSpec>
+    <content>
+      <rng:data type="decimal">
+        <rng:param name="minInclusive">0</rng:param>
+      </rng:data>
+    </content>
+  </macroSpec>
   <macroSpec ident="data.MIDIMSPB" module="MEI" type="dt">
     <desc>Tempo expressed as microseconds per "beat", where "beat" is always defined as a quarter
       note, *not the numerator of the time signature or the metronomic indication*.</desc>


### PR DESCRIPTION
> With BPM, sometimes you have to deal with fractional tempos (for example, 100.3 BPM) if you want to allow a finer resolution to the tempo.

See http://midi.teragonaudio.com/tech/midifile/ppqn.htm.

Also see discussion on https://github.com/rism-digital/verovio/issues/1953.

Refers to https://github.com/music-encoding/music-encoding/issues/295.