### PR TITLE
Make divline a valid child of layer

### DIFF
--- a/source/modules/MEI.neumes.xml
+++ b/source/modules/MEI.neumes.xml
@@ -531,7 +531,7 @@
       <memberOf key="att.visibility" />
       <memberOf key="att.xy" />
       <memberOf key="att.visualOffset.ho" />
-      <memberOf key="model.layerPart.neumes"/>
+      <memberOf key="model.eventLike.neumes"/>
     </classes>
     <attList>
       <attDef ident="form" usage="opt">

--- a/source/modules/MEI.neumes.xml
+++ b/source/modules/MEI.neumes.xml
@@ -531,7 +531,7 @@
       <memberOf key="att.visibility" />
       <memberOf key="att.xy" />
       <memberOf key="att.visualOffset.ho" />
-      <memberOf key="model.eventLike"/>
+      <memberOf key="model.layerPart.neumes"/>
     </classes>
     <attList>
       <attDef ident="form" usage="opt">

--- a/source/modules/MEI.neumes.xml
+++ b/source/modules/MEI.neumes.xml
@@ -531,6 +531,7 @@
       <memberOf key="att.visibility" />
       <memberOf key="att.xy" />
       <memberOf key="att.visualOffset.ho" />
+      <memberOf key="model.eventLike"/>
     </classes>
     <attList>
       <attDef ident="form" usage="opt">


### PR DESCRIPTION
We added the module `model.layerPart.neumes` to `divline` in `MEI.neumes.xml` to make `divline` a valid child of `layer`. We have also validate the new schema. Attached are the screenshot of the successful validation, the new schema, and the test file. Please let us know if there is a better way to do this. Thank you!

<img width="954" alt="screenshot" src="https://user-images.githubusercontent.com/74484576/136417101-897f4517-b7d3-492e-ae83-7823b8fece20.png">
[fix_divline.zip](https://github.com/music-encoding/music-encoding/files/7305020/fix_divline.zip)

