### PR TITLE
Fix data.MIDINAMES

### DIFF
--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -2092,656 +2092,529 @@
     <content>
       <valList type="closed">
         <valItem ident="Acoustic_Grand_Piano">
-          <altIdent>Acoustic Grand Piano</altIdent>
-          <desc>Program #0.</desc>
+          <desc>Acoustic Grand Piano, MIDI Program Change #1.</desc>
         </valItem>
         <valItem ident="Bright_Acoustic_Piano">
-          <altIdent>Bright Acoustic Piano</altIdent>
-          <desc>Program #1.</desc>
+          <desc>Bright Acoustic Piano, MIDI Program Change #2.</desc>
         </valItem>
         <valItem ident="Electric_Grand_Piano">
-          <altIdent>Electric Grand Piano</altIdent>
-          <desc>Program #2.</desc>
+          <desc>Electric Grand Piano, MIDI Program Change #3.</desc>
         </valItem>
         <valItem ident="Honky-tonk_Piano">
-          <altIdent>Honky-tonk Piano</altIdent>
-          <desc>Program #3.</desc>
+          <desc>Honky-tonk Piano, MIDI Program Change #4.</desc>
         </valItem>
         <valItem ident="Electric_Piano_1">
-          <altIdent>Electric Piano 1</altIdent>
-          <desc>Program #4.</desc>
+          <desc>Electric Piano 1, MIDI Program Change #5.</desc>
         </valItem>
         <valItem ident="Electric_Piano_2">
-          <altIdent>Electric Piano 2</altIdent>
-          <desc>Program #5.</desc>
+          <desc>Electric Piano 2, MIDI Program Change #6.</desc>
         </valItem>
         <valItem ident="Harpsichord">
-          <desc>Program #6.</desc>
+          <desc>Harpsichord, MIDI Program Change #7.</desc>
         </valItem>
         <valItem ident="Clavi">
-          <desc>Program #7.</desc>
+          <desc>Clavi, MIDI Program Change #8.</desc>
         </valItem>
         <valItem ident="Celesta">
-          <desc>Program #8.</desc>
+          <desc>Celesta, MIDI Program Change #9.</desc>
         </valItem>
         <valItem ident="Glockenspiel">
-          <desc>Program #9.</desc>
+          <desc>Glockenspiel, MIDI Program Change #10.</desc>
         </valItem>
         <valItem ident="Music_Box">
-          <desc>Program #10.</desc>
+          <desc>Music Box, MIDI Program Change #11.</desc>
         </valItem>
         <valItem ident="Vibraphone">
-          <desc>Program #11.</desc>
+          <desc>Vibraphone, MIDI Program Change #12.</desc>
         </valItem>
         <valItem ident="Marimba">
-          <desc>Program #12.</desc>
+          <desc>Marimba, MIDI Program Change #13.</desc>
         </valItem>
         <valItem ident="Xylophone">
-          <desc>Program #13.</desc>
+          <desc>Xylophone, MIDI Program Change #14.</desc>
         </valItem>
         <valItem ident="Tubular_Bells">
-          <altIdent>Tubular Bells</altIdent>
-          <desc>Program #14.</desc>
+          <desc>Tubular Bells, MIDI Program Change #15.</desc>
         </valItem>
         <valItem ident="Dulcimer">
-          <desc>Program #15.</desc>
+          <desc>Dulcimer, MIDI Program Change #16.</desc>
         </valItem>
         <valItem ident="Drawbar_Organ">
-          <altIdent>Drawbar Organ</altIdent>
-          <desc>Program #16.</desc>
+          <desc>Drawbar Organ, MIDI Program Change #17.</desc>
         </valItem>
         <valItem ident="Percussive_Organ">
-          <altIdent>Percussive Organ</altIdent>
-          <desc>Program #17.</desc>
+          <desc>Percussive Organ, MIDI Program Change #18.</desc>
         </valItem>
         <valItem ident="Rock_Organ">
-          <altIdent>Rock Organ</altIdent>
-          <desc>Program #18.</desc>
+          <desc>Rock Organ, MIDI Program Change #19.</desc>
         </valItem>
         <valItem ident="Church_Organ">
-          <altIdent>Church Organ</altIdent>
-          <desc>Program #19.</desc>
+          <desc>Church Organ, MIDI Program Change #20.</desc>
         </valItem>
         <valItem ident="Reed_Organ">
-          <altIdent>Reed Organ</altIdent>
-          <desc>Program #20.</desc>
+          <desc>Reed Organ, MIDI Program Change #21.</desc>
         </valItem>
         <valItem ident="Accordion">
-          <desc>Program #21.</desc>
+          <desc>Accordion, MIDI Program Change #22.</desc>
         </valItem>
         <valItem ident="Harmonica">
-          <desc>Program #22.</desc>
+          <desc>Harmonica, MIDI Program Change #23.</desc>
         </valItem>
         <valItem ident="Tango_Accordion">
-          <altIdent>Tango Accordion</altIdent>
-          <desc>Program #23.</desc>
+          <desc>Tango Accordion, MIDI Program Change #24.</desc>
         </valItem>
         <valItem ident="Acoustic_Guitar_nylon">
-          <altIdent>Acoustic Guitar (nylon)</altIdent>
-          <desc>Program #24.</desc>
+          <desc>Acoustic Guitar (nylon), MIDI Program Change #25.</desc>
         </valItem>
         <valItem ident="Acoustic_Guitar_steel">
-          <altIdent>Acoustic Guitar (steel)</altIdent>
-          <desc>Program #25.</desc>
+          <desc>Acoustic Guitar (steel), MIDI Program Change #26.</desc>
         </valItem>
         <valItem ident="Electric_Guitar_jazz">
-          <altIdent>Electric Guitar (jazz)</altIdent>
-          <desc>Program #26.</desc>
+          <desc>Electric Guitar (jazz), MIDI Program Change #27.</desc>
         </valItem>
         <valItem ident="Electric_Guitar_clean">
-          <altIdent>Electric Guitar (clean)</altIdent>
-          <desc>Program #27.</desc>
+          <desc>Electric Guitar (clean), MIDI Program Change #28.</desc>
         </valItem>
         <valItem ident="Electric_Guitar_muted">
-          <altIdent>Electric Guitar (muted)</altIdent>
-          <desc>Program #28.</desc>
+          <desc>Electric Guitar (muted), MIDI Program Change #29.</desc>
         </valItem>
         <valItem ident="Overdriven_Guitar">
-          <altIdent>Overdriven Guitar</altIdent>
-          <desc>Program #29.</desc>
+          <desc>Overdriven Guitar, MIDI Program Change #30.</desc>
         </valItem>
         <valItem ident="Distortion_Guitar">
-          <altIdent>Distortion Guitar</altIdent>
-          <desc>Program #30.</desc>
+          <desc>Distortion Guitar, MIDI Program Change #31.</desc>
         </valItem>
         <valItem ident="Guitar_harmonics">
-          <altIdent>Guitar harmonics</altIdent>
-          <desc>Program #31.</desc>
+          <desc>Guitar harmonics, MIDI Program Change #32.</desc>
         </valItem>
         <valItem ident="Acoustic_Bass">
-          <altIdent>Acoustic Bass</altIdent>
-          <desc>Program #32.</desc>
+          <desc>Acoustic Bass, MIDI Program Change #33.</desc>
         </valItem>
         <valItem ident="Electric_Bass_finger">
-          <altIdent>Electric Bass (finger)</altIdent>
-          <desc>Program #33.</desc>
+          <desc>Electric Bass (finger), MIDI Program Change #34.</desc>
         </valItem>
         <valItem ident="Electric_Bass_pick">
-          <altIdent>Electric Bass (pick)</altIdent>
-          <desc>Program #34.</desc>
+          <desc>Electric Bass (pick), MIDI Program Change #35.</desc>
         </valItem>
         <valItem ident="Fretless_Bass">
