### PR TITLE
Allow clef changes within fingered tremolos

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -1581,6 +1581,9 @@
       <rng:choice>
         <rng:group>
           <rng:ref name="chord"/>
+          <rng:optional>
+            <rng:ref name="clef"/>
+          </rng:optional>
           <rng:choice>
             <rng:ref name="chord"/>
             <rng:ref name="note"/>
@@ -1588,6 +1591,9 @@
         </rng:group>
         <rng:group>
           <rng:ref name="note"/>
+          <rng:optional>
+            <rng:ref name="clef"/>
+          </rng:optional>
           <rng:choice>
             <rng:ref name="chord"/>
             <rng:ref name="note"/>


### PR DESCRIPTION
This PR adds the possibility to have clef changes within tremolos. 
![](https://user-images.githubusercontent.com/3487289/98452409-ed9c6400-2103-11eb-8116-a7914adc627b.png)

Not a common thing, but it could appear.
See https://github.com/rism-digital/verovio/issues/1804.