### PR TITLE
schema: develop placement clarification

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -56,6 +56,56 @@
       </valList>
     </content>
   </macroSpec>
+  <macroSpec ident="data.POSITION.cmn" module="MEI.cmn" type="dt">
+    <desc>Location of musical material from the CMN repertoire.</desc>
+    <content>
+      <rng:choice>
+        <rng:ref name="data.POSITION.cmn.basic"/>
+        <rng:ref name="data.POSITION.cmn.extended"/>
+      </rng:choice>
+    </content>
+    <constraintSpec ident="between_requires_adjacent_staves" scheme="isoschematron">
+      <constraint>
+        <sch:rule context="mei:*[@place eq 'between']">
+          <sch:assert test="count(tokenize(normalize-space(string(@staff)), '\s+')) = 2">The @staff
+            attribute must contain 2 numerically-adjacent integer values.</sch:assert>
+          <sch:let name="tokenizedStaff" value="tokenize(normalize-space(string(@staff)), '\s+')"/>
+          <sch:let name="maxValue"
+            value="max((number($tokenizedStaff[1]), number($tokenizedStaff[2])))"/>
+          <sch:let name="minValue"
+            value="min((number($tokenizedStaff[1]), number($tokenizedStaff[2])))"/>
+          <sch:assert test="$maxValue - $minValue = 1">Staves <sch:value-of select="$minValue"/> and
+            <sch:value-of select="$maxValue"/> are not adjacent.</sch:assert>
+        </sch:rule>
+      </constraint>
+    </constraintSpec>
+  </macroSpec>
+  <macroSpec ident="data.POSITION.cmn.basic" module="MEI" type="dt">
+    <desc>Location of symbol relative to a staff.</desc>
+    <content>
+      <valList type="closed">
+        <valItem ident="above">
+          <desc>Above the staff.</desc>
+        </valItem>
+        <valItem ident="below">
+          <desc>Below the staff.</desc>
+        </valItem>
+      </valList>
+    </content>
+  </macroSpec>
+  <macroSpec ident="data.POSITION.cmn.extended" module="MEI" type="dt">
+    <desc>Location of symbol relative to a staff.</desc>
+    <content>
+      <valList type="closed">
+        <valItem ident="between">
+          <desc>Between staves.</desc>
+        </valItem>
+        <valItem ident="within">
+          <desc>Within/on the staff.</desc>
+        </valItem>
+      </valList>
+    </content>
+  </macroSpec>
   <macroSpec ident="data.STAFFITEM.cmn" module="MEI.cmn" type="dt">
     <desc>Items in the CMN repertoire that may be printed near a staff.</desc>
     <content>

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -931,7 +931,7 @@
       <attDef ident="num.place" usage="opt">
         <desc>Indicates where the number is written in relation to its reference object.</desc>
         <datatype>
-          <rng:ref name="data.STAFFREL.basic"/>
+          <rng:ref name="data.POSITION.cmn.basic"/>
         </datatype>
       </attDef>
       <attDef ident="num.visible" usage="opt">

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -875,17 +875,16 @@
     </attList>
   </classSpec>
   <classSpec ident="att.numberPlacement" module="MEI.cmn" type="atts">
-    <desc>Attributes that record the placement and visibility of numbers that accompany a bowed
-      tremolo or tuplet.</desc>
+    <desc>Attributes that record the placement and visibility of numbers that accompany a notational object.</desc>
     <attList>
       <attDef ident="num.place" usage="opt">
-        <desc>States where the tuplet number will be placed in relation to the note heads.</desc>
+        <desc>Indicates where the number is written in relation to its reference object.</desc>
         <datatype>
           <rng:ref name="data.STAFFREL.basic"/>
         </datatype>
       </attDef>
       <attDef ident="num.visible" usage="opt">
-        <desc>Determines if the tuplet number is visible.</desc>
+        <desc>Determines if the number is visible.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -493,7 +493,7 @@
     <desc>Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>

--- a/source/modules/MEI.edittrans.xml
+++ b/source/modules/MEI.edittrans.xml
@@ -62,7 +62,7 @@
   <classSpec ident="att.metaMark.vis" module="MEI.edittrans" type="atts">
     <desc>Visual domain attributes.</desc>
     <classes>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
     </classes>
   </classSpec>
   <classSpec ident="att.reasonIdent" module="MEI.edittrans" type="atts">

--- a/source/modules/MEI.neumes.xml
+++ b/source/modules/MEI.neumes.xml
@@ -7,6 +7,53 @@
   <moduleSpec ident="MEI.neumes">
     <desc>Neume repertoire component declarations.</desc>
   </moduleSpec>
