### PR TITLE
Add accid to neume components

### DIFF
--- a/source/modules/MEI.analytical.xml
+++ b/source/modules/MEI.analytical.xml
@@ -329,6 +329,8 @@
   <classSpec ident="att.nc.anl" module="MEI.analytical" type="atts">
     <desc>Analytical domain attributes.</desc>
     <classes>
+      <memberOf key="att.accidental"/>
+      <memberOf key="att.articulation"/>
       <memberOf key="att.harmonicFunction"/>
       <memberOf key="att.intervalMelodic"/>
       <memberOf key="att.melodicFunction"/>

--- a/source/modules/MEI.analytical.xml
+++ b/source/modules/MEI.analytical.xml
@@ -330,7 +330,6 @@
     <desc>Analytical domain attributes.</desc>
     <classes>
       <memberOf key="att.accidental"/>
-      <memberOf key="att.articulation"/>
       <memberOf key="att.harmonicFunction"/>
       <memberOf key="att.intervalMelodic"/>
       <memberOf key="att.melodicFunction"/>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -4164,6 +4164,7 @@
       <memberOf key="att.accid.ges"/>
       <memberOf key="att.accid.anl"/>
       <memberOf key="model.noteModifierLike"/>
+      <memberOf key="model.neumeComponentModifierLike"/>
     </classes>
     <content>
       <rng:empty/>


### PR DESCRIPTION
Hi, we added both `accid` attribute and element to neume components. We have built the schema locally, and the validation succeeded. Please have a look at it. Thank you!