### PR TITLE
Removal of explicit

### DIFF
--- a/source/modules/MEI.msDesc.xml
+++ b/source/modules/MEI.msDesc.xml
@@ -261,23 +261,6 @@
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
-  <elementSpec ident="explicit" module="MEI.msDesc">
-    <desc>Contains the explicit of a manuscript item; that is, the closing words of the text proper,
-      exclusive of any rubric or colophon which might follow it.</desc>
-    <classes>
-      <memberOf key="att.common"/>
-      <memberOf key="att.bibl"/>
-      <memberOf key="att.facsimile"/>
-      <memberOf key="att.lang"/>
-      <memberOf key="model.physDescPart"/>
-    </classes>
-    <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
-    </content>
-    <remarks>
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
-    </remarks>
-  </elementSpec>
   <elementSpec ident="foliation" module="MEI.msDesc">
     <desc>Describes the numbering system or systems used to count the leaves or pages in a
       codex.</desc>


### PR DESCRIPTION
The Metadata IG agreed to deprecate `explicit`, since this element regards mainly textual content and thus use cases for it are very uncommon/rare in the musicological context. Furthermore `explicit` isn't modeled the way `incipit` is, which works very well in MEI as it has been thought through thoroughly. If someone really needs/wants to encode the last measures etc. of a piece for identification purposes in the header the Metadata IG sees this as a case for a customization. 

Please refer to music-encoding/metadata-ig/issues/14 for more context.
