### PR TITLE
adapt instrDef to staffDef

### DIFF
--- a/source/modules/MEI.midi.xml
+++ b/source/modules/MEI.midi.xml
@@ -303,7 +303,13 @@
   <elementSpec ident="instrDef" module="MEI.midi">
     <desc>(instrument definition) – MIDI instrument declaration.</desc>
     <classes>
-      <memberOf key="att.common"/>
+      <memberOf key="att.basic"/>
+      <memberOf key="att.labelled"/>
+      <memberOf key="att.linking"/>
+      <memberOf key="att.metadataPointing"/>
+      <memberOf key="att.nInteger"/>
+      <memberOf key="att.responsibility"/>
+      <memberOf key="att.typed"/>
       <memberOf key="att.instrDef.anl"/>
       <memberOf key="att.instrDef.ges"/>
       <memberOf key="att.instrDef.log"/>


### PR DESCRIPTION
Using `att.nNumberLike` instead of `att.nInteger` for `instrDef` seemed a bit inconsistent, as `staffDef` and `layerDef` are part of the latter. 

This PR proposes to model it like `staffDef` instead of using `att.common`.
