### PR TITLE
Ftr build any customization

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -136,7 +136,7 @@
         <basename property="odd.basename" file="${customization.path}" suffix=".xml"/>
         <echo>building rng ${odd.basename} from ${customization.path}</echo>
         <ant dir="submodules/Stylesheets/relaxng/" antfile="build-to.xml" target="dist" inheritall="true" usenativebasedir="true"><!-- check whether nativebasdir is required -->
-            <property name="inputFile" value="${basedir}/${customization.path}"/>
+            <property name="inputFile" value="${customization.path}"/>
             <property name="outputFile" value="${dir.dist.schemata}/${odd.basename}.rng"/>
             <property name="defaultSource" value="${dir.dist.schemata}/mei-source_canonicalized.xml"/>
             <property name="verbose">true</property>


### PR DESCRIPTION
remove ant `${basedir}` prefix from customization_path when building rng in order to allow any ODD (wherever living on the build system) to be processes.