-          <altIdent>Fretless Bass</altIdent>
-          <desc>Program #35.</desc>
+          <desc>Fretless Bass, MIDI Program Change #36.</desc>
         </valItem>
         <valItem ident="Slap_Bass_1">
-          <altIdent>Slap Bass 1</altIdent>
-          <desc>Program #36.</desc>
+          <desc>Slap Bass 1, MIDI Program Change #37.</desc>
         </valItem>
         <valItem ident="Slap_Bass_2">
-          <altIdent>Slap Bass 2</altIdent>
-          <desc>Program #37.</desc>
+          <desc>Slap Bass 2, MIDI Program Change #38.</desc>
         </valItem>
         <valItem ident="Synth_Bass_1">
-          <altIdent>Synth Bass 1</altIdent>
-          <desc>Program #38.</desc>
+          <desc>Synth Bass 1, MIDI Program Change #39.</desc>
         </valItem>
         <valItem ident="Synth_Bass_2">
-          <altIdent>Synth Bass 2</altIdent>
-          <desc>Program #39.</desc>
+          <desc>Synth Bass 2, MIDI Program Change #40.</desc>
         </valItem>
         <valItem ident="Violin">
-          <desc>Program #40.</desc>
+          <desc>Violin, MIDI Program Change #41.</desc>
         </valItem>
         <valItem ident="Viola">
-          <desc>Program #41.</desc>
+          <desc>Viola, MIDI Program Change #42.</desc>
         </valItem>
         <valItem ident="Cello">
-          <desc>Program #42.</desc>
+          <desc>Cello, MIDI Program Change #43.</desc>
         </valItem>
         <valItem ident="Contrabass">
-          <desc>Program #43.</desc>
+          <desc>Contrabass, MIDI Program Change #44.</desc>
         </valItem>
         <valItem ident="Tremolo_Strings">
-          <altIdent>Tremolo Strings</altIdent>
-          <desc>Program #44.</desc>
+          <desc>Tremolo Strings, MIDI Program Change #45.</desc>
         </valItem>
         <valItem ident="Pizzicato_Strings">
-          <altIdent>Pizzicato Strings</altIdent>
-          <desc>Program #45.</desc>
+          <desc>Pizzicato Strings, MIDI Program Change #46.</desc>
         </valItem>
         <valItem ident="Orchestral_Harp">
-          <altIdent>Orchestral Harp</altIdent>
-          <desc>Program #46.</desc>
+          <desc>Orchestral Harp, MIDI Program Change #47.</desc>
         </valItem>
         <valItem ident="Timpani">
-          <desc>Program #47.</desc>
+          <desc>Timpani, MIDI Program Change #48.</desc>
         </valItem>
         <valItem ident="String_Ensemble_1">
-          <altIdent>String Ensemble 1</altIdent>
-          <desc>Program #48.</desc>
+          <desc>String Ensemble 1, MIDI Program Change #49.</desc>
         </valItem>
         <valItem ident="String_Ensemble_2">
-          <altIdent>String Ensemble 2</altIdent>
-          <desc>Program #49.</desc>
+          <desc>String Ensemble 2, MIDI Program Change #50.</desc>
         </valItem>
         <valItem ident="SynthStrings_1">
-          <altIdent>SynthStrings 1</altIdent>
-          <desc>Program #50.</desc>
+          <desc>SynthStrings 1, MIDI Program Change #51.</desc>
         </valItem>
         <valItem ident="SynthStrings_2">
-          <altIdent>SynthStrings 2</altIdent>
-          <desc>Program #51.</desc>
+          <desc>SynthStrings 2, MIDI Program Change #52.</desc>
         </valItem>
         <valItem ident="Choir_Aahs">
-          <altIdent>Choir Aahs</altIdent>
-          <desc>Program #52.</desc>
+          <desc>Choir Aahs, MIDI Program Change #53.</desc>
         </valItem>
         <valItem ident="Voice_Oohs">
-          <altIdent>Voice Oohs</altIdent>
-          <desc>Program #53.</desc>
+          <desc>Voice Oohs, MIDI Program Change #54.</desc>
         </valItem>
         <valItem ident="Synth_Voice">
-          <altIdent>Synth Voice</altIdent>
-          <desc>Program #54.</desc>
+          <desc>Synth Voice, MIDI Program Change #55.</desc>
         </valItem>
         <valItem ident="Orchestra_Hit">
-          <altIdent>Orchestra Hit</altIdent>
-          <desc>Program #55.</desc>
+          <desc>Orchestra Hit, MIDI Program Change #56.</desc>
         </valItem>
         <valItem ident="Trumpet">
-          <desc>Program #56.</desc>
+          <desc>Trumpet, MIDI Program Change #57.</desc>
         </valItem>
         <valItem ident="Trombone">
-          <desc>Program #57.</desc>
+          <desc>Trombone, MIDI Program Change #58.</desc>
         </valItem>
         <valItem ident="Tuba">
-          <desc>Program #58.</desc>
+          <desc>Tuba, MIDI Program Change #59.</desc>
         </valItem>
         <valItem ident="Muted_Trumpet">
-          <altIdent>Muted Trumpet</altIdent>
-          <desc>Program #59.</desc>
+          <desc>Muted Trumpet, MIDI Program Change #60.</desc>
         </valItem>
         <valItem ident="French_Horn">
-          <altIdent>French Horn</altIdent>
-          <desc>Program #60.</desc>
+          <desc>French Horn, MIDI Program Change #61.</desc>
         </valItem>
         <valItem ident="Brass_Section">
-          <altIdent>Brass Section</altIdent>
-          <desc>Program #61.</desc>
+          <desc>Brass Section, MIDI Program Change #62.</desc>
         </valItem>
         <valItem ident="SynthBrass_1">
-          <altIdent>SynthBrass 1</altIdent>
-          <desc>Program #62.</desc>
+          <desc>SynthBrass 1, MIDI Program Change #63.</desc>
         </valItem>
         <valItem ident="SynthBrass_2">
-          <altIdent>SynthBrass 2</altIdent>
-          <desc>Program #63.</desc>
+          <desc>SynthBrass 2, MIDI Program Change #64.</desc>
         </valItem>
         <valItem ident="Soprano_Sax">
-          <altIdent>Soprano Sax</altIdent>
-          <desc>Program #64.</desc>
+          <desc>Soprano Sax, MIDI Program Change #65.</desc>
         </valItem>
         <valItem ident="Alto_Sax">
-          <altIdent>Alto Sax</altIdent>
-          <desc>Program #65.</desc>
+          <desc>Alto Sax, MIDI Program Change #66.</desc>
         </valItem>
         <valItem ident="Tenor_Sax">
-          <altIdent>Tenor Sax</altIdent>
-          <desc>Program #66.</desc>
+          <desc>Tenor Sax, MIDI Program Change #67.</desc>
         </valItem>
         <valItem ident="Baritone_Sax">
-          <altIdent>Baritone Sax</altIdent>
-          <desc>Program #67.</desc>
+          <desc>Baritone Sax, MIDI Program Change #68.</desc>
         </valItem>
         <valItem ident="Oboe">
-          <desc>Program #68.</desc>
+          <desc>Oboe, MIDI Program Change #69.</desc>
         </valItem>
         <valItem ident="English_Horn">
-          <altIdent>English Horn</altIdent>
-          <desc>Program #69.</desc>
+          <desc>English Horn, MIDI Program Change #70.</desc>
         </valItem>
         <valItem ident="Bassoon">
-          <desc>Program #70.</desc>
+          <desc>Bassoon, MIDI Program Change #71.</desc>
         </valItem>
         <valItem ident="Clarinet">
-          <desc>Program #71.</desc>
+          <desc>Clarinet, MIDI Program Change #72.</desc>
         </valItem>
         <valItem ident="Piccolo">
-          <desc>Program #72.</desc>
+          <desc>Piccolo, MIDI Program Change #73.</desc>
         </valItem>
         <valItem ident="Flute">