+  <macroSpec ident="data.POSITION.neumes" module="MEI.neumes" type="dt">
+    <desc>Location of musical material relative to a symbol on a staff instead of the staff.</desc>
+    <content>
+      <alternate>
+        <macroRef key="data.POSITION.neumes.basic"/>
+        <macroRef key="data.POSITION.neumes.extended"/>
+      </alternate>
+    </content>
+  </macroSpec>
+  <macroSpec ident="data.POSITION.neumes.basic" module="MEI" type="dt">
+    <desc>Location of musical material relative to a symbol other than a staff.</desc>
+    <content>
+      <valList type="closed">
+        <valItem ident="above">
+          <desc>Above.</desc>
+        </valItem>
+        <valItem ident="below">
+          <desc>Below.</desc>
+        </valItem>
+        <valItem ident="left">
+          <desc>Left.</desc>
+        </valItem>
+        <valItem ident="right">
+          <desc>Right.</desc>
+        </valItem>
+      </valList>
+    </content>
+  </macroSpec>
+  <macroSpec ident="data.POSITION.neumes.extended" module="MEI" type="dt">
+    <desc>Location of musical material relative to a symbol other than a staff.</desc>
+    <content>
+      <valList type="closed">
+        <valItem ident="above-left">
+          <desc>Above and left; north-west.</desc>
+        </valItem>
+        <valItem ident="above-right">
+          <desc>Above and right; north-east.</desc>
+        </valItem>
+        <valItem ident="below-left">
+          <desc>Below and left; south-west.</desc>
+        </valItem>
+        <valItem ident="below-right">
+          <desc>Below and right; south-east.</desc>
+        </valItem>
+      </valList>
+    </content>
+  </macroSpec>
   <macroSpec ident="data.STAFFITEM.neumes" module="MEI.neumes" type="dt">
     <desc>Items in the Neume repertoire that may be printed near a staff.</desc>
   </macroSpec>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -2520,28 +2520,15 @@
        </attDef>
     </attList>
   </classSpec>   
-  <classSpec ident="att.placementRelEvent" module="MEI.shared" type="atts">
-    <desc>Attributes capturing placement information with respect to an event.</desc>
+  <classSpec ident="att.placement" module="MEI.shared" type="atts">
+    <desc>Attributes capturing relative placement information.</desc>
     <attList>
        <attDef ident="place" usage="opt">
-          <desc>Captures the placement of the item with respect to the event with which it is
-             associated.</desc>
+          <desc>Captures the placement of the item.</desc>
           <datatype>
              <rng:ref name="data.POSITION"/>
           </datatype>
        </attDef>
-    </attList>
-  </classSpec>
-  <classSpec ident="att.placementRelStaff" module="MEI.shared" type="atts">
-    <desc>Attributes capturing placement information with respect to the staff.</desc>
-    <attList>
-      <attDef ident="place" usage="opt">
-        <desc>Captures the placement of the item with respect to the staff with which it is
-          associated.</desc>
-        <datatype>
-          <rng:ref name="data.POSITION"/>
-        </datatype>
-      </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.plist" module="MEI.shared" type="atts">

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -581,7 +581,7 @@
       <attDef ident="clef.dis.place" usage="opt">
         <desc>Records the direction of octave displacement to be applied to the clef.</desc>
         <datatype>
-          <rng:ref name="data.STAFFREL.basic"/>
+          <rng:ref name="data.POSITION.cmn.basic"/>
         </datatype>
       </attDef>
     </attList>
@@ -1169,7 +1169,7 @@
           fermata needs to be recorded, then a <gi scheme="MEI">fermata</gi> element should be
           employed instead.</desc>
         <datatype>
-          <rng:ref name="data.STAFFREL.basic"/>
+          <rng:ref name="data.POSITION.cmn.basic"/>
         </datatype>
       </attDef>
     </attList>
@@ -2250,7 +2250,7 @@
       <attDef ident="dis.place" usage="opt">
         <desc>Records the direction of octave displacement.</desc>
         <datatype>
-          <rng:ref name="data.STAFFREL.basic"/>
+          <rng:ref name="data.POSITION.cmn.basic"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -2527,7 +2527,7 @@
           <desc>Captures the placement of the item with respect to the event with which it is
              associated.</desc>
           <datatype>
-             <rng:ref name="data.STAFFREL"/>
+             <rng:ref name="data.POSITION"/>
           </datatype>
        </attDef>
     </attList>
@@ -2539,7 +2539,7 @@
         <desc>Captures the placement of the item with respect to the staff with which it is
           associated.</desc>
         <datatype>
