### PR TITLE
restrict constraint on clef lines

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -4856,7 +4856,7 @@
     </content>
     <constraintSpec ident="Clef_position_lines" scheme="isoschematron">
       <constraint>
-        <sch:rule context="mei:clef[ancestor::mei:staffDef[@lines]]">
+        <sch:rule context="mei:clef[matches(@shape, '[FCG]')][ancestor::mei:staffDef[@lines]]">
           <sch:let name="thisstaff" value="ancestor::mei:staffDef/@n"/>
           <sch:assert
             test="number(@line) &lt;= number(ancestor::mei:staffDef[@n=$thisstaff and @lines][1]/@lines)"


### PR DESCRIPTION
This brings the constraint inline with another one (line 596). As correctly stated there, percussion and tabular clef don't need a `line` specified, yet `<clef shape="perc" />` or `<clef shape="TAB" />` were marked as an error. 