### PR TITLE
fix file paths for build process

### DIFF
--- a/utils/guidelines_xslt/odd2html/config.xsl
+++ b/utils/guidelines_xslt/odd2html/config.xsl
@@ -66,6 +66,14 @@
             </xsl:otherwise>
         </xsl:choose>    
     </xsl:variable>
+
+    <xd:doc>
+        <xd:desc>
+            <xd:p>A variable for the parent directory. Used in the context of relative paths.</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:variable name="parentdir.rel" select="'../'" as="xs:string"/>
+
     
     <xd:doc>
         <xd:desc>
@@ -87,11 +95,19 @@
     <xd:doc>
         <xd:desc>
             <xd:p>The folder, in which MEI files are placed that need to be turned into SVG images. 
-                Those images will eventually be placed in $dist.folder.generated.images.</xd:p>
+                Those images will eventually be placed in $dist.folder.generated.images. Relative path.</xd:p>
         </xd:desc>
     </xd:doc>
-    <xsl:variable name="build.folder.generated.images" select="$build.folder || 'images/'" as="xs:string"/>
-    
+    <xsl:variable name="build.folder.generated.images.rel" select="'./images/'" as="xs:string"/>
+
+    <xd:doc>
+        <xd:desc>
+            <xd:p>The folder, in which MEI files are placed that need to be turned into SVG images.
+                Those images will eventually be placed in $dist.folder.generated.images. Absolute path.</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:variable name="build.folder.generated.images.abs" select="$build.folder || substring($build.folder.generated.images.rel, 3)" as="xs:string"/>
+
     <xd:doc>
         <xd:desc>
             <xd:p>The dist folder, in which the final results of the XSLT are stored.</xd:p>
@@ -127,5 +143,5 @@
             point to the files in the source folder.</xd:p>
         </xd:desc>
     </xd:doc>
-    <xsl:variable name="css.folder.print" select="$cleaned.basedir || 'source/css/print/'" as="xs:string"/>
+    <xsl:variable name="css.folder.print" select="$parentdir.rel || 'source/css/print/'" as="xs:string"/>
 </xsl:stylesheet>

--- a/utils/guidelines_xslt/odd2html/prepareLiveExamples.xsl
+++ b/utils/guidelines_xslt/odd2html/prepareLiveExamples.xsl
@@ -47,7 +47,7 @@
         <xsl:for-each select="$guidelinesSources//egx:egXML['verovio' = tokenize(normalize-space(@rend),' ')]">
             <xsl:variable name="id" select="generate-id(.)" as="xs:string"/>
             <xsl:try>
-                <xsl:result-document href="{$build.folder.generated.images}{$id}.mei" method="xml" indent="yes">
+                <xsl:result-document href="{$build.folder.generated.images.abs}{$id}.mei" method="xml" indent="yes">
                     <xsl:sequence select="parse-xml(node())"/>
                 </xsl:result-document>
                 <xsl:catch>

--- a/utils/guidelines_xslt/odd2html/preparePDF.xsl
+++ b/utils/guidelines_xslt/odd2html/preparePDF.xsl
@@ -194,10 +194,10 @@
                 <xsl:next-match/>
             </xsl:when>
             <xsl:when test="starts-with(.,'images/') and not(contains(.,'/generated/'))">
-                <xsl:attribute name="src" select="$cleaned.basedir || 'source/' || ."/>
+                <xsl:attribute name="src" select="$parentdir.rel || 'source/' || ."/>
             </xsl:when>
             <xsl:when test="starts-with(.,'./images/generated/')">
-                <xsl:attribute name="src" select="$build.folder.generated.images || substring(.,20)"/>
+                <xsl:attribute name="src" select="$build.folder.generated.images.rel || substring(.,20)"/>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:message terminate="yes" select="'dunno how to resolve image src=' || ."/>


### PR DESCRIPTION
This PR fixes the wrong file paths in the PDF guidelines build process. Tested for print version. CSS assets for online version need to be moved in correct folder in another step.

Adresses #959 