### PR TITLE
Develop accents

### DIFF
--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -200,6 +200,15 @@
         <valItem ident="acc">
           <desc>Accent (Unicode 1D17B).</desc>
         </valItem>
+        <valItem ident="acc-inv">
+          <desc>Inverted accent.</desc>
+        </valItem>
+        <valItem ident="acc-long">
+          <desc>Long accent, used to indicate an elongated accent mark. It is the responsibility of the encoder to distinguish between accents and a hairpins.</desc>
+        </valItem>
+        <valItem ident="acc-soft">
+          <desc>Soft accent, see SMuFL Articulation supplement (U+ED40–U+ED4F).</desc>
+        </valItem>
         <valItem ident="stacc">
           <desc>Staccato (Unicode 1D17C).</desc>
         </valItem>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -204,7 +204,7 @@
           <desc>Inverted accent.</desc>
         </valItem>
         <valItem ident="acc-long">
-          <desc>Long accent, used to indicate an elongated accent mark. It is the responsibility of the encoder to distinguish between accents and a hairpins.</desc>
+          <desc>Long accent, used to indicate an elongated accent mark. It is the responsibility of the encoder to distinguish between accents and hairpins.</desc>
         </valItem>
         <valItem ident="acc-soft">
           <desc>Soft accent, see SMuFL Articulation supplement (U+ED40–U+ED4F).</desc>


### PR DESCRIPTION
This PR adds three new accent values to `data.ARTICULATION` as discussed in ODD meeting: 

- `acc-inv`
- `acc-long`
- `acc-soft`


First is to encode _inverted_ or _reversed_ accents, as seen in 19th-century vocal music:
![Viardot Garcia](https://user-images.githubusercontent.com/7693447/127296043-ec0ef69e-2973-4606-9d33-580f98b0eef8.jpg)


Second is to address "longer" accents, that may look like a hairpin: 
![Chopin](https://user-images.githubusercontent.com/7693447/127297257-8f4fca0e-6f56-4427-ba7a-3a79a1415aa0.png)


Third is a combination of an inverted and a normal accent:
![Brahms](https://user-images.githubusercontent.com/7693447/127299555-f82a950d-81d9-4a64-91b6-d44a64ee4747.png)

![Lortzing](https://lists.w3.org/Archives/Public/public-music-notation-contrib/2015Oct/att-0054/excerpt__Zar_und_Zimmermann_.jpg)

SMuFL has added them as `articSoftAccentAbove` to the `Articulation supplement`:
![articSoftAccentAbove](https://smufl-browser.edirom.de/ED40.png)

Closes #768