-          <desc>Program #73.</desc>
+          <desc>Flute, MIDI Program Change #74.</desc>
         </valItem>
         <valItem ident="Recorder">
-          <desc>Program #74.</desc>
+          <desc>Recorder, MIDI Program Change #75.</desc>
         </valItem>
         <valItem ident="Pan_Flute">
-          <altIdent>Pan Flute</altIdent>
-          <desc>Program #75.</desc>
+          <desc>Pan Flute, MIDI Program Change #76.</desc>
         </valItem>
         <valItem ident="Blown_Bottle">
-          <altIdent>Blown Bottle</altIdent>
-          <desc>Program #76.</desc>
+          <desc>Blown Bottle, MIDI Program Change #77.</desc>
         </valItem>
         <valItem ident="Shakuhachi">
-          <desc>Program #77.</desc>
+          <desc>Shakuhachi, MIDI Program Change #78.</desc>
         </valItem>
         <valItem ident="Whistle">
-          <desc>Program #78.</desc>
+          <desc>Whistle, MIDI Program Change #79.</desc>
         </valItem>
         <valItem ident="Ocarina">
-          <desc>Program #79.</desc>
+          <desc>Ocarina, MIDI Program Change #80.</desc>
         </valItem>
         <valItem ident="Lead_1_square">
-          <altIdent>Lead 1 (square)</altIdent>
-          <desc>Program #80.</desc>
+          <desc>Lead 1 (square), MIDI Program Change #81.</desc>
         </valItem>
         <valItem ident="Lead_2_sawtooth">
-          <altIdent>Lead 2 (sawtooth)</altIdent>
-          <desc>Program #81.</desc>
+          <desc>Lead 2 (sawtooth), MIDI Program Change #82.</desc>
         </valItem>
         <valItem ident="Lead_3_calliope">
-          <altIdent>Lead 3 (calliope)</altIdent>
-          <desc>Program #82.</desc>
+          <desc>Lead 3 (calliope), MIDI Program Change #83.</desc>
         </valItem>
         <valItem ident="Lead_4_chiff">
-          <altIdent>Lead 4 (chiff)</altIdent>
-          <desc>Program #83.</desc>
+          <desc>Lead 4 (chiff), MIDI Program Change #84.</desc>
         </valItem>
         <valItem ident="Lead_5_charang">
-          <altIdent>Lead 5 (charang)</altIdent>
-          <desc>Program #84.</desc>
+          <desc>Lead 5 (charang), MIDI Program Change #85.</desc>
         </valItem>
         <valItem ident="Lead_6_voice">
-          <altIdent>Lead 6 (voice)</altIdent>
-          <desc>Program #85.</desc>
+          <desc>Lead 6 (voice), MIDI Program Change #86.</desc>
         </valItem>
         <valItem ident="Lead_7_fifths">
-          <altIdent>Lead 7 (fifths)</altIdent>
-          <desc>Program #86.</desc>
+          <desc>Lead 7 (fifths), MIDI Program Change #87.</desc>
         </valItem>
         <valItem ident="Lead_8_bass_and_lead">
-          <altIdent>Lead 8 (bass + lead)</altIdent>
-          <desc>Program #87.</desc>
+          <desc>Lead 8 (bass + lead), MIDI Program Change #88.</desc>
         </valItem>
         <valItem ident="Pad_1_new_age">
-          <altIdent>Pad 1 (new age)</altIdent>
-          <desc>Program #88.</desc>
+          <desc>Pad 1 (new age), MIDI Program Change #89.</desc>
         </valItem>
         <valItem ident="Pad_2_warm">
-          <altIdent>Pad 2 (warm)</altIdent>
-          <desc>Program #89.</desc>
+          <desc>Pad 2 (warm), MIDI Program Change #90.</desc>
         </valItem>
         <valItem ident="Pad_3_polysynth">
-          <altIdent>Pad 3 (polysynth)</altIdent>
-          <desc>Program #90.</desc>
+          <desc>Pad 3 (polysynth), MIDI Program Change #91.</desc>
         </valItem>
         <valItem ident="Pad_4_choir">
-          <altIdent>Pad 4 (choir)</altIdent>
-          <desc>Program #91.</desc>
+          <desc>Pad 4 (choir), MIDI Program Change #92.</desc>
         </valItem>
         <valItem ident="Pad_5_bowed">
-          <altIdent>Pad 5 (bowed)</altIdent>
-          <desc>Program #92.</desc>
+          <desc>Pad 5 (bowed), MIDI Program Change #93.</desc>
         </valItem>
         <valItem ident="Pad_6_metallic">
-          <altIdent>Pad 6 (metallic)</altIdent>
-          <desc>Program #93.</desc>
+          <desc>Pad 6 (metallic), MIDI Program Change #94.</desc>
         </valItem>
         <valItem ident="Pad_7_halo">
-          <altIdent>Pad 7 (halo)</altIdent>
-          <desc>Program #94.</desc>
+          <desc>Pad 7 (halo), MIDI Program Change #95.</desc>
         </valItem>
         <valItem ident="Pad_8_sweep">
-          <altIdent>Pad 8 (sweep)</altIdent>
-          <desc>Program #95.</desc>
+          <desc>Pad 8 (sweep), MIDI Program Change #96.</desc>
         </valItem>
         <valItem ident="FX_1_rain">
-          <altIdent>FX 1 (rain)</altIdent>
-          <desc>Program #96.</desc>
+          <desc>FX 1 (rain), MIDI Program Change #97.</desc>
         </valItem>
         <valItem ident="FX_2_soundtrack">
-          <altIdent>FX 2 (soundtrack)</altIdent>
-          <desc>Program #97.</desc>
+          <desc>FX 2 (soundtrack), MIDI Program Change #98.</desc>
         </valItem>
         <valItem ident="FX_3_crystal">
-          <altIdent>FX 3 (crystal)</altIdent>
-          <desc>Program #98.</desc>
+          <desc>FX 3 (crystal), MIDI Program Change #99.</desc>
         </valItem>
         <valItem ident="FX_4_atmosphere">
-          <altIdent>FX 4 (atmosphere)</altIdent>
-          <desc>Program #99.</desc>
+          <desc>FX 4 (atmosphere), MIDI Program Change #100.</desc>
         </valItem>
         <valItem ident="FX_5_brightness">
-          <altIdent>FX 5 (brightness)</altIdent>
-          <desc>Program #100.</desc>
+          <desc>FX 5 (brightness), MIDI Program Change #101.</desc>
         </valItem>
         <valItem ident="FX_6_goblins">
-          <altIdent>FX 6 (goblins)</altIdent>
-          <desc>Program #101.</desc>
+          <desc>FX 6 (goblins), MIDI Program Change #102.</desc>
         </valItem>
         <valItem ident="FX_7_echoes">
-          <altIdent>FX 7 (echoes)</altIdent>
-          <desc>Program #102.</desc>
+          <desc>FX 7 (echoes), MIDI Program Change #103.</desc>
         </valItem>
         <valItem ident="FX_8_sci-fi">
-          <altIdent>FX 8 (sci-fi)</altIdent>
-          <desc>Program #103.</desc>
+          <desc>FX 8 (sci-fi), MIDI Program Change #104.</desc>
         </valItem>
         <valItem ident="Sitar">
-          <desc>Program #104.</desc>
+          <desc>Sitar, MIDI Program Change #105.</desc>
         </valItem>
         <valItem ident="Banjo">
-          <desc>Program #105.</desc>
+          <desc>Banjo, MIDI Program Change #106.</desc>
         </valItem>
         <valItem ident="Shamisen">
-          <desc>Program #106.</desc>
+          <desc>Shamisen, MIDI Program Change #107.</desc>
         </valItem>
         <valItem ident="Koto">
