### PR TITLE
Fixed: Update PR labeller

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -13,13 +13,11 @@ on:
       - edited
       - reopened
       - synchronize
-#  workflow_dispatch:
 
 jobs:
   label:
-
     runs-on: ubuntu-latest
-
+    if: github.repository_owner == 'music-encoding'
     steps:
     - uses: actions/labeler@v2
       with:

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -7,7 +7,7 @@
 
 name: PR Labeler
 on: 
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'music-encoding'
     steps:
-    - uses: actions/labeler@v2
+    - uses: actions/labeler@v3
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true


### PR DESCRIPTION
Updates the PR labeller to run on the PR target, rather than the pull request, to get around a permissions issue running on a fork.

Fixes #766