### PR TITLE
remove deprecated fingerprint

### DIFF
--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -1195,21 +1195,6 @@
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
-  <elementSpec ident="fingerprint" module="MEI.header">
-    <desc>Contains a string that uniquely identifies an item, such as those constructed by combining
-      groups of characters transcribed from specified pages of a printed item or a file's
-      checksum.</desc>
-    <classes>
-      <memberOf key="att.common"/>
-      <memberOf key="att.authorized"/>
-      <memberOf key="att.bibl"/>
-      <memberOf key="model.msInline"/>
-      <memberOf key="model.physDescPart"/>
-    </classes>
-    <content>
-      <rng:text/>
-    </content>
-  </elementSpec>
   <elementSpec ident="foliaDesc" module="MEI.header">
     <desc>Describes the order of folia and bifolia making up the text block of a manuscript or
       print.</desc>

--- a/source/modules/MEI.msDesc.xml
+++ b/source/modules/MEI.msDesc.xml
@@ -845,8 +845,7 @@
   <constraintSpec ident="check_msDesc_inline" module="MEI.msDesc" scheme="isoschematron">
     <constraint>
       <sch:rule
-        context="mei:catchwords | mei:fingerprint | mei:heraldry | mei:secFolio | 
-        mei:signatures | mei:watermark">
+        context="mei:catchwords | mei:heraldry | mei:secFolio | mei:signatures | mei:watermark">
         <sch:assert test="ancestor::mei:physDesc">The <sch:name/> element may only appear as a
           descendant of the physDesc element.</sch:assert>
       </sch:rule>


### PR DESCRIPTION
This PR brings the long overdue removal of `fingerprint` that is deprecated since ten years. 
Closes #885