### PR TITLE
Remove font name in favor of font family

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1711,12 +1711,6 @@
           <rng:ref name="data.FONTFAMILY"/>
         </datatype>
       </attDef>
-      <attDef ident="lyric.name" usage="opt">
-        <desc>Sets the font name default value for lyrics.</desc>
-        <datatype>
-          <rng:ref name="data.FONTNAME"/>
-        </datatype>
-      </attDef>
       <attDef ident="lyric.size" usage="opt">
         <desc>Sets the default font size value for lyrics.</desc>
         <datatype>
@@ -3375,13 +3369,6 @@
           <rng:ref name="data.FONTFAMILY"/>
         </datatype>
       </attDef>
-      <attDef ident="text.name" usage="opt">
-        <desc>Provides a default value for the font name of text (other than lyrics) when this
-          information is not provided on the individual elements.</desc>
-        <datatype>
-          <rng:ref name="data.FONTNAME"/>
-        </datatype>
-      </attDef>
       <attDef ident="text.size" usage="opt">
         <desc>Provides a default value for the font size of text (other than lyrics) when this
           information is not provided on the individual elements.</desc>
@@ -3505,12 +3492,6 @@
         <desc>Contains the name of a font-family.</desc>
         <datatype>
           <rng:ref name="data.FONTFAMILY"/>
-        </datatype>
-      </attDef>
-      <attDef ident="fontname" usage="opt">
-        <desc>Holds the name of a font.</desc>
-        <datatype>
-          <rng:ref name="data.FONTNAME"/>
         </datatype>
       </attDef>
       <attDef ident="fontsize" usage="opt">

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -1287,12 +1287,6 @@
       <rng:data type="token"/>
     </content>
   </macroSpec>
-  <macroSpec ident="data.FONTNAME" module="MEI" type="dt">
-    <desc>Font name (for text) attribute values.</desc>
-    <content>
-      <rng:data type="token"/>
-    </content>
-  </macroSpec>
   <macroSpec ident="data.FONTSIZE" module="MEI" type="dt">
     <desc>Font size expressions.</desc>
     <content>


### PR DESCRIPTION
This removes `@lyric.name`, `@text.name` and `@fontname` with the respective `data.FONTNAME` from the schema. 
closes #716
