### PR TITLE
fixes #797

### DIFF
--- a/source/modules/MEI.edittrans.xml
+++ b/source/modules/MEI.edittrans.xml
@@ -54,7 +54,7 @@
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.startEndId"/>
-      <memberOf key="att.timestamp2.gestural"/>
+      <memberOf key="att.timestamp2.logical"/>
       <memberOf key="att.edit"/>
       <memberOf key="att.trans"/>
     </classes>


### PR DESCRIPTION
this will allow `@tstamp2` on `<metaMark>`, and will disallow `@tstamp2.ges` and `@tstamp2.real`. The two latter might be useful, but this is clearly a bug and needs to be fixed as proposed. Adding the other two attributes should be done when there's a request for this. 