-          <desc>Program #107.</desc>
+          <desc>Koto, MIDI Program Change #108.</desc>
         </valItem>
         <valItem ident="Kalimba">
-          <desc>Program #108.</desc>
+          <desc>Kalimba, MIDI Program Change #109.</desc>
         </valItem>
-        <valItem ident="Bagpipe">
-          <desc>Program #109.</desc>
+        <valItem ident="Bag_pipe">
+          <desc>Bag pipe, MIDI Program Change #110.</desc>
         </valItem>
         <valItem ident="Fiddle">
-          <desc>Program #110.</desc>
+          <desc>Fiddle, MIDI Program Change #111.</desc>
         </valItem>
         <valItem ident="Shanai">
-          <desc>Program #111.</desc>
+          <desc>Shanai, MIDI Program Change #112.</desc>
         </valItem>
         <valItem ident="Tinkle_Bell">
-          <altIdent>Tinkle Bell</altIdent>
-          <desc>Program #112.</desc>
+          <desc>Tinkle Bell, MIDI Program Change #113.</desc>
         </valItem>
         <valItem ident="Agogo">
-          <desc>Program #113.</desc>
+          <desc>Agogo, MIDI Program Change #114.</desc>
         </valItem>
         <valItem ident="Steel_Drums">
-          <altIdent>Steel Drums</altIdent>
-          <desc>Program #114.</desc>
+          <desc>Steel Drums, MIDI Program Change #115.</desc>
         </valItem>
         <valItem ident="Woodblock">
-          <desc>Program #115.</desc>
+          <desc>Woodblock, MIDI Program Change #116.</desc>
         </valItem>
         <valItem ident="Taiko_Drum">
-          <altIdent>Taiko Drum</altIdent>
-          <desc>Program #116.</desc>
+          <desc>Taiko Drum, MIDI Program Change #117.</desc>
         </valItem>
         <valItem ident="Melodic_Tom">
-          <altIdent>Melodic Tom</altIdent>
-          <desc>Program #117.</desc>
+          <desc>Melodic Tom, MIDI Program Change #118.</desc>
         </valItem>
         <valItem ident="Synth_Drum">
-          <altIdent>Synth Drum</altIdent>
-          <desc>Program #118.</desc>
+          <desc>Synth Drum, MIDI Program Change #119.</desc>
         </valItem>
         <valItem ident="Reverse_Cymbal">
-          <altIdent>Reverse Cymbal</altIdent>
-          <desc>Program #119.</desc>
+          <desc>Reverse Cymbal, MIDI Program Change #120.</desc>
         </valItem>
         <valItem ident="Guitar_Fret_Noise">
-          <altIdent>Guitar Fret Noise</altIdent>
-          <desc>Program #120.</desc>
+          <desc>Guitar Fret Noise, MIDI Program Change #121.</desc>
         </valItem>
         <valItem ident="Breath_Noise">
-          <altIdent>Breath Noise</altIdent>
-          <desc>Program #121.</desc>
+          <desc>Breath Noise, MIDI Program Change #122.</desc>
         </valItem>
         <valItem ident="Seashore">
-          <desc>Program #122.</desc>
+          <desc>Seashore, MIDI Program Change #123.</desc>
         </valItem>
         <valItem ident="Bird_Tweet">
-          <altIdent>Bird Tweet</altIdent>
-          <desc>Program #123.</desc>
+          <desc>Bird Tweet, MIDI Program Change #124.</desc>
         </valItem>
         <valItem ident="Telephone_Ring">
-          <altIdent>Telephone Ring</altIdent>
-          <desc>Program #124.</desc>
+          <desc>Telephone Ring, MIDI Program Change #125.</desc>
         </valItem>
         <valItem ident="Helicopter">
-          <desc>Program #125.</desc>
+          <desc>Helicopter, MIDI Program Change #126.</desc>
         </valItem>
         <valItem ident="Applause">
-          <desc>Program #126.</desc>
+          <desc>Applause, MIDI Program Change #127.</desc>
         </valItem>
         <valItem ident="Gunshot">
-          <desc>Program #127.</desc>
+          <desc>Gunshot, MIDI Program Change #128.</desc>
         </valItem>
         <valItem ident="Acoustic_Bass_Drum">
-          <altIdent>Acoustic Bass Drum</altIdent>
-          <desc>Key #35.</desc>
+          <desc>Acoustic Bass Drum, Key #35.</desc>
         </valItem>
         <valItem ident="Bass_Drum_1">
-          <altIdent>Bass Drum 1</altIdent>
-          <desc>Key #36.</desc>
+          <desc>Bass Drum 1, Key #36.</desc>
         </valItem>
         <valItem ident="Side_Stick">
-          <altIdent>Side Stick</altIdent>
-          <desc>Key #37.</desc>
+          <desc>Side Stick, Key #37.</desc>
         </valItem>
         <valItem ident="Acoustic_Snare">
-          <altIdent>Acoustic Snare</altIdent>
-          <desc>Key #38.</desc>
+          <desc>Acoustic Snare, Key #38.</desc>
         </valItem>
         <valItem ident="Hand_Clap">
-          <altIdent>Hand Clap</altIdent>
-          <desc>Key #39.</desc>
+          <desc>Hand Clap, Key #39.</desc>
         </valItem>
         <valItem ident="Electric_Snare">
-          <altIdent>Electric Snare</altIdent>
-          <desc>Key #40.</desc>
+          <desc>Electric Snare, Key #40.</desc>
         </valItem>
         <valItem ident="Low_Floor_Tom">
-          <altIdent>Low Floor Tom</altIdent>
-          <desc>Key #41.</desc>
+          <desc>Low Floor Tom, Key #41.</desc>
         </valItem>
         <valItem ident="Closed_Hi_Hat">
-          <altIdent>Closed Hi Hat</altIdent>
-          <desc>Key #42.</desc>
+          <desc>Closed Hi Hat, Key #42.</desc>
         </valItem>
         <valItem ident="High_Floor_Tom">
-          <altIdent>High Floor Tom</altIdent>
-          <desc>Key #43.</desc>
+          <desc>High Floor Tom, Key #43.</desc>
         </valItem>
         <valItem ident="Pedal_Hi-Hat">
-          <altIdent>Pedal Hi-Hat</altIdent>
-          <desc>Key #44.</desc>
+          <desc>Pedal Hi-Hat, Key #44.</desc>
         </valItem>
         <valItem ident="Low_Tom">
-          <altIdent>Low Tom</altIdent>
-          <desc>Key #45.</desc>
+          <desc>Low Tom, Key #45.</desc>
         </valItem>
         <valItem ident="Open_Hi-Hat">
-          <altIdent>Open Hi-Hat</altIdent>
-          <desc>Key #46.</desc>
+          <desc>Open Hi-Hat, Key #46.</desc>
         </valItem>
         <valItem ident="Low-Mid_Tom">
-          <altIdent>Low-Mid Tom</altIdent>
-          <desc>Key #47.</desc>
+          <desc>Low-Mid Tom, Key #47.</desc>
         </valItem>
         <valItem ident="Hi-Mid_Tom">
-          <altIdent>Hi-Mid Tom</altIdent>
-          <desc>Key #48.</desc>
+          <desc>Hi-Mid Tom, Key #48.</desc>
         </valItem>
         <valItem ident="Crash_Cymbal_1">
-          <altIdent>Crash Cymbal 1</altIdent>
-          <desc>Key #49.</desc>
+          <desc>Crash Cymbal 1, Key #49.</desc>
         </valItem>
         <valItem ident="High_Tom">
-          <altIdent>High Tom</altIdent>
-          <desc>Key #50.</desc>
+          <desc>High Tom, Key #50.</desc>
         </valItem>
         <valItem ident="Ride_Cymbal_1">
-          <altIdent>Ride Cymbal 1</altIdent>
-          <desc>Key #51.</desc>
+          <desc>Ride Cymbal 1, Key #51.</desc>
         </valItem>
         <valItem ident="Chinese_Cymbal">
