### PR TITLE
schema: Add encoding of numbers as parts of mensuration signs

### DIFF
--- a/source/docs/05-mensural.xml
+++ b/source/docs/05-mensural.xml
@@ -284,12 +284,13 @@
             </div>
             <div xml:id="mensuralProportions" type="div2">
                <head>Proportions</head>
-               <p>Proportions can also be indicated within the <gi scheme="MEI">staffDef</gi> element. The <att>proport.num</att> and <att>proport.numbase</att> attributes are available for encoding the numerator and the denominator of the proportion, respectively. There is also a <gi scheme="MEI">proport</gi> element that can be used as an alternative, with the corresponding <att>num</att> and <att>numbase</att> attributes.</p>
+               <p>Proportions can also be indicated within the <gi scheme="MEI">staffDef</gi> element. The <att>proport.num</att> and <att>proport.numbase</att> attributes are available for encoding the numerator and the denominator of the proportion, respectively. There is also a <gi scheme="MEI">proport</gi> element that can be used as an alternative, with the corresponding <att>num</att> and <att>numbase</att>.</p>
                <p>
                   <specList>
                      <specDesc key="proport"/>
                   </specList>
                </p>
+               <p>The time signatures of the actual proportion sign can be encoded with <att>sign.num</att> and <att>sign.numbase</att>, respectively <att>mensur.sign.num</att> and <att>mensur.sign.numbase</att> within <gi scheme="MEI">staffDef</gi>. <att>proport.num</att> and <att>proport.numbase</att>, respectively <att>num</att> and <att>numbase</att>, do not cover the visual information and should only be used to indicate the ratio of the given diminution or augmentation.</p>
             </div>
             <div xml:id="mensuralLigatures" type="div2">
                <head>Ligatures</head>

--- a/source/docs/05-mensural.xml
+++ b/source/docs/05-mensural.xml
@@ -291,6 +291,11 @@
                   </specList>
                </p>
                <p>The time signatures of the actual proportion sign can be encoded with <att>sign.num</att> and <att>sign.numbase</att>, respectively <att>mensur.sign.num</att> and <att>mensur.sign.numbase</att> within <gi scheme="MEI">staffDef</gi>. <att>proport.num</att> and <att>proport.numbase</att>, respectively <att>num</att> and <att>numbase</att>, do not cover the visual information and should only be used to indicate the ratio of the given diminution or augmentation.</p>
+               <div xml:id="mensuralProportionVsMensur" type="div3">
+                  <head>Proportion vs. mensuration</head>
+                  <p>Proportion signs, e.g. "3", can not only indicate a shift in duration but as well in mensuration. This may include the application of rules of imperfection and augmentation.</p>
+                  <p>While <gi scheme="MEI">mensur</gi> supports the explicit description of mensuration signs and note division levels, it should be used whenever there is an implicit or explicit change in the division levels or a mensuration or division sign is present. On the contrary, <gi scheme="MEI">proport</gi> only supports attributes describing time signatures and general diminution or augmentation. Therefore it is recommended to use <gi scheme="MEI">proport</gi> only for proportions that do not include any implicit change of mensuration.</p>
+               </div>
             </div>
             <div xml:id="mensuralLigatures" type="div2">
                <head>Ligatures</head>

--- a/source/docs/05-mensural.xml
+++ b/source/docs/05-mensural.xml
@@ -230,14 +230,14 @@
                      <specDesc key="att.mensural.shared" atts="modusmaior modusminor tempus prolatio"/>
                   </specList>
                </p>
-               <p>The mensur signs themselves can be encoded in the <att>mensur.sign</att> attribute with a possible value of "C" or "O". Its orientation can be encoded in the <att>mensur.orient</att> attribute, for example, with the value "reversed" for a flipped C sign. The number of slashes (up to 6) can be given in the <att>mensur.slash</att> attribute. There is also a <att>mensur.dot</att> attribute for indicating the presence of a dot through the boolean values "true" or "false".</p>
+               <p>The mensur signs themselves can be encoded in the <att>mensur.sign</att> attribute with a possible value of "C" or "O". Its orientation can be encoded in the <att>mensur.orient</att> attribute, for example, with the value "reversed" for a flipped C sign. The number of slashes (up to 6) can be given in the <att>mensur.slash</att> attribute. There is also a <att>mensur.dot</att> attribute for indicating the presence of a dot through the boolean values "true" or "false". To encode numbers accompanying a mensur sign, <att>mensur.sign.num</att> is used for numbers following the sign, <att>mensur.sign.numbase</att> could be used for numbers beneath the sign.</p>
                <p>
                   <specList>
