### PR TITLE
fix(guidelines): fix search box positioning and layout

### DIFF
--- a/source/web/css/search.css
+++ b/source/web/css/search.css
@@ -12,23 +12,20 @@ http://www.tipue.com/search
 
 /* search box */
 
-
-/*#search_input
-{
-     float: left;
-     width: 200px;
-     background-color: #f3f3f3;
-     border: none;
-     padding: 9px 6px 10px 15px;
-     height: 56px;
-     border-radius: 3px;
-	-moz-appearance: none;
-	-webkit-appearance: none;
-	box-sizing: border-box;
-     box-shadow: none;
-	outline: 0;
-	margin: 0;
-}*/
+.search_input {
+    float: left;
+    width: 200px;
+    height: 1.4rem;
+    background-color: #ffffff;
+    border-radius: 3px;
+    border: .5px solid #213b9d;
+    box-sizing: border-box;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    padding: .2rem .5rem .2rem .5rem;
+    outline: 0;
+    margin: 0;
+}
 
 .search_icon {
     transform: rotate(-45deg);
@@ -37,16 +34,19 @@ http://www.tipue.com/search
     -webkit-appearance: none;
     box-sizing: border-box;
     box-shadow: none;
-    color: #666666;
+    color: #ffffff;
 }
 
 .search_button {
-    position: relative;
-    top: 5px;
+    position: inherit;
+    height: 1.4rem;
+    margin-left: -3px;
     padding: 1.5px 5px 3px 5px;
+    background-color: #2440aa;
+    border: .5px solid #213b9d;
     border-radius: 0 3px 3px 0;
-    left: -2px;
-    border: 1px solid #999999;
+    box-sizing: border-box;
+    cursor: pointer;
 }
 
 

--- a/utils/guidelines_xslt/odd2html/htmlFile.xsl
+++ b/utils/guidelines_xslt/odd2html/htmlFile.xsl
@@ -98,9 +98,12 @@
                                         
                                         <div class="searchbox">
                                             
-                                            <form><div class="search_group">
-                                                <input id="search_inputTop" title="At least 3 characters" type="text"></input><button type="submit" id="submitSearchButtonTop" class="search_button"><span class="search_icon">⚲</span></button>
-                                            </div></form>
+                                            <form>
+                                                <div class="search_group">
+                                                    <input id="search_inputTop" class="search_input" title="At least 3 characters" type="text"></input>
+                                                    <button type="submit" id="submitSearchButtonTop" class="search_button"><span class="search_icon">⚲</span></button>
+                                                </div>
+                                            </form>
                                             
                                         </div>
                                         
@@ -117,9 +120,12 @@
                                         <span class="gitLink">(<a href="https://github.com/music-encoding/music-encoding/commit/{$hash}" target="_blank" rel="noopener noreferrer">#<xsl:value-of select="substring($hash,1,7)"/></a>)</span>   
                                     </div>
                                     
-                                    <form><div class="search_group">
-                                        <input name="q" id="search_input" title="At least 3 characters" type="text"></input><button type="submit" id="submitSearchButtonSide" class="search_button"><span class="search_icon">⚲</span></button>
-                                    </div></form>
+                                    <form>
+                                        <div class="search_group">
+                                            <input name="q" id="search_input" class="search_input" title="At least 3 characters" type="text"></input>
+                                            <button type="submit" id="submitSearchButtonSide" class="search_button"><span class="search_icon">⚲</span></button>
+                                        </div>
+                                    </form>
                                     
                                     <ul class="nav"> 
                                         <li class="nav-item">


### PR DESCRIPTION
This PR addresses the second part of music-encoding/music-encoding.github.io#303 (after #903).

It improves the position and layout of the search box of the guidelines (dev version).

Looks like this after changes:
<img width="473" alt="Screenshot 2022-04-27 193004" src="https://user-images.githubusercontent.com/21059419/165586455-e72bee46-1a23-4b10-9868-e1f38e159e15.png">

<img width="332" alt="Screenshot 2022-04-27 193124" src="https://user-images.githubusercontent.com/21059419/165586467-1f652685-f33c-48f1-ac69-61317925a587.png">


Fixes music-encoding/music-encoding.github.io#303 .