-          <altIdent>Chinese Cymbal</altIdent>
-          <desc>Key #52.</desc>
+          <desc>Chinese Cymbal, Key #52.</desc>
         </valItem>
         <valItem ident="Ride_Bell">
-          <altIdent>Ride Bell</altIdent>
-          <desc>Key #53.</desc>
+          <desc>Ride Bell, Key #53.</desc>
         </valItem>
         <valItem ident="Tambourine">
-          <desc>Key #54.</desc>
+          <desc>Tambourine, Key #54.</desc>
         </valItem>
         <valItem ident="Splash_Cymbal">
-          <altIdent>Splash Cymbal</altIdent>
-          <desc>Key #55.</desc>
+          <desc>Splash Cymbal, Key #55.</desc>
         </valItem>
         <valItem ident="Cowbell">
-          <desc>Key #56.</desc>
+          <desc>Cowbell, Key #56.</desc>
         </valItem>
         <valItem ident="Crash_Cymbal_2">
-          <altIdent>Crash Cymbal 2</altIdent>
-          <desc>Key #57.</desc>
+          <desc>Crash Cymbal 2, Key #57.</desc>
         </valItem>
         <valItem ident="Vibraslap">
-          <desc>Key #58.</desc>
+          <desc>Vibraslap, Key #58.</desc>
         </valItem>
         <valItem ident="Ride_Cymbal_2">
-          <altIdent>Ride Cymbal 2</altIdent>
-          <desc>Key #59.</desc>
+          <desc>Ride Cymbal 2, Key #59.</desc>
         </valItem>
         <valItem ident="Hi_Bongo">
-          <altIdent>Hi Bongo</altIdent>
-          <desc>Key #60.</desc>
+          <desc>Hi Bongo, Key #60.</desc>
         </valItem>
         <valItem ident="Low_Bongo">
-          <altIdent>Low Bongo</altIdent>
-          <desc>Key #61.</desc>
+          <desc>Low Bongo, Key #61.</desc>
         </valItem>
         <valItem ident="Mute_Hi_Conga">
-          <altIdent>Mute Hi Conga</altIdent>
-          <desc>Key #62.</desc>
+          <desc>Mute Hi Conga, Key #62.</desc>
         </valItem>
         <valItem ident="Open_Hi_Conga">
-          <altIdent>Open Hi Conga</altIdent>
-          <desc>Key #63.</desc>
+          <desc>Open Hi Conga, Key #63.</desc>
         </valItem>
         <valItem ident="Low_Conga">
-          <altIdent>Low Conga</altIdent>
-          <desc>Key #64.</desc>
+          <desc>Low Conga, Key #64.</desc>
         </valItem>
         <valItem ident="High_Timbale">
-          <altIdent>High Timbale</altIdent>
-          <desc>Key #65.</desc>
+          <desc>High Timbale, Key #65.</desc>
         </valItem>
         <valItem ident="Low_Timbale">
-          <altIdent>Low Timbale</altIdent>
-          <desc>Key #66.</desc>
+          <desc>Low Timbale, Key #66.</desc>
         </valItem>
         <valItem ident="High_Agogo">
-          <altIdent>High Agogo</altIdent>
-          <desc>Key #67.</desc>
+          <desc>High Agogo, Key #67.</desc>
         </valItem>
         <valItem ident="Low_Agogo">
-          <altIdent>Low Agogo</altIdent>
-          <desc>Key #68.</desc>
+          <desc>Low Agogo, Key #68.</desc>
         </valItem>
         <valItem ident="Cabasa">
-          <desc>Key #69.</desc>
+          <desc>Cabasa, Key #69.</desc>
         </valItem>
         <valItem ident="Maracas">
-          <desc>Key #70.</desc>
+          <desc>Maracas, Key #70.</desc>
         </valItem>
         <valItem ident="Short_Whistle">
-          <altIdent>Short Whistle</altIdent>
-          <desc>Key #71.</desc>
+          <desc>Short Whistle, Key #71.</desc>
         </valItem>
         <valItem ident="Long_Whistle">
-          <altIdent>Long Whistle</altIdent>
-          <desc>Key #72.</desc>
+          <desc>Long Whistle, Key #72.</desc>
         </valItem>
         <valItem ident="Short_Guiro">
-          <altIdent>Short Guiro</altIdent>
-          <desc>Key #73.</desc>
+          <desc>Short Guiro, Key #73.</desc>
         </valItem>
         <valItem ident="Long_Guiro">
-          <altIdent>Long Guiro</altIdent>
-          <desc>Key #74.</desc>
+          <desc>Long Guiro, Key #74.</desc>
         </valItem>
         <valItem ident="Claves">
-          <desc>Key #75.</desc>
+          <desc>Claves, Key #75.</desc>
         </valItem>
         <valItem ident="Hi_Wood_Block">
-          <altIdent>Hi Wood Block</altIdent>
-          <desc>Key #76.</desc>
+          <desc>Hi Wood Block, Key #76.</desc>
         </valItem>
         <valItem ident="Low_Wood_Block">
-          <altIdent>Low Wood Block</altIdent>
-          <desc>Key #77.</desc>
+          <desc>Low Wood Block, Key #77.</desc>
         </valItem>
         <valItem ident="Mute_Cuica">
-          <altIdent>Mute Cuica</altIdent>
-          <desc>Key #78.</desc>
+          <desc>Mute Cuica, Key #78.</desc>
         </valItem>
         <valItem ident="Open_Cuica">
-          <altIdent>Open Cuica</altIdent>
-          <desc>Key #79.</desc>
+          <desc>Open Cuica, Key #79.</desc>
         </valItem>
         <valItem ident="Mute_Triangle">
-          <altIdent>Mute Triangle</altIdent>
-          <desc>Key #80.</desc>
+          <desc>Mute Triangle, Key #80.</desc>
         </valItem>
         <valItem ident="Open_Triangle">
-          <altIdent>Open Triangle</altIdent>
-          <desc>Key #81.</desc>
+          <desc>Open Triangle, Key #81.</desc>
         </valItem>
       </valList>
     </content>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -2092,388 +2092,388 @@
     <content>
       <valList type="closed">
         <valItem ident="Acoustic_Grand_Piano">
-          <desc>Acoustic Grand Piano, MIDI Program Change #1.</desc>
+          <desc>Acoustic Grand Piano, Program #0.</desc>
         </valItem>
         <valItem ident="Bright_Acoustic_Piano">
-          <desc>Bright Acoustic Piano, MIDI Program Change #2.</desc>
+          <desc>Bright Acoustic Piano, Program #1.</desc>
         </valItem>
         <valItem ident="Electric_Grand_Piano">
-          <desc>Electric Grand Piano, MIDI Program Change #3.</desc>
+          <desc>Electric Grand Piano, Program #2.</desc>
         </valItem>
         <valItem ident="Honky-tonk_Piano">
-          <desc>Honky-tonk Piano, MIDI Program Change #4.</desc>
+          <desc>Honky-tonk Piano, Program #3.</desc>
         </valItem>
         <valItem ident="Electric_Piano_1">
-          <desc>Electric Piano 1, MIDI Program Change #5.</desc>
+          <desc>Electric Piano 1, Program #4.</desc>
         </valItem>
         <valItem ident="Electric_Piano_2">
-          <desc>Electric Piano 2, MIDI Program Change #6.</desc>
+          <desc>Electric Piano 2, Program #5.</desc>
         </valItem>
         <valItem ident="Harpsichord">
-          <desc>Harpsichord, MIDI Program Change #7.</desc>
+          <desc>Harpsichord, Program #6.</desc>
         </valItem>
         <valItem ident="Clavi">
-          <desc>Clavi, MIDI Program Change #8.</desc>
+          <desc>Clavi, Program #7.</desc>
         </valItem>
         <valItem ident="Celesta">
