### PR TITLE
respect multiple remarks

### DIFF
--- a/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
@@ -1411,7 +1411,7 @@
             <div class="facet remarks">
                 <div class="label">Remarks</div>
                 <div class="statement remarks">
-                    <p><xsl:apply-templates select="$object/tei:remarks/tei:p/node()" mode="guidelines"/></p>
+                    <xsl:apply-templates select="$object/tei:remarks/node()" mode="guidelines"/>
                 </div>
             </div>
         </xsl:if>


### PR DESCRIPTION
Multiple remarks have been concatenated without even a space. To fix this, this PR changes the XSLT to handle each paragraph in the remarks separately. 

### Before
<img width="686" alt="image" src="https://user-images.githubusercontent.com/7693447/151825567-9b626ec8-c7b0-4445-aa35-eca2dbe4e1ce.png">

### After
<img width="686" alt="image" src="https://user-images.githubusercontent.com/7693447/151825695-a13ff1c4-4519-46f6-ab56-65549dd0a387.png">
