### PR TITLE
Added sforzando/sforzato `sf` to `data.ARTICULATION`

### DIFF
--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -216,7 +216,10 @@
           <desc>Soft accent, see SMuFL Articulation supplement (U+ED40–U+ED4F).</desc>
         </valItem>
         <valItem ident="sf">
-          <desc>Sforzando, sforzato.</desc>
+          <desc>Sforzando.</desc>
+        </valItem>
+        <valItem ident="sfz">
+          <desc>Sforzato.</desc>
         </valItem>
         <valItem ident="stacc">
           <desc>Staccato (Unicode 1D17C).</desc>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -215,6 +215,9 @@
         <valItem ident="acc-soft">
           <desc>Soft accent, see SMuFL Articulation supplement (U+ED40–U+ED4F).</desc>
         </valItem>
+        <valItem ident="sf">
+          <desc>Sforzando, sforzato.</desc>
+        </valItem>
         <valItem ident="stacc">
           <desc>Staccato (Unicode 1D17C).</desc>
         </valItem>


### PR DESCRIPTION
This pull request adds `sf` to the value list of `data.ARTICULATION` as discussed in issue #608.