-          <desc>Celesta, MIDI Program Change #9.</desc>
+          <desc>Celesta, Program #8.</desc>
         </valItem>
         <valItem ident="Glockenspiel">
-          <desc>Glockenspiel, MIDI Program Change #10.</desc>
+          <desc>Glockenspiel, Program #9.</desc>
         </valItem>
         <valItem ident="Music_Box">
-          <desc>Music Box, MIDI Program Change #11.</desc>
+          <desc>Music Box, Program #10.</desc>
         </valItem>
         <valItem ident="Vibraphone">
-          <desc>Vibraphone, MIDI Program Change #12.</desc>
+          <desc>Vibraphone, Program #11.</desc>
         </valItem>
         <valItem ident="Marimba">
-          <desc>Marimba, MIDI Program Change #13.</desc>
+          <desc>Marimba, Program #12.</desc>
         </valItem>
         <valItem ident="Xylophone">
-          <desc>Xylophone, MIDI Program Change #14.</desc>
+          <desc>Xylophone, Program #13.</desc>
         </valItem>
         <valItem ident="Tubular_Bells">
-          <desc>Tubular Bells, MIDI Program Change #15.</desc>
+          <desc>Tubular Bells, Program #14.</desc>
         </valItem>
         <valItem ident="Dulcimer">
-          <desc>Dulcimer, MIDI Program Change #16.</desc>
+          <desc>Dulcimer, Program #15.</desc>
         </valItem>
         <valItem ident="Drawbar_Organ">
-          <desc>Drawbar Organ, MIDI Program Change #17.</desc>
+          <desc>Drawbar Organ, Program #16.</desc>
         </valItem>
         <valItem ident="Percussive_Organ">
-          <desc>Percussive Organ, MIDI Program Change #18.</desc>
+          <desc>Percussive Organ, Program #17.</desc>
         </valItem>
         <valItem ident="Rock_Organ">
-          <desc>Rock Organ, MIDI Program Change #19.</desc>
+          <desc>Rock Organ, Program #18.</desc>
         </valItem>
         <valItem ident="Church_Organ">
-          <desc>Church Organ, MIDI Program Change #20.</desc>
+          <desc>Church Organ, Program #19.</desc>
         </valItem>
         <valItem ident="Reed_Organ">
-          <desc>Reed Organ, MIDI Program Change #21.</desc>
+          <desc>Reed Organ, Program #20.</desc>
         </valItem>
         <valItem ident="Accordion">
-          <desc>Accordion, MIDI Program Change #22.</desc>
+          <desc>Accordion, Program #21.</desc>
         </valItem>
         <valItem ident="Harmonica">
-          <desc>Harmonica, MIDI Program Change #23.</desc>
+          <desc>Harmonica, Program #22.</desc>
         </valItem>
         <valItem ident="Tango_Accordion">
-          <desc>Tango Accordion, MIDI Program Change #24.</desc>
+          <desc>Tango Accordion, Program #23.</desc>
         </valItem>
         <valItem ident="Acoustic_Guitar_nylon">
-          <desc>Acoustic Guitar (nylon), MIDI Program Change #25.</desc>
+          <desc>Acoustic Guitar (nylon), Program #24.</desc>
         </valItem>
         <valItem ident="Acoustic_Guitar_steel">
-          <desc>Acoustic Guitar (steel), MIDI Program Change #26.</desc>
+          <desc>Acoustic Guitar (steel), Program #25.</desc>
         </valItem>
         <valItem ident="Electric_Guitar_jazz">
-          <desc>Electric Guitar (jazz), MIDI Program Change #27.</desc>
+          <desc>Electric Guitar (jazz), Program #26.</desc>
         </valItem>
         <valItem ident="Electric_Guitar_clean">
-          <desc>Electric Guitar (clean), MIDI Program Change #28.</desc>
+          <desc>Electric Guitar (clean), Program #27.</desc>
         </valItem>
         <valItem ident="Electric_Guitar_muted">
-          <desc>Electric Guitar (muted), MIDI Program Change #29.</desc>
+          <desc>Electric Guitar (muted), Program #28.</desc>
         </valItem>
         <valItem ident="Overdriven_Guitar">
-          <desc>Overdriven Guitar, MIDI Program Change #30.</desc>
+          <desc>Overdriven Guitar, Program #29.</desc>
         </valItem>
         <valItem ident="Distortion_Guitar">
-          <desc>Distortion Guitar, MIDI Program Change #31.</desc>
+          <desc>Distortion Guitar, Program #30.</desc>
         </valItem>
         <valItem ident="Guitar_harmonics">
-          <desc>Guitar harmonics, MIDI Program Change #32.</desc>
+          <desc>Guitar harmonics, Program #31.</desc>
         </valItem>
         <valItem ident="Acoustic_Bass">
-          <desc>Acoustic Bass, MIDI Program Change #33.</desc>
+          <desc>Acoustic Bass, Program #32.</desc>
         </valItem>
         <valItem ident="Electric_Bass_finger">
-          <desc>Electric Bass (finger), MIDI Program Change #34.</desc>
+          <desc>Electric Bass (finger), Program #33.</desc>
         </valItem>
         <valItem ident="Electric_Bass_pick">
-          <desc>Electric Bass (pick), MIDI Program Change #35.</desc>
+          <desc>Electric Bass (pick), Program #34.</desc>
         </valItem>
         <valItem ident="Fretless_Bass">
-          <desc>Fretless Bass, MIDI Program Change #36.</desc>
+          <desc>Fretless Bass, Program #35.</desc>
         </valItem>
         <valItem ident="Slap_Bass_1">
-          <desc>Slap Bass 1, MIDI Program Change #37.</desc>
+          <desc>Slap Bass 1, Program #36.</desc>
         </valItem>
         <valItem ident="Slap_Bass_2">
-          <desc>Slap Bass 2, MIDI Program Change #38.</desc>
+          <desc>Slap Bass 2, Program #37.</desc>
         </valItem>
         <valItem ident="Synth_Bass_1">
-          <desc>Synth Bass 1, MIDI Program Change #39.</desc>
+          <desc>Synth Bass 1, Program #38.</desc>
         </valItem>
         <valItem ident="Synth_Bass_2">
-          <desc>Synth Bass 2, MIDI Program Change #40.</desc>
+          <desc>Synth Bass 2, Program #39.</desc>
         </valItem>
         <valItem ident="Violin">
-          <desc>Violin, MIDI Program Change #41.</desc>
+          <desc>Violin, Program #40.</desc>
         </valItem>
         <valItem ident="Viola">
-          <desc>Viola, MIDI Program Change #42.</desc>
+          <desc>Viola, Program #41.</desc>
         </valItem>
         <valItem ident="Cello">
-          <desc>Cello, MIDI Program Change #43.</desc>
+          <desc>Cello, Program #42.</desc>
         </valItem>
         <valItem ident="Contrabass">
-          <desc>Contrabass, MIDI Program Change #44.</desc>
+          <desc>Contrabass, Program #43.</desc>
         </valItem>
         <valItem ident="Tremolo_Strings">
-          <desc>Tremolo Strings, MIDI Program Change #45.</desc>
+          <desc>Tremolo Strings, Program #44.</desc>
         </valItem>
         <valItem ident="Pizzicato_Strings">
-          <desc>Pizzicato Strings, MIDI Program Change #46.</desc>
+          <desc>Pizzicato Strings, Program #45.</desc>
         </valItem>
         <valItem ident="Orchestral_Harp">
-          <desc>Orchestral Harp, MIDI Program Change #47.</desc>
+          <desc>Orchestral Harp, Program #46.</desc>
         </valItem>
         <valItem ident="Timpani">
-          <desc>Timpani, MIDI Program Change #48.</desc>
+          <desc>Timpani, Program #47.</desc>
         </valItem>
         <valItem ident="String_Ensemble_1">
