### PR TITLE
Move dblwhole to head.shape

### DIFF
--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3077,12 +3077,22 @@
     <desc>Captures text rendered in the center of the notehead.</desc>
     <content>
       <rng:choice>
-        <rng:data type="string">
-          <rng:param name="pattern">centertext\((A|B|C|D|E|F|G)(f|♭|n|♮|s|♯)?\)</rng:param>
-        </rng:data>
-        <rng:data type="string">
-          <rng:param name="pattern">centertext\(H(s|♯)?\)</rng:param>
-        </rng:data>
+        <rng:choice>
+          <rng:data type="string">
+            <rng:param name="pattern">centertext\((A|B|C|D|E|F|G)(f|♭|n|♮|s|♯)?\)</rng:param>
+          </rng:data>
+          <rng:data type="string">
+            <rng:param name="pattern">centertext\(H(s|♯)?\)</rng:param>
+          </rng:data>
+        </rng:choice>
+        <rng:choice>
+          <rng:data type="string">
+            <rng:param name="pattern">centertext\((Do|Re|Mi|Fa|So|La|Ti|Si)\)</rng:param>
+          </rng:data>
+          <rng:data type="string">
+            <rng:param name="pattern">centertext\((Di|Ri|Ra|Fi|Se|Li|Le|Te)\)</rng:param>
+          </rng:data>
+        </rng:choice>
       </rng:choice>
     </content>
   </macroSpec>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -1474,6 +1474,9 @@
         <valItem ident="whole">
           <desc>Unfilled, rotated oval (Unicode 1D15D).</desc>
         </valItem>
+        <valItem ident="dblwhole">
+          <desc>Unfilled, rotated oval with vertical lines on either side (Unicode 1D15C).</desc>
+        </valItem>
         <valItem ident="backslash">
           <desc>Unfilled backslash (~ reflection of Unicode 1D10D).</desc>
         </valItem>
@@ -3066,9 +3069,6 @@
         </valItem>
         <valItem ident="circle">
           <desc>Enclosing circle.</desc>
-        </valItem>
-        <valItem ident="dblwhole">
-          <desc>Enclosing "fences".</desc>
         </valItem>
       </valList>
     </content>


### PR DESCRIPTION
This moves `dblwhole` back to `head.shape` and extends `data.NOTEHEADMODIFIER.pat` to allow solmization syllables. 

Compare the SMuFL ranges
https://w3c.github.io/smufl/latest/tables/note-name-noteheads.html
https://w3c.github.io/smufl/latest/tables/note-name-noteheads-supplement.html