### PR TITLE
Refine MIDI names description and link

### DIFF
--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -2746,9 +2746,9 @@
       </valList>
     </content>
     <remarks>
-      <p>Instrument names are taken from the list at <ref
-        target="https://www.midi.org/specifications/item/gm-level-1-sound-set"
-        >https://www.midi.org/specifications/item/gm-level-1-sound-set</ref>. </p>
+      <p>Instrument names are based on the official list in the <ref
+        target="https://midi.org/specifications/midi1-specifications/general-midi-specifications"
+        >General MIDI Specifications</ref>.</p>
       <p>MEI uses 0-based program numbers.</p>
       <p>Percussion sounds are available when the MIDI channel is set to "10".</p>
     </remarks>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -2747,7 +2747,7 @@
     </content>
     <remarks>
       <p>Instrument names are based on the official list in the <ref
-        target="https://midi.org/specifications/midi1-specifications/general-midi-specifications"
+        target="https://www.midi.org/specifications-old/item/gm-level-1-sound-set"
         >General MIDI Specifications</ref>.</p>
       <p>MEI uses 0-based program numbers.</p>
       <p>Percussion sounds are available when the MIDI channel is set to "10".</p>


### PR DESCRIPTION
As the allowed values for MIDI instrument names in MEI all have underscores and no parentheses they are not simply "taken from" but "based on" the official names list. 
Also this updates the link.