-          <desc>String Ensemble 1, MIDI Program Change #49.</desc>
+          <desc>String Ensemble 1, Program #48.</desc>
         </valItem>
         <valItem ident="String_Ensemble_2">
-          <desc>String Ensemble 2, MIDI Program Change #50.</desc>
+          <desc>String Ensemble 2, Program #49.</desc>
         </valItem>
         <valItem ident="SynthStrings_1">
-          <desc>SynthStrings 1, MIDI Program Change #51.</desc>
+          <desc>SynthStrings 1, Program #50.</desc>
         </valItem>
         <valItem ident="SynthStrings_2">
-          <desc>SynthStrings 2, MIDI Program Change #52.</desc>
+          <desc>SynthStrings 2, Program #51.</desc>
         </valItem>
         <valItem ident="Choir_Aahs">
-          <desc>Choir Aahs, MIDI Program Change #53.</desc>
+          <desc>Choir Aahs, Program #52.</desc>
         </valItem>
         <valItem ident="Voice_Oohs">
-          <desc>Voice Oohs, MIDI Program Change #54.</desc>
+          <desc>Voice Oohs, Program #53.</desc>
         </valItem>
         <valItem ident="Synth_Voice">
-          <desc>Synth Voice, MIDI Program Change #55.</desc>
+          <desc>Synth Voice, Program #54.</desc>
         </valItem>
         <valItem ident="Orchestra_Hit">
-          <desc>Orchestra Hit, MIDI Program Change #56.</desc>
+          <desc>Orchestra Hit, Program #55.</desc>
         </valItem>
         <valItem ident="Trumpet">
-          <desc>Trumpet, MIDI Program Change #57.</desc>
+          <desc>Trumpet, Program #56.</desc>
         </valItem>
         <valItem ident="Trombone">
-          <desc>Trombone, MIDI Program Change #58.</desc>
+          <desc>Trombone, Program #57.</desc>
         </valItem>
         <valItem ident="Tuba">
-          <desc>Tuba, MIDI Program Change #59.</desc>
+          <desc>Tuba, Program #58.</desc>
         </valItem>
         <valItem ident="Muted_Trumpet">
-          <desc>Muted Trumpet, MIDI Program Change #60.</desc>
+          <desc>Muted Trumpet, Program #59.</desc>
         </valItem>
         <valItem ident="French_Horn">
-          <desc>French Horn, MIDI Program Change #61.</desc>
+          <desc>French Horn, Program #60.</desc>
         </valItem>
         <valItem ident="Brass_Section">
-          <desc>Brass Section, MIDI Program Change #62.</desc>
+          <desc>Brass Section, Program #61.</desc>
         </valItem>
         <valItem ident="SynthBrass_1">
-          <desc>SynthBrass 1, MIDI Program Change #63.</desc>
+          <desc>SynthBrass 1, Program #62.</desc>
         </valItem>
         <valItem ident="SynthBrass_2">
-          <desc>SynthBrass 2, MIDI Program Change #64.</desc>
+          <desc>SynthBrass 2, Program #63.</desc>
         </valItem>
         <valItem ident="Soprano_Sax">
-          <desc>Soprano Sax, MIDI Program Change #65.</desc>
+          <desc>Soprano Sax, Program #64.</desc>
         </valItem>
         <valItem ident="Alto_Sax">
-          <desc>Alto Sax, MIDI Program Change #66.</desc>
+          <desc>Alto Sax, Program #65.</desc>
         </valItem>
         <valItem ident="Tenor_Sax">
-          <desc>Tenor Sax, MIDI Program Change #67.</desc>
+          <desc>Tenor Sax, Program #66.</desc>
         </valItem>
         <valItem ident="Baritone_Sax">
-          <desc>Baritone Sax, MIDI Program Change #68.</desc>
+          <desc>Baritone Sax, Program #67.</desc>
         </valItem>
         <valItem ident="Oboe">
-          <desc>Oboe, MIDI Program Change #69.</desc>
+          <desc>Oboe, Program #68.</desc>
         </valItem>
         <valItem ident="English_Horn">
-          <desc>English Horn, MIDI Program Change #70.</desc>
+          <desc>English Horn, Program #69.</desc>
         </valItem>
         <valItem ident="Bassoon">
-          <desc>Bassoon, MIDI Program Change #71.</desc>
+          <desc>Bassoon, Program #70.</desc>
         </valItem>
         <valItem ident="Clarinet">
-          <desc>Clarinet, MIDI Program Change #72.</desc>
+          <desc>Clarinet, Program #71.</desc>
         </valItem>
         <valItem ident="Piccolo">
-          <desc>Piccolo, MIDI Program Change #73.</desc>
+          <desc>Piccolo, Program #72.</desc>
         </valItem>
         <valItem ident="Flute">
-          <desc>Flute, MIDI Program Change #74.</desc>
+          <desc>Flute, Program #73.</desc>
         </valItem>
         <valItem ident="Recorder">
-          <desc>Recorder, MIDI Program Change #75.</desc>
+          <desc>Recorder, Program #74.</desc>
         </valItem>
         <valItem ident="Pan_Flute">
-          <desc>Pan Flute, MIDI Program Change #76.</desc>
+          <desc>Pan Flute, Program #75.</desc>
         </valItem>
         <valItem ident="Blown_Bottle">
-          <desc>Blown Bottle, MIDI Program Change #77.</desc>
+          <desc>Blown Bottle, Program #76.</desc>
         </valItem>
         <valItem ident="Shakuhachi">
-          <desc>Shakuhachi, MIDI Program Change #78.</desc>
+          <desc>Shakuhachi, Program #77.</desc>
         </valItem>
         <valItem ident="Whistle">
-          <desc>Whistle, MIDI Program Change #79.</desc>
+          <desc>Whistle, Program #78.</desc>
         </valItem>
         <valItem ident="Ocarina">
-          <desc>Ocarina, MIDI Program Change #80.</desc>
+          <desc>Ocarina, Program #79.</desc>
         </valItem>
         <valItem ident="Lead_1_square">
-          <desc>Lead 1 (square), MIDI Program Change #81.</desc>
+          <desc>Lead 1 (square), Program #80.</desc>
         </valItem>
         <valItem ident="Lead_2_sawtooth">
-          <desc>Lead 2 (sawtooth), MIDI Program Change #82.</desc>
+          <desc>Lead 2 (sawtooth), Program #81.</desc>
         </valItem>
         <valItem ident="Lead_3_calliope">
-          <desc>Lead 3 (calliope), MIDI Program Change #83.</desc>
+          <desc>Lead 3 (calliope), Program #82.</desc>
         </valItem>
         <valItem ident="Lead_4_chiff">
-          <desc>Lead 4 (chiff), MIDI Program Change #84.</desc>
+          <desc>Lead 4 (chiff), Program #83.</desc>
         </valItem>
         <valItem ident="Lead_5_charang">
-          <desc>Lead 5 (charang), MIDI Program Change #85.</desc>
+          <desc>Lead 5 (charang), Program #84.</desc>
         </valItem>
         <valItem ident="Lead_6_voice">
-          <desc>Lead 6 (voice), MIDI Program Change #86.</desc>
+          <desc>Lead 6 (voice), Program #85.</desc>
         </valItem>
         <valItem ident="Lead_7_fifths">
-          <desc>Lead 7 (fifths), MIDI Program Change #87.</desc>
+          <desc>Lead 7 (fifths), Program #86.</desc>
         </valItem>
         <valItem ident="Lead_8_bass_and_lead">
-          <desc>Lead 8 (bass + lead), MIDI Program Change #88.</desc>
+          <desc>Lead 8 (bass + lead), Program #87.</desc>
         </valItem>
         <valItem ident="Pad_1_new_age">
-          <desc>Pad 1 (new age), MIDI Program Change #89.</desc>
+          <desc>Pad 1 (new age), Program #88.</desc>
         </valItem>
         <valItem ident="Pad_2_warm">
