### PR TITLE
Fix wrong reference to model class

### DIFF
--- a/customizations/mei-Neumes.xml
+++ b/customizations/mei-Neumes.xml
@@ -124,7 +124,7 @@
           <desc>groups event elements that occur in the neume repertoire.</desc>
           <classes>
             <memberOf key="model.syllablePart"/>
-            <memberOf key="model.rdgPart.critapp"/>
+            <memberOf key="model.rdgPart.music"/>
           </classes>
         </classSpec>
         


### PR DESCRIPTION
With [this commit](https://github.com/music-encoding/music-encoding/commit/796ccf65ef57e0e0b2038683866051be6ea3bd11), `model.rdgPart.critapp` has been renamed to `model.rdgPart.music`. It seems that this has been forgotten in the mei-Neumes customization.

Fixes #957 