-          <rng:ref name="data.STAFFREL"/>
+          <rng:ref name="data.POSITION"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1756,7 +1756,7 @@
         <desc>Used to state where a tuplet bracket will be placed in relation to the note
           heads.</desc>
         <datatype>
-          <rng:ref name="data.STAFFREL.basic"/>
+          <rng:ref name="data.POSITION.cmn.basic"/>
         </datatype>
       </attDef>
       <attDef ident="bracket.visible" usage="opt">

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -15,7 +15,7 @@
       <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extSym"/>
       <memberOf key="att.placementOnStaff"/>
-      <memberOf key="att.placementRelEvent"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.staffLoc.pitched"/>
       <memberOf key="att.typography"/>
@@ -110,7 +110,7 @@
       <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extSym"/>
        <memberOf key="att.placementOnStaff"/>       
-      <memberOf key="att.placementRelEvent"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.staffLoc.pitched"/>
       <memberOf key="att.typography"/>
@@ -122,7 +122,7 @@
     <desc>Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.extender"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
@@ -282,7 +282,7 @@
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
       <memberOf key="att.extSym"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.staffLoc.pitched"/>
       <memberOf key="att.typography"/>
@@ -302,7 +302,7 @@
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
       <memberOf key="att.extSym"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.staffLoc.pitched"/>
       <memberOf key="att.typography"/>
@@ -385,7 +385,7 @@
       <memberOf key="att.color"/>
       <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extSym"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
@@ -420,7 +420,7 @@
     <desc>Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.extender"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
@@ -446,7 +446,7 @@
     <desc>Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.extender"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
@@ -499,7 +499,7 @@
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.extender"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>
@@ -515,7 +515,7 @@
       <memberOf key="att.color"/>
       <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extSym"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
@@ -555,7 +555,7 @@
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.extender"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>
@@ -569,7 +569,7 @@
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.extender"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>
@@ -657,7 +657,7 @@
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.lineRend.base"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2"/>
@@ -689,7 +689,7 @@
     <desc>Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.extender"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
       <memberOf key="att.visualOffset2.to"/>
@@ -718,7 +718,7 @@
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
       <memberOf key="att.extSym"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
@@ -833,7 +833,7 @@
     <desc>Attributes for describing the visual appearance of a line.</desc>
     <classes>
       <memberOf key="att.color"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2"/>
       <memberOf key="att.xy"/>
@@ -954,7 +954,7 @@
   <classSpec ident="att.lyrics.vis" module="MEI.visual" type="atts">
     <desc>Visual domain attributes.</desc>
     <classes>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.typography"/>
     </classes>
   </classSpec>
@@ -1116,7 +1116,7 @@
       <memberOf key="att.color"/>
       <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extSym"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.visualOffset"/>
     </classes>
@@ -1286,7 +1286,7 @@
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
       <memberOf key="att.enclosingChars"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
       <memberOf key="att.visualOffset2.to"/>
@@ -1332,7 +1332,7 @@
       <memberOf key="att.color"/>
       <memberOf key="att.extSym"/>
       <memberOf key="att.lineRend"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
@@ -1411,7 +1411,7 @@
     <desc>Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.visualOffset.to"/>
       <memberOf key="att.visualOffset.vo"/>
@@ -1423,7 +1423,7 @@
     <desc>Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
@@ -1554,7 +1554,7 @@
   <classSpec ident="att.sp.vis" module="MEI.visual" type="atts">
     <desc>Visual domain attributes.</desc>
     <classes>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
       <memberOf key="att.visualOffset2.to"/>
@@ -1664,7 +1664,7 @@
   <classSpec ident="att.stageDir.vis" module="MEI.visual" type="atts">
     <desc>Visual domain attributes.</desc>
     <classes>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
       <memberOf key="att.visualOffset2.to"/>
@@ -1688,7 +1688,7 @@
   <classSpec ident="att.syl.vis" module="MEI.visual" type="atts">
     <desc>Visual domain attributes.</desc>
     <classes>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
@@ -1724,7 +1724,7 @@
   <classSpec ident="att.tempo.vis" module="MEI.visual" type="atts">
     <desc>Visual domain attributes.</desc>
     <classes>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
@@ -1756,7 +1756,7 @@
       <memberOf key="att.color"/>
       <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extender"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.extSym"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.visualOffset"/>
@@ -1817,7 +1817,7 @@
       <memberOf key="att.color"/>
       <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extSym"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
@@ -1827,7 +1827,7 @@
     <desc>Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
-      <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.visualOffset.to"/>
       <memberOf key="att.visualOffset.vo"/>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -467,6 +467,7 @@
       <memberOf key="att.color"/>
       <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extSym"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.visibility"/>
