### PR TITLE
Fix SMuFL glyphs in guidelines

### DIFF
--- a/utils/guidelines_xslt/generateGuidelines.xsl
+++ b/utils/guidelines_xslt/generateGuidelines.xsl
@@ -2052,7 +2052,7 @@
     <xsl:template name="getSinglePage">
         <xsl:param name="contents" as="node()*"/>
         
-        <html xml:lang="en">
+        <html lang="en">
             <head>
                 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
                 <xsl:comment>THIS FILE IS GENERATED FROM AN XML TEMPLATE. DO NOT EDIT!</xsl:comment>

--- a/utils/guidelines_xslt/odd2html/generateWebsite.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsite.xsl
@@ -1055,7 +1055,14 @@
         </xd:desc>
     </xd:doc>
     <xsl:template match="img/@src" mode="get.website">
-        <xsl:attribute name="src" select="'../' || ."/>
+        <xsl:choose>
+            <xsl:when test="starts-with(., 'http')">
+                <xsl:attribute name="src" select="."/>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:attribute name="src" select="'../' || ."/>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     
 </xsl:stylesheet>

--- a/utils/guidelines_xslt/odd2html/guidelines.xsl
+++ b/utils/guidelines_xslt/odd2html/guidelines.xsl
@@ -482,7 +482,14 @@
         </xd:desc>
     </xd:doc>
     <xsl:template match="tei:graphic" mode="guidelines">
-        <img class="graphic" src="{tools:adjustImageUrl(@url)}"/>
+        <xsl:choose>
+            <xsl:when test="@rend">
+                <img alt="SMuFL glyph" class="smufl" src="{@url}"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <img class="graphic" src="{tools:adjustImageUrl(@url)}"/>
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
     
     <xd:doc>

--- a/utils/guidelines_xslt/odd2html/guidelines.xsl
+++ b/utils/guidelines_xslt/odd2html/guidelines.xsl
@@ -487,7 +487,7 @@
                 <img alt="SMuFL glyph" class="smufl" src="{@url}"/>
             </xsl:when>
             <xsl:otherwise>
-                <img class="graphic" src="{tools:adjustImageUrl(@url)}"/>
+                <img alt="example" class="graphic" src="{tools:adjustImageUrl(@url)}"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>

--- a/utils/guidelines_xslt/odd2html/htmlFile.xsl
+++ b/utils/guidelines_xslt/odd2html/htmlFile.xsl
@@ -33,7 +33,7 @@
         <xsl:param name="reducedLevels" as="xs:boolean?"/>
         
         <xsl:variable name="cssPath" select="if($reducedLevels) then('') else('../')" as="xs:string"/>
-        <html xml:lang="en">
+        <html lang="en">
             <head>
                 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
                 <xsl:comment>THIS FILE IS GENERATED FROM AN XML TEMPLATE. DO NOT EDIT!</xsl:comment>


### PR DESCRIPTION
This PR fixes the wrong prefixing of URLs and brings a special treatment for SMuFL glyphs. 
Also this fixes the HTML lang attribute which was giving a validation error.
closes #908