### PR TITLE
Add att.rotating

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -2764,6 +2764,18 @@
       </attDef>
     </attList>
   </classSpec>
+  <classSpec ident="att.rotating" module="MEI.shared" type="atts">
+    <desc>Visual domain attributes.</desc>
+    <attList>
+      <attDef ident="rotation" usage="opt">
+        <desc>A positive value for rotation rotates the object in a counter-clockwise fashion, while
+          negative values produce clockwise rotation.</desc>
+        <datatype>
+          <rng:ref name="data.DEGREES"/>
+        </datatype>
+      </attDef>
+    </attList>
+  </classSpec>
   <classSpec ident="att.sb.log" module="MEI.shared" type="atts">
     <desc>Logical domain attributes.</desc>
     <classes>
@@ -7242,6 +7254,7 @@
       <memberOf key="att.common"/>
       <memberOf key="att.horizontalAlign"/>
       <memberOf key="att.lang"/>
+      <memberOf key="att.rotating"/>
       <memberOf key="att.textRendition"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.verticalAlign"/>
@@ -7258,15 +7271,6 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <attList>
-      <attDef ident="rotation" usage="opt">
-        <desc>A positive value for rotation rotates the text in a counter-clockwise fashion, while
-          negative values produce clockwise rotation.</desc>
-        <datatype>
-          <rng:ref name="data.DEGREES"/>
-        </datatype>
-      </attDef>
-    </attList>
     <remarks>
       <p>When an entire element should be rendered in a special way, a style sheet function should
         be used instead of the <gi scheme="MEI">rend</gi> element.</p>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -656,6 +656,7 @@
       <memberOf key="att.color"/>
       <memberOf key="att.lineRend.base"/>
       <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.rotating"/>
       <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2"/>


### PR DESCRIPTION
This moves `rotation` from `rend` into a new class `att.rotating` to be used in other elements, starting with `hairpin`.  