-                     <specDesc key="att.mensural.vis" atts="mensur.sign mensur.dot mensur.slash mensur.orient"/>
+                     <specDesc key="att.mensural.vis" atts="mensur.sign mensur.dot mensur.slash mensur.orient mensur.sign.num mensur.sign.numbase"/>
                   </specList>
                </p>
                <p>
-                  <gi scheme="MEI">mensur</gi> elements can also be used instead of <gi scheme="MEI">staffDef</gi> and its attributes. In <gi scheme="MEI">mensur</gi>, the division levels are encoded with the previously mentioned <att>modusmaior</att>, <att>modusminor</att>, <att>tempus</att>, and <att>prolatio</att> attributes, while the attributes to indicate the mensur signs are: <att>sign</att>, <att>orient</att>, <att>slash</att>, and <att>dot</att>. <gi scheme="MEI">mensur</gi> can be a child of the <gi scheme="MEI">staffDef</gi> and <gi scheme="MEI">layer</gi> elements.</p>
+                  <gi scheme="MEI">mensur</gi> elements can also be used instead of <gi scheme="MEI">staffDef</gi> and its attributes. In <gi scheme="MEI">mensur</gi>, the division levels are encoded with the previously mentioned <att>modusmaior</att>, <att>modusminor</att>, <att>tempus</att>, and <att>prolatio</att> attributes, while the attributes to indicate the mensur signs are: <att>sign</att>, <att>orient</att>, <att>slash</att>, <att>dot</att>, <att>sign.num</att>, and <att>sign.numbase</att>. <gi scheme="MEI">mensur</gi> can be a child of the <gi scheme="MEI">staffDef</gi> and <gi scheme="MEI">layer</gi> elements.</p>
                <p>
                   <specList>
                      <specDesc key="mensur"/>
@@ -252,6 +252,7 @@
                   <specList>
                      <specDesc key="att.mensur.vis" atts="sign dot orient"/>
                      <specDesc key="att.slashCount" atts="slash"/>
+                     <specDesc key="att.signnumbers" atts="sign.num sign.numbase"/>
                   </specList>
                </p>
                <div xml:id="changeinmensuration" type="div3">

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -973,6 +973,7 @@
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.slashCount"/>
+      <memberOf key="att.signnumbers"/>
     </classes>
     <attList>
       <attDef ident="dot" usage="opt">
@@ -1063,6 +1064,18 @@
           added for what we now call 'alla breve'.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
+        </datatype>
+      </attDef>
+      <attDef ident="mensur.sign.num" usage="opt">
+        <desc>Numbers following the base symbol in a mensuration sign.</desc>
+        <datatype>
+          <rng:ref name="data.MENSURATIONSIGNNUMBERS" />
+        </datatype>
+      </attDef>
+      <attDef ident="mensur.sign.numbase" usage="opt">
+        <desc>Base numbers following or beneath the base symbol in a mensuration sign.</desc>
+        <datatype>
+          <rng:ref name="data.MENSURATIONSIGNNUMBERS" />
         </datatype>
       </attDef>
     </attList>
@@ -1374,6 +1387,7 @@
       <memberOf key="att.extSym"/>
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.typography"/>
+      <memberOf key="att.signnumbers"/>
     </classes>
   </classSpec>
   <classSpec ident="att.quilisma.vis" module="MEI.visual" type="atts">
@@ -1531,6 +1545,26 @@
           neume component with which it is associated.</desc>
         <datatype>
           <rng:ref name="data.EVENTREL"/>
