### PR TITLE
Develop custos

### DIFF
--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -375,6 +375,18 @@
       </attDef>
     </attList>
   </classSpec>
+  <classSpec ident="att.custodes.vis" module="MEI.visual" type="atts">
+    <desc>Used by staffDef and scoreDef to provide default rendition for custodes.</desc>
+      <attList>
+        <attDef ident="custos.onstaff" usage="opt">
+           <desc>Indicates the default placement of a custos on the page. 
+             A value of <val>true</val> means before the end of the staff and <val>false</val> after the end of the staff.</desc>
+           <datatype>
+              <rng:ref name="data.BOOLEAN"/>
+           </datatype>
+        </attDef>
+     </attList>
+   </classSpec>
   <classSpec ident="att.clefGrp.vis" module="MEI.visual" type="atts">
     <desc>Visual domain attributes.</desc>
   </classSpec>
@@ -1472,6 +1484,7 @@
     <classes>
       <memberOf key="att.barring"/>
       <memberOf key="att.cleffing.vis"/>
+      <memberOf key="att.custodes.vis"/>
       <memberOf key="att.distances"/>
       <memberOf key="att.endings"/>
       <memberOf key="att.keySigDefault.vis"/>
@@ -1587,6 +1600,7 @@
     <classes>
       <memberOf key="att.barring"/>
       <memberOf key="att.cleffing.vis"/>
+      <memberOf key="att.custodes.vis"/>
       <memberOf key="att.distances"/>
       <memberOf key="att.keySigDefault.vis"/>
       <memberOf key="att.lyricStyle"/>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -409,6 +409,7 @@
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
       <memberOf key="att.extSym"/>
+      <memberOf key="att.placementOnStaff"/>       
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.typography"/>
     </classes>


### PR DESCRIPTION
This PR adds the `@onstaff` attribute to `custos`. 
Based on [this comment](https://github.com/music-encoding/music-encoding/issues/944#issuecomment-1102526832) it introduces a new `@custos.onstaff` for `scoreDef` and `staffDef` as a global styling option.

Closes #944.