### PR TITLE
add enclose attribute to arpeg

### DIFF
--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -51,6 +51,7 @@
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
+      <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extSym"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.visualOffset"/>


### PR DESCRIPTION
This PR is a follow up to #729 and adds `@enclose` to `arpeg`, what was missed originally.