+        </datatype>
+      </attDef>
+    </attList>
+  </classSpec>
+  <classSpec ident="att.signnumbers" module="MEI.visual" type="atts">
+    <desc>Attributes for recording numbers as part of the physical appearance 
+      of a mensuration or proportion sign.</desc>
+    <attList>
+      <attDef ident="sign.num" usage="opt">
+        <desc>Numbers following the base symbol in a mensuration sign or visual number 
+          in a proportion sign.</desc>
+        <datatype>
+          <rng:ref name="data.MENSURATIONSIGNNUMBERS" />
+        </datatype>
+      </attDef>
+      <attDef ident="sign.numbase" usage="opt">
+        <desc>Base numbers following or beneath the base symbol in a mensuration sign 
+          or base of a proportion sign.</desc>
+        <datatype>
+          <rng:ref name="data.MENSURATIONSIGNNUMBERS" />
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -2021,7 +2021,8 @@
       </rng:data>
     </content>
     <remarks>
-      <p>The glyph "Z" used in 17th century Spanish manuscripts is treated as number.</p>
+      <p>Allows for multiple tokens to deal with signs containing multiple numbers, like "O 2 2" in Hothby’s “Ora pro nobis” (Codex Faenza fol. 28r).</p>
+      <p>The glyph "Z" used in 17th century Spanish manuscripts is treated as number 3.</p>
     </remarks>
   </macroSpec>
   <macroSpec ident="data.METERFORM" module="MEI" type="dt">

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -2013,6 +2013,17 @@
       </valList>
     </content>
   </macroSpec>
+  <macroSpec ident="data.MENSURATIONSIGNNUMBERS" module="MEI" type="dt">
+    <desc>Number values as part of mensuration signs.</desc>
+    <content>
+      <rng:data type="token">
+        <rng:param name="pattern">[\d|Z]?[ [\d|Z]]*</rng:param>
+      </rng:data>
+    </content>
+    <remarks>
+      <p>The glyph "Z" used in 17th century Spanish manuscripts is treated as number.</p>
+    </remarks>
+  </macroSpec>
   <macroSpec ident="data.METERFORM" module="MEI" type="dt">
     <desc>Contains an indication of how a meter signature should be rendered.</desc>
     <content>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -2022,7 +2022,7 @@
     </content>
     <remarks>
       <p>Allows for multiple tokens to deal with signs containing multiple numbers, like "O 2 2" in Hothby’s “Ora pro nobis” (Codex Faenza fol. 28r).</p>
-      <p>The glyph "Z" used in 17th century Spanish manuscripts is treated as number 3.</p>
+      <p>The glyph "Z" used in 17th-century Spanish manuscripts is treated as the proportion 3:2.</p>
     </remarks>
   </macroSpec>
   <macroSpec ident="data.METERFORM" module="MEI" type="dt">