@@ -484,13 +485,6 @@
             <desc>Vertical stroke.</desc>
           </valItem>
         </valList>
-      </attDef>
-      <attDef ident="place" usage="rec">
-        <desc>Captures the placement of the episema with respect to the neume or neume component
-          with which it is associated.</desc>
-        <datatype>
-          <rng:ref name="data.EVENTREL"/>
-        </datatype>
       </attDef>
     </attList>
   </classSpec>
@@ -731,6 +725,7 @@
       <memberOf key="att.color"/>
       <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extSym"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.visibility"/>
@@ -738,13 +733,6 @@
       <memberOf key="att.xy"/>
     </classes>
     <attList>
-      <attDef ident="place" usage="rec">
-        <desc>Captures the placement of the tick mark with respect to the neume or neume component
-          with which it is associated.</desc>
-        <datatype>
-          <rng:ref name="data.EVENTREL"/>
-        </datatype>
-      </attDef>
       <attDef ident="tilt" usage="rec">
         <desc>Direction toward which the mark points.</desc>
         <datatype>
@@ -1522,21 +1510,13 @@
       <memberOf key="att.color"/>
       <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extSym"/>
+      <memberOf key="att.placement"/>
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.visibility"/>
       <memberOf key="att.visualOffset.ho"/>
       <memberOf key="att.xy"/>
     </classes>
