### PR TITLE
add template for abbreveations

### DIFF
--- a/utils/guidelines_xslt/odd2html/guidelines.xsl
+++ b/utils/guidelines_xslt/odd2html/guidelines.xsl
@@ -382,6 +382,15 @@
     
     <xd:doc>
         <xd:desc>
+            <xd:p>abbr</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="tei:abbr" mode="guidelines">
+        <abbr><xsl:apply-templates select="node()" mode="#current"/></abbr>
+    </xsl:template>
+    
+    <xd:doc>
+        <xd:desc>
             <xd:p>bibl</xd:p>
         </xd:desc>
     </xd:doc>


### PR DESCRIPTION
After #875 is merged this brings a special rule for the HTML version of the Guidelines to handle abbreviations correctly.