--- a/tests/mei-Mensural/mensurations_proportions.mei
+++ b/tests/mei-Mensural/mensurations_proportions.mei
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../schemata/mei-Mensural.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="../../schemata/mei-Mensural.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei meiversion="5.0.0-dev" xmlns="http://www.music-encoding.org/ns/mei">
+    <meiHead>
+        <fileDesc>
+            <titleStmt>
+                <title>mensuration and proportion sign tests</title>
+            </titleStmt>
+            <pubStmt/>
+        </fileDesc>
+    </meiHead>
+    <music>
+        <body>
+            <mdiv>
+                <score>
+                    <scoreDef>
+                        <staffGrp>
+                            <staffDef n="1" label="modus-com-tempore" clef.line="2" clef.shape="G" lines="5" 
+                                mensur.sign="O" mensur.sign.num="2 2" 
+                                modusmaior="3" modusminor="2" tempus="2" proport.num="4" proport.numbase="1" />
+                            <staffDef n="2" label="sesquialtera" clef.line="2" clef.shape="G" lines="5"
+                                mensur.sign="C" mensur.slash="1" 
+                                tempus="2" prolatio="2" proport.num="2" proport.numbase="1" />
+                            <staffDef n="3" label="proporcion-mayor-menor" clef.line="2" clef.shape="G" lines="5"
+                                mensur.sign="C" mensur.slash="1" mensur.sign.num="Z"
+                                modusmaior="2" modusminor="2" tempus="3" prolatio="2"/>
+                        </staffGrp>
+                    </scoreDef>
+                    <section>
+                        <staff n="1">
+                            <layer>
+                                <note dur="longa"/>
+                                <!-- Dufay example of O2 -->
+                                <mensur sign="O" sign.num="2" 
+                                    modusminor="3" tempus="2" num="2" numbase="1" />
+                                <note dur="longa"/>
+                                <!-- Cordier example of O2 -->
+                                <mensur sign="O" sign.num="2" 
+                                    modusminor="2" tempus="3" num="2" numbase="1"/>
+                                <note dur="longa"/>
+                                <!-- Busnoys -->
+                                <mensur sign="C" sign.num="3"
+                                    modusminor="2" tempus="3" num="2" numbase="1" />
+                                <note dur="longa"/>
+                                <!-- again Hothby as is <staffDef> -->
+                                <mensur sign="O" sign.num="2 2" 
+                                    modusmaior="3" modusminor="2" tempus="2" num="4" numbase="1" />
+                                <note dur="longa"/>
+                                <barLine form="dbl"/>
+                            </layer>
+                        </staff>
+                        <staff n="2">
+                            <layer>
+                                <note dur="semibrevis"/>
+                                <note dur="semibrevis"/>
+                                <!-- 3 as sesquialtera with implicit change of tempus -->
+                                <mensur sign.num="3" tempus="3" prolatio="2" num="2" numbase="1"/>
+                                <note dur="semibrevis"/>
+                                <note dur="semibrevis"/>
+                                <note dur="semibrevis"/>
+                                <mensur sign="C" slash="1" tempus="2" prolatio="2" num="2" numbase="1"/>
+                                <note dur="semibrevis"/>
+                                <note dur="semibrevis"/>
+                                <!-- Petrucci's sesquialtera sign -->
+                                <mensur sign="O" sign.numbase="3" tempus="3" prolatio="2" num="2" numbase="1"/>
+                                <note dur="semibrevis"/>
+                                <note dur="semibrevis"/>
+                                <note dur="semibrevis"/>
+                                <mensur sign="C" slash="1" tempus="2" prolatio="2" num="2" numbase="1"/>
+                                <note dur="semibrevis"/>
+                                <note dur="semibrevis"/>
+                                <!-- no implicit change of mensuration here! -->
+                                <proport sign.num="3" num="3" numbase="2"/>
+                                <note dur="semibrevis"/>
+                                <note dur="semibrevis"/>
+                                <barLine form="dbl"/>
+                            </layer>
+                        </staff>
+                        <staff n="3">
+                            <layer>
+                                <!-- propocion mayor in <staffDef> -->
+                                <note dur="semibrevis"/>
+                                <note dur="minima"/>
+                                <note dur="minima"/>
+                                <note dur="semibrevis"/>
+                                <!-- proporcion menor -->
+                                <mensur sign="C" sign.num="Z" tempus="2" prolatio="3"/>
+                                <note dur="semibrevis"/>
+                                <note dur="minima"/>
+                                <note dur="minima"/>
+                                <note dur="minima"/>
+                                <barLine form="dbl"/>
+                            </layer>
+                        </staff>
+                    </section>
+                </score>
+            </mdiv>
+        </body>
+    </music>
+</mei>


### PR DESCRIPTION
This PR implements the result of the discussion on mensuration and proportion signs of the Mensural IG.
For more insights and examples, see [here](https://docs.google.com/document/d/1M_CUqlvPNFiS-EI39DgggzwmX4VoLp0nvMXPp_rCbLY/edit#heading=h.gjdgxs).

If adds the attributes `@sign.num` and `@sign.numbase` or `@mensur.sign.num` and `@mensur.sign.numbase` for the encoding of numbers as parts of mensuration signs in the visual domain.
Due to technical reasons, currently "Z" is treated as number to avoid a lack of clarity on mensuration signs encoded in `@sign`.

To do:
* [x] Guidelines: Stress that num & numbase is not to be used as time signature (that is sign.num and sign.numbase), only to state general diminution or other general shifts in duration.
* [x] Guidelines: Add documentation about when to use `<mensur>` and when to use `<proport>`
* [x] Add remark to `data.MENSURATIONSIGNNUMBERS` that it allows tokens to deal with multiple numbers
