### PR TITLE
Remodel exhibHist et. al. after provenance

### DIFF
--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -1119,11 +1119,29 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
+      <memberOf key="att.datable"/>
       <memberOf key="att.lang"/>
-      <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <rng:choice>
+        <rng:group>
+          <rng:zeroOrMore>
+            <rng:ref name="model.headLike"/>
+          </rng:zeroOrMore>
+          <rng:zeroOrMore>
+            <rng:choice>
+              <rng:ref name="eventList"/>
+              <rng:ref name="model.pLike"/>
+            </rng:choice>
+          </rng:zeroOrMore>
+        </rng:group>
+        <rng:zeroOrMore>
+          <rng:choice>
+            <rng:text/>
+            <rng:ref name="model.textPhraseLike.limited"/>
+          </rng:choice>
+        </rng:zeroOrMore>
+      </rng:choice>
     </content>
     <remarks>
       <p>This element is modelled on an element in the Encoded Archival Description (EAD)
@@ -1317,6 +1335,7 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
+      <memberOf key="model.physDescPart"/>
     </classes>
     <content>
       <rng:zeroOrMore>
@@ -1325,7 +1344,10 @@
       <rng:zeroOrMore>
         <rng:choice>
           <rng:ref name="acquisition"/>
+          <rng:ref name="exhibHist"/>
           <rng:ref name="provenance"/>
+          <rng:ref name="treatHist"/>
+          <rng:ref name="treatSched"/>
           <rng:ref name="model.divLike"/>
           <rng:ref name="model.textComponentLike"/>
         </rng:choice>
@@ -2615,11 +2637,29 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
+      <memberOf key="att.datable"/>
       <memberOf key="att.lang"/>
-      <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <rng:choice>
+        <rng:group>
+          <rng:zeroOrMore>
+            <rng:ref name="model.headLike"/>
+          </rng:zeroOrMore>
+          <rng:zeroOrMore>
+            <rng:choice>
+              <rng:ref name="eventList"/>
+              <rng:ref name="model.pLike"/>
+            </rng:choice>
+          </rng:zeroOrMore>
+        </rng:group>
+        <rng:zeroOrMore>
+          <rng:choice>
+            <rng:text/>
+            <rng:ref name="model.textPhraseLike.limited"/>
+          </rng:choice>
+        </rng:zeroOrMore>
+      </rng:choice>
     </content>
     <remarks>
       <p>Treatment history may also comprise details of the treatment process (<abbr>e.g.</abbr>, chemical
@@ -2636,11 +2676,29 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
+      <memberOf key="att.datable"/>
       <memberOf key="att.lang"/>
-      <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <rng:choice>
+        <rng:group>
+          <rng:zeroOrMore>
+            <rng:ref name="model.headLike"/>
+          </rng:zeroOrMore>
+          <rng:zeroOrMore>
+            <rng:choice>
+              <rng:ref name="eventList"/>
+              <rng:ref name="model.pLike"/>
+            </rng:choice>
+          </rng:zeroOrMore>
+        </rng:group>
+        <rng:zeroOrMore>
+          <rng:choice>
+            <rng:text/>
+            <rng:ref name="model.textPhraseLike.limited"/>
+          </rng:choice>
+        </rng:zeroOrMore>
+      </rng:choice>
     </content>
     <remarks>
       <p>This element is modelled on an element in the Encoded Archival Description (EAD)


### PR DESCRIPTION
This PR remodels `<exhibHist>`, `<treatHist>` and `<treatSched>`after `<provenance>` as proposed by the Metadata IG in #879. It also adds `<history>` to `<physDesc>`. Closes #879 