-          <desc>Pad 2 (warm), MIDI Program Change #90.</desc>
+          <desc>Pad 2 (warm), Program #89.</desc>
         </valItem>
         <valItem ident="Pad_3_polysynth">
-          <desc>Pad 3 (polysynth), MIDI Program Change #91.</desc>
+          <desc>Pad 3 (polysynth), Program #90.</desc>
         </valItem>
         <valItem ident="Pad_4_choir">
-          <desc>Pad 4 (choir), MIDI Program Change #92.</desc>
+          <desc>Pad 4 (choir), Program #91.</desc>
         </valItem>
         <valItem ident="Pad_5_bowed">
-          <desc>Pad 5 (bowed), MIDI Program Change #93.</desc>
+          <desc>Pad 5 (bowed), Program #92.</desc>
         </valItem>
         <valItem ident="Pad_6_metallic">
-          <desc>Pad 6 (metallic), MIDI Program Change #94.</desc>
+          <desc>Pad 6 (metallic), Program #93.</desc>
         </valItem>
         <valItem ident="Pad_7_halo">
-          <desc>Pad 7 (halo), MIDI Program Change #95.</desc>
+          <desc>Pad 7 (halo), Program #94.</desc>
         </valItem>
         <valItem ident="Pad_8_sweep">
-          <desc>Pad 8 (sweep), MIDI Program Change #96.</desc>
+          <desc>Pad 8 (sweep), Program #95.</desc>
         </valItem>
         <valItem ident="FX_1_rain">
-          <desc>FX 1 (rain), MIDI Program Change #97.</desc>
+          <desc>FX 1 (rain), Program #96.</desc>
         </valItem>
         <valItem ident="FX_2_soundtrack">
-          <desc>FX 2 (soundtrack), MIDI Program Change #98.</desc>
+          <desc>FX 2 (soundtrack), Program #97.</desc>
         </valItem>
         <valItem ident="FX_3_crystal">
-          <desc>FX 3 (crystal), MIDI Program Change #99.</desc>
+          <desc>FX 3 (crystal), Program #98.</desc>
         </valItem>
         <valItem ident="FX_4_atmosphere">
-          <desc>FX 4 (atmosphere), MIDI Program Change #100.</desc>
+          <desc>FX 4 (atmosphere), Program #99.</desc>
         </valItem>
         <valItem ident="FX_5_brightness">
-          <desc>FX 5 (brightness), MIDI Program Change #101.</desc>
+          <desc>FX 5 (brightness), Program #100.</desc>
         </valItem>
         <valItem ident="FX_6_goblins">
-          <desc>FX 6 (goblins), MIDI Program Change #102.</desc>
+          <desc>FX 6 (goblins), Program #101.</desc>
         </valItem>
         <valItem ident="FX_7_echoes">
-          <desc>FX 7 (echoes), MIDI Program Change #103.</desc>
+          <desc>FX 7 (echoes), Program #102.</desc>
         </valItem>
         <valItem ident="FX_8_sci-fi">
-          <desc>FX 8 (sci-fi), MIDI Program Change #104.</desc>
+          <desc>FX 8 (sci-fi), Program #103.</desc>
         </valItem>
         <valItem ident="Sitar">
-          <desc>Sitar, MIDI Program Change #105.</desc>
+          <desc>Sitar, Program #104.</desc>
         </valItem>
         <valItem ident="Banjo">
-          <desc>Banjo, MIDI Program Change #106.</desc>
+          <desc>Banjo, Program #105.</desc>
         </valItem>
         <valItem ident="Shamisen">
-          <desc>Shamisen, MIDI Program Change #107.</desc>
+          <desc>Shamisen, Program #106.</desc>
         </valItem>
         <valItem ident="Koto">
-          <desc>Koto, MIDI Program Change #108.</desc>
+          <desc>Koto, Program #107.</desc>
         </valItem>
         <valItem ident="Kalimba">
-          <desc>Kalimba, MIDI Program Change #109.</desc>
+          <desc>Kalimba, Program #108.</desc>
         </valItem>
         <valItem ident="Bag_pipe">
-          <desc>Bag pipe, MIDI Program Change #110.</desc>
+          <desc>Bag pipe, Program #109.</desc>
         </valItem>
         <valItem ident="Fiddle">
-          <desc>Fiddle, MIDI Program Change #111.</desc>
+          <desc>Fiddle, Program #110.</desc>
         </valItem>
         <valItem ident="Shanai">
-          <desc>Shanai, MIDI Program Change #112.</desc>
+          <desc>Shanai, Program #111.</desc>
         </valItem>
         <valItem ident="Tinkle_Bell">
-          <desc>Tinkle Bell, MIDI Program Change #113.</desc>
+          <desc>Tinkle Bell, Program #112.</desc>
         </valItem>
         <valItem ident="Agogo">
-          <desc>Agogo, MIDI Program Change #114.</desc>
+          <desc>Agogo, Program #113.</desc>
         </valItem>
         <valItem ident="Steel_Drums">
-          <desc>Steel Drums, MIDI Program Change #115.</desc>
+          <desc>Steel Drums, Program #114.</desc>
         </valItem>
         <valItem ident="Woodblock">
-          <desc>Woodblock, MIDI Program Change #116.</desc>
+          <desc>Woodblock, Program #115.</desc>
         </valItem>
         <valItem ident="Taiko_Drum">
-          <desc>Taiko Drum, MIDI Program Change #117.</desc>
+          <desc>Taiko Drum, Program #116.</desc>
         </valItem>
         <valItem ident="Melodic_Tom">
-          <desc>Melodic Tom, MIDI Program Change #118.</desc>
+          <desc>Melodic Tom, Program #117.</desc>
         </valItem>
         <valItem ident="Synth_Drum">
-          <desc>Synth Drum, MIDI Program Change #119.</desc>
+          <desc>Synth Drum, Program #118.</desc>
         </valItem>
         <valItem ident="Reverse_Cymbal">
-          <desc>Reverse Cymbal, MIDI Program Change #120.</desc>
+          <desc>Reverse Cymbal, Program #119.</desc>
         </valItem>
         <valItem ident="Guitar_Fret_Noise">
-          <desc>Guitar Fret Noise, MIDI Program Change #121.</desc>
+          <desc>Guitar Fret Noise, Program #120.</desc>
         </valItem>
         <valItem ident="Breath_Noise">
-          <desc>Breath Noise, MIDI Program Change #122.</desc>
+          <desc>Breath Noise, Program #121.</desc>
         </valItem>
         <valItem ident="Seashore">
-          <desc>Seashore, MIDI Program Change #123.</desc>
+          <desc>Seashore, Program #122.</desc>
         </valItem>
         <valItem ident="Bird_Tweet">
-          <desc>Bird Tweet, MIDI Program Change #124.</desc>
+          <desc>Bird Tweet, Program #123.</desc>
         </valItem>
         <valItem ident="Telephone_Ring">
-          <desc>Telephone Ring, MIDI Program Change #125.</desc>
+          <desc>Telephone Ring, Program #124.</desc>
         </valItem>
         <valItem ident="Helicopter">
-          <desc>Helicopter, MIDI Program Change #126.</desc>
+          <desc>Helicopter, Program #125.</desc>
         </valItem>
         <valItem ident="Applause">
-          <desc>Applause, MIDI Program Change #127.</desc>
+          <desc>Applause, Program #126.</desc>
         </valItem>
         <valItem ident="Gunshot">
-          <desc>Gunshot, MIDI Program Change #128.</desc>
+          <desc>Gunshot, Program #127.</desc>
         </valItem>
         <valItem ident="Acoustic_Bass_Drum">
           <desc>Acoustic Bass Drum, Key #35.</desc>


### PR DESCRIPTION
This resolves the problematic `altIdent` in `data.MIDINAMES` and fixes a wrong value in this range, as *Bag pipe* should become "Bag_pipe" instead of "Bagpipe".

This is also a bugfix for MEI 4.
closes #812