### PR TITLE
Clarify that @oct in <note> changes between B and C

### DIFF
--- a/source/docs/04-cmn.xml
+++ b/source/docs/04-cmn.xml
@@ -262,7 +262,7 @@
                            </figure>
                         </p>
                         <p>Because these attributes may not be required in all situations (such as <att>dur</att> for the notes of a chord), processing software should anticipate retrieving the information that would have been provided by missing attributes from a preceding note or <gi scheme="MEI">chord</gi> parent in the same <gi scheme="MEI">layer</gi>. Only information from <att>pname</att>, <att>oct</att> and <att>dur</att> attributes can be gathered in this fashion. No other attributes can be treated this way.</p>
-                        <p>The default values for <att>pname</att> and <att>oct</att> conform to the Acoustical Society of America representation for pitch name; that is, the letters A - G, albeit in lower case, and the numbers 0 - 9.</p>
+                        <p>The default values for <att>pname</att> and <att>oct</att> conform to the <ref target="https://en.wikipedia.org/wiki/Scientific_pitch_notation">Acoustical Society of America representation for pitch name</ref>; that is, the letters A - G, albeit in lower case, and the numbers 0 - 9. The value for <att>oct</att> changes between B and C.</p>
                         <p>The usual CMN-specific values for <att>dur</att> are:</p>
                         <list type="gloss">
                            <label>1</label>


### PR DESCRIPTION
The main documentation for `<note>` says that pname and oct conform to Acoustical Society of America representation, but didn't say that oct changes between B and C, not G-A. The tutorial at https://music-encoding.org/tutorials/101-quickstart  also links to this Wikipedia page, so I added it here for more detail and added a sentence for clarification of oct.

I'm not sure how to build these docs to test them - I copied the `<ref>` syntax from another source file, I think it's correct.