-    <attList>
-      <attDef ident="place" usage="rec">
-        <desc>Captures the placement of the sequence of characters with respect to the neume or
-          neume component with which it is associated.</desc>
-        <datatype>
-          <rng:ref name="data.EVENTREL"/>
-        </datatype>
-      </attDef>
-    </attList>
   </classSpec>
   <classSpec ident="att.slur.vis" module="MEI.visual" type="atts">
     <desc>Visual domain attributes for slur. The vo attribute is the vertical offset (from its

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3210,47 +3210,6 @@
         <rng:ref name="data.STAFFREL.extended"/>
       </rng:choice>
     </content>
-    <constraintSpec ident="between_requires_adjacent_staves" scheme="isoschematron">
-      <constraint>
-        <sch:rule context="mei:*[@place eq 'between']">
-          <sch:assert test="count(tokenize(normalize-space(string(@staff)), '\s+')) = 2">The @staff
-            attribute must contain 2 numerically-adjacent integer values.</sch:assert>
-          <sch:let name="tokenizedStaff" value="tokenize(normalize-space(string(@staff)), '\s+')"/>
-          <sch:let name="maxValue"
-            value="max((number($tokenizedStaff[1]), number($tokenizedStaff[2])))"/>
-          <sch:let name="minValue"
-            value="min((number($tokenizedStaff[1]), number($tokenizedStaff[2])))"/>
-          <sch:assert test="$maxValue - $minValue = 1">Staves <sch:value-of select="$minValue"/> and
-            <sch:value-of select="$maxValue"/> are not adjacent.</sch:assert>
-        </sch:rule>
-      </constraint>
-    </constraintSpec>
-  </macroSpec>
-  <macroSpec ident="data.STAFFREL.basic" module="MEI" type="dt">
-    <desc>Location of symbol relative to a staff.</desc>
-    <content>
-      <valList type="closed">
-        <valItem ident="above">
-          <desc>Above the staff.</desc>
-        </valItem>
-        <valItem ident="below">
-          <desc>Below the staff.</desc>
-        </valItem>
-      </valList>
-    </content>
-  </macroSpec>
-  <macroSpec ident="data.STAFFREL.extended" module="MEI" type="dt">
-    <desc>Location of symbol relative to a staff.</desc>
-    <content>
-      <valList type="closed">
-        <valItem ident="between">
-          <desc>Between staves.</desc>
-        </valItem>
-        <valItem ident="within">
-          <desc>Within/on the staff.</desc>
-        </valItem>
-      </valList>
-    </content>
   </macroSpec>
   <macroSpec ident="data.STEMDIRECTION" module="MEI" type="dt">
     <desc>Stem direction.</desc>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3076,7 +3076,7 @@
     <desc>Location information.</desc>
     <content>
       <rng:choice>
-        <rng:ref name="data.STAFFREL"/>
+        <rng:ref name="data.POSITION"/>
         <rng:ref name="data.NONSTAFFPLACE"/>
         <rng:ref name="data.NMTOKEN"/>
       </rng:choice>
@@ -3249,7 +3249,7 @@
       <rng:data type="integer"/>
     </content>
   </macroSpec>
-  <macroSpec ident="data.STAFFREL" module="MEI" type="dt">
+  <macroSpec ident="data.POSITION" module="MEI" type="dt">
     <desc>Location of musical material relative to a staff.</desc>
     <content>
       <rng:choice>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3250,7 +3250,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.POSITION" module="MEI" type="dt">
-    <desc>Location of musical material relative to a staff.</desc>
+    <desc>Location of musical material.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.STAFFREL.basic"/>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3206,8 +3206,8 @@
     <desc>Location of musical material.</desc>
     <content>
       <rng:choice>
-        <rng:ref name="data.STAFFREL.basic"/>
-        <rng:ref name="data.STAFFREL.extended"/>
+        <rng:ref name="data.POSITION.cmn"/>
+        <rng:ref name="data.POSITION.neumes"/>
       </rng:choice>
     </content>
   </macroSpec>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -1190,53 +1190,6 @@
       </valList>
     </content>
   </macroSpec>
-  <macroSpec ident="data.EVENTREL" module="MEI" type="dt">
-    <desc>Location of musical material relative to a symbol on a staff instead of the staff.</desc>
-    <content>
-      <alternate>
-        <macroRef key="data.EVENTREL.basic"/>
-        <macroRef key="data.EVENTREL.extended"/>
-      </alternate>
-    </content>
-  </macroSpec>
-  <macroSpec ident="data.EVENTREL.basic" module="MEI" type="dt">
-    <desc>Location of musical material relative to a symbol other than a staff.</desc>
-    <content>
-      <valList type="closed">
-        <valItem ident="above">
-          <desc>Above.</desc>
-        </valItem>
-        <valItem ident="below">
-          <desc>Below.</desc>
-        </valItem>
-        <valItem ident="left">
-          <desc>Left.</desc>
-        </valItem>
-        <valItem ident="right">
-          <desc>Right.</desc>
-        </valItem>
-      </valList>
-    </content>
-  </macroSpec>
-  <macroSpec ident="data.EVENTREL.extended" module="MEI" type="dt">
-    <desc>Location of musical material relative to a symbol other than a staff.</desc>
-    <content>
-      <valList type="closed">
-        <valItem ident="above-left">
-          <desc>Above and left; north-west.</desc>
-        </valItem>
-        <valItem ident="above-right">
-          <desc>Above and right; north-east.</desc>
-        </valItem>
-        <valItem ident="below-left">
-          <desc>Below and left; south-west.</desc>
-        </valItem>
-        <valItem ident="below-right">
-          <desc>Below and right; south-east.</desc>
-        </valItem>
-      </valList>
-    </content>
-  </macroSpec>
   <macroSpec ident="data.FILL" module="MEI" type="dt">
     <desc>Describes how a graphical object, such as a note head, should be filled. The relative
       values — top, bottom, left, and right — indicate these locations *after* rotation is


### PR DESCRIPTION
This PR is a continuation of the discussions at #853. 
These commits are the first step to clarify the use of place attributes. Here's a summary of the problems we tried to solve: 

- In MEI.neumes, the `@place` attribute is individually added to `<hispanTick>`, `<episema>`, and `<signifLet>`. They all use the `data.EVENTREL` datatype. 
- This datatype is somewhat similar to `data.STAFFREL`, including its child data types. There are slightly different values, though. 
- In the CMN part, there are two different `@place` attributes, as defined by the `att.placementRelStaff` and `att.placementRelEvent` attribute classes. 
- Right now, the only way a user can notice the difference between those is by the description of the attribute(s) shown in some editors. Without those descriptions, a user cannot tell the difference between staff-related and event-related placements. 

We wanted to keep all attributes as they are, so that instances don't get invalid. Here's a summary of what we did:

- `data.STAFFREL` has been merged with `data.EVENTREL` and renamed to `data.POSITION`.
- `data.POSITION` now references `data.POSITION.cmn` and `data.POSITION.neumes`, which are located in the proper modules and take care of allowing only the intended values, depending on activated modules. 
- `att.placementRelStaff` and `att.placementRelEvent` are merged into `att.placement`.

This leaves the question whether a user should be able to specify the anchor to which `@place` refers. In the current setup (before the changes in here), this was not possible, but could be infered from the elements that bear the `@place` attribute. The same could be achieved by proper documentation. If, however, more fine-grained control is wanted, a new attribute seems like a reasonable option. Potential names are `@place.relativeTo` with values like `event`, `staff`, or maybe even `notehead` and `stem`. 

Before proceeding, we would like to discuss this proposal to make sure it doesn't have any unwanted side effects. As soon as the specs are worked out, documentation will be adjusted.