### PR TITLE
Develop style

### DIFF
--- a/source/modules/MEI.analytical.xml
+++ b/source/modules/MEI.analytical.xml
@@ -5,143 +5,143 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.analytical">
   <moduleSpec ident="MEI.analytical">
-    <desc>Analytical component declarations.</desc>
+    <desc xml:lang="en">Analytical component declarations.</desc>
   </moduleSpec>
   <classSpec ident="att.accid.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.ambNote.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.annot.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.arpeg.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.artic.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.attacca.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.barLine.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.beam.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.beamSpan.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.beatRpt.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.bend.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.bracketSpan.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.breath.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.bTrem.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.caesura.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.chord.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
     <classes>
       <memberOf key="att.chord.anl.cmn"/>
     </classes>
   </classSpec>
   <classSpec ident="att.chordDef.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.chordMember.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
     <classes>
       <memberOf key="att.intervalHarmonic"/>
     </classes>
   </classSpec>
   <classSpec ident="att.clef.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.clefGrp.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.cpMark.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.curve.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.custos.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.mdiv.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.dir.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.dot.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.dynam.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.ending.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.episema.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.f.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.fermata.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.fing.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.fingGrp.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.fTrem.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.gliss.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.grpSym.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.hairpin.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.halfmRpt.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.harm.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
     <classes>
       <memberOf key="att.intervalHarmonic"/>
     </classes>
     <attList>
       <attDef ident="form" usage="opt">
-        <desc>Indicates to what degree the harmonic label is supported by the notation.</desc>
+        <desc xml:lang="en">Indicates to what degree the harmonic label is supported by the notation.</desc>
         <valList type="closed">
           <valItem ident="explicit">
-            <desc>The notation contains all the notes necessary for the harmonic label, <abbr>e.g.</abbr>, the
+            <desc xml:lang="en">The notation contains all the notes necessary for the harmonic label, <abbr>e.g.</abbr>, the
               notes "D F♯ A" for the harmonic label "D".</desc>
           </valItem>
           <valItem ident="implied">
-            <desc>The harmonic label relies on notes implied, but not actually present, in the
+            <desc xml:lang="en">The harmonic label relies on notes implied, but not actually present, in the
               notation, <abbr>e.g.</abbr>, the notes "D F♯ C" for the harmonic label "D7". The note "A" is
               missing from the notation, but can be implied.</desc>
           </valItem>
@@ -150,10 +150,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.harmonicFunction" module="MEI.analytical" type="atts">
-    <desc>Attributes describing the harmonic function of a single pitch.</desc>
+    <desc xml:lang="en">Attributes describing the harmonic function of a single pitch.</desc>
     <attList>
       <attDef ident="deg" usage="opt">
-        <desc>Captures scale degree information using <ref target="https://www.humdrum.org/rep/deg/">Humdrum **deg syntax</ref> -- an optional indicator
+        <desc xml:lang="en">Captures scale degree information using <ref target="https://www.humdrum.org/rep/deg/">Humdrum **deg syntax</ref> -- an optional indicator
           of melodic approach (^ = ascending approach, v = descending approach), a scale degree
           value (1 = tonic ... 7 = leading tone), and an optional indication of chromatic
           alteration, <val>1</val>, <val>v7</val>, <val>^1</val>, or <val>v5+</val>, for example. 
@@ -165,19 +165,19 @@
     </attList>
   </classSpec>
   <classSpec ident="att.harpPedal.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.hispanTick.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.instrDef.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.intervalHarmonic" module="MEI.analytical" type="atts">
-    <desc>Attributes that describe harmonic intervals.</desc>
+    <desc xml:lang="en">Attributes that describe harmonic intervals.</desc>
     <attList>
       <attDef ident="inth" usage="opt">
-        <desc>Encodes the harmonic interval between pitches occurring at the same time.</desc>
+        <desc xml:lang="en">Encodes the harmonic interval between pitches occurring at the same time.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.INTERVAL.HARMONIC"/>
         </datatype>
@@ -185,10 +185,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.intervalMelodic" module="MEI.analytical" type="atts">
-    <desc>Attributes that provide for description of intervallic content.</desc>
+    <desc xml:lang="en">Attributes that provide for description of intervallic content.</desc>
     <attList>
       <attDef ident="intm" usage="opt">
-        <desc>Encodes the melodic interval from the previous pitch. The value may be a general
+        <desc xml:lang="en">Encodes the melodic interval from the previous pitch. The value may be a general
           directional indication (u, d, s, etc.), an indication of diatonic interval direction,
           quality, and size, or a precise numeric value in half steps.</desc>
         <datatype>
@@ -198,24 +198,24 @@
     </attList>
   </classSpec>
   <classSpec ident="att.intervallicDesc" module="MEI.analytical" type="atts">
-    <desc>Attributes that provide for description of intervallic content.</desc>
+    <desc xml:lang="en">Attributes that provide for description of intervallic content.</desc>
     <classes>
       <memberOf key="att.intervalHarmonic"/>
       <memberOf key="att.intervalMelodic"/>
     </classes>
   </classSpec>
   <classSpec ident="att.keyAccid.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.keySig.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
     <classes>
       <memberOf key="att.accidental"/>
       <memberOf key="att.pitch"/>
     </classes>
     <attList>
       <attDef ident="mode" usage="opt">
-        <desc>Indicates major, minor, or other tonality.</desc>
+        <desc xml:lang="en">Indicates major, minor, or other tonality.</desc>
         <datatype>
           <rng:ref name="data.MODE"/>
         </datatype>
@@ -223,24 +223,24 @@
     </attList>
   </classSpec>
   <classSpec ident="att.keySigDefault.anl" module="MEI.analytical" type="atts">
-    <desc>Used by staffDef and scoreDef to provide default values for attributes in the analytical
+    <desc xml:lang="en">Used by staffDef and scoreDef to provide default values for attributes in the analytical
       domain that are related to key signatures.</desc>
     <attList>
       <attDef ident="key.accid" usage="opt">
-        <desc>Contains an accidental for the tonic key, if one is required, <abbr>e.g.</abbr>, if <att>key.pname</att>
+        <desc xml:lang="en">Contains an accidental for the tonic key, if one is required, <abbr>e.g.</abbr>, if <att>key.pname</att>
           equals <val>c</val> and <att>key.accid</att> equals <val>s</val>, then a tonic of C# is indicated.</desc>
         <datatype>
           <rng:ref name="data.ACCIDENTAL.GESTURAL"/>
         </datatype>
       </attDef>
       <attDef ident="key.mode" usage="opt">
-        <desc>Indicates major, minor, or other tonality.</desc>
+        <desc xml:lang="en">Indicates major, minor, or other tonality.</desc>
         <datatype>
           <rng:ref name="data.MODE"/>
         </datatype>
       </attDef>
       <attDef ident="key.pname" usage="opt">
-        <desc>Holds the pitch name of the tonic key, <abbr>e.g.</abbr>, <val>c</val> for the key of C.</desc>
+        <desc xml:lang="en">Holds the pitch name of the tonic key, <abbr>e.g.</abbr>, <val>c</val> for the key of C.</desc>
         <datatype>
           <rng:ref name="data.PITCHNAME"/>
         </datatype>
@@ -248,37 +248,37 @@
     </attList>
   </classSpec>
   <classSpec ident="att.layer.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.layerDef.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.ligature.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.line.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.liquescent.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.lv.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.lyrics.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.measure.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
     <classes>
       <memberOf key="att.joined"/>
     </classes>
   </classSpec>
   <classSpec ident="att.melodicFunction" module="MEI.analytical" type="atts">
-    <desc>Attributes describing melodic function.</desc>
+    <desc xml:lang="en">Attributes describing melodic function.</desc>
     <attList>
       <attDef ident="mfunc" usage="opt">
-        <desc>Describes melodic function using <ref target="https://www.humdrum.org/rep/embel/">Humdrum **embel syntax</ref>.</desc>
+        <desc xml:lang="en">Describes melodic function using <ref target="https://www.humdrum.org/rep/embel/">Humdrum **embel syntax</ref>.</desc>
         <datatype>
           <rng:ref name="data.MELODICFUNCTION"/>
         </datatype>
@@ -286,34 +286,34 @@
     </attList>
   </classSpec>
   <classSpec ident="att.mensur.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.meterSig.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.meterSigGrp.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.midi.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.mordent.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.mRest.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes in the CMN repertoire.</desc>
+    <desc xml:lang="en">Analytical domain attributes in the CMN repertoire.</desc>
     <classes>
       <memberOf key="att.fermataPresent"/>
     </classes>
   </classSpec>
   <classSpec ident="att.mRpt.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.mRpt2.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.mSpace.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes in the CMN repertoire. Use the n attribute to explicitly
+    <desc xml:lang="en">Analytical domain attributes in the CMN repertoire. Use the n attribute to explicitly
       encode this measure’s position in a string of measures containing only <gi scheme="MEI"
       >mRest</gi> elements.</desc>
     <classes>
@@ -321,13 +321,13 @@
     </classes>
   </classSpec>
   <classSpec ident="att.multiRest.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.multiRpt.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.nc.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
     <classes>
       <memberOf key="att.harmonicFunction"/>
       <memberOf key="att.intervalMelodic"/>
@@ -337,13 +337,13 @@
     </classes>
   </classSpec>
   <classSpec ident="att.ncGrp.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.neume.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.note.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
     <classes>
       <memberOf key="att.accidental"/>
       <memberOf key="att.articulation"/>
@@ -358,43 +358,43 @@
     </classes>
   </classSpec>
   <classSpec ident="att.octave.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.ornam.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.oriscus.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.ossia.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.pad.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.part.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.parts.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.pb.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.pedal.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.phrase.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
     <classes>
       <memberOf key="att.joined"/>
     </classes>
   </classSpec>
   <classSpec ident="att.pitchClass" module="MEI.analytical" type="atts">
-    <desc>Attributes that describe pitch class.</desc>
+    <desc xml:lang="en">Attributes that describe pitch class.</desc>
     <attList>
       <attDef ident="pclass" usage="opt">
-        <desc>Holds pitch class information.</desc>
+        <desc xml:lang="en">Holds pitch class information.</desc>
         <datatype>
           <rng:ref name="data.PITCHCLASS"/>
         </datatype>
@@ -402,55 +402,55 @@
     </attList>
   </classSpec>
   <classSpec ident="att.proport.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.quilisma.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.rdg.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.refrain.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.reh.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.rest.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
     <classes>
       <memberOf key="att.rest.anl.cmn"/>
     </classes>
   </classSpec>
   <classSpec ident="att.sb.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.score.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.scoreDef.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
     <classes>
       <memberOf key="att.keySigDefault.anl"/>
     </classes>
   </classSpec>
   <classSpec ident="att.section.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.slur.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
     <classes>
       <memberOf key="att.joined"/>
     </classes>
   </classSpec>
   <classSpec ident="att.signifLet.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.solfa" module="MEI.analytical" type="atts">
-    <desc>Attributes that specify pitch using sol-fa.</desc>
+    <desc xml:lang="en">Attributes that specify pitch using sol-fa.</desc>
     <attList>
       <attDef ident="psolfa" usage="opt">
-        <desc>Contains sol-fa designation, <abbr>e.g.</abbr>, do, re, mi, etc., in either a fixed or movable Do
+        <desc xml:lang="en">Contains sol-fa designation, <abbr>e.g.</abbr>, do, re, mi, etc., in either a fixed or movable Do
           system.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
@@ -459,66 +459,66 @@
     </attList>
   </classSpec>
   <classSpec ident="att.sp.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.space.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
     <classes>
       <memberOf key="att.space.anl.cmn"/>
     </classes>
   </classSpec>
   <classSpec ident="att.staff.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.staffDef.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
     <classes>
       <memberOf key="att.keySigDefault.anl"/>
     </classes>
   </classSpec>
   <classSpec ident="att.staffGrp.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.stageDir.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.strophicus.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.syl.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.syllable.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.symbol.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.tempo.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.tie.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.trill.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.tuplet.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.tupletSpan.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
     <classes>
       <memberOf key="att.tuplet.anl"/>
     </classes>
   </classSpec>
   <classSpec ident="att.turn.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.verse.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.volta.anl" module="MEI.analytical" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
 </specGrp>

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -5,144 +5,144 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.cmn">
   <moduleSpec ident="MEI.cmn">
-    <desc>Common Music Notation (CMN) repertoire component declarations.</desc>
+    <desc xml:lang="en">Common Music Notation (CMN) repertoire component declarations.</desc>
   </moduleSpec>
   <macroSpec ident="data.DURATION.cmn" module="MEI.cmn" type="dt">
-    <desc>Logical, that is, written, duration attribute values for the CMN repertoire.</desc>
+    <desc xml:lang="en">Logical, that is, written, duration attribute values for the CMN repertoire.</desc>
     <content>
       <valList type="closed">
         <valItem ident="long">
-          <desc>Quadruple whole note.</desc>
+          <desc xml:lang="en">Quadruple whole note.</desc>
         </valItem>
         <valItem ident="breve">
-          <desc>Double whole note.</desc>
+          <desc xml:lang="en">Double whole note.</desc>
         </valItem>
         <valItem ident="1">
-          <desc>Whole note.</desc>
+          <desc xml:lang="en">Whole note.</desc>
         </valItem>
         <valItem ident="2">
-          <desc>Half note.</desc>
+          <desc xml:lang="en">Half note.</desc>
         </valItem>
         <valItem ident="4">
-          <desc>Quarter note.</desc>
+          <desc xml:lang="en">Quarter note.</desc>
         </valItem>
         <valItem ident="8">
-          <desc>8th note.</desc>
+          <desc xml:lang="en">8th note.</desc>
         </valItem>
         <valItem ident="16">
-          <desc>16th note.</desc>
+          <desc xml:lang="en">16th note.</desc>
         </valItem>
         <valItem ident="32">
-          <desc>32nd note.</desc>
+          <desc xml:lang="en">32nd note.</desc>
         </valItem>
         <valItem ident="64">
-          <desc>64th note.</desc>
+          <desc xml:lang="en">64th note.</desc>
         </valItem>
         <valItem ident="128">
-          <desc>128th note.</desc>
+          <desc xml:lang="en">128th note.</desc>
         </valItem>
         <valItem ident="256">
-          <desc>256th note.</desc>
+          <desc xml:lang="en">256th note.</desc>
         </valItem>
         <valItem ident="512">
-          <desc>512th note.</desc>
+          <desc xml:lang="en">512th note.</desc>
         </valItem>
         <valItem ident="1024">
-          <desc>1024th note.</desc>
+          <desc xml:lang="en">1024th note.</desc>
         </valItem>
         <valItem ident="2048">
-          <desc>2048th note.</desc>
+          <desc xml:lang="en">2048th note.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.STAFFITEM.cmn" module="MEI.cmn" type="dt">
-    <desc>Items in the CMN repertoire that may be printed near a staff.</desc>
+    <desc xml:lang="en">Items in the CMN repertoire that may be printed near a staff.</desc>
     <content>
       <valList type="closed">
         <valItem ident="beam">
-          <desc>Beams.</desc>
+          <desc xml:lang="en">Beams.</desc>
         </valItem>
         <!-- beamSpan is subsumed within "beam" -->
         <!--<valItem ident="beamSpan"/>-->
         <valItem ident="bend">
-          <desc>Bend indications.</desc>
+          <desc xml:lang="en">Bend indications.</desc>
         </valItem>
         <valItem ident="bracketSpan">
-          <desc>Brackets, <abbr>e.g.</abbr>, for transcribed ligatures.</desc>
+          <desc xml:lang="en">Brackets, <abbr>e.g.</abbr>, for transcribed ligatures.</desc>
         </valItem>
         <valItem ident="breath">
-          <desc>Breath marks.</desc>
+          <desc xml:lang="en">Breath marks.</desc>
         </valItem>
         <valItem ident="cpMark">
-          <desc>Copy marks.</desc>
+          <desc xml:lang="en">Copy marks.</desc>
         </valItem>
         <valItem ident="fermata">
-          <desc>Fermatas.</desc>
+          <desc xml:lang="en">Fermatas.</desc>
         </valItem>
         <valItem ident="fing">
-          <desc>Fingerings.</desc>
+          <desc xml:lang="en">Fingerings.</desc>
         </valItem>
         <!-- fingGrp is subsumed within "fing" -->
         <!--<valItem ident="fingGrp"/>-->
         <valItem ident="hairpin">
-          <desc>Hairpin dynamics.</desc>
+          <desc xml:lang="en">Hairpin dynamics.</desc>
         </valItem>
         <valItem ident="harpPedal">
-          <desc>Harp pedals.</desc>
+          <desc xml:lang="en">Harp pedals.</desc>
         </valItem>
         <valItem ident="lv">
-          <desc>Laissez vibrer indications, sometimes called "open ties".</desc>
+          <desc xml:lang="en">Laissez vibrer indications, sometimes called "open ties".</desc>
         </valItem>
         <valItem ident="mordent">
-          <desc>Mordents.</desc>
+          <desc xml:lang="en">Mordents.</desc>
         </valItem>
         <valItem ident="octave">
-          <desc>Octaviation marks.</desc>
+          <desc xml:lang="en">Octaviation marks.</desc>
         </valItem>
         <valItem ident="pedal">
-          <desc>Piano pedal marks.</desc>
+          <desc xml:lang="en">Piano pedal marks.</desc>
         </valItem>
         <valItem ident="reh">
-          <desc>Rehearsal marks.</desc>
+          <desc xml:lang="en">Rehearsal marks.</desc>
         </valItem>
         <!-- more note-attached than staff-attached? -->
         <!--<valItem ident="slur"/>-->
         <valItem ident="tie">
-          <desc>Ties.</desc>
+          <desc xml:lang="en">Ties.</desc>
         </valItem>
         <valItem ident="trill">
-          <desc>Trills.</desc>
+          <desc xml:lang="en">Trills.</desc>
         </valItem>
         <valItem ident="tuplet">
-          <desc>Tuplets.</desc>
+          <desc xml:lang="en">Tuplets.</desc>
         </valItem>
         <!-- tupletSpan is subsumed within "tuplet" -->
         <!--<valItem ident="tupletSpan"/>-->
         <valItem ident="turn">
-          <desc>Turns.</desc>
+          <desc xml:lang="en">Turns.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <classSpec ident="att.arpeg.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.startId"/>
     </classes>
     <attList>
       <attDef ident="order" usage="opt">
-        <desc>Describes the direction in which an arpeggio is to be performed.</desc>
+        <desc xml:lang="en">Describes the direction in which an arpeggio is to be performed.</desc>
         <valList type="closed">
           <valItem ident="up">
-            <desc>Lowest to highest pitch.</desc>
+            <desc xml:lang="en">Lowest to highest pitch.</desc>
           </valItem>
           <valItem ident="down">
-            <desc>Highest to lowest pitch.</desc>
+            <desc xml:lang="en">Highest to lowest pitch.</desc>
           </valItem>
           <valItem ident="nonarp">
-            <desc>Non-arpeggiated style (usually rendered with a preceding bracket instead of a wavy
+            <desc xml:lang="en">Non-arpeggiated style (usually rendered with a preceding bracket instead of a wavy
               line).</desc>
           </valItem>
         </valList>
@@ -150,17 +150,17 @@
     </attList>
   </classSpec>
   <classSpec ident="att.beam.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.event"/>
       <memberOf key="att.beamedWith"/>
     </classes>
   </classSpec>
   <classSpec ident="att.beamedWith" module="MEI.cmn" type="atts">
-    <desc>Attributes indicating cross-staff beaming.</desc>
+    <desc xml:lang="en">Attributes indicating cross-staff beaming.</desc>
     <attList>
       <attDef ident="beam.with" usage="opt">
-        <desc>In the case of cross-staff beams, the beam.with attribute is used to indicate which
+        <desc xml:lang="en">In the case of cross-staff beams, the beam.with attribute is used to indicate which
           staff the beam is connected to; that is, the staff above or the staff below.</desc>
         <datatype>
           <rng:ref name="data.OTHERSTAFF"/>
@@ -169,18 +169,18 @@
     </attList>
   </classSpec>
   <classSpec ident="att.beaming.log" module="MEI.cmn" type="atts">
-    <desc>Used by layerDef, staffDef, and scoreDef to provide default values for attributes in the
+    <desc xml:lang="en">Used by layerDef, staffDef, and scoreDef to provide default values for attributes in the
       logical domain related to beaming.</desc>
     <attList>
       <attDef ident="beam.group" usage="opt">
-        <desc>Provides an example of how automated beaming (including secondary beams) is to be
+        <desc xml:lang="en">Provides an example of how automated beaming (including secondary beams) is to be
           performed.</desc>
         <datatype>
           <rng:data type="string"/>
         </datatype>
       </attDef>
       <attDef ident="beam.rests" usage="opt">
-        <desc>Indicates whether automatically-drawn beams should include rests shorter than a
+        <desc xml:lang="en">Indicates whether automatically-drawn beams should include rests shorter than a
           quarter note duration.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
@@ -203,10 +203,10 @@
     </remarks>
   </classSpec>
   <classSpec ident="att.beamPresent" module="MEI.cmn" type="atts">
-    <desc>Attributes that indicate whether an event lies under a beam.</desc>
+    <desc xml:lang="en">Attributes that indicate whether an event lies under a beam.</desc>
     <attList>
       <attDef ident="beam" usage="opt">
-        <desc>Indicates that this event is "under a beam".</desc>
+        <desc xml:lang="en">Indicates that this event is "under a beam".</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.BEAM"/>
         </datatype>
@@ -214,30 +214,30 @@
     </attList>
   </classSpec>
   <classSpec ident="att.beamRend" module="MEI.cmn" type="atts">
-    <desc>Attributes that record the visual rendition of beams.</desc>
+    <desc xml:lang="en">Attributes that record the visual rendition of beams.</desc>
     <attList>
       <attDef ident="form" usage="opt">
-        <desc>Captures whether a beam is "feathered" and in which direction.</desc>
+        <desc xml:lang="en">Captures whether a beam is "feathered" and in which direction.</desc>
         <valList type="closed">
           <valItem ident="acc">
-            <desc>(accelerando) means that the secondary beams become progressively more distant
+            <desc xml:lang="en">(accelerando) means that the secondary beams become progressively more distant
               toward the end of the beam.</desc>
           </valItem>
           <valItem ident="mixed">
-            <desc>(mixed acc and rit) for beams that are "feathered" in both directions.</desc>
+            <desc xml:lang="en">(mixed acc and rit) for beams that are "feathered" in both directions.</desc>
           </valItem>
           <valItem ident="rit">
-            <desc>(ritardando) indicates that the secondary beams get progressively closer together
+            <desc xml:lang="en">(ritardando) indicates that the secondary beams get progressively closer together
             toward the end of the beam.</desc>
           </valItem>
           <valItem ident="norm">
-            <desc>(normal) indicates that the secondary beams are equidistant along the course of
+            <desc xml:lang="en">(normal) indicates that the secondary beams are equidistant along the course of
               the beam.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="place" usage="opt">
-        <desc>Records the placement of the beam relative to the events it affects.</desc>
+        <desc xml:lang="en">Records the placement of the beam relative to the events it affects.</desc>
         <datatype>
           <rng:ref name="data.BEAMPLACE"/>
         </datatype>
@@ -263,13 +263,13 @@
         </constraintSpec>
       </attDef>
       <attDef ident="slash" usage="opt">
-        <desc>Indicates presence of slash through the beam.</desc>
+        <desc xml:lang="en">Indicates presence of slash through the beam.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
       </attDef>
       <attDef ident="slope" usage="opt">
-        <desc>Records the slope of the beam.</desc>
+        <desc xml:lang="en">Records the slope of the beam.</desc>
         <datatype>
           <rng:data type="decimal"/>
         </datatype>
@@ -277,10 +277,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.beamSecondary" module="MEI.cmn" type="atts">
-    <desc>Attributes that capture information about secondary beaming.</desc>
+    <desc xml:lang="en">Attributes that capture information about secondary beaming.</desc>
     <attList>
       <attDef ident="breaksec" usage="opt">
-        <desc>Presence of this attribute indicates that the secondary beam should be broken
+        <desc xml:lang="en">Presence of this attribute indicates that the secondary beam should be broken
           following this note/chord. The value of the attribute records the number of beams which
           should remain unbroken.</desc>
         <datatype>
@@ -290,7 +290,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.beamSpan.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.beamedWith"/>
@@ -300,13 +300,13 @@
     </classes>
   </classSpec>
   <classSpec ident="att.beatRpt.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.event"/>
     </classes>
     <attList>
       <attDef ident="beatdef" usage="opt">
-        <desc>Indicates the performed duration represented by the beatRpt symbol; expressed in time
+        <desc xml:lang="en">Indicates the performed duration represented by the beatRpt symbol; expressed in time
           signature denominator units.</desc>
         <datatype>
           <rng:data type="decimal">
@@ -317,7 +317,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.bend.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
@@ -326,7 +326,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.bracketSpan.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
@@ -335,26 +335,26 @@
     </classes>
     <attList>
       <attDef ident="func" usage="req">
-        <desc>Describes the function of the bracketed event sequence.</desc>
+        <desc xml:lang="en">Describes the function of the bracketed event sequence.</desc>
         <datatype>
           <rng:data type="NMTOKENS"/>
         </datatype>
         <valList type="semi">
           <valItem ident="coloration">
-            <desc>Represents coloration in the mensural notation source material.</desc>
+            <desc xml:lang="en">Represents coloration in the mensural notation source material.</desc>
           </valItem>
           <valItem ident="cross-rhythm">
-            <desc>Marks a sequence which does not match the current meter.</desc>
+            <desc xml:lang="en">Marks a sequence which does not match the current meter.</desc>
           </valItem>
           <valItem ident="ligature">
-            <desc>Represents a ligature in the mensural notation source material.</desc>
+            <desc xml:lang="en">Represents a ligature in the mensural notation source material.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.breath.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.alignment"/>
       <memberOf key="att.layerIdent"/>
@@ -365,7 +365,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.bTrem.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.event"/>
       <memberOf key="att.augmentDots"/>
@@ -374,20 +374,20 @@
     </classes>
     <attList>
       <attDef ident="form" usage="opt">
-        <desc>Indicates whether the tremolo is measured or unmeasured.</desc>
+        <desc xml:lang="en">Indicates whether the tremolo is measured or unmeasured.</desc>
         <valList type="closed">
           <valItem ident="meas">
-            <desc>Measured tremolo.</desc>
+            <desc xml:lang="en">Measured tremolo.</desc>
           </valItem>
           <valItem ident="unmeas">
-            <desc>Unmeasured tremolo.</desc>
+            <desc xml:lang="en">Unmeasured tremolo.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.chord.anl.cmn" module="MEI.cmn" type="atts">
-    <desc>Analytical domain attributes in the CMN repertoire.</desc>
+    <desc xml:lang="en">Analytical domain attributes in the CMN repertoire.</desc>
     <classes>
       <memberOf key="att.beamPresent"/>
       <memberOf key="att.fermataPresent"/>
@@ -399,16 +399,16 @@
     </classes>
   </classSpec>
   <classSpec ident="att.chord.ges.cmn" module="MEI.cmn" type="atts">
-    <desc>Gestural domain attributes for CMN features.</desc>
+    <desc xml:lang="en">Gestural domain attributes for CMN features.</desc>
   </classSpec>
   <classSpec ident="att.chord.log.cmn" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes in the CMN repertoire.</desc>
+    <desc xml:lang="en">Logical domain attributes in the CMN repertoire.</desc>
     <classes>
       <memberOf key="att.graced"/>
     </classes>
   </classSpec>
   <classSpec ident="att.chord.vis.cmn" module="MEI.cmn" type="atts">
-    <desc>Visual domain attributes for chord. The slur, slur.dir, slur.rend, tie, tie.dir, and
+    <desc xml:lang="en">Visual domain attributes for chord. The slur, slur.dir, slur.rend, tie, tie.dir, and
       tie.rend attributes here are "syntactic sugar" for these attributes on each of the chord's
       individual notes. The values here apply to all the notes in the chord. If some notes are
       slurred or tied while others aren't, then the individual note attributes must be used.</desc>
@@ -417,30 +417,30 @@
     </classes>
   </classSpec>
   <classSpec ident="att.cutout" module="MEI.cmn" type="atts">
-    <desc>Attributes that indicate how to render the staff lines of the measure containing an
+    <desc xml:lang="en">Attributes that indicate how to render the staff lines of the measure containing an
       element belonging to this attribute class.</desc>
     <attList>
       <attDef ident="cutout" usage="opt">
-        <desc>"Cut-out" style.</desc>
+        <desc xml:lang="en">"Cut-out" style.</desc>
         <valList type="closed">
           <valItem ident="cutout">
-            <desc>The staff lines should not be drawn.</desc>
+            <desc xml:lang="en">The staff lines should not be drawn.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.mNum.anl" module="MEI.cmn" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.mNum.ges" module="MEI.cmn" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.mNum.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.mNum.vis" module="MEI.cmn" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.placementRelStaff"/>
@@ -450,11 +450,11 @@
     </classes>
   </classSpec>
   <classSpec ident="att.expandable" module="MEI.cmn" type="atts">
-    <desc>Attributes that indicate whether to render a repeat symbol or the source material to which
+    <desc xml:lang="en">Attributes that indicate whether to render a repeat symbol or the source material to which
       it refers.</desc>
     <attList>
       <attDef ident="expand" usage="opt">
-        <desc>Indicates whether to render a repeat symbol or the source material to which it refers.
+        <desc xml:lang="en">Indicates whether to render a repeat symbol or the source material to which it refers.
           A value of 'true' renders the source material, while 'false' displays the repeat
           symbol.</desc>
         <datatype>
@@ -464,14 +464,14 @@
     </attList>
   </classSpec>
   <classSpec ident="att.fermata.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.startEndId"/>
     </classes>
   </classSpec>
   <classSpec ident="att.fTrem.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.event"/>
       <memberOf key="att.augmentDots"/>
@@ -479,23 +479,23 @@
     </classes>
     <attList>
       <attDef ident="form" usage="opt">
-        <desc>Describes the style of the tremolo.</desc>
+        <desc xml:lang="en">Describes the style of the tremolo.</desc>
         <valList type="closed">
           <valItem ident="meas">
-            <desc>Measured tremolo.</desc>
+            <desc xml:lang="en">Measured tremolo.</desc>
           </valItem>
           <valItem ident="unmeas">
-            <desc>Unmeasured tremolo.</desc>
+            <desc xml:lang="en">Unmeasured tremolo.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.glissPresent" module="MEI.cmn" type="atts">
-    <desc>Attributes that indicate whether an event participates in a glissando.</desc>
+    <desc xml:lang="en">Attributes that indicate whether an event participates in a glissando.</desc>
     <attList>
       <attDef ident="gliss" usage="opt">
-        <desc>Indicates that this element participates in a glissando. If visual information about
+        <desc xml:lang="en">Indicates that this element participates in a glissando. If visual information about
           the glissando needs to be recorded, then a <gi scheme="MEI">gliss</gi> element should be
           employed instead.</desc>
         <datatype>
@@ -505,7 +505,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.gliss.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
@@ -514,18 +514,18 @@
     </classes>
   </classSpec>
   <classSpec ident="att.graced" module="MEI.cmn" type="atts">
-    <desc>Attributes that mark a note or chord as a "grace", how it should "steal" time, and how
+    <desc xml:lang="en">Attributes that mark a note or chord as a "grace", how it should "steal" time, and how
       much time should be allotted to the grace note/chord.</desc>
     <attList>
       <attDef ident="grace" usage="opt">
-        <desc>Marks a note or chord as a "grace" (without a definite performed duration) and records
+        <desc xml:lang="en">Marks a note or chord as a "grace" (without a definite performed duration) and records
           from which other note/chord it should "steal" time.</desc>
         <datatype>
           <rng:ref name="data.GRACE"/>
         </datatype>
       </attDef>
       <attDef ident="grace.time" usage="opt">
-        <desc>Records the amount of time to be "stolen" from a non-grace note/chord.</desc>
+        <desc xml:lang="en">Records the amount of time to be "stolen" from a non-grace note/chord.</desc>
         <datatype>
           <rng:ref name="data.PERCENT"/>
         </datatype>
@@ -533,43 +533,43 @@
     </attList>
   </classSpec>
   <classSpec ident="att.graceGrp.anl" module="MEI.cmn" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.graceGrp.ges" module="MEI.cmn" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.graceGrp.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.event"/>
       <memberOf key="att.graced"/>
     </classes>
     <attList>
       <attDef ident="attach" usage="opt">
-        <desc>Records whether the grace note group is attached to the following event or to the
+        <desc xml:lang="en">Records whether the grace note group is attached to the following event or to the
           preceding one. The usual name for the latter is "Nachschlag".</desc>
         <valList type="closed">
           <valItem ident="pre">
-            <desc>Attached to the preceding event.</desc>
+            <desc xml:lang="en">Attached to the preceding event.</desc>
           </valItem>
           <valItem ident="post">
-            <desc>Attached to the following event.</desc>
+            <desc xml:lang="en">Attached to the following event.</desc>
           </valItem>
           <valItem ident="unknown">
-            <desc>Attachment is ambiguous.</desc>
+            <desc xml:lang="en">Attachment is ambiguous.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.graceGrp.vis" module="MEI.cmn" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
     </classes>
   </classSpec>
   <classSpec ident="att.hairpin.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
@@ -578,19 +578,19 @@
     </classes>
     <attList>
       <attDef ident="form" usage="req">
-        <desc>Captures the visual rendition and function of the hairpin; that is, whether it
+        <desc xml:lang="en">Captures the visual rendition and function of the hairpin; that is, whether it
           indicates an increase or a decrease in volume.</desc>
         <valList type="closed">
           <valItem ident="cres">
-            <desc>Crescendo; <abbr>i.e.</abbr>, louder.</desc>
+            <desc xml:lang="en">Crescendo; <abbr>i.e.</abbr>, louder.</desc>
           </valItem>
           <valItem ident="dim">
-            <desc>Diminuendo; <abbr>i.e.</abbr>, softer.</desc>
+            <desc xml:lang="en">Diminuendo; <abbr>i.e.</abbr>, softer.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="niente" usage="opt">
-        <desc>Indicates that the hairpin starts from or ends in silence. Often rendered as a small
+        <desc xml:lang="en">Indicates that the hairpin starts from or ends in silence. Often rendered as a small
           circle attached to the closed end of the hairpin. See Gould, p. 108.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
@@ -599,14 +599,14 @@
     </attList>
   </classSpec>
   <classSpec ident="att.halfmRpt.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.event"/>
       <memberOf key="att.duration.logical"/>
     </classes>
   </classSpec>
   <classSpec ident="att.harpPedal.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes. The pedal setting, <abbr>i.e.</abbr>, flat, natural, or sharp, for each
+    <desc xml:lang="en">Logical domain attributes. The pedal setting, <abbr>i.e.</abbr>, flat, natural, or sharp, for each
       diatonic pitch name is indicated by the seven letter-named attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
@@ -614,120 +614,120 @@
     </classes>
     <attList>
       <attDef ident="c" usage="opt">
-        <desc>Indicates the pedal setting for the harp’s C strings.</desc>
+        <desc xml:lang="en">Indicates the pedal setting for the harp’s C strings.</desc>
         <defaultVal>n</defaultVal>
         <valList type="closed">
           <valItem ident="f">
-            <desc>Flat.</desc>
+            <desc xml:lang="en">Flat.</desc>
           </valItem>
           <valItem ident="n">
-            <desc>Natural.</desc>
+            <desc xml:lang="en">Natural.</desc>
           </valItem>
           <valItem ident="s">
-            <desc>Sharp.</desc>
+            <desc xml:lang="en">Sharp.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="d" usage="opt">
-        <desc>Indicates the pedal setting for the harp’s D strings.</desc>
+        <desc xml:lang="en">Indicates the pedal setting for the harp’s D strings.</desc>
         <defaultVal>n</defaultVal>
         <valList type="closed">
           <valItem ident="f">
-            <desc>Flat.</desc>
+            <desc xml:lang="en">Flat.</desc>
           </valItem>
           <valItem ident="n">
-            <desc>Natural.</desc>
+            <desc xml:lang="en">Natural.</desc>
           </valItem>
           <valItem ident="s">
-            <desc>Sharp.</desc>
+            <desc xml:lang="en">Sharp.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="e" usage="opt">
-        <desc>Indicates the pedal setting for the harp’s E strings.</desc>
+        <desc xml:lang="en">Indicates the pedal setting for the harp’s E strings.</desc>
         <defaultVal>n</defaultVal>
         <valList type="closed">
           <valItem ident="f">
-            <desc>Flat.</desc>
+            <desc xml:lang="en">Flat.</desc>
           </valItem>
           <valItem ident="n">
-            <desc>Natural.</desc>
+            <desc xml:lang="en">Natural.</desc>
           </valItem>
           <valItem ident="s">
-            <desc>Sharp.</desc>
+            <desc xml:lang="en">Sharp.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="f" usage="opt">
-        <desc>Indicates the pedal setting for the harp’s F strings.</desc>
+        <desc xml:lang="en">Indicates the pedal setting for the harp’s F strings.</desc>
         <defaultVal>n</defaultVal>
         <valList type="closed">
           <valItem ident="f">
-            <desc>Flat.</desc>
+            <desc xml:lang="en">Flat.</desc>
           </valItem>
           <valItem ident="n">
-            <desc>Natural.</desc>
+            <desc xml:lang="en">Natural.</desc>
           </valItem>
           <valItem ident="s">
-            <desc>Sharp.</desc>
+            <desc xml:lang="en">Sharp.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="g" usage="opt">
-        <desc>Indicates the pedal setting for the harp’s G strings.</desc>
+        <desc xml:lang="en">Indicates the pedal setting for the harp’s G strings.</desc>
         <defaultVal>n</defaultVal>
         <valList type="closed">
           <valItem ident="f">
-            <desc>Flat.</desc>
+            <desc xml:lang="en">Flat.</desc>
           </valItem>
           <valItem ident="n">
-            <desc>Natural.</desc>
+            <desc xml:lang="en">Natural.</desc>
           </valItem>
           <valItem ident="s">
-            <desc>Sharp.</desc>
+            <desc xml:lang="en">Sharp.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="a" usage="opt">
-        <desc>Indicates the pedal setting for the harp’s A strings.</desc>
+        <desc xml:lang="en">Indicates the pedal setting for the harp’s A strings.</desc>
         <defaultVal>n</defaultVal>
         <valList type="closed">
           <valItem ident="f">
-            <desc>Flat.</desc>
+            <desc xml:lang="en">Flat.</desc>
           </valItem>
           <valItem ident="n">
-            <desc>Natural.</desc>
+            <desc xml:lang="en">Natural.</desc>
           </valItem>
           <valItem ident="s">
-            <desc>Sharp.</desc>
+            <desc xml:lang="en">Sharp.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="b" usage="opt">
-        <desc>Indicates the pedal setting for the harp’s B strings.</desc>
+        <desc xml:lang="en">Indicates the pedal setting for the harp’s B strings.</desc>
         <defaultVal>n</defaultVal>
         <valList type="closed">
           <valItem ident="f">
-            <desc>Flat.</desc>
+            <desc xml:lang="en">Flat.</desc>
           </valItem>
           <valItem ident="n">
-            <desc>Natural.</desc>
+            <desc xml:lang="en">Natural.</desc>
           </valItem>
           <valItem ident="s">
-            <desc>Sharp.</desc>
+            <desc xml:lang="en">Sharp.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.layerDef.log.cmn" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.beaming.log"/>
     </classes>
   </classSpec>
   <classSpec ident="att.lv.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.startEndId"/>
@@ -735,12 +735,12 @@
     </classes>
   </classSpec>
   <classSpec ident="att.lvPresent" module="MEI.cmn" type="atts">
-    <desc>Attributes that indicate the presence of an l.v. (laissez vibrer) marking attached to a
+    <desc xml:lang="en">Attributes that indicate the presence of an l.v. (laissez vibrer) marking attached to a
       feature. If visual information about the lv sign needs to be recorded, then an <gi
       scheme="MEI">lv</gi> element should be employed.</desc>
     <attList>
       <attDef ident="lv" usage="opt">
-        <desc>Indicates the attachment of an l.v. (laissez vibrer) sign to this element.</desc>
+        <desc xml:lang="en">Indicates the attachment of an l.v. (laissez vibrer) sign to this element.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
@@ -748,7 +748,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.measure.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes. The n attribute contains a name or number associated with the
+    <desc xml:lang="en">Logical domain attributes. The n attribute contains a name or number associated with the
       measure (Read, p. 445). Often, this is an integer, but not always. For example, some measures,
       especially incomplete measures or those under an ending mark, may have labels that contain an
       integer plus a suffix, such as '12a'. Measures may even have labels, especially in editorial
@@ -762,7 +762,7 @@
     </classes>
     <attList>
       <attDef ident="left" usage="opt">
-        <desc>Indicates the visual rendition of the left bar line. It is present here only for
+        <desc xml:lang="en">Indicates the visual rendition of the left bar line. It is present here only for
           facilitation of translation from legacy encodings which use it. Usually, it can be safely
           ignored.</desc>
         <datatype>
@@ -770,7 +770,7 @@
         </datatype>
       </attDef>
       <attDef ident="right" usage="opt">
-        <desc>Indicates the function of the right bar line and is structurally important.</desc>
+        <desc xml:lang="en">Indicates the function of the right bar line and is structurally important.</desc>
         <datatype>
           <rng:ref name="data.BARRENDITION"/>
         </datatype>
@@ -778,19 +778,19 @@
     </attList>
   </classSpec>
   <classSpec ident="att.meterSigGrp.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <attList>
       <attDef ident="func" usage="req">
-        <desc>Function of the meter signature group.</desc>
+        <desc xml:lang="en">Function of the meter signature group.</desc>
         <valList type="closed">
           <valItem ident="alternating">
-            <desc>Meter signatures apply to alternating measures.</desc>
+            <desc xml:lang="en">Meter signatures apply to alternating measures.</desc>
           </valItem>
           <valItem ident="interchanging">
-            <desc>Meter signatures are interchangeable, <abbr>e.g.</abbr>, 3/4 and 6/8.</desc>
+            <desc xml:lang="en">Meter signatures are interchangeable, <abbr>e.g.</abbr>, 3/4 and 6/8.</desc>
           </valItem>
           <valItem ident="mixed">
-            <desc>Meter signatures with different unit values are used to express a complex metrical
+            <desc xml:lang="en">Meter signatures with different unit values are used to express a complex metrical
               pattern that is not expressible using traditional means, such as 2/4+1/8.</desc>
           </valItem>
         </valList>
@@ -798,7 +798,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.mRest.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.cue"/>
       <memberOf key="att.duration.additive"/>
@@ -806,41 +806,41 @@
     </classes>
   </classSpec>
   <classSpec ident="att.mRpt.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.event"/>
       <memberOf key="att.numbered"/>
     </classes>
   </classSpec>
   <classSpec ident="att.mRpt2.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.event"/>
     </classes>
   </classSpec>
   <classSpec ident="att.mSpace.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes in the CMN repertoire.</desc>
+    <desc xml:lang="en">Logical domain attributes in the CMN repertoire.</desc>
     <classes>
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.event"/>
     </classes>
   </classSpec>
   <classSpec ident="att.multiRest.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.event"/>
       <memberOf key="att.numbered"/>
     </classes>
   </classSpec>
   <classSpec ident="att.multiRpt.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.event"/>
       <memberOf key="att.numbered"/>
     </classes>
   </classSpec>
   <classSpec ident="att.note.anl.cmn" module="MEI.cmn" type="atts">
-    <desc>Analytical domain attributes in the CMN repertoire.</desc>
+    <desc xml:lang="en">Analytical domain attributes in the CMN repertoire.</desc>
     <classes>
       <memberOf key="att.beamPresent"/>
       <memberOf key="att.glissPresent"/>
@@ -853,22 +853,22 @@
     </classes>
   </classSpec>
   <classSpec ident="att.note.log.cmn" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.graced"/>
     </classes>
   </classSpec>
   <classSpec ident="att.note.vis.cmn" module="MEI.cmn" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.beamSecondary"/>
     </classes>
   </classSpec>
   <classSpec ident="att.numbered" module="MEI.cmn" type="atts">
-    <desc>Attributes that record numbers to be displayed with a feature.</desc>
+    <desc xml:lang="en">Attributes that record numbers to be displayed with a feature.</desc>
     <attList>
       <attDef ident="num" usage="opt">
-        <desc>Records a number or count accompanying a notational feature.</desc>
+        <desc xml:lang="en">Records a number or count accompanying a notational feature.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
@@ -876,17 +876,17 @@
     </attList>
   </classSpec>
   <classSpec ident="att.numberPlacement" module="MEI.cmn" type="atts">
-    <desc>Attributes that record the placement and visibility of numbers that accompany a bowed
+    <desc xml:lang="en">Attributes that record the placement and visibility of numbers that accompany a bowed
       tremolo or tuplet.</desc>
     <attList>
       <attDef ident="num.place" usage="opt">
-        <desc>States where the tuplet number will be placed in relation to the note heads.</desc>
+        <desc xml:lang="en">States where the tuplet number will be placed in relation to the note heads.</desc>
         <datatype>
           <rng:ref name="data.STAFFREL.basic"/>
         </datatype>
       </attDef>
       <attDef ident="num.visible" usage="opt">
-        <desc>Determines if the tuplet number is visible.</desc>
+        <desc xml:lang="en">Determines if the tuplet number is visible.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
@@ -894,7 +894,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.octave.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
@@ -904,23 +904,23 @@
     </classes>
     <attList>
       <attDef ident="coll" usage="opt">
-        <desc>Indicates whether the octave displacement should be performed simultaneously with the
+        <desc xml:lang="en">Indicates whether the octave displacement should be performed simultaneously with the
           written notes, <abbr>i.e.</abbr>, "coll' ottava". Unlike other octave signs which are indicated by
           broken lines, coll' ottava typically uses an unbroken line or a series of longer broken
           lines, ending with a short vertical stroke. See Read, p. 47-48.</desc>
         <valList type="closed">
           <valItem ident="coll">
-            <desc>Coll' ottava (with the octave).</desc>
+            <desc xml:lang="en">Coll' ottava (with the octave).</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.ossia.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.pedal.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.startEndId"/>
@@ -928,46 +928,46 @@
     </classes>
     <attList>
       <attDef ident="dir" usage="req">
-        <desc>Records the position of the piano damper pedal.</desc>
+        <desc xml:lang="en">Records the position of the piano damper pedal.</desc>
         <valList type="closed">
           <valItem ident="down">
-            <desc>Depress the pedal.</desc>
+            <desc xml:lang="en">Depress the pedal.</desc>
           </valItem>
           <valItem ident="up">
-            <desc>Release the pedal.</desc>
+            <desc xml:lang="en">Release the pedal.</desc>
           </valItem>
           <valItem ident="half">
-            <desc>Half pedal.</desc>
+            <desc xml:lang="en">Half pedal.</desc>
           </valItem>
           <valItem ident="bounce">
-            <desc>Release then immediately depress the pedal.</desc>
+            <desc xml:lang="en">Release then immediately depress the pedal.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="func" usage="opt">
-        <desc>Indicates the function of the depressed pedal, but not necessarily the text associated
+        <desc xml:lang="en">Indicates the function of the depressed pedal, but not necessarily the text associated
           with its use. Use the <gi>dir</gi> element for such text.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="sustain">
-            <desc>The sustain pedal, also referred to as the "damper" pedal, allows the piano
+            <desc xml:lang="en">The sustain pedal, also referred to as the "damper" pedal, allows the piano
               strings to vibrate sympathetically with the struck strings. It is the right-most and
               the most frequently used pedal on modern pianos.</desc>
           </valItem>
           <valItem ident="soft">
-            <desc>The soft pedal, sometimes called the "una corda", "piano", or "half-blow" pedal,
+            <desc xml:lang="en">The soft pedal, sometimes called the "una corda", "piano", or "half-blow" pedal,
               reduces the volume and modifies the timbre of the piano. On the modern piano, it is
               the left-most pedal.</desc>
           </valItem>
           <valItem ident="sostenuto">
-            <desc>The sostenuto or tone-sustaining pedal allows notes already undamped to continue
+            <desc xml:lang="en">The sostenuto or tone-sustaining pedal allows notes already undamped to continue
               to ring while other notes are damped normally; that is, on their release by the
               fingers. This is usually the center pedal of the modern piano.</desc>
           </valItem>
           <valItem ident="silent">
-            <desc>The silent or practice pedal mutes the volume of the piano so that one may
+            <desc xml:lang="en">The silent or practice pedal mutes the volume of the piano so that one may
               practice quietly. It is sometimes a replacement for the sostenuto pedal, especially on
               an upright or vertical instrument.</desc>
           </valItem>
@@ -976,29 +976,29 @@
     </attList>
   </classSpec>
   <classSpec ident="att.phrase.vis.cmn" module="MEI.cmn" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.curvature"/>
       <memberOf key="att.curveRend"/>
     </classes>
   </classSpec>
   <classSpec ident="att.pianoPedals" module="MEI.cmn" type="atts">
-    <desc>Used by scoreDef and staffDef to provide default description of piano pedal
+    <desc xml:lang="en">Used by scoreDef and staffDef to provide default description of piano pedal
       rendition.</desc>
     <attList>
       <attDef ident="pedal.style" usage="opt">
-        <desc>Determines whether piano pedal marks should be rendered as lines or as terms.</desc>
+        <desc xml:lang="en">Determines whether piano pedal marks should be rendered as lines or as terms.</desc>
         <valList type="closed">
           <valItem ident="line">
-            <desc>Continuous line with start and end positions rendered by vertical bars and bounces
+            <desc xml:lang="en">Continuous line with start and end positions rendered by vertical bars and bounces
               shown by upward-pointing "blips".</desc>
           </valItem>
           <valItem ident="pedstar">
-            <desc>Pedal down and half pedal rendered with "Ped.", pedal up rendered by "*", pedal
+            <desc xml:lang="en">Pedal down and half pedal rendered with "Ped.", pedal up rendered by "*", pedal
               "bounce" rendered with "* Ped.".</desc>
           </valItem>
           <valItem ident="altpedstar">
-            <desc>Pedal up and down indications same as with "pedstar", but bounce is rendered with
+            <desc xml:lang="en">Pedal up and down indications same as with "pedstar", but bounce is rendered with
               "Ped." only.</desc>
           </valItem>
         </valList>
@@ -1006,7 +1006,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.reh.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.alignment"/>
       <memberOf key="att.partIdent"/>
@@ -1017,27 +1017,27 @@
     </classes>
   </classSpec>
   <classSpec ident="att.rehearsal" module="MEI.cmn" type="atts">
-    <desc>Attributes used by scoreDef and staffDef to provide default information about rehearsal
+    <desc xml:lang="en">Attributes used by scoreDef and staffDef to provide default information about rehearsal
       numbers/letters.</desc>
     <attList>
       <attDef ident="reh.enclose" usage="opt">
-        <desc>Describes the enclosing shape for rehearsal marks.</desc>
+        <desc xml:lang="en">Describes the enclosing shape for rehearsal marks.</desc>
         <valList type="closed">
           <valItem ident="box">
-            <desc>Enclosed by box.</desc>
+            <desc xml:lang="en">Enclosed by box.</desc>
           </valItem>
           <valItem ident="circle">
-            <desc>Enclosed by circle.</desc>
+            <desc xml:lang="en">Enclosed by circle.</desc>
           </valItem>
           <valItem ident="none">
-            <desc>No enclosing shape.</desc>
+            <desc xml:lang="en">No enclosing shape.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.rest.anl.cmn" module="MEI.cmn" type="atts">
-    <desc>Analytical domain attributes in the CMN repertoire.</desc>
+    <desc xml:lang="en">Analytical domain attributes in the CMN repertoire.</desc>
     <classes>
       <memberOf key="att.beamPresent"/>
       <memberOf key="att.fermataPresent"/>
@@ -1045,22 +1045,22 @@
     </classes>
   </classSpec>
   <classSpec ident="att.rest.log.cmn" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes in the CMN repertoire.</desc>
+    <desc xml:lang="en">Logical domain attributes in the CMN repertoire.</desc>
   </classSpec>
   <classSpec ident="att.rest.vis.cmn" module="MEI.cmn" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.beamSecondary"/>
     </classes>
   </classSpec>
   <classSpec ident="att.scoreDef.log.cmn" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.beaming.log"/>
     </classes>
   </classSpec>
   <classSpec ident="att.scoreDef.vis.cmn" module="MEI.cmn" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.beaming.vis"/>
       <memberOf key="att.pianoPedals"/>
@@ -1070,7 +1070,7 @@
     </classes>
     <attList>
       <attDef ident="grid.show" usage="opt">
-        <desc>Determines whether to display guitar chord grids.</desc>
+        <desc xml:lang="en">Determines whether to display guitar chord grids.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
@@ -1078,7 +1078,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.slur.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
@@ -1087,7 +1087,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.slurRend" module="MEI.cmn" type="atts">
-    <desc>Attributes that describe the rendition of slurs.</desc>
+    <desc xml:lang="en">Attributes that describe the rendition of slurs.</desc>
     <attList>
       <attDef ident="slur.lform">
         <datatype>
@@ -1102,7 +1102,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.space.anl.cmn" module="MEI.cmn" type="atts">
-    <desc>Analytical domain attributes in the CMN repertoire.</desc>
+    <desc xml:lang="en">Analytical domain attributes in the CMN repertoire.</desc>
     <classes>
       <memberOf key="att.beamPresent"/>
       <memberOf key="att.fermataPresent"/>
@@ -1110,16 +1110,16 @@
     </classes>
   </classSpec>
   <classSpec ident="att.space.log.cmn" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes in the CMN repertoire.</desc>
+    <desc xml:lang="en">Logical domain attributes in the CMN repertoire.</desc>
   </classSpec>
   <classSpec ident="att.staffDef.log.cmn" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes for staffDef in the CMN repertoire.</desc>
+    <desc xml:lang="en">Logical domain attributes for staffDef in the CMN repertoire.</desc>
     <classes>
       <memberOf key="att.beaming.log"/>
     </classes>
   </classSpec>
   <classSpec ident="att.staffDef.vis.cmn" module="MEI.cmn" type="atts">
-    <desc>Visual domain attributes for staffDef in the CMN repertoire.</desc>
+    <desc xml:lang="en">Visual domain attributes for staffDef in the CMN repertoire.</desc>
     <classes>
       <memberOf key="att.beaming.vis"/>
       <memberOf key="att.pianoPedals"/>
@@ -1129,11 +1129,11 @@
     </classes>
   </classSpec>
   <classSpec ident="att.stems.cmn" module="MEI.cmn" type="atts">
-    <desc>Attributes that describe the properties of stemmed features; that is, chords and
+    <desc xml:lang="en">Attributes that describe the properties of stemmed features; that is, chords and
       notes.</desc>
     <attList>
       <attDef ident="stem.with" usage="opt">
-        <desc>Contains an indication of which staff a note or chord that logically belongs to the
+        <desc xml:lang="en">Contains an indication of which staff a note or chord that logically belongs to the
           current staff should be visually placed on; that is, the one above or the one
           below.</desc>
         <datatype>
@@ -1143,7 +1143,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.tie.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.startEndId"/>
@@ -1151,7 +1151,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.tieRend" module="MEI.cmn" type="atts">
-    <desc>Attributes that describe the rendition of ties.</desc>
+    <desc xml:lang="en">Attributes that describe the rendition of ties.</desc>
     <attList>
       <attDef ident="tie.lform">
         <datatype>
@@ -1166,10 +1166,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.tremMeasured" module="MEI.cmn" type="atts">
-    <desc>Attributes that describe measured tremolandi.</desc>
+    <desc xml:lang="en">Attributes that describe measured tremolandi.</desc>
     <attList>
       <attDef ident="unitdur" usage="opt">
-        <desc>The performed duration of an individual note in a measured tremolo.</desc>
+        <desc xml:lang="en">The performed duration of an individual note in a measured tremolo.</desc>
         <datatype>
           <rng:ref name="data.DURATION.cmn"/>
         </datatype>
@@ -1177,7 +1177,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.tuplet.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.beamedWith"/>
       <memberOf key="att.duration.additive"/>
@@ -1187,7 +1187,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.tupletSpan.log" module="MEI.cmn" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.beamedWith"/>
       <memberOf key="att.controlEvent"/>
@@ -1198,7 +1198,7 @@
     </classes>
   </classSpec>
   <classSpec ident="model.controlEventLike.cmn" module="MEI.cmn" type="model">
-    <desc>Groups control events that appear in CMN.</desc>
+    <desc xml:lang="en">Groups control events that appear in CMN.</desc>
     <classes>
       <memberOf key="model.measurePart"/>
       <memberOf key="model.rdgPart.music"/>
@@ -1206,47 +1206,47 @@
     </classes>
   </classSpec>
   <classSpec ident="model.eventLike.cmn" module="MEI.cmn" type="model">
-    <desc>Groups events that appear in CMN.</desc>
+    <desc xml:lang="en">Groups events that appear in CMN.</desc>
     <classes>
       <memberOf key="model.layerPart.cmn"/>
     </classes>
   </classSpec>
   <classSpec ident="model.eventLike.measureFilling" module="MEI.cmn" type="model">
-    <desc>Groups events that completely fill a CMN measure.</desc>
+    <desc xml:lang="en">Groups events that completely fill a CMN measure.</desc>
     <classes>
       <memberOf key="model.layerPart.cmn"/>
     </classes>
   </classSpec>
   <classSpec ident="model.layerPart.cmn" module="MEI.cmn" type="model">
-    <desc>Groups notated events that may appear at the layer level in CMN.</desc>
+    <desc xml:lang="en">Groups notated events that may appear at the layer level in CMN.</desc>
     <classes>
       <memberOf key="model.layerPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.measureLike" module="MEI.cmn" type="model">
-    <desc>Groups CMN measure-like elements.</desc>
+    <desc xml:lang="en">Groups CMN measure-like elements.</desc>
     <classes>
       <memberOf key="model.sectionPart.cmn"/>
     </classes>
   </classSpec>
   <classSpec ident="model.measurePart" module="MEI.cmn" type="model">
-    <desc>Groups elements that may appear within a CMN measure.</desc>
+    <desc xml:lang="en">Groups elements that may appear within a CMN measure.</desc>
   </classSpec>
   <classSpec ident="model.ossiaLike" module="MEI.cmn" type="model">
-    <desc>Groups elements that function like ossia.</desc>
+    <desc xml:lang="en">Groups elements that function like ossia.</desc>
     <classes>
       <memberOf key="model.measurePart"/>
       <memberOf key="model.staffPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.sectionPart.cmn" module="MEI.cmn" type="model">
-    <desc>Groups elements that may appear as part of a section.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of a section.</desc>
     <classes>
       <memberOf key="model.sectionPart"/>
     </classes>
   </classSpec>
   <elementSpec ident="arpeg" module="MEI.cmn">
-    <desc>(arpeggiation) – Indicates that the notes of a chord are to be performed successively
+    <desc xml:lang="en">(arpeggiation) – Indicates that the notes of a chord are to be performed successively
       rather than simultaneously, usually from lowest to highest. Sometimes called a "roll".</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1274,7 +1274,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="attacca" module="MEI.cmn">
-    <desc>An instruction to begin the next section or movement of a composition without
+    <desc xml:lang="en">An instruction to begin the next section or movement of a composition without
       pause.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1317,7 +1317,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="beam" module="MEI.cmn">
-    <desc>A container for a series of explicitly beamed events that begins and ends entirely within
+    <desc xml:lang="en">A container for a series of explicitly beamed events that begins and ends entirely within
       a measure.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1358,7 +1358,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="beamSpan" module="MEI.cmn">
-    <desc>(beam span) – Alternative element for explicitly encoding beams, particularly those which
+    <desc xml:lang="en">(beam span) – Alternative element for explicitly encoding beams, particularly those which
       extend across bar lines.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1391,7 +1391,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="beatRpt" module="MEI.cmn">
-    <desc>(beat repeat) – An indication that material on a preceding beat should be repeated.</desc>
+    <desc xml:lang="en">(beat repeat) – An indication that material on a preceding beat should be repeated.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1414,7 +1414,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="bend" module="MEI.cmn">
-    <desc>A variation in pitch (often micro-tonal) upwards or downwards during the course of a
+    <desc xml:lang="en">A variation in pitch (often micro-tonal) upwards or downwards during the course of a
       note.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1440,7 +1440,7 @@
     </constraintSpec>
   </elementSpec>
   <elementSpec ident="bracketSpan" module="MEI.cmn">
-    <desc>Marks a sequence of notational events grouped by a bracket.</desc>
+    <desc xml:lang="en">Marks a sequence of notational events grouped by a bracket.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bracketSpan.log"/>
@@ -1479,7 +1479,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="breath" module="MEI.cmn">
-    <desc>(breath mark) – An indication of a point at which the performer on an instrument requiring
+    <desc xml:lang="en">(breath mark) – An indication of a point at which the performer on an instrument requiring
       breath (including the voice) may breathe.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1515,7 +1515,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="bTrem" module="MEI.cmn">
-    <desc>(bowed tremolo) – A rapid alternation on a single pitch or chord.</desc>
+    <desc xml:lang="en">(bowed tremolo) – A rapid alternation on a single pitch or chord.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1533,7 +1533,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="fermata" module="MEI.cmn">
-    <desc>An indication placed over a note or rest to indicate that it should be held longer than
+    <desc xml:lang="en">An indication placed over a note or rest to indicate that it should be held longer than
       its written value. May also occur over a bar line to indicate the end of a phrase or section.
       Sometimes called a 'hold' or 'pause'.</desc>
     <classes>
@@ -1567,7 +1567,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="fTrem" module="MEI.cmn">
-    <desc>(fingered tremolo) – A rapid alternation between a pair of notes (or chords or perhaps
+    <desc xml:lang="en">(fingered tremolo) – A rapid alternation between a pair of notes (or chords or perhaps
       between a note and a chord) that are (usually) farther apart than a major second.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1604,7 +1604,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="gliss" module="MEI.cmn">
-    <desc>(glissando) – A continuous or sliding movement from one pitch to another, usually
+    <desc xml:lang="en">(glissando) – A continuous or sliding movement from one pitch to another, usually
       indicated by a straight or wavy line.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1646,7 +1646,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="graceGrp" module="MEI.cmn">
-    <desc>A container for a sequence of grace notes.</desc>
+    <desc xml:lang="en">A container for a sequence of grace notes.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1687,7 +1687,7 @@
     </constraintSpec>
   </elementSpec>
   <elementSpec ident="hairpin" module="MEI.cmn">
-    <desc>Indicates continuous dynamics expressed on the score as wedge-shaped graphics, <abbr>e.g.</abbr>, &lt;
+    <desc xml:lang="en">Indicates continuous dynamics expressed on the score as wedge-shaped graphics, <abbr>e.g.</abbr>, &lt;
       and &gt;.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1725,7 +1725,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="halfmRpt" module="MEI.cmn">
-    <desc>(half-measure repeat) – A half-measure repeat in any meter.</desc>
+    <desc xml:lang="en">(half-measure repeat) – A half-measure repeat in any meter.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1740,7 +1740,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="harpPedal" module="MEI.cmn">
-    <desc>(harp pedal) – Harp pedal diagram.</desc>
+    <desc xml:lang="en">(harp pedal) – Harp pedal diagram.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1768,7 +1768,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="lv" module="MEI.cmn">
-    <desc>(laissez vibrer) – A "tie-like" indication that a note should ring beyond its written duration.</desc>
+    <desc xml:lang="en">(laissez vibrer) – A "tie-like" indication that a note should ring beyond its written duration.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1810,7 +1810,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="measure" module="MEI.cmn">
-    <desc>Unit of musical time consisting of a fixed number of note values of a given type, as
+    <desc xml:lang="en">Unit of musical time consisting of a fixed number of note values of a given type, as
       determined by the prevailing meter, and delimited in musical notation by bar lines.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1851,7 +1851,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="meterSig" module="MEI.cmn">
-    <desc>(meter signature) – Written meter signature.</desc>
+    <desc xml:lang="en">(meter signature) – Written meter signature.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1866,7 +1866,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="meterSigGrp" module="MEI.cmn">
-    <desc>(meter signature group) – Used to capture alternating, interchanging, and mixed meter
+    <desc xml:lang="en">(meter signature group) – Used to capture alternating, interchanging, and mixed meter
       signatures.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1892,7 +1892,7 @@
     </constraintSpec>
   </elementSpec>
   <elementSpec ident="mNum" module="MEI.cmn">
-    <desc>(measure number) – Designation, name, or label for a measure, often but not always
+    <desc xml:lang="en">(measure number) – Designation, name, or label for a measure, often but not always
       consisting of digits. Use this element when the <att>n</att> attribute on <gi scheme="MEI"
       >measure</gi> does not adequately capture the appearance or placement of the measure
       number/label.</desc>
@@ -1919,7 +1919,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="mRest" module="MEI.cmn">
-    <desc>(measure rest) – Complete measure rest in any meter. <!-- (Read, p. 97-98). --> </desc>
+    <desc xml:lang="en">(measure rest) – Complete measure rest in any meter. <!-- (Read, p. 97-98). --> </desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1939,7 +1939,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="mRpt" module="MEI.cmn">
-    <desc>(measure repeat) – An indication that the previous measure should be repeated.</desc>
+    <desc xml:lang="en">(measure repeat) – An indication that the previous measure should be repeated.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1959,7 +1959,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="mRpt2" module="MEI.cmn">
-    <desc>(2-measure repeat) – An indication that the previous two measures should be
+    <desc xml:lang="en">(2-measure repeat) – An indication that the previous two measures should be
       repeated.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1975,7 +1975,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="mSpace" module="MEI.cmn">
-    <desc>(measure space) – A measure containing only empty space in any meter.</desc>
+    <desc xml:lang="en">(measure space) – A measure containing only empty space in any meter.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1995,7 +1995,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="multiRest" module="MEI.cmn">
-    <desc>(multiple rest) – Multiple measures of rest compressed into a single symbol, frequently
+    <desc xml:lang="en">(multiple rest) – Multiple measures of rest compressed into a single symbol, frequently
       found in performer parts.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2013,7 +2013,7 @@
         the note. See Read, p. 102-105.</p></remarks>-->
   </elementSpec>
   <elementSpec ident="multiRpt" module="MEI.cmn">
-    <desc>(multiple repeat) – Multiple repeated measures.</desc>
+    <desc xml:lang="en">(multiple repeat) – Multiple repeated measures.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -2034,7 +2034,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="octave" module="MEI.cmn">
-    <desc>An indication that a passage should be performed one or more octaves above or below its
+    <desc xml:lang="en">An indication that a passage should be performed one or more octaves above or below its
       written pitch.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2076,7 +2076,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="oLayer" module="MEI.cmn">
-    <desc>(ossia layer) – A layer that contains an alternative to material in another layer.</desc>
+    <desc xml:lang="en">(ossia layer) – A layer that contains an alternative to material in another layer.</desc>
     <classes>
       <memberOf key="att.basic"/>
       <memberOf key="att.facsimile"/>
@@ -2106,7 +2106,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="ossia" module="MEI.cmn">
-    <desc>Captures original notation and a differently notated version <hi rend="bold">*present in
+    <desc xml:lang="en">Captures original notation and a differently notated version <hi rend="bold">*present in
       the source being transcribed*</hi>.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2161,7 +2161,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="oStaff" module="MEI.cmn">
-    <desc>(ossia staff) – A staff that holds an alternative passage which may be played instead of
+    <desc xml:lang="en">(ossia staff) – A staff that holds an alternative passage which may be played instead of
       the original material.</desc>
     <classes>
       <memberOf key="att.basic"/>
@@ -2194,7 +2194,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="pedal" module="MEI.cmn">
-    <desc>Piano pedal mark.</desc>
+    <desc xml:lang="en">Piano pedal mark.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -2222,7 +2222,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="reh" module="MEI.cmn">
-    <desc>(rehearsal mark) – In an orchestral score and its corresponding parts, a mark indicating a
+    <desc xml:lang="en">(rehearsal mark) – In an orchestral score and its corresponding parts, a mark indicating a
       convenient point from which to resume rehearsal after a break.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2250,7 +2250,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="slur" module="MEI.cmn">
-    <desc>Indication of 1) a "unified melodic idea" or 2) performance technique.</desc>
+    <desc xml:lang="en">Indication of 1) a "unified melodic idea" or 2) performance technique.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -2308,7 +2308,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="tie" module="MEI.cmn">
-    <desc>An indication that two notes of the same pitch form a single note with their combined
+    <desc xml:lang="en">An indication that two notes of the same pitch form a single note with their combined
       rhythmic values.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2353,7 +2353,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="tuplet" module="MEI.cmn">
-    <desc>A group of notes with "irregular" (sometimes called "irrational") rhythmic values, for
+    <desc xml:lang="en">A group of notes with "irregular" (sometimes called "irrational") rhythmic values, for
       example, three notes in the time normally occupied by two or nine in the time of five.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2391,7 +2391,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="tupletSpan" module="MEI.cmn">
-    <desc>(tuplet span) – Alternative element for encoding tuplets, especially useful for tuplets
+    <desc xml:lang="en">(tuplet span) – Alternative element for encoding tuplets, especially useful for tuplets
       that extend across bar lines.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -220,18 +220,22 @@
         <desc xml:lang="en">Captures whether a beam is "feathered" and in which direction.</desc>
         <valList type="closed">
           <valItem ident="acc">
-            <desc xml:lang="en">(accelerando) means that the secondary beams become progressively more distant
+            <gloss versionDate="2022-05-18" xml:lang="en">accelerando</gloss>
+            <desc xml:lang="en">means that the secondary beams become progressively more distant
               toward the end of the beam.</desc>
           </valItem>
           <valItem ident="mixed">
-            <desc xml:lang="en">(mixed acc and rit) for beams that are "feathered" in both directions.</desc>
+            <gloss versionDate="2022-05-18" xml:lang="en">mixed acc and rit</gloss>
+            <desc xml:lang="en">for beams that are "feathered" in both directions.</desc>
           </valItem>
           <valItem ident="rit">
-            <desc xml:lang="en">(ritardando) indicates that the secondary beams get progressively closer together
+            <gloss versionDate="2022-05-18" xml:lang="en">ritardando</gloss>
+            <desc xml:lang="en">indicates that the secondary beams get progressively closer together
             toward the end of the beam.</desc>
           </valItem>
           <valItem ident="norm">
-            <desc xml:lang="en">(normal) indicates that the secondary beams are equidistant along the course of
+            <gloss versionDate="2022-05-18" xml:lang="en">normal</gloss>
+            <desc xml:lang="en">indicates that the secondary beams are equidistant along the course of
               the beam.</desc>
           </valItem>
         </valList>
@@ -1246,7 +1250,8 @@
     </classes>
   </classSpec>
   <elementSpec ident="arpeg" module="MEI.cmn">
-    <desc xml:lang="en">(arpeggiation) – Indicates that the notes of a chord are to be performed successively
+    <gloss versionDate="2022-05-18" xml:lang="en">arpeggiation</gloss>
+    <desc xml:lang="en">Indicates that the notes of a chord are to be performed successively
       rather than simultaneously, usually from lowest to highest. Sometimes called a "roll".</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1358,7 +1363,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="beamSpan" module="MEI.cmn">
-    <desc xml:lang="en">(beam span) – Alternative element for explicitly encoding beams, particularly those which
+    <gloss versionDate="2022-05-18" xml:lang="en">beam span</gloss>
+    <desc xml:lang="en">Alternative element for explicitly encoding beams, particularly those which
       extend across bar lines.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1391,7 +1397,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="beatRpt" module="MEI.cmn">
-    <desc xml:lang="en">(beat repeat) – An indication that material on a preceding beat should be repeated.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">beat repeat</gloss>
+    <desc xml:lang="en">An indication that material on a preceding beat should be repeated.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1479,7 +1486,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="breath" module="MEI.cmn">
-    <desc xml:lang="en">(breath mark) – An indication of a point at which the performer on an instrument requiring
+    <gloss versionDate="2022-05-18" xml:lang="en">breath mark</gloss>
+    <desc xml:lang="en">An indication of a point at which the performer on an instrument requiring
       breath (including the voice) may breathe.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1515,7 +1523,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="bTrem" module="MEI.cmn">
-    <desc xml:lang="en">(bowed tremolo) – A rapid alternation on a single pitch or chord.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">bowed tremolo</gloss>
+    <desc xml:lang="en">A rapid alternation on a single pitch or chord.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1567,7 +1576,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="fTrem" module="MEI.cmn">
-    <desc xml:lang="en">(fingered tremolo) – A rapid alternation between a pair of notes (or chords or perhaps
+    <gloss versionDate="2022-05-18" xml:lang="en">fingered tremolo</gloss>
+    <desc xml:lang="en">A rapid alternation between a pair of notes (or chords or perhaps
       between a note and a chord) that are (usually) farther apart than a major second.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1604,7 +1614,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="gliss" module="MEI.cmn">
-    <desc xml:lang="en">(glissando) – A continuous or sliding movement from one pitch to another, usually
+    <gloss versionDate="2022-05-18" xml:lang="en">glissando</gloss>
+    <desc xml:lang="en">A continuous or sliding movement from one pitch to another, usually
       indicated by a straight or wavy line.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1725,7 +1736,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="halfmRpt" module="MEI.cmn">
-    <desc xml:lang="en">(half-measure repeat) – A half-measure repeat in any meter.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">half-measure repeat</gloss>
+    <desc xml:lang="en">A half-measure repeat in any meter.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1740,7 +1752,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="harpPedal" module="MEI.cmn">
-    <desc xml:lang="en">(harp pedal) – Harp pedal diagram.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">harp pedal</gloss>
+    <desc xml:lang="en">Harp pedal diagram.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1768,7 +1781,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="lv" module="MEI.cmn">
-    <desc xml:lang="en">(laissez vibrer) – A "tie-like" indication that a note should ring beyond its written duration.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">laissez vibrer</gloss>
+    <desc xml:lang="en">A "tie-like" indication that a note should ring beyond its written duration.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1794,9 +1808,9 @@
     <constraintSpec ident="lv_containing_curve" scheme="isoschematron">
       <constraint>
         <sch:rule
-          context="mei:lv[mei:curve[@bezier or @bulge or @curvedir or @lform or @lwidth or              @ho or @startho or @endho or @to or @startto or @endto or @vo or @startvo or              @endvo or @x or @y or @x2 or @y2]]">
+          context="mei:lv[mei:curve[@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or @startho or @endho or @to or @startto or @endto or @vo or @startvo or              @endvo or @x or @y or @x2 or @y2]]">
           <sch:assert
-            test="not(@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or @startho or                @endho or @to or @startto or @endto or @vo or @startvo or @endvo or @x or @y or @x2 or @y2)"
+            test="not(@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or @startho or @endho or @to or @startto or @endto or @vo or @startvo or @endvo or @x or @y or @x2 or @y2)"
             role="warning">The visual attributes of the lv element (@bezier, @bulge, @curvedir,
             @lform, @lwidth, @ho, @startho, @endho, @to, @startto, @endto, @vo, @startvo, @endvo,
             @x, @y, @x2, and @y2) will be overridden by visual attributes of the contained curve
@@ -1851,7 +1865,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="meterSig" module="MEI.cmn">
-    <desc xml:lang="en">(meter signature) – Written meter signature.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">meter signature</gloss>
+    <desc xml:lang="en">Written meter signature.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1866,8 +1881,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="meterSigGrp" module="MEI.cmn">
-    <desc xml:lang="en">(meter signature group) – Used to capture alternating, interchanging, and mixed meter
-      signatures.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">meter signature group</gloss>
+    <desc xml:lang="en">Used to capture alternating, interchanging, and mixed meter signatures.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1892,7 +1907,8 @@
     </constraintSpec>
   </elementSpec>
   <elementSpec ident="mNum" module="MEI.cmn">
-    <desc xml:lang="en">(measure number) – Designation, name, or label for a measure, often but not always
+    <gloss versionDate="2022-05-18" xml:lang="en">measure number</gloss>
+    <desc xml:lang="en">Designation, name, or label for a measure, often but not always
       consisting of digits. Use this element when the <att>n</att> attribute on <gi scheme="MEI"
       >measure</gi> does not adequately capture the appearance or placement of the measure
       number/label.</desc>
@@ -1919,7 +1935,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="mRest" module="MEI.cmn">
-    <desc xml:lang="en">(measure rest) – Complete measure rest in any meter. <!-- (Read, p. 97-98). --> </desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">measure rest</gloss>
+    <desc xml:lang="en">Complete measure rest in any meter. <!-- (Read, p. 97-98). --> </desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1939,7 +1956,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="mRpt" module="MEI.cmn">
-    <desc xml:lang="en">(measure repeat) – An indication that the previous measure should be repeated.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">measure repeat</gloss>
+    <desc xml:lang="en">An indication that the previous measure should be repeated.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1959,7 +1977,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="mRpt2" module="MEI.cmn">
-    <desc xml:lang="en">(2-measure repeat) – An indication that the previous two measures should be
+    <gloss versionDate="2022-05-18" xml:lang="en">2-measure repeat</gloss>
+    <desc xml:lang="en">An indication that the previous two measures should be
       repeated.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1975,7 +1994,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="mSpace" module="MEI.cmn">
-    <desc xml:lang="en">(measure space) – A measure containing only empty space in any meter.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">measure space</gloss>
+    <desc xml:lang="en">A measure containing only empty space in any meter.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -1995,7 +2015,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="multiRest" module="MEI.cmn">
-    <desc xml:lang="en">(multiple rest) – Multiple measures of rest compressed into a single symbol, frequently
+    <gloss versionDate="2022-05-18" xml:lang="en">multiple rest</gloss>
+    <desc xml:lang="en">Multiple measures of rest compressed into a single symbol, frequently
       found in performer parts.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2013,7 +2034,8 @@
         the note. See Read, p. 102-105.</p></remarks>-->
   </elementSpec>
   <elementSpec ident="multiRpt" module="MEI.cmn">
-    <desc xml:lang="en">(multiple repeat) – Multiple repeated measures.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">multiple repeat</gloss>
+    <desc xml:lang="en">Multiple repeated measures.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -2076,7 +2098,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="oLayer" module="MEI.cmn">
-    <desc xml:lang="en">(ossia layer) – A layer that contains an alternative to material in another layer.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">ossia layer</gloss>
+    <desc xml:lang="en">A layer that contains an alternative to material in another layer.</desc>
     <classes>
       <memberOf key="att.basic"/>
       <memberOf key="att.facsimile"/>
@@ -2161,7 +2184,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="oStaff" module="MEI.cmn">
-    <desc xml:lang="en">(ossia staff) – A staff that holds an alternative passage which may be played instead of
+    <gloss versionDate="2022-05-18" xml:lang="en">ossia staff</gloss>
+    <desc xml:lang="en">A staff that holds an alternative passage which may be played instead of
       the original material.</desc>
     <classes>
       <memberOf key="att.basic"/>
@@ -2222,7 +2246,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="reh" module="MEI.cmn">
-    <desc xml:lang="en">(rehearsal mark) – In an orchestral score and its corresponding parts, a mark indicating a
+    <gloss versionDate="2022-05-18" xml:lang="en">rehearsal mark</gloss>
+    <desc xml:lang="en">In an orchestral score and its corresponding parts, a mark indicating a
       convenient point from which to resume rehearsal after a break.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2278,9 +2303,9 @@
     <constraintSpec ident="slur_containing_curve" scheme="isoschematron">
       <constraint>
         <sch:rule
-          context="mei:slur[mei:curve[@bezier or @bulge or @curvedir or @lform or @lwidth or              @ho or @startho or @endho or @to or @startto or @endto or @vo or @startvo or @endvo or              @x or @y or @x2 or @y2]]">
+          context="mei:slur[mei:curve[@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or @startho or @endho or @to or @startto or @endto or @vo or @startvo or @endvo or @x or @y or @x2 or @y2]]">
           <sch:assert
-            test="not(@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or @startho or                @endho or @to or @startto or @endto or @vo or @startvo or @endvo or @x or @y or @x2 or @y2)"
+            test="not(@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or @startho or @endho or @to or @startto or @endto or @vo or @startvo or @endvo or @x or @y or @x2 or @y2)"
             role="warning">The visual attributes of the slur (@bezier, @bulge, @curvedir, @lform,
             @lwidth, @ho, @startho, @endho, @to, @startto, @endto, @vo, @startvo, @endvo, @x, @y,
             @x2, and @y2) will be overridden by visual attributes of the contained curve
@@ -2337,9 +2362,9 @@
     <constraintSpec ident="tie_containing_curve" scheme="isoschematron">
       <constraint>
         <sch:rule
-          context="mei:tie[mei:curve[@bezier or @bulge or @curvedir or @lform or @lwidth or              @ho or @startho or @endho or @to or @startto or @endto or @vo or @startvo or              @endvo or @x or @y or @x2 or @y2]]">
+          context="mei:tie[mei:curve[@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or @startho or @endho or @to or @startto or @endto or @vo or @startvo or @endvo or @x or @y or @x2 or @y2]]">
           <sch:assert
-            test="not(@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or @startho or                @endho or @to or @startto or @endto or @vo or @startvo or @endvo or @x or @y or @x2 or @y2)"
+            test="not(@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or @startho or @endho or @to or @startto or @endto or @vo or @startvo or @endvo or @x or @y or @x2 or @y2)"
             role="warning">The visual attributes of the tie (@bezier, @bulge, @curvedir, @lform,
             @lwidth, @ho, @startho, @endho, @to, @startto, @endto, @vo, @startvo, @endvo, @x, @y,
             @x2, and @y2) will be overridden by visual attributes of the contained curve
@@ -2391,7 +2416,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="tupletSpan" module="MEI.cmn">
-    <desc xml:lang="en">(tuplet span) – Alternative element for encoding tuplets, especially useful for tuplets
+    <gloss versionDate="2022-05-18" xml:lang="en">tuplet span</gloss>
+    <desc xml:lang="en">Alternative element for encoding tuplets, especially useful for tuplets
       that extend across bar lines.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -187,7 +187,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>beam.group</att> attribute can be used to set a default beaming pattern to be used
         when no beaming is indicated at the event level. <att>beam.group</att> must contain a
         comma-separated list of time values that add up to a measure, <abbr>e.g.</abbr>, in 4/4 time '4,4,4,4'
@@ -1260,7 +1260,7 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The modern arpeggiation symbol is a vertical wavy line preceding the chord. When the notes
         of the chord are to be performed from highest to lowest, an arrowhead may be added to the
         lower end of the line. Even though it is redundant, an arrowhead is sometimes added to the
@@ -1306,7 +1306,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>As a specialized directive, <gi scheme="MEI">attacca</gi> is a control element. That is, it
         can be linked via its attributes to other events. The starting point of the attacca
         directive may be indicated by either a <att>startid</att>, <att>tstamp</att>,
@@ -1349,7 +1349,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>For beams that cross the bar line, use the <gi scheme="MEI">beamSpan</gi> element.
         Secondary beams may be broken explicitly using the <att>breaksec</att> attribute on the
         notes or chords under the beam. Automated beaming, as opposed to explicitly marked beams,
@@ -1382,7 +1382,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The starting point of the beam may be indicated by either a <att>startid</att>,
         <att>tstamp</att>, <att>tstamp.ges</att>, or <att>tstamp.real</att> attribute, while the
         ending point may be recorded by either a <att>dur</att>, <att>dur.ges</att>,
@@ -1406,7 +1406,7 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p> <gi scheme="MEI">beatRpt</gi> may also be used in guitar or rhythm parts to indicate where
         chord changes occur. When these parts require durations longer or shorter than a beat;
         however, <gi scheme="MEI">note</gi> elements with appropriately-shaped note heads should be
@@ -1469,7 +1469,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Text that interrupts the bracket used to mark the event group may be captured as the
         content of <gi scheme="MEI">bracketSpan</gi>. The starting point of the group/bracket may be
         indicated by either a <att>startid</att>, <att>tstamp</att>, <att>tstamp.ges</att>, or
@@ -1501,7 +1501,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element may also indicate a short pause or break for instruments *not* requiring
         breath. In such cases, it functions as a guide to phrasing. The starting point of the breath
         mark may be indicated by either a <att>startid</att>, <att>tstamp</att>,
@@ -1556,7 +1556,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>shape</att> attribute may be used to record whether the fermata is curved, square,
         or triangular, while <att>form</att> may be used to capture whether the fermata is
         "upright", <abbr>i.e.</abbr>, has the curve or bracket above the dot, or inverted, <abbr>i.e.</abbr>, has the curve or
@@ -1633,7 +1633,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Commonly also called a 'slide'. The term 'glissando' is frequently used to indicate both
         the case where distinct intermediate pitches are produced (as on the piano) and the case
         where they are not (as on the trombone), though the latter is sometimes referred to as
@@ -1711,7 +1711,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <gi scheme="MEI">hairpin</gi> element is used for <emph>graphical</emph>, <abbr>i.e.</abbr>,
         crescendo and diminuendo, dynamic markings. For instantaneous or continuous
         <emph>textual</emph> dynamics, such as 'p', 'mf', or 'cres. poco a poco', the <gi
@@ -1761,7 +1761,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The starting point of the harp pedal diagram may be indicated by either a
         <att>tstamp</att>, <att>tstamp.ges</att>, <att>tstamp.real</att> or <att>startid</att>
         attribute. It is a semantic error not to specify a starting point attribute.</p>
@@ -1804,7 +1804,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The lv element captures the graphical, "tie-like" symbol. Any associated text, such as
         "l.v.", must be captured using a <gi scheme="MEI">dir</gi> element.</p>
     </remarks>
@@ -1842,7 +1842,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>In MEI, the <gi scheme="MEI">measure</gi> element is a grouping mechanism for events and
         control events. Pointing attributes make it possible to connect this element to other
         internal or external entities, such as media objects or annotations. The <att>width</att>
@@ -1914,7 +1914,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p> <gi scheme="MEI">mNum</gi> uses a subset of model.textPhraseLike.limited.</p>
     </remarks>
   </elementSpec>
@@ -1932,7 +1932,7 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Automatically-generated numbering of consecutive measures of rest may be controlled via the
         <att>multi.number</att> attribute on the <gi scheme="MEI">scoreDef</gi> or <gi scheme="MEI"
         >staffDef</gi> elements.</p>
@@ -1952,7 +1952,7 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The automated numbering of consecutive measures of rest may be controlled via the
         <att>multi.number</att> attribute on the <gi scheme="MEI">scoreDef</gi> or <gi scheme="MEI"
         >staffDef</gi> elements.</p>
@@ -1988,7 +1988,7 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The automated numbering of consecutive measures of space may be controlled via the
         <att>multi.number</att> attribute on the <gi scheme="MEI">scoreDef</gi> or <gi scheme="MEI"
         >staffDef</gi> elements.</p>
@@ -2009,7 +2009,7 @@
     <content>
       <rng:empty/>
     </content>
-    <!--<remarks><p>The num attribute can used to store a number to be rendered along with
+    <!--<remarks xml:lang="en"><p>The num attribute can used to store a number to be rendered along with
         the note. See Read, p. 102-105.</p></remarks>-->
   </elementSpec>
   <elementSpec ident="multiRpt" module="MEI.cmn">
@@ -2026,7 +2026,7 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>In modern publishing practice, repeats of more than two measures should be written out
         using repeat signs. This element, however, is provided for handling non-standard practices
         often found in manuscript. The <att>num</att> attribute records the number of measures to be
@@ -2063,7 +2063,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>dis</att> and <att>dis.place</att> attributes record the amount and direction of
         displacement, respectively. The <att>lform</att> and <att>lwidth</att> attributes capture
         the appearance of the continuation line associated with the octave displacement. The
@@ -2151,7 +2151,7 @@
         </sch:pattern>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The alternative material in an ossia often provides a simpler, easier-to-perform option,
         while at other times the alternate material provides indications of performance practice,
         such as ornamentation. Often an ossia is rendered above the main staff on a reduced-size
@@ -2215,7 +2215,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The starting point of the pedal mark may be indicated by either a <att>startid</att>,
         <att>tstamp</att>, <att>tstamp.ges</att>, or <att>tstamp.real</att> attribute. It is a
         semantic error not to specify one of these attributes.</p>
@@ -2243,7 +2243,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>It may also be called a "rehearsal figure", or when numbers are used instead of letters, a
         "rehearsal number". See Read, p. 443. <gi scheme="MEI">reh</gi> uses a subset of
         model.textPhraseLike.limited.</p>
@@ -2288,7 +2288,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Historically, the term "slur" indicated two notes performed legato, while the term "phrase"
         was used for a "unified melodic idea". Nowadays, however, "slur" often has the same meaning
         as "phrase" (See Read, p. 265-266), since the visual rendition of the two concepts is the
@@ -2347,7 +2347,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Most often, a tie is rendered as a curved line connecting the two notes. See Read, p.
         110-111, 122.</p>
     </remarks>
@@ -2375,7 +2375,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <gi scheme="MEI">beam</gi> sub-element is allowed so that custom beaming may be
         indicated, <abbr>e.g.</abbr>, a septuplet may be divided into a group of three plus a group of four
         notes. See Read, p. 187-215. The <gi scheme="MEI">tuplet</gi> element may also used for
@@ -2416,7 +2416,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The starting point of the tuplet may be indicated by either a <att>startid</att>,
         <att>tstamp</att>, <att>tstamp.ges</att>, or <att>tstamp.real</att> attribute, while the
         ending point may be recorded by either a <att>dur</att>, <att>dur.ges</att>,

--- a/source/modules/MEI.cmnOrnaments.xml
+++ b/source/modules/MEI.cmnOrnaments.xml
@@ -5,10 +5,10 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.cmnOrnaments">
   <moduleSpec ident="MEI.cmnOrnaments">
-    <desc>CMN ornament component declarations.</desc>
+    <desc xml:lang="en">CMN ornament component declarations.</desc>
   </moduleSpec>
   <macroSpec ident="data.ORNAM.cmn" module="MEI.cmnOrnaments" type="dt">
-    <desc>CMN ornam attribute values: A = appogiatura (upper neighbor); a = acciaccatura (lower
+    <desc xml:lang="en">CMN ornam attribute values: A = appogiatura (upper neighbor); a = acciaccatura (lower
       neighbor); b = bebung; I = ascending slide; i = descending slide; k = delayed turn; K = 5-note
       turn; m = mordent (alternation with lower neighbor); M = inverted mordent (alternation with
       upper neighbor); N = Nachschlag (upper neighbor); n = Nachschlag (lower neighbor); S = turn; s
@@ -22,7 +22,7 @@
     </content>
   </macroSpec>
   <classSpec ident="att.mordent.log" module="MEI.cmnOrnaments" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.startEndId"/>
@@ -30,24 +30,24 @@
     </classes>
     <attList>
       <attDef ident="form" usage="opt">
-        <desc>Records semantic meaning, <abbr>i.e.</abbr>, intended performance, of the mordent. The
+        <desc xml:lang="en">Records semantic meaning, <abbr>i.e.</abbr>, intended performance, of the mordent. The
             <att>altsym</att>, <att>glyph.name</att>, or <att>glyph.num</att> attributes may be used
           to specify the appropriate symbol.</desc>
         <valList type="closed">
           <valItem ident="lower">
-            <desc>Starts with the written note, followed by its lower neighbor, with a return to the
+            <desc xml:lang="en">Starts with the written note, followed by its lower neighbor, with a return to the
               written note. In modern practice, this is called an "inverted mordent" and indicated
               by a short wavy line with a vertical line through it.</desc>
           </valItem>
           <valItem ident="upper">
-            <desc>Starts with the written note, followed by its upper neighbor, with a return to the
+            <desc xml:lang="en">Starts with the written note, followed by its upper neighbor, with a return to the
               principal note. In modern practice, the symbol lacks the vertical line used for the
               inverted form.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="long" usage="opt">
-        <desc>When set to 'true', a double or long mordent, sometimes called a "pincé double",
+        <desc xml:lang="en">When set to 'true', a double or long mordent, sometimes called a "pincé double",
           consisting of 5 notes, is indicated.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
@@ -56,16 +56,16 @@
     </attList>
   </classSpec>
   <classSpec ident="att.ornamentAccid" module="MEI.cmnOrnaments" type="atts">
-    <desc>Accidentals associated with ornaments.</desc>
+    <desc xml:lang="en">Accidentals associated with ornaments.</desc>
     <attList>
       <attDef ident="accidupper" usage="opt">
-        <desc>Records the written accidental associated with an upper neighboring note.</desc>
+        <desc xml:lang="en">Records the written accidental associated with an upper neighboring note.</desc>
         <datatype>
           <rng:ref name="data.ACCIDENTAL.WRITTEN"/>
         </datatype>
       </attDef>
       <attDef ident="accidlower" usage="opt">
-        <desc>Records the written accidental associated with a lower neighboring note.</desc>
+        <desc xml:lang="en">Records the written accidental associated with a lower neighboring note.</desc>
         <datatype>
           <rng:ref name="data.ACCIDENTAL.WRITTEN"/>
         </datatype>
@@ -73,10 +73,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.ornamPresent" module="MEI.cmnOrnaments" type="atts">
-    <desc>Attributes for marking the presence of an ornament.</desc>
+    <desc xml:lang="en">Attributes for marking the presence of an ornament.</desc>
     <attList>
       <attDef ident="ornam" usage="opt">
-        <desc>Indicates that this element has an attached ornament. If visual information about the
+        <desc xml:lang="en">Indicates that this element has an attached ornament. If visual information about the
           ornament is needed, then one of the elements that represents an ornament (mordent, trill,
           or turn) should be employed.</desc>
         <datatype maxOccurs="unbounded">
@@ -86,7 +86,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.trill.log" module="MEI.cmnOrnaments" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
@@ -96,7 +96,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.turn.log" module="MEI.cmnOrnaments" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.ornamentAccid"/>
@@ -104,34 +104,34 @@
     </classes>
     <attList>
       <attDef ident="delayed" usage="opt">
-        <desc>When set to 'true', the turn begins on the second half of the beat.</desc>
+        <desc xml:lang="en">When set to 'true', the turn begins on the second half of the beat.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
       </attDef>
       <attDef ident="form" usage="opt">
-        <desc>Records meaning; <abbr>i.e.</abbr>, intended performance, of the turn. The <att>altsym</att>,
+        <desc xml:lang="en">Records meaning; <abbr>i.e.</abbr>, intended performance, of the turn. The <att>altsym</att>,
             <att>glyph.name</att>, or <att>glyph.num</att> attributes may be used to specify the
           appropriate symbol.</desc>
         <valList type="closed">
           <valItem ident="lower">
-            <desc>Begins on the note below the written note.</desc>
+            <desc xml:lang="en">Begins on the note below the written note.</desc>
           </valItem>
           <valItem ident="upper">
-            <desc>Begins on the note above the written note.</desc>
+            <desc xml:lang="en">Begins on the note above the written note.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="model.ornamentLike.cmn" module="MEI.cmnOrnaments" type="model">
-    <desc>Groups CMN ornament elements.</desc>
+    <desc xml:lang="en">Groups CMN ornament elements.</desc>
     <classes>
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
   </classSpec>
   <elementSpec ident="mordent" module="MEI.cmnOrnaments">
-    <desc>An ornament indicating rapid alternation of the main note with a secondary note, usually a
+    <desc xml:lang="en">An ornament indicating rapid alternation of the main note with a secondary note, usually a
       step below, but sometimes a step above. <!--See Read, p. 245-246.-->
     </desc>
     <classes>
@@ -161,7 +161,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="trill" module="MEI.cmnOrnaments">
-    <desc>Rapid alternation of a note with another (usually at the interval of a second
+    <desc xml:lang="en">Rapid alternation of a note with another (usually at the interval of a second
       above).</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -195,7 +195,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="turn" module="MEI.cmnOrnaments">
-    <desc>An ornament consisting of four notes — the upper neighbor of the written note, the written
+    <desc xml:lang="en">An ornament consisting of four notes — the upper neighbor of the written note, the written
       note, the lower neighbor, and the written note.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.cmnOrnaments.xml
+++ b/source/modules/MEI.cmnOrnaments.xml
@@ -154,7 +154,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The starting point of the mordent may be indicated by either a <att>startid</att>,
           <att>tstamp</att>, <att>tstamp.ges</att>, or <att>tstamp.real</att> attribute. It is a
         semantic error not to specify one of these attributes.</p>
@@ -183,7 +183,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The interval between the main and auxiliary notes is usually understood to be diatonic
         unless altered by an accidental. The starting note of the trill; <abbr>i.e.</abbr>, the written one or
         the ornamenting one, and the speed of alternation depends on performance practice. The
@@ -217,7 +217,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>See Read, p. 246-247. Whether the turn is accented or unaccented may be inferred from the
         timestamp — accented turns occur directly on the affected beat, unaccented ones do not.</p>
     </remarks>

--- a/source/modules/MEI.corpus.xml
+++ b/source/modules/MEI.corpus.xml
@@ -11,7 +11,8 @@
     <desc xml:lang="en">Groups elements that may be document elements when the corpus module is invoked.</desc>
   </classSpec>
   <elementSpec ident="meiCorpus" module="MEI.corpus">
-    <desc xml:lang="en">(MEI corpus) – A group of related MEI documents, consisting of a header for the group, and
+    <gloss versionDate="2022-05-18" xml:lang="en">MEI corpus</gloss>
+    <desc xml:lang="en">A group of related MEI documents, consisting of a header for the group, and
       one or more <gi scheme="MEI">mei</gi> elements, each with its own complete header.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.corpus.xml
+++ b/source/modules/MEI.corpus.xml
@@ -5,13 +5,13 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.corpus">
   <moduleSpec ident="MEI.corpus">
-    <desc>Corpus component declarations.</desc>
+    <desc xml:lang="en">Corpus component declarations.</desc>
   </moduleSpec>
   <classSpec ident="model.startLike.corpus" module="MEI.corpus" type="model">
-    <desc>Groups elements that may be document elements when the corpus module is invoked.</desc>
+    <desc xml:lang="en">Groups elements that may be document elements when the corpus module is invoked.</desc>
   </classSpec>
   <elementSpec ident="meiCorpus" module="MEI.corpus">
-    <desc>(MEI corpus) – A group of related MEI documents, consisting of a header for the group, and
+    <desc xml:lang="en">(MEI corpus) – A group of related MEI documents, consisting of a header for the group, and
       one or more <gi scheme="MEI">mei</gi> elements, each with its own complete header.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.corpus.xml
+++ b/source/modules/MEI.corpus.xml
@@ -24,7 +24,7 @@
         <rng:ref name="mei"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on the teiCorpus element in the Text Encoding Initiative (TEI)
         standard. The MEI instances making up the corpus may be related in a number of ways, for
         example, by composer, by similar instrumentation, by holding institution, etc. This

--- a/source/modules/MEI.critapp.xml
+++ b/source/modules/MEI.critapp.xml
@@ -5,10 +5,10 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.critapp">
   <moduleSpec ident="MEI.critapp">
-    <desc>Critical apparatus component declarations.</desc>
+    <desc xml:lang="en">Critical apparatus component declarations.</desc>
   </moduleSpec>
   <classSpec ident="att.crit" module="MEI.critapp" type="atts">
-    <desc>Attributes common to all elements representing variant readings.</desc>
+    <desc xml:lang="en">Attributes common to all elements representing variant readings.</desc>
     <classes>
       <memberOf key="att.handIdent"/>
       <memberOf key="att.sequence"/>
@@ -16,7 +16,7 @@
     </classes>
     <attList>
       <attDef ident="cause" usage="opt">
-        <desc>Classifies the cause for the variant reading, according to any appropriate typology of
+        <desc xml:lang="en">Classifies the cause for the variant reading, according to any appropriate typology of
           possible origins.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
@@ -25,28 +25,28 @@
     </attList>
   </classSpec>
   <classSpec ident="att.rdg.log" module="MEI.critapp" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
   </classSpec>
   <classSpec ident="model.appLike" module="MEI.critapp" type="model">
-    <desc>Groups elements that contain a critical apparatus entry.</desc>
+    <desc xml:lang="en">Groups elements that contain a critical apparatus entry.</desc>
   </classSpec>
   <classSpec ident="model.rdgPart" module="MEI.critapp" type="model">
-    <desc>Groups elements that may appear as part of a textual or musical variant.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of a textual or musical variant.</desc>
   </classSpec>
   <classSpec ident="model.rdgPart.music" module="MEI.critapp" type="model">
-    <desc>Groups elements that may appear as part of a musical variant.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of a musical variant.</desc>
     <classes>
       <memberOf key="model.rdgPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.rdgPart.text" module="MEI.critapp" type="model">
-    <desc>Groups elements that may appear as part of a textual variant.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of a textual variant.</desc>
     <classes>
       <memberOf key="model.rdgPart"/>
     </classes>
   </classSpec>
   <elementSpec ident="app" module="MEI.critapp">
-    <desc>(apparatus) – Contains one or more alternative encodings.</desc>
+    <desc xml:lang="en">(apparatus) – Contains one or more alternative encodings.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="model.appLike"/>
@@ -73,7 +73,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="lem" module="MEI.critapp">
-    <desc>(lemma) – Contains the lemma, or base text, of a textual variation.</desc>
+    <desc xml:lang="en">(lemma) – Contains the lemma, or base text, of a textual variation.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.crit"/>
@@ -124,7 +124,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="rdg" module="MEI.critapp">
-    <desc>(reading) – Contains a single reading within a textual variation.</desc>
+    <desc xml:lang="en">(reading) – Contains a single reading within a textual variation.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.crit"/>

--- a/source/modules/MEI.critapp.xml
+++ b/source/modules/MEI.critapp.xml
@@ -60,7 +60,7 @@
         <rng:ref name="rdg"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The alternatives provided in <gi scheme="MEI">lem</gi> and/or <gi scheme="MEI">rdg</gi>
         sub-elements may be thought of as exclusive or as parallel. The <att>type</att> attribute
         may contain any convenient descriptive word, describing the extent of the variation (<abbr>e.g.</abbr>,
@@ -68,7 +68,7 @@
         unclear), or the nature of the variation or the principles required to understand it (<abbr>e.g.</abbr>,
         lectio difficilior, usus auctoris, etc.).</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -106,7 +106,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <gi scheme="MEI">lem</gi> element may also be used, under some circumstances, to record
         the base text of the source edition, to mark the readings of a base witness, to indicate the
         preference of an editor or encoder for a particular reading, or to make clear, in cases of
@@ -119,7 +119,7 @@
         example, when used as a descendent of <gi scheme="MEI">verse</gi>, <gi scheme="MEI">lem</gi>
         should only contain those elements allowed within <gi scheme="MEI">verse</gi>.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -157,19 +157,19 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Since a reading can be a multi-measure section, the <gi scheme="MEI">scoreDef</gi> element
         is allowed so that a reading may have its own meta-data without incurring the overhead of
         child <gi scheme="MEI">section</gi> elements. The <gi scheme="MEI">app</gi> sub-element is
         permitted in order to allow nested sub-variants.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>In no case should <gi scheme="MEI">rdg</gi> contain elements that would not otherwise be
         permitted to occur within the parent of its own <gi scheme="MEI">app</gi> ancestor. For
         example, when used as a descendent of <gi scheme="MEI">verse</gi>, <gi scheme="MEI">rdg</gi>
         should only contain those elements allowed within <gi scheme="MEI">verse</gi>.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>

--- a/source/modules/MEI.drama.xml
+++ b/source/modules/MEI.drama.xml
@@ -31,7 +31,8 @@
     </classes>
   </classSpec>
   <elementSpec ident="sp" module="MEI.drama">
-    <desc xml:lang="en">(speech) – Contains an individual speech in a performance text.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">speech</gloss>
+    <desc xml:lang="en">Contains an individual speech in a performance text.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -112,7 +113,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="stageDir" module="MEI.drama">
-    <desc xml:lang="en">(stage direction) – Contains any kind of stage direction within a dramatic text or
+    <gloss versionDate="2022-05-18" xml:lang="en">stage direction</gloss>
+    <desc xml:lang="en">Contains any kind of stage direction within a dramatic text or
       fragment.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.drama.xml
+++ b/source/modules/MEI.drama.xml
@@ -5,10 +5,10 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.drama">
   <moduleSpec ident="MEI.drama">
-    <desc>Dramatic text component declarations.</desc>
+    <desc xml:lang="en">Dramatic text component declarations.</desc>
   </moduleSpec>
   <classSpec ident="att.sp.log" module="MEI.drama" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.startEndId"/>
@@ -16,7 +16,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.stageDir.log" module="MEI.drama" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.startEndId"/>
@@ -24,14 +24,14 @@
     </classes>
   </classSpec>
   <classSpec ident="model.stageDirLike" module="MEI.drama" type="model">
-    <desc>Groups elements containing stage directions in performance texts.</desc>
+    <desc xml:lang="en">Groups elements containing stage directions in performance texts.</desc>
     <classes>
       <memberOf key="model.controlEventLike"/>
       <memberOf key="model.paracontentPart"/>
     </classes>
   </classSpec>
   <elementSpec ident="sp" module="MEI.drama">
-    <desc>(speech) – Contains an individual speech in a performance text.</desc>
+    <desc xml:lang="en">(speech) – Contains an individual speech in a performance text.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -112,7 +112,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="stageDir" module="MEI.drama">
-    <desc>(stage direction) – Contains any kind of stage direction within a dramatic text or
+    <desc xml:lang="en">(stage direction) – Contains any kind of stage direction within a dramatic text or
       fragment.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.drama.xml
+++ b/source/modules/MEI.drama.xml
@@ -102,12 +102,12 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>In a musical context <gi scheme="MEI">sp</gi> must have a start-type attribute when it's
         not a descendant of <gi scheme="MEI">sp</gi>. In a textual content <gi scheme="MEI">sp</gi>
         must NOT have any musical attributes.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -155,12 +155,12 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>In a musical context <gi scheme="MEI">stageDir</gi> must have a start-type attribute when
         it’s not a descendant of <gi scheme="MEI">sp</gi>. In a textual content <gi scheme="MEI"
           >stageDir</gi> must NOT have any musical attributes.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>

--- a/source/modules/MEI.edittrans.xml
+++ b/source/modules/MEI.edittrans.xml
@@ -160,14 +160,14 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>In no case should <gi scheme="MEI">abbr</gi> contain elements that would not otherwise be
         permitted to occur within the parent of its own <gi scheme="MEI">app</gi> ancestor. For
         example, when used as a descendent of <gi scheme="MEI">verse</gi>, <gi scheme="MEI"
         >abbr</gi> should only contain those elements allowed within <gi scheme="MEI"
         >verse</gi>.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -209,7 +209,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <gi scheme="MEI">add</gi> element contains material inserted by an author, scribe,
         annotator, or corrector. The agent responsible for the addition may be encoded using the
         <att>hand</att> attribute, while the <att>resp</att> attribute records the editor or
@@ -223,7 +223,7 @@
         example, when used as a descendent of <gi scheme="MEI">verse</gi>, <gi scheme="MEI">add</gi>
         should only contain those elements allowed within <gi scheme="MEI">verse</gi>.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -240,14 +240,14 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Because the children of a <gi scheme="MEI">choice</gi> element all represent alternative
         ways of encoding the same sequence, it is natural to think of them as mutually exclusive.
         However, there may be cases where a full representation of a text requires the alternative
         encodings to be considered as parallel. Note also that <gi scheme="MEI">choice</gi> elements
         may be recursively nested.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -283,7 +283,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>cert</att> attribute signifies the degree of certainty ascribed to correction. The
         <att>resp</att> attribute contains an ID reference to an element containing the name of the
         editor or transcriber responsible for suggesting the correction held as the content of the
@@ -296,7 +296,7 @@
         >corr</gi> should only contain those elements allowed within <gi scheme="MEI"
         >verse</gi>.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -347,7 +347,7 @@
           <cpMark tstamp="2" tstamp2="2m+3.5" staff="9" origin.staff="8" dis="8" dis.place="below">in 8va</cpMark>
         </egXML>
     </exemplum>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Typical examples are <foreign>colla parte</foreign> instructions (such as "col Basso") or
         other indications intended to result in filling gaps in the score with material written
         elsewhere. It is recommended to capture the position of the indication itself with the
@@ -407,14 +407,14 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>In no case should <gi scheme="MEI">damage</gi> contain elements that would not otherwise be
         permitted to occur within the parent of its own <gi scheme="MEI">app</gi> ancestor. For
         example, when used as a descendent of <gi scheme="MEI">verse</gi>, <gi scheme="MEI"
         >damage</gi> should only contain those elements allowed within <gi scheme="MEI"
         >verse</gi>.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -452,7 +452,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>resp</att> attribute contains an ID reference to an element containing the name of
         the editor or transcriber responsible for identifying the hand of the deletion. The
         <att>cert</att> attribute signifies the degree of certainty ascribed to the identification
@@ -464,7 +464,7 @@
         example, when used as a descendent of <gi scheme="MEI">verse</gi>, <gi scheme="MEI">del</gi>
         should only contain those elements allowed within <gi scheme="MEI">verse</gi>.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -508,14 +508,14 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>In no case should <gi scheme="MEI">expan</gi> contain elements that would not otherwise be
         permitted to occur within the parent of its own <gi scheme="MEI">app</gi> ancestor. For
         example, when used as a descendent of <gi scheme="MEI">verse</gi>, <gi scheme="MEI"
         >expan</gi> should only contain those elements allowed within <gi scheme="MEI"
         >verse</gi>.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -534,7 +534,7 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>When material is omitted because it is illegible or inaudible, <gi scheme="MEI"
         >unclear</gi> should be used instead. Similarly, use <gi scheme="MEI">damage</gi> if the
         omission is due to damage and <gi scheme="MEI">del</gi> if the omission is because the
@@ -551,7 +551,7 @@
         deletion by an identifiable hand. The <att>cert</att> attribute signifies the degree of
         certainty ascribed to the identification of the extent of the missing material.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -614,7 +614,7 @@
         </constraintSpec>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>character</att> attribute describes characteristics of the hand, particularly
         those related to the quality of the writing, <abbr>e.g.</abbr>, <val>shaky</val>, <val>thick</val>, <val>regular</val>. A description
         of the tint or type of ink, <abbr>e.g.</abbr>, <val>brown</val> or the writing medium, <abbr>e.g.</abbr>, <val>pencil</val>, may be placed
@@ -625,7 +625,7 @@
         attribute signifies the degree of certainty ascribed to the identification of the new
         hand.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -704,7 +704,7 @@
         </valList>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is used to encode <ref
         target="http://beethovens-werkstatt.de/glossary/metatext/">explicit metatexts</ref> as
         defined by the Beethovens Werkstatt project.</p>
@@ -743,7 +743,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element will often be combined with a regularized form within a choice element. The
         editor(s) responsible for asserting that the material is original may be recorded in the
         <att>resp</att> attribute. The value of resp must point to one or more identifiers declared
@@ -755,7 +755,7 @@
         >orig</gi> should only contain those elements allowed within <gi scheme="MEI"
         >verse</gi>.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -792,7 +792,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>It is possible to identify the individual responsible for the regularization, and, using
         the <gi scheme="MEI">choice</gi> and <gi scheme="MEI">orig</gi> elements, to provide both
         original and regularized readings. The editor(s) responsible for asserting the regularized
@@ -804,7 +804,7 @@
         example, when used as a descendent of <gi scheme="MEI">verse</gi>, <gi scheme="MEI">reg</gi>
         should only contain those elements allowed within <gi scheme="MEI">verse</gi>.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -850,14 +850,14 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>In no case should <gi scheme="MEI">restore</gi> contain elements that would not otherwise
         be permitted to occur within the parent of its own <gi scheme="MEI">app</gi> ancestor. For
         example, when used as a descendent of <gi scheme="MEI">verse</gi>, <gi scheme="MEI"
         >restore</gi> should only contain those elements allowed within <gi scheme="MEI"
         >verse</gi>.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -893,7 +893,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>A correction for the apparent error may be given in an accompanying child or sibling <gi
         scheme="MEI">corr</gi> element.</p>
       <p>In no case should <gi scheme="MEI">sic</gi> contain elements that would not otherwise be
@@ -901,7 +901,7 @@
         example, when used as a descendent of <gi scheme="MEI">verse</gi>, <gi scheme="MEI">sic</gi>
         should only contain those elements allowed within <gi scheme="MEI">verse</gi>.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -920,7 +920,7 @@
         <rng:ref name="model.transcriptionLike"/>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -957,7 +957,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>When the presumed loss of text arises from an identifiable cause, agent signifies the
         causative agent. When the presumed loss of text arises from action (partial deletion, etc.)
         assignable to an identifiable hand, the <att>hand</att> attribute signifies the hand
@@ -975,7 +975,7 @@
         >supplied</gi> should only contain those elements allowed within <gi scheme="MEI"
         >verse</gi>.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -1015,7 +1015,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Where the difficulty in transcription arises from an identifiable cause, the
         <att>agent</att> attribute signifies the causative agent. The <att>cert</att> attribute
         signifies the degree of certainty ascribed to the transcription of the text contained within
@@ -1032,7 +1032,7 @@
         >unclear</gi> should only contain those elements allowed within <gi scheme="MEI"
         >verse</gi>.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>

--- a/source/modules/MEI.edittrans.xml
+++ b/source/modules/MEI.edittrans.xml
@@ -5,13 +5,13 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.edittrans">
   <moduleSpec ident="MEI.edittrans">
-    <desc>Editorial and transcriptional component declarations.</desc>
+    <desc xml:lang="en">Editorial and transcriptional component declarations.</desc>
   </moduleSpec>
   <classSpec ident="att.agentIdent" module="MEI.edittrans" type="atts">
-    <desc>Attributes for the identification of a causative agent.</desc>
+    <desc xml:lang="en">Attributes for the identification of a causative agent.</desc>
     <attList>
       <attDef ident="agent" usage="opt">
-        <desc>Signifies the causative agent of damage, illegibility, or other loss of original
+        <desc xml:lang="en">Signifies the causative agent of damage, illegibility, or other loss of original
           text.</desc>
         <datatype>
           <rng:data type="string"/>
@@ -20,7 +20,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.cpMark.log" module="MEI.edittrans" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.origin.timestamp.logical"/>
@@ -33,7 +33,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.edit" module="MEI.edittrans" type="atts">
-    <desc>Attributes describing the nature of an encoded scholarly intervention or
+    <desc xml:lang="en">Attributes describing the nature of an encoded scholarly intervention or
       interpretation.</desc>
     <classes>
       <memberOf key="att.source"/>
@@ -41,16 +41,16 @@
     </classes>
   </classSpec>
   <classSpec ident="att.metaMark.anl" module="MEI.edittrans" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.metaMark.ges" module="MEI.edittrans" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.metaMark.log" module="MEI.edittrans" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.startEndId"/>
@@ -60,16 +60,16 @@
     </classes>
   </classSpec>
   <classSpec ident="att.metaMark.vis" module="MEI.edittrans" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.placementRelStaff"/>
     </classes>
   </classSpec>
   <classSpec ident="att.reasonIdent" module="MEI.edittrans" type="atts">
-    <desc>Attributes that identify the reason why an editorial feature is used.</desc>
+    <desc xml:lang="en">Attributes that identify the reason why an editorial feature is used.</desc>
     <attList>
       <attDef ident="reason" usage="opt">
-        <desc>Holds a short phrase describing the reason for missing textual material (gap), why
+        <desc xml:lang="en">Holds a short phrase describing the reason for missing textual material (gap), why
           material is supplied (supplied), or why transcription is difficult (unclear).</desc>
         <datatype>
           <rng:data type="string"/>
@@ -78,7 +78,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.trans" module="MEI.edittrans" type="atts">
-    <desc>Attributes for elements encoding authorial or scribal intervention when transcribing
+    <desc xml:lang="en">Attributes for elements encoding authorial or scribal intervention when transcribing
       manuscript or similar sources.</desc>
     <classes>
       <memberOf key="att.geneticState"/>
@@ -88,10 +88,10 @@
     </classes>
   </classSpec>
   <classSpec ident="model.choicePart" module="MEI.edittrans" type="model">
-    <desc>Groups elements that may appear as part of the content of a choice element.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of the content of a choice element.</desc>
   </classSpec>
   <classSpec ident="model.editLike" module="MEI.edittrans" type="model">
-    <desc>Groups elements for editorial interventions that may be useful both in transcribing and in
+    <desc xml:lang="en">Groups elements for editorial interventions that may be useful both in transcribing and in
       authoring processes.</desc>
     <classes>
       <memberOf key="model.paracontentPart"/>
@@ -99,30 +99,30 @@
     </classes>
   </classSpec>
   <classSpec ident="model.editTransPart" module="MEI.edittrans" type="model">
-    <desc>Groups elements that may appear as part of editorial and transcription elements.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of editorial and transcription elements.</desc>
   </classSpec>
   <classSpec ident="model.editTransPart.music" module="MEI.edittrans" type="model">
-    <desc>Groups elements that may appear as part of editorial and transcription elements in music
+    <desc xml:lang="en">Groups elements that may appear as part of editorial and transcription elements in music
       notation.</desc>
     <classes>
       <memberOf key="model.editTransPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.editTransPart.text" module="MEI.edittrans" type="model">
-    <desc>Groups elements that may appear as part of editorial and transcription elements in
+    <desc xml:lang="en">Groups elements that may appear as part of editorial and transcription elements in
       prose.</desc>
     <classes>
       <memberOf key="model.editTransPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.transcriptionLike" module="MEI.edittrans" type="model">
-    <desc>Groups elements used for editorial transcription of pre-existing source materials.</desc>
+    <desc xml:lang="en">Groups elements used for editorial transcription of pre-existing source materials.</desc>
     <classes>
       <memberOf key="model.paracontentPart"/>
     </classes>
   </classSpec>
   <elementSpec ident="abbr" module="MEI.edittrans" ns="http://www.music-encoding.org/ns/mei">
-    <desc>(abbreviation) – A generic element for 1) a shortened form of a word, including an acronym
+    <desc xml:lang="en">(abbreviation) – A generic element for 1) a shortened form of a word, including an acronym
       or 2) a shorthand notation.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -154,7 +154,7 @@
     </content>
     <attList>
       <attDef ident="expan" usage="opt">
-        <desc>Records the expansion of a text abbreviation.</desc>
+        <desc xml:lang="en">Records the expansion of a text abbreviation.</desc>
         <datatype>
           <rng:data type="string"/>
         </datatype>
@@ -173,7 +173,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="add" module="MEI.edittrans">
-    <desc>(addition) – Marks an addition to the text.</desc>
+    <desc xml:lang="en">(addition) – Marks an addition to the text.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -203,7 +203,7 @@
     </content>
     <attList>
       <attDef ident="place">
-        <desc>Location of the addition.</desc>
+        <desc xml:lang="en">Location of the addition.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.PLACEMENT"/>
         </datatype>
@@ -228,7 +228,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="choice" module="MEI.edittrans">
-    <desc>Groups a number of alternative encodings for the same point in a text.</desc>
+    <desc xml:lang="en">Groups a number of alternative encodings for the same point in a text.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="model.editLike"/>
@@ -252,7 +252,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="corr" module="MEI.edittrans">
-    <desc>(correction) – Contains the correct form of an apparent erroneous passage.</desc>
+    <desc xml:lang="en">(correction) – Contains the correct form of an apparent erroneous passage.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.edit"/>
@@ -301,7 +301,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="cpMark" module="MEI.edittrans">
-    <desc>(copy/colla parte mark) – A verbal or graphical indication to copy musical material
+    <desc xml:lang="en">(copy/colla parte mark) – A verbal or graphical indication to copy musical material
       written elsewhere.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -368,7 +368,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="damage" module="MEI.edittrans">
-    <desc>Contains an area of damage to the physical medium.</desc>
+    <desc xml:lang="en">Contains an area of damage to the physical medium.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.agentIdent"/>
@@ -401,7 +401,7 @@
     </content>
     <attList>
       <attDef ident="degree" usage="opt">
-        <desc>Records the degree of damage.</desc>
+        <desc xml:lang="en">Records the degree of damage.</desc>
         <datatype>
           <rng:data type="string"/>
         </datatype>
@@ -419,7 +419,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="del" module="MEI.edittrans">
-    <desc>(deletion) – Contains information deleted, marked as deleted, or otherwise indicated as
+    <desc xml:lang="en">(deletion) – Contains information deleted, marked as deleted, or otherwise indicated as
       superfluous or spurious in the copy text by an author, scribe, annotator, or corrector.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -470,7 +470,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="expan" module="MEI.edittrans">
-    <desc>(expansion) – Contains the expansion of an abbreviation.</desc>
+    <desc xml:lang="en">(expansion) – Contains the expansion of an abbreviation.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.edit"/>
@@ -502,7 +502,7 @@
     </content>
     <attList>
       <attDef ident="abbr" usage="opt">
-        <desc>Captures the abbreviated form of the text.</desc>
+        <desc xml:lang="en">Captures the abbreviated form of the text.</desc>
         <datatype>
           <rng:data type="string"/>
         </datatype>
@@ -521,7 +521,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="gap" module="MEI.edittrans">
-    <desc>Indicates a point where material has been omitted in a transcription, whether as part of
+    <desc xml:lang="en">Indicates a point where material has been omitted in a transcription, whether as part of
       sampling practice or for editorial reasons described in the MEI header.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -556,7 +556,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="handShift" module="MEI.edittrans">
-    <desc>Marks the beginning of a passage written in a new hand, or of a change in the scribe,
+    <desc xml:lang="en">Marks the beginning of a passage written in a new hand, or of a change in the scribe,
       writing style, ink or character of the document hand.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -570,13 +570,13 @@
     </content>
     <attList>
       <attDef ident="character" usage="opt">
-        <desc>Describes the character of the new hand.</desc>
+        <desc xml:lang="en">Describes the character of the new hand.</desc>
         <datatype>
           <rng:text/>
         </datatype>
       </attDef>
       <attDef ident="new" usage="opt">
-        <desc>Identifies the new hand. The value must contain the ID of a hand element given
+        <desc xml:lang="en">Identifies the new hand. The value must contain the ID of a hand element given
           elsewhere in the document.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
@@ -595,7 +595,7 @@
         </constraintSpec>
       </attDef>
       <attDef ident="old" usage="opt">
-        <desc>Identifies the old hand. The value must contain the ID of a hand element given
+        <desc xml:lang="en">Identifies the old hand. The value must contain the ID of a hand element given
           elsewhere in the document.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
@@ -630,7 +630,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="metaMark" module="MEI.edittrans">
-    <desc>A graphical or textual statement with additional / explanatory information about the
+    <desc xml:lang="en">A graphical or textual statement with additional / explanatory information about the
       musical text. The textual consequences of this intervention are encoded independently via
       other means; that is, with elements such as &lt;add&gt;, &lt;del&gt;, etc.</desc>
     <classes>
@@ -665,41 +665,41 @@
     </constraintSpec>
     <attList>
       <attDef ident="function">
-        <desc>Describes the purpose of the metaMark.</desc>
+        <desc xml:lang="en">Describes the purpose of the metaMark.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="confirmation">
-            <desc>confirmation of a previous textual decision; <abbr>i.e.</abbr>, cancellation of a deleted
+            <desc xml:lang="en">confirmation of a previous textual decision; <abbr>i.e.</abbr>, cancellation of a deleted
               passage in a different writing medium.</desc>
           </valItem>
           <valItem ident="addition">
-            <desc>denoted material is to be inserted in the musical text.</desc>
+            <desc xml:lang="en">denoted material is to be inserted in the musical text.</desc>
           </valItem>
           <valItem ident="deletion">
-            <desc>denoted material is no longer part of the musical text.</desc>
+            <desc xml:lang="en">denoted material is no longer part of the musical text.</desc>
           </valItem>
           <valItem ident="substitution">
-            <desc>denoted material is replaced, either by the musical text pointed at with the
+            <desc xml:lang="en">denoted material is replaced, either by the musical text pointed at with the
               @target attribute or the musical content of the metaMark element itself.</desc>
           </valItem>
           <valItem ident="clarification">
-            <desc>attempt to clarify a potentially illegible or otherwise unclear part of the
+            <desc xml:lang="en">attempt to clarify a potentially illegible or otherwise unclear part of the
               musical text.</desc>
           </valItem>
           <valItem ident="question">
-            <desc>marks a section of the musical text which is to be considered further.</desc>
+            <desc xml:lang="en">marks a section of the musical text which is to be considered further.</desc>
           </valItem>
           <valItem ident="investigation">
-            <desc>marks a section of the musical text as an investigation of the consequences of
+            <desc xml:lang="en">marks a section of the musical text as an investigation of the consequences of
               certain compositional decisions or potential alternatives.</desc>
           </valItem>
           <valItem ident="restoration">
-            <desc>declares a formerly cancelled part of the musical text as valid again.</desc>
+            <desc xml:lang="en">declares a formerly cancelled part of the musical text as valid again.</desc>
           </valItem>
           <valItem ident="navigation">
-            <desc>clarification of the reading order of the musical text.</desc>
+            <desc xml:lang="en">clarification of the reading order of the musical text.</desc>
           </valItem>
         </valList>
       </attDef>
@@ -711,7 +711,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="orig" module="MEI.edittrans">
-    <desc>(original) – Contains material which is marked as following the original, rather than
+    <desc xml:lang="en">(original) – Contains material which is marked as following the original, rather than
       being normalized or corrected.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -760,7 +760,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="reg" module="MEI.edittrans">
-    <desc>(regularization) – Contains material which has been regularized or normalized in some
+    <desc xml:lang="en">(regularization) – Contains material which has been regularized or normalized in some
       sense.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -809,7 +809,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="restore" module="MEI.edittrans">
-    <desc>Indicates restoration of material to an earlier state by cancellation of an editorial or
+    <desc xml:lang="en">Indicates restoration of material to an earlier state by cancellation of an editorial or
       authorial marking or instruction.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -843,7 +843,7 @@
     </content>
     <attList>
       <attDef ident="desc" usage="opt">
-        <desc>Provides a description of the means of restoration, <val>stet</val> or <val>strike-down</val>, 
+        <desc xml:lang="en">Provides a description of the means of restoration, <val>stet</val> or <val>strike-down</val>, 
           for example.</desc>
         <datatype>
           <rng:data type="string"/>
@@ -862,7 +862,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="sic" module="MEI.edittrans">
-    <desc>Contains apparently incorrect or inaccurate material.</desc>
+    <desc xml:lang="en">Contains apparently incorrect or inaccurate material.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.edit"/>
@@ -906,7 +906,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="subst" module="MEI.edittrans">
-    <desc>(substitution) – Groups transcriptional elements when the combination is to be regarded as
+    <desc xml:lang="en">(substitution) – Groups transcriptional elements when the combination is to be regarded as
       a single intervention in the text.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -925,7 +925,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="supplied" module="MEI.edittrans">
-    <desc>Contains material supplied by the transcriber or editor for any reason.</desc>
+    <desc xml:lang="en">Contains material supplied by the transcriber or editor for any reason.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.agentIdent"/>
@@ -980,7 +980,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="unclear" module="MEI.edittrans">
-    <desc>Contains material that cannot be transcribed with certainty because it is illegible or
+    <desc xml:lang="en">Contains material that cannot be transcribed with certainty because it is illegible or
       inaudible in the source.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.edittrans.xml
+++ b/source/modules/MEI.edittrans.xml
@@ -122,7 +122,8 @@
     </classes>
   </classSpec>
   <elementSpec ident="abbr" module="MEI.edittrans" ns="http://www.music-encoding.org/ns/mei">
-    <desc xml:lang="en">(abbreviation) – A generic element for 1) a shortened form of a word, including an acronym
+    <gloss versionDate="2022-05-18" xml:lang="en">abbreviation</gloss>
+    <desc xml:lang="en">A generic element for 1) a shortened form of a word, including an acronym
       or 2) a shorthand notation.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -173,7 +174,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="add" module="MEI.edittrans">
-    <desc xml:lang="en">(addition) – Marks an addition to the text.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">addition</gloss>
+    <desc xml:lang="en">Marks an addition to the text.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -252,7 +254,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="corr" module="MEI.edittrans">
-    <desc xml:lang="en">(correction) – Contains the correct form of an apparent erroneous passage.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">correction</gloss>
+    <desc xml:lang="en">Contains the correct form of an apparent erroneous passage.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.edit"/>
@@ -301,7 +304,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="cpMark" module="MEI.edittrans">
-    <desc xml:lang="en">(copy/colla parte mark) – A verbal or graphical indication to copy musical material
+    <gloss versionDate="2022-05-18" xml:lang="en">copy/colla parte mark</gloss>
+    <desc xml:lang="en">A verbal or graphical indication to copy musical material
       written elsewhere.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -419,7 +423,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="del" module="MEI.edittrans">
-    <desc xml:lang="en">(deletion) – Contains information deleted, marked as deleted, or otherwise indicated as
+    <gloss versionDate="2022-05-18" xml:lang="en">deletion</gloss>
+    <desc xml:lang="en">Contains information deleted, marked as deleted, or otherwise indicated as
       superfluous or spurious in the copy text by an author, scribe, annotator, or corrector.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -470,7 +475,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="expan" module="MEI.edittrans">
-    <desc xml:lang="en">(expansion) – Contains the expansion of an abbreviation.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">expansion</gloss>
+    <desc xml:lang="en">Contains the expansion of an abbreviation.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.edit"/>
@@ -711,7 +717,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="orig" module="MEI.edittrans">
-    <desc xml:lang="en">(original) – Contains material which is marked as following the original, rather than
+    <gloss versionDate="2022-05-18" xml:lang="en">original</gloss>
+    <desc xml:lang="en">Contains material which is marked as following the original, rather than
       being normalized or corrected.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -760,7 +767,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="reg" module="MEI.edittrans">
-    <desc xml:lang="en">(regularization) – Contains material which has been regularized or normalized in some
+    <gloss versionDate="2022-05-18" xml:lang="en">regularization</gloss>
+    <desc xml:lang="en">Contains material which has been regularized or normalized in some
       sense.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -906,7 +914,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="subst" module="MEI.edittrans">
-    <desc xml:lang="en">(substitution) – Groups transcriptional elements when the combination is to be regarded as
+    <gloss versionDate="2022-05-18" xml:lang="en">substitution</gloss>
+    <desc xml:lang="en">Groups transcriptional elements when the combination is to be regarded as
       a single intervention in the text.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.externalsymbols.xml
+++ b/source/modules/MEI.externalsymbols.xml
@@ -5,26 +5,26 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.externalsymbols">
   <moduleSpec ident="MEI.externalsymbols">
-    <desc>External symbols component declarations.</desc>
+    <desc xml:lang="en">External symbols component declarations.</desc>
   </moduleSpec>
   <classSpec ident="att.extSym" module="MEI.externalsymbols" type="atts">
-    <desc>Attributes used to associate MEI features with corresponding glyphs in an
+    <desc xml:lang="en">Attributes used to associate MEI features with corresponding glyphs in an
       externally-defined standard such as SMuFL.</desc>
     <attList>
       <attDef ident="glyph.auth" usage="opt">
-        <desc>A name or label associated with the controlled vocabulary from which the value of
+        <desc xml:lang="en">A name or label associated with the controlled vocabulary from which the value of
             <att>glyph.name</att> or <att>glyph.num</att> is taken.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="smufl">
-            <desc>Standard Music Font Layout.</desc>
+            <desc xml:lang="en">Standard Music Font Layout.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="glyph.name" usage="opt">
-        <desc>Glyph name.</desc>
+        <desc xml:lang="en">Glyph name.</desc>
         <datatype>
           <rng:data type="string"/>
         </datatype>
@@ -38,7 +38,7 @@
         </constraintSpec>
       </attDef>
       <attDef ident="glyph.num" usage="opt">
-        <desc>Numeric glyph reference in hexadecimal notation, <abbr>e.g.</abbr>, "#xE000" or "U+E000". N.B. SMuFL
+        <desc xml:lang="en">Numeric glyph reference in hexadecimal notation, <abbr>e.g.</abbr>, "#xE000" or "U+E000". N.B. SMuFL
           version 1.18 uses the range U+E000 - U+ECBF.</desc>
         <datatype>
           <rng:ref name="data.HEXNUM"/>
@@ -55,7 +55,7 @@
         </constraintSpec>
       </attDef>
       <attDef ident="glyph.uri" usage="opt">
-        <desc>The web-accessible location of the controlled vocabulary from which the value of
+        <desc xml:lang="en">The web-accessible location of the controlled vocabulary from which the value of
             <att>glyph.name</att> or <att>glyph.num</att> is taken.</desc>
         <datatype>
           <rng:ref name="data.URI"/>

--- a/source/modules/MEI.facsimile.xml
+++ b/source/modules/MEI.facsimile.xml
@@ -5,13 +5,13 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.facsimile">
   <moduleSpec ident="MEI.facsimile">
-    <desc>Facsimile component declarations.</desc>
+    <desc xml:lang="en">Facsimile component declarations.</desc>
   </moduleSpec>
   <classSpec ident="att.facsimile" module="MEI.facsimile" type="atts">
-    <desc>Attributes that associate a feature corresponding with all or part of an image.</desc>
+    <desc xml:lang="en">Attributes that associate a feature corresponding with all or part of an image.</desc>
     <attList>
       <attDef ident="facs" usage="opt">
-        <desc>Permits the current element to reference a facsimile surface or image zone which
+        <desc xml:lang="en">Permits the current element to reference a facsimile surface or image zone which
           corresponds to it.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
@@ -32,7 +32,7 @@
     </attList>
   </classSpec>
   <elementSpec ident="facsimile" module="MEI.facsimile">
-    <desc>Contains a representation of a written source in the form of a set of images rather than
+    <desc xml:lang="en">Contains a representation of a written source in the form of a set of images rather than
       as transcribed or encoded text.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -61,7 +61,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="surface" module="MEI.facsimile">
-    <desc>Defines a writing surface in terms of a rectangular coordinate space, optionally grouping
+    <desc xml:lang="en">Defines a writing surface in terms of a rectangular coordinate space, optionally grouping
       one or more graphic representations of that space, and rectangular zones of interest within
       it.</desc>
     <classes>
@@ -93,7 +93,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="zone" module="MEI.facsimile">
-    <desc>Defines an area of interest within a surface or graphic file.</desc>
+    <desc xml:lang="en">Defines an area of interest within a surface or graphic file.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.coordinated"/>

--- a/source/modules/MEI.facsimile.xml
+++ b/source/modules/MEI.facsimile.xml
@@ -47,7 +47,7 @@
         <rng:ref name="surface"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <gi scheme="MEI">graphic</gi> element is provided within facsimile for association of
         the facsimile with graphic files capable of representing multiple pages, such as TIFF or PDF
         formats. When more than one graphic element is used, each must represent the same material.
@@ -56,7 +56,7 @@
       <p>The <att>decls</att> attribute may be used to link the collection of images with a
         particular source described in the header.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -82,13 +82,13 @@
         <rng:ref name="zone"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Scalable Vector Graphics (SVG) markup may be used when allowed by the graphicLike
         model.</p>
       <p>The <att>startid</att> attribute may be used to hold a reference to the first feature
         occurring on this surface.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -107,7 +107,7 @@
         <rng:ref name="model.graphicLike"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Scalable Vector Graphics (SVG) markup may be used when allowed by the graphicLike
         model.</p>
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>

--- a/source/modules/MEI.figtable.xml
+++ b/source/modules/MEI.figtable.xml
@@ -5,19 +5,19 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.figtable">
   <moduleSpec ident="MEI.figtable">
-    <desc>Figures and tables component declarations.</desc>
+    <desc xml:lang="en">Figures and tables component declarations.</desc>
   </moduleSpec>
   <classSpec ident="att.tabular" module="MEI.figtable" type="atts">
-    <desc>Attributes shared by table cells.</desc>
+    <desc xml:lang="en">Attributes shared by table cells.</desc>
     <attList>
       <attDef ident="colspan" usage="opt">
-        <desc>The number of columns spanned by this cell.</desc>
+        <desc xml:lang="en">The number of columns spanned by this cell.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
       </attDef>
       <attDef ident="rowspan" usage="opt">
-        <desc>The number of rows spanned by this cell.</desc>
+        <desc xml:lang="en">The number of rows spanned by this cell.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
@@ -25,29 +25,29 @@
     </attList>
   </classSpec>
   <classSpec ident="model.figDescLike" module="MEI.figtable" type="model">
-    <desc>Groups elements that provide a brief prose description of the appearance or content of a
+    <desc xml:lang="en">Groups elements that provide a brief prose description of the appearance or content of a
       graphic figure.</desc>
   </classSpec>
   <classSpec ident="model.figureLike" module="MEI.figtable" type="model">
-    <desc>Groups elements representing or containing graphic information such as an illustration or
+    <desc xml:lang="en">Groups elements representing or containing graphic information such as an illustration or
       figure.</desc>
     <classes>
       <memberOf key="model.textPhraseLike.limited"/>
     </classes>
   </classSpec>
   <classSpec ident="model.graphicLike" module="MEI.figtable" type="model">
-    <desc>Groups elements that indicate the location of an inline graphic, illustration, or
+    <desc xml:lang="en">Groups elements that indicate the location of an inline graphic, illustration, or
       figure.</desc>
   </classSpec>
   <classSpec ident="model.tableLike" module="MEI.figtable" type="model">
-    <desc>Groups table-like elements.</desc>
+    <desc xml:lang="en">Groups table-like elements.</desc>
     <classes>
       <memberOf key="model.paracontentPart"/>
       <memberOf key="model.textComponentLike"/>
     </classes>
   </classSpec>
   <elementSpec ident="fig" module="MEI.figtable">
-    <desc>(figure) – Groups elements representing or containing graphic information such as an
+    <desc xml:lang="en">(figure) – Groups elements representing or containing graphic information such as an
       illustration or figure.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -73,7 +73,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="figDesc" module="MEI.figtable">
-    <desc>(figure description) – Contains a brief prose description of the appearance or content of
+    <desc xml:lang="en">(figure description) – Contains a brief prose description of the appearance or content of
       a graphic figure, for use when documenting an image without displaying it.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -105,7 +105,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="graphic" module="MEI.figtable">
-    <desc>Indicates the location of an inline graphic.</desc>
+    <desc xml:lang="en">Indicates the location of an inline graphic.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.dimensions"/>
@@ -142,13 +142,13 @@
     </constraintSpec>
     <attList>
       <attDef ident="ulx" usage="opt">
-        <desc>Indicates the upper-left corner x coordinate.</desc>
+        <desc xml:lang="en">Indicates the upper-left corner x coordinate.</desc>
         <datatype>
           <rng:data type="nonNegativeInteger"/>
         </datatype>
       </attDef>
       <attDef ident="uly" usage="opt">
-        <desc>Indicates the upper-left corner y coordinate.</desc>
+        <desc xml:lang="en">Indicates the upper-left corner y coordinate.</desc>
         <datatype>
           <rng:data type="nonNegativeInteger"/>
         </datatype>
@@ -159,7 +159,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="table" module="MEI.figtable">
-    <desc>Contains text displayed in tabular form.</desc>
+    <desc xml:lang="en">Contains text displayed in tabular form.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -184,7 +184,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="td" module="MEI.figtable">
-    <desc>(table data) – Designates a table cell that contains data as opposed to a cell that
+    <desc xml:lang="en">(table data) – Designates a table cell that contains data as opposed to a cell that
       contains column or row heading information.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -213,7 +213,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="th" module="MEI.figtable">
-    <desc>(table header) – Designates a table cell containing column or row heading information as
+    <desc xml:lang="en">(table header) – Designates a table cell containing column or row heading information as
       opposed to one containing data.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -242,7 +242,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="tr" module="MEI.figtable">
-    <desc>(table row) – A formatting element that contains one or more cells (intersection of a row
+    <desc xml:lang="en">(table row) – A formatting element that contains one or more cells (intersection of a row
       and a column) in a <gi scheme="MEI">table</gi>.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.figtable.xml
+++ b/source/modules/MEI.figtable.xml
@@ -67,7 +67,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on the figure element in the Text Encoding Initiative (TEI)
         standard.</p>
     </remarks>
@@ -95,12 +95,12 @@
         </rng:zeroOrMore>
       </rng:choice>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Best practice suggests the use of controlled vocabulary for figure descriptions. Don't
         confuse this entity with a figure caption. A caption is text primarily intended for display
         with an illustration. It may or may not function as a description of the illustration.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -154,7 +154,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -178,7 +178,7 @@
         <rng:ref name="model.captionLike"/>
       </rng:optional>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Encoded Archival Description (EAD), Text
         Encoding Initiative (TEI), and HTML standards.</p>
     </remarks>
@@ -204,11 +204,11 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>colspan</att> and <att>rowspan</att> attributes record tabular display rendering
         information.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the HTML standard.</p>
     </remarks>
   </elementSpec>
@@ -233,11 +233,11 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>colspan</att> and <att>rowspan</att> attributes record tabular display rendering
         information.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the HTML standard.</p>
     </remarks>
   </elementSpec>
@@ -258,10 +258,10 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>More precise rendition of the table and its cells can be specified in a style sheet.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the HTML standard.</p>
     </remarks>
   </elementSpec>

--- a/source/modules/MEI.figtable.xml
+++ b/source/modules/MEI.figtable.xml
@@ -47,7 +47,8 @@
     </classes>
   </classSpec>
   <elementSpec ident="fig" module="MEI.figtable">
-    <desc xml:lang="en">(figure) – Groups elements representing or containing graphic information such as an
+    <gloss versionDate="2022-05-18" xml:lang="en">figure</gloss>
+    <desc xml:lang="en">Groups elements representing or containing graphic information such as an
       illustration or figure.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -73,7 +74,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="figDesc" module="MEI.figtable">
-    <desc xml:lang="en">(figure description) – Contains a brief prose description of the appearance or content of
+    <gloss versionDate="2022-05-18" xml:lang="en">figure description</gloss>
+    <desc xml:lang="en">Contains a brief prose description of the appearance or content of
       a graphic figure, for use when documenting an image without displaying it.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -184,7 +186,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="td" module="MEI.figtable">
-    <desc xml:lang="en">(table data) – Designates a table cell that contains data as opposed to a cell that
+    <gloss versionDate="2022-05-18" xml:lang="en">table data</gloss>
+    <desc xml:lang="en">Designates a table cell that contains data as opposed to a cell that
       contains column or row heading information.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -213,7 +216,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="th" module="MEI.figtable">
-    <desc xml:lang="en">(table header) – Designates a table cell containing column or row heading information as
+    <gloss versionDate="2022-05-18" xml:lang="en">table header</gloss>
+    <desc xml:lang="en">Designates a table cell containing column or row heading information as
       opposed to one containing data.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -242,7 +246,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="tr" module="MEI.figtable">
-    <desc xml:lang="en">(table row) – A formatting element that contains one or more cells (intersection of a row
+    <gloss versionDate="2022-05-18" xml:lang="en">table row</gloss>
+    <desc xml:lang="en">A formatting element that contains one or more cells (intersection of a row
       and a column) in a <gi scheme="MEI">table</gi>.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.fingering.xml
+++ b/source/modules/MEI.fingering.xml
@@ -5,10 +5,10 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.fingering">
   <moduleSpec ident="MEI.fingering">
-    <desc>Fingering component declarations.</desc>
+    <desc xml:lang="en">Fingering component declarations.</desc>
   </moduleSpec>
   <classSpec ident="att.fing.log" module="MEI.fingering" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
@@ -17,7 +17,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.fingGrp.log" module="MEI.fingering" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
@@ -28,27 +28,27 @@
       <attDef ident="form" usage="opt">
         <valList type="closed">
           <valItem ident="alter">
-            <desc>alternation of fingers.</desc>
+            <desc xml:lang="en">alternation of fingers.</desc>
           </valItem>
           <valItem ident="combi">
-            <desc>combination of fingers.</desc>
+            <desc xml:lang="en">combination of fingers.</desc>
           </valItem>
           <valItem ident="subst">
-            <desc>substitution of fingers.</desc>
+            <desc xml:lang="en">substitution of fingers.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="model.fingeringLike" module="MEI.fingering" type="model">
-    <desc>Groups elements that capture performance instructions regarding the use of the fingers of
+    <desc xml:lang="en">Groups elements that capture performance instructions regarding the use of the fingers of
       the hand (or a subset of them).</desc>
     <classes>
       <memberOf key="model.controlEventLike"/>
     </classes>
   </classSpec>
   <elementSpec ident="fing" module="MEI.fingering">
-    <desc>finger – An individual finger in a fingering indication.</desc>
+    <desc xml:lang="en">finger – An individual finger in a fingering indication.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -87,7 +87,7 @@
     </constraintSpec>
   </elementSpec>
   <elementSpec ident="fingGrp" module="MEI.fingering">
-    <desc>(finger group)– A group of individual fingers in a fingering indication.</desc>
+    <desc xml:lang="en">(finger group)– A group of individual fingers in a fingering indication.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>

--- a/source/modules/MEI.frbr.xml
+++ b/source/modules/MEI.frbr.xml
@@ -221,7 +221,7 @@
         <rng:ref name="extMeta"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <gi scheme="MEI">perfDuration</gi> element captures the <emph>intended duration</emph>
         of the expression, while <gi scheme="MEI">extent</gi> records scope of the expression in
         other terms, such as number of pages, measures, etc.</p>

--- a/source/modules/MEI.frbr.xml
+++ b/source/modules/MEI.frbr.xml
@@ -5,150 +5,150 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.frbr">
   <moduleSpec ident="MEI.frbr">
-    <desc>FRBR (Functional Requirements for Bibliographic Records) declarations.</desc>
+    <desc xml:lang="en">FRBR (Functional Requirements for Bibliographic Records) declarations.</desc>
   </moduleSpec>
   <macroSpec ident="data.FRBRRELATIONSHIP" module="MEI.frbr" type="dt">
-    <desc>Relationships between FRBR entities.</desc>
+    <desc xml:lang="en">Relationships between FRBR entities.</desc>
     <content>
       <valList type="closed">
         <valItem ident="hasAbridgement">
-          <desc>Target is an abridgement, condensation, or expurgation of the current entity.</desc>
+          <desc xml:lang="en">Target is an abridgement, condensation, or expurgation of the current entity.</desc>
         </valItem>
         <valItem ident="isAbridgementOf">
-          <desc>Reciprocal relationship of hasAbridgement.</desc>
+          <desc xml:lang="en">Reciprocal relationship of hasAbridgement.</desc>
         </valItem>
         <valItem ident="hasAdaptation">
-          <desc>Target is an adaptation, paraphrase, free translation, variation (music),
+          <desc xml:lang="en">Target is an adaptation, paraphrase, free translation, variation (music),
             harmonization (music), or fantasy (music) of the current entity.</desc>
         </valItem>
         <valItem ident="isAdaptationOf">
-          <desc>Reciprocal relationship of hasAdaptation.</desc>
+          <desc xml:lang="en">Reciprocal relationship of hasAdaptation.</desc>
         </valItem>
         <valItem ident="hasAlternate">
-          <desc>Target is an alternate format or simultaneously released edition of the current
+          <desc xml:lang="en">Target is an alternate format or simultaneously released edition of the current
             entity.</desc>
         </valItem>
         <valItem ident="isAlternateOf">
-          <desc>Reciprocal relationship of hasAlternate.</desc>
+          <desc xml:lang="en">Reciprocal relationship of hasAlternate.</desc>
         </valItem>
         <valItem ident="hasArrangement">
-          <desc>Target is an arrangement (music) of the current entity.</desc>
+          <desc xml:lang="en">Target is an arrangement (music) of the current entity.</desc>
         </valItem>
         <valItem ident="isArrangementOf">
-          <desc>Reciprocal relationship of hasArrangement.</desc>
+          <desc xml:lang="en">Reciprocal relationship of hasArrangement.</desc>
         </valItem>
         <valItem ident="hasComplement">
-          <desc>Target is a cadenza, libretto, choreography, ending for unfinished work, incidental
+          <desc xml:lang="en">Target is a cadenza, libretto, choreography, ending for unfinished work, incidental
             music, or musical setting of a text of the current entity.</desc>
         </valItem>
         <valItem ident="isComplementOf">
-          <desc>Reciprocal relationship of hasComplement.</desc>
+          <desc xml:lang="en">Reciprocal relationship of hasComplement.</desc>
         </valItem>
         <valItem ident="hasEmbodiment">
-          <desc>Target is a physical embodiment of the current abstract entity; describes the
+          <desc xml:lang="en">Target is a physical embodiment of the current abstract entity; describes the
             expression-to-manifestation relationship.</desc>
         </valItem>
         <valItem ident="isEmbodimentOf">
-          <desc>Reciprocal relationship of hasEmbodiment.</desc>
+          <desc xml:lang="en">Reciprocal relationship of hasEmbodiment.</desc>
         </valItem>
         <valItem ident="hasExemplar">
-          <desc>Target is an exemplar of the class of things represented by the current entity;
+          <desc xml:lang="en">Target is an exemplar of the class of things represented by the current entity;
             describes the manifestation-to-item relationship.</desc>
         </valItem>
         <valItem ident="isExemplarOf">
-          <desc>Reciprocal relationship of hasExamplar.</desc>
+          <desc xml:lang="en">Reciprocal relationship of hasExamplar.</desc>
         </valItem>
         <valItem ident="hasImitation">
-          <desc>Target is a parody, imitation, or travesty of the current entity.</desc>
+          <desc xml:lang="en">Target is a parody, imitation, or travesty of the current entity.</desc>
         </valItem>
         <valItem ident="isImitationOf">
-          <desc>Reciprocal relationship of hasImitation.</desc>
+          <desc xml:lang="en">Reciprocal relationship of hasImitation.</desc>
         </valItem>
         <valItem ident="hasPart">
-          <desc>Target is a chapter, section, part, etc.; volume of a multivolume manifestation;
+          <desc xml:lang="en">Target is a chapter, section, part, etc.; volume of a multivolume manifestation;
             volume/issue of serial; intellectual part of a multi-part work; illustration for a text;
             sound aspect of a film; soundtrack for a film on separate medium; soundtrack for a film
             embedded in film; monograph in a series; physical component of a particular copy; the
             binding of a book of the current entity.</desc>
         </valItem>
         <valItem ident="isPartOf">
-          <desc>Reciprocal relationship of hasPart.</desc>
+          <desc xml:lang="en">Reciprocal relationship of hasPart.</desc>
         </valItem>
         <valItem ident="hasRealization">
-          <desc>Target is a realization of the current entity; describes the work-to-expression
+          <desc xml:lang="en">Target is a realization of the current entity; describes the work-to-expression
             relationship.</desc>
         </valItem>
         <valItem ident="isRealizationOf">
-          <desc>Reciprocal relationship of hasRealization.</desc>
+          <desc xml:lang="en">Reciprocal relationship of hasRealization.</desc>
         </valItem>
         <valItem ident="hasReconfiguration">
-          <desc>Target has been reconfigured: bound with, split into, extracted from the current
+          <desc xml:lang="en">Target has been reconfigured: bound with, split into, extracted from the current
             entity.</desc>
         </valItem>
         <valItem ident="isReconfigurationOf">
-          <desc>Reciprocal relationship of hasReconfiguration.</desc>
+          <desc xml:lang="en">Reciprocal relationship of hasReconfiguration.</desc>
         </valItem>
         <valItem ident="hasReproduction">
-          <desc>Target is a reproduction, microreproduction, macroreproduction, reprint,
+          <desc xml:lang="en">Target is a reproduction, microreproduction, macroreproduction, reprint,
             photo-offset reprint, or facsimile of the current entity.</desc>
         </valItem>
         <valItem ident="isReproductionOf">
-          <desc>Reciprocal relationship of hasReproduction.</desc>
+          <desc xml:lang="en">Reciprocal relationship of hasReproduction.</desc>
         </valItem>
         <valItem ident="hasRevision">
-          <desc>Target is a revised edition, enlarged edition, or new state (graphic) of the current
+          <desc xml:lang="en">Target is a revised edition, enlarged edition, or new state (graphic) of the current
             entity.</desc>
         </valItem>
         <valItem ident="isRevisionOf">
-          <desc>Reciprocal relationship of hasRevision.</desc>
+          <desc xml:lang="en">Reciprocal relationship of hasRevision.</desc>
         </valItem>
         <valItem ident="hasSuccessor">
-          <desc>Target is a sequel or succeeding work of the current entity.</desc>
+          <desc xml:lang="en">Target is a sequel or succeeding work of the current entity.</desc>
         </valItem>
         <valItem ident="isSuccessorOf">
-          <desc>Reciprocal relationship of hasSuccessor.</desc>
+          <desc xml:lang="en">Reciprocal relationship of hasSuccessor.</desc>
         </valItem>
         <valItem ident="hasSummarization">
-          <desc>Target is a digest or abstract of the current entity.</desc>
+          <desc xml:lang="en">Target is a digest or abstract of the current entity.</desc>
         </valItem>
         <valItem ident="isSummarizationOf">
-          <desc>Reciprocal relationship of hasSummarization.</desc>
+          <desc xml:lang="en">Reciprocal relationship of hasSummarization.</desc>
         </valItem>
         <valItem ident="hasSupplement">
-          <desc>Target is an index, concordance, teacher’s guide, gloss, supplement, or appendix of
+          <desc xml:lang="en">Target is an index, concordance, teacher’s guide, gloss, supplement, or appendix of
             the current entity.</desc>
         </valItem>
         <valItem ident="isSupplementOf">
-          <desc>Reciprocal relationship of hasSupplement.</desc>
+          <desc xml:lang="en">Reciprocal relationship of hasSupplement.</desc>
         </valItem>
         <valItem ident="hasTransformation">
-          <desc>Target is a dramatization, novelization, versification, or screenplay of the current
+          <desc xml:lang="en">Target is a dramatization, novelization, versification, or screenplay of the current
             entity.</desc>
         </valItem>
         <valItem ident="isTransformationOf">
-          <desc>Reciprocal relationship of hasTransformation.</desc>
+          <desc xml:lang="en">Reciprocal relationship of hasTransformation.</desc>
         </valItem>
         <valItem ident="hasTranslation">
-          <desc>Target is a literal translation or transcription (music) of the current
+          <desc xml:lang="en">Target is a literal translation or transcription (music) of the current
             entity.</desc>
         </valItem>
         <valItem ident="isTranslationOf">
-          <desc>Reciprocal relationship of hasTranslation.</desc>
+          <desc xml:lang="en">Reciprocal relationship of hasTranslation.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <classSpec ident="model.expressionLike" type="model" module="MEI.frbr">
-    <desc>Collects FRBR expression-like elements.</desc>
+    <desc xml:lang="en">Collects FRBR expression-like elements.</desc>
   </classSpec>
   <classSpec ident="model.itemLike" type="model" module="MEI.frbr">
-    <desc>Collects FRBR item-like elements.</desc>
+    <desc xml:lang="en">Collects FRBR item-like elements.</desc>
   </classSpec>
   <classSpec ident="model.manifestationLike" type="model" module="MEI.frbr">
-    <desc>Collects FRBR manifestation-like elements.</desc>
+    <desc xml:lang="en">Collects FRBR manifestation-like elements.</desc>
   </classSpec>
   <elementSpec ident="expression" module="MEI.frbr">
-    <desc>Intellectual or artistic realization of a work.</desc>
+    <desc xml:lang="en">Intellectual or artistic realization of a work.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.authorized"/>
@@ -228,7 +228,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="expressionList" module="MEI.frbr">
-    <desc>Gathers bibliographic expression entities.</desc>
+    <desc xml:lang="en">Gathers bibliographic expression entities.</desc>
     <classes>
       <memberOf key="att.common"/>
     </classes>
@@ -242,7 +242,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="item" module="MEI.frbr">
-    <desc>Single instance or exemplar of a source/manifestation.</desc>
+    <desc xml:lang="en">Single instance or exemplar of a source/manifestation.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.authorized"/>
@@ -289,7 +289,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="itemList" module="MEI.frbr">
-    <desc>Gathers bibliographic item entities.</desc>
+    <desc xml:lang="en">Gathers bibliographic item entities.</desc>
     <classes>
       <memberOf key="att.common"/>
     </classes>
@@ -303,7 +303,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="manifestation" module="MEI.frbr">
-    <desc>A bibliographic description of a physical embodiment of an expression of a work.</desc>
+    <desc xml:lang="en">A bibliographic description of a physical embodiment of an expression of a work.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.authorized"/>
@@ -383,7 +383,7 @@
     </attList>
   </elementSpec>
   <elementSpec ident="manifestationList" module="MEI.frbr">
-    <desc>A container for the descriptions of physical embodiments of an expression of a
+    <desc xml:lang="en">A container for the descriptions of physical embodiments of an expression of a
       work.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.genetic.xml
+++ b/source/modules/MEI.genetic.xml
@@ -5,10 +5,10 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.genetic">
   <moduleSpec ident="MEI.genetic">
-    <desc>Genetic encoding component declarations.</desc>
+    <desc xml:lang="en">Genetic encoding component declarations.</desc>
   </moduleSpec>
   <classSpec ident="att.geneticState" module="MEI.genetic" type="atts">
-    <desc>Attributes that pertain to a genetic state.</desc>
+    <desc xml:lang="en">Attributes that pertain to a genetic state.</desc>
     <constraintSpec ident="check_changeState.targets" scheme="schematron">
       <constraint>
         <sch:rule context="@state">
@@ -23,7 +23,7 @@
     </constraintSpec>
     <attList>
       <attDef ident="instant">
-        <desc>The @instant attribute is syntactic sugar for classifying a scribal intervention as an
+        <desc xml:lang="en">The @instant attribute is syntactic sugar for classifying a scribal intervention as an
           ad-hoc modification; that is, one which does not interrupt the writing process.</desc>
         <datatype>
           <rng:choice>
@@ -33,7 +33,7 @@
         </datatype>
       </attDef>
       <attDef ident="state">
-        <desc>Points to the genetic state that results from this modification.</desc>
+        <desc xml:lang="en">Points to the genetic state that results from this modification.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
         </datatype>
@@ -41,7 +41,7 @@
     </attList>
   </classSpec>
   <elementSpec ident="genDesc" module="MEI.genetic">
-    <desc>(genetic description) - Bundles information about the textual development of a
+    <desc xml:lang="en">(genetic description) - Bundles information about the textual development of a
       work.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -58,7 +58,7 @@
     </content>
     <attList>
       <attDef ident="ordered">
-        <desc>When set to "true" the child elements are known to be in chronological order. When set
+        <desc xml:lang="en">When set to "true" the child elements are known to be in chronological order. When set
           to "false" or when not provided, the order of child elements is unknown.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
@@ -75,7 +75,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="genState" module="MEI.genetic">
-    <desc>Describes a distinctive state in the textual development of a work.</desc>
+    <desc xml:lang="en">Describes a distinctive state in the textual development of a work.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>

--- a/source/modules/MEI.genetic.xml
+++ b/source/modules/MEI.genetic.xml
@@ -65,7 +65,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The development of a work can be traced in one or more sources.</p>
       <p>When the <gi scheme="MEI">genDesc</gi> element is nested, the inner element describes a
         group of processes with unknown chronological order inside a larger set of processes with
@@ -95,7 +95,7 @@
         <rng:ref name="model.dateLike"/>
       </rng:optional>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Any scribal modifications encoded with elements, such as <gi scheme="MEI">add</gi>, <gi
         scheme="MEI">del</gi>, etc., which refer to a genState element, are regarded as the
         operations that need to be implemented to reach this state; that is, they precede this

--- a/source/modules/MEI.gestural.xml
+++ b/source/modules/MEI.gestural.xml
@@ -495,7 +495,7 @@
             <desc xml:lang="en">Lowest note the performer can play.</desc>
           </valItem>
         </valList>
-        <remarks>
+        <remarks xml:lang="en">
           <p>On a wind instrument, the "highest note possible" depends on the player’s abilities. On
             a string instrument, the "lowest note possible" depends on how much a string is
             de-tuned; that is, loosened using the tuning peg. Use of the <att>pname</att> and
@@ -661,7 +661,7 @@
         <datatype>
           <rng:ref name="data.DEGREES"/>
         </datatype>
-        <remarks>
+        <remarks xml:lang="en">
           <p>A value of 0, 360, or -360 is directly in front of the listener, while a value of 180
             or -180 is directly behind.</p>
         </remarks>
@@ -671,7 +671,7 @@
         <datatype>
           <rng:ref name="data.DEGREES"/>
         </datatype>
-        <remarks>
+        <remarks xml:lang="en">
           <p>A value of 0, 360, or -360 is directly above the listener, while a value of 180 or -180
             is directly below.</p>
         </remarks>

--- a/source/modules/MEI.gestural.xml
+++ b/source/modules/MEI.gestural.xml
@@ -5,19 +5,19 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.gestural">
   <moduleSpec ident="MEI.gestural">
-    <desc>Gestural component declarations.</desc>
+    <desc xml:lang="en">Gestural component declarations.</desc>
   </moduleSpec>
   <classSpec ident="att.accid.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.accidental.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.accidental.gestural" module="MEI.gestural" type="atts">
-    <desc>Attributes for capturing momentary pitch inflection in the gestural domain.</desc>
+    <desc xml:lang="en">Attributes for capturing momentary pitch inflection in the gestural domain.</desc>
     <attList>
       <attDef ident="accid.ges" usage="opt">
-        <desc>Records the performed pitch inflection.</desc>
+        <desc xml:lang="en">Records the performed pitch inflection.</desc>
         <datatype>
           <rng:ref name="data.ACCIDENTAL.GESTURAL"/>
         </datatype>
@@ -33,10 +33,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.ambNote.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.annot.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.timestamp.gestural"/>
@@ -44,19 +44,19 @@
     </classes>
   </classSpec>
   <classSpec ident="att.arpeg.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.artic.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.articulation.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.articulation.gestural" module="MEI.gestural" type="atts">
-    <desc>Attributes describing the method of performance.</desc>
+    <desc xml:lang="en">Attributes describing the method of performance.</desc>
     <attList>
       <attDef ident="artic.ges" usage="opt">
-        <desc>Records performed articulation that differs from the written value.</desc>
+        <desc xml:lang="en">Records performed articulation that differs from the written value.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.ARTICULATION"/>
         </datatype>
@@ -64,35 +64,35 @@
     </attList>
   </classSpec>
   <classSpec ident="att.attacca.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.barLine.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.beam.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.beamSpan.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.beatRpt.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.bend.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
     <attList>
       <attDef ident="amount" usage="opt">
-        <desc>Records the amount of detuning. The decimal values should be rendered as a fraction
+        <desc xml:lang="en">Records the amount of detuning. The decimal values should be rendered as a fraction
           (or an integer plus a fraction) along with the bend symbol.</desc>
         <datatype>
           <rng:ref name="data.BEND.AMOUNT"/>
@@ -101,33 +101,33 @@
     </attList>
   </classSpec>
   <classSpec ident="att.bracketSpan.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.breath.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.timestamp.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.bTrem.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.tremMeasured"/>
     </classes>
   </classSpec>
   <classSpec ident="att.caesura.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.timestamp.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.chord.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.articulation.gestural"/>
       <memberOf key="att.duration.gestural"/>
@@ -136,38 +136,38 @@
     </classes>
   </classSpec>
   <classSpec ident="att.chordDef.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.chordMember.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.accidental.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.clef.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.clefGrp.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.cpMark.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.curve.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.custos.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.mdiv.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <attList>
       <attDef ident="attacca">
-        <desc>Indicates that the performance of the next musical division should begin immediately
+        <desc xml:lang="en">Indicates that the performance of the next musical division should begin immediately
           following this one.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
@@ -176,34 +176,34 @@
     </attList>
   </classSpec>
   <classSpec ident="att.dir.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.dot.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.duration.gestural" module="MEI.gestural" type="atts">
-    <desc>Attributes that record performed duration that differs from a feature’s written
+    <desc xml:lang="en">Attributes that record performed duration that differs from a feature’s written
       duration.</desc>
     <attList>
       <attDef ident="dur.ges" usage="opt">
-        <desc>Records performed duration information that differs from the written duration.</desc>
+        <desc xml:lang="en">Records performed duration information that differs from the written duration.</desc>
         <datatype>
           <rng:ref name="data.DURATION.gestural"/>
         </datatype>
       </attDef>
       <attDef ident="dots.ges" usage="opt">
-        <desc>Number of dots required for a gestural duration when different from that of the
+        <desc xml:lang="en">Number of dots required for a gestural duration when different from that of the
           written duration.</desc>
         <datatype>
           <rng:ref name="data.AUGMENTDOT"/>
         </datatype>
       </attDef>
       <attDef ident="dur.metrical" usage="opt">
-        <desc>Duration as a count of units provided in the time signature denominator.</desc>
+        <desc xml:lang="en">Duration as a count of units provided in the time signature denominator.</desc>
         <datatype>
           <rng:data type="decimal">
             <rng:param name="pattern">\d+(\.\d+)?</rng:param>
@@ -211,14 +211,14 @@
         </datatype>
       </attDef>
       <attDef ident="dur.ppq" usage="opt">
-        <desc>Duration recorded as pulses-per-quarter note, <abbr>e.g.</abbr>, MIDI clicks or MusicXML
+        <desc xml:lang="en">Duration recorded as pulses-per-quarter note, <abbr>e.g.</abbr>, MIDI clicks or MusicXML
           divisions.</desc>
         <datatype>
           <rng:data type="nonNegativeInteger"/>
         </datatype>
       </attDef>
       <attDef ident="dur.real" usage="opt">
-        <desc>Duration in seconds, <abbr>e.g.</abbr>, <val>1.732</val>.</desc>
+        <desc xml:lang="en">Duration in seconds, <abbr>e.g.</abbr>, <val>1.732</val>.</desc>
         <datatype>
           <rng:data type="decimal">
             <rng:param name="pattern">\d+(\.\d+)?</rng:param>
@@ -226,7 +226,7 @@
         </datatype>
       </attDef>
       <attDef ident="dur.recip" usage="opt">
-        <desc>Duration as an optionally dotted <ref target="https://www.humdrum.org/rep/recip/">Humdrum **recip value</ref>.</desc>
+        <desc xml:lang="en">Duration as an optionally dotted <ref target="https://www.humdrum.org/rep/recip/">Humdrum **recip value</ref>.</desc>
         <datatype>
           <rng:data type="token">
             <rng:param name="pattern">[0-9]+(%[0-9]+)?\.*q?</rng:param>
@@ -236,7 +236,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.dynam.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.midiValue"/>
@@ -245,59 +245,59 @@
     </classes>
   </classSpec>
   <classSpec ident="att.ending.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.episema.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.articulation.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.f.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.fermata.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.fing.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.fingGrp.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.fTrem.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.tremMeasured"/>
     </classes>
   </classSpec>
   <classSpec ident="att.gliss.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.grpSym.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.hairpin.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.midiValue"/>
@@ -306,29 +306,29 @@
     </classes>
   </classSpec>
   <classSpec ident="att.halfmRpt.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.harm.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.harpPedal.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.hispanTick.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.instrDef.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.channelized"/>
       <memberOf key="att.midiInstrument"/>
@@ -336,44 +336,44 @@
     </classes>
   </classSpec>
   <classSpec ident="att.keyAccid.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.keySig.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.layer.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.layerDef.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.instrumentIdent"/>
     </classes>
   </classSpec>
   <classSpec ident="att.ligature.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.line.ges" module="MEI.gestural" type="atts">
-    <desc>Attributes for describing the performed components of a line.</desc>
+    <desc xml:lang="en">Attributes for describing the performed components of a line.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.liquescent.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.lv.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.lyrics.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.measure.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes. The tstamp.ges and tstamp.real attributes encode the onset
+    <desc xml:lang="en">Gestural domain attributes. The tstamp.ges and tstamp.real attributes encode the onset
       time of the measure. In reality, this is usually the same as the onset time of the first event
       in the measure.</desc>
     <classes>
@@ -381,49 +381,49 @@
     </classes>
   </classSpec>
   <classSpec ident="att.mensur.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.meterSig.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.meterSigGrp.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.midi.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.mordent.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.mRest.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.mRpt.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.mRpt2.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.mSpace.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.multiRest.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.multiRpt.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.nc.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <!-- most of the same attributes as note element! -->
       <memberOf key="att.accidental.gestural"/>
@@ -434,19 +434,19 @@
     </classes>
     <attList>
       <attDef ident="oct.ges" usage="opt">
-        <desc>Records performed octave information that differs from the written value.</desc>
+        <desc xml:lang="en">Records performed octave information that differs from the written value.</desc>
         <datatype>
           <rng:ref name="data.OCTAVE"/>
         </datatype>
       </attDef>
       <attDef ident="pname.ges" usage="opt">
-        <desc>Contains a performed pitch name that differs from the written value.</desc>
+        <desc xml:lang="en">Contains a performed pitch name that differs from the written value.</desc>
         <datatype>
           <rng:ref name="data.PITCHNAME.GES"/>
         </datatype>
       </attDef>
       <attDef ident="pnum" usage="opt">
-        <desc>Holds a pitch-to-number mapping, a base-40 or MIDI note number, for example.</desc>
+        <desc xml:lang="en">Holds a pitch-to-number mapping, a base-40 or MIDI note number, for example.</desc>
         <datatype>
           <rng:ref name="data.PITCHNUMBER"/>
         </datatype>
@@ -454,19 +454,19 @@
     </attList>
   </classSpec>
   <classSpec ident="att.ncGrp.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.timestamp.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.neume.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.timestamp.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.note.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.accidental.gestural"/>
       <memberOf key="att.articulation.gestural"/>
@@ -486,13 +486,13 @@
     </constraintSpec>
     <attList>
       <attDef ident="extremis" usage="opt">
-        <desc>Indicates an extreme, indefinite performed pitch.</desc>
+        <desc xml:lang="en">Indicates an extreme, indefinite performed pitch.</desc>
         <valList type="closed">
           <valItem ident="highest">
-            <desc>Highest note the performer can play.</desc>
+            <desc xml:lang="en">Highest note the performer can play.</desc>
           </valItem>
           <valItem ident="lowest">
-            <desc>Lowest note the performer can play.</desc>
+            <desc xml:lang="en">Lowest note the performer can play.</desc>
           </valItem>
         </valList>
         <remarks>
@@ -504,19 +504,19 @@
         </remarks>
       </attDef>
       <attDef ident="oct.ges" usage="opt">
-        <desc>Records performed octave information that differs from the written value.</desc>
+        <desc xml:lang="en">Records performed octave information that differs from the written value.</desc>
         <datatype>
           <rng:ref name="data.OCTAVE"/>
         </datatype>
       </attDef>
       <attDef ident="pname.ges" usage="opt">
-        <desc>Contains a performed pitch name that differs from the written value.</desc>
+        <desc xml:lang="en">Contains a performed pitch name that differs from the written value.</desc>
         <datatype>
           <rng:ref name="data.PITCHNAME.GES"/>
         </datatype>
       </attDef>
       <attDef ident="pnum" usage="opt">
-        <desc>Holds a pitch-to-number mapping, a base-40 or MIDI note number, for example.</desc>
+        <desc xml:lang="en">Holds a pitch-to-number mapping, a base-40 or MIDI note number, for example.</desc>
         <datatype>
           <rng:ref name="data.PITCHNUMBER"/>
         </datatype>
@@ -524,80 +524,80 @@
     </attList>
   </classSpec>
   <classSpec ident="att.octave.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.oriscus.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.ornam.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.ossia.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.pad.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.part.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.parts.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.pb.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.pedal.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.phrase.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.proport.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.quilisma.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.rdg.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.refrain.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.reh.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.rest.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.rest.ges.mensural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.sb.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.score.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.scoreDef.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes for scoreDef. The values set in these attributes act as
+    <desc xml:lang="en">Gestural domain attributes for scoreDef. The values set in these attributes act as
       score-wide defaults for attributes that are not set in descendant elements. For example, the
       grace attribute value here applies to all the grace attribute values in the score (or, more
       accurately, until the next <gi scheme="MEI">scoreDef</gi> element) without having to
@@ -612,19 +612,19 @@
     </classes>
     <attList>
       <attDef ident="tune.pname" usage="opt">
-        <desc>Holds the pitch name of a tuning reference pitch.</desc>
+        <desc xml:lang="en">Holds the pitch name of a tuning reference pitch.</desc>
         <datatype>
           <rng:ref name="data.PITCHNAME"/>
         </datatype>
       </attDef>
       <attDef ident="tune.Hz" usage="opt">
-        <desc>Holds a value for cycles per second, <abbr>i.e.</abbr>, Hertz, for a tuning reference pitch.</desc>
+        <desc xml:lang="en">Holds a value for cycles per second, <abbr>i.e.</abbr>, Hertz, for a tuning reference pitch.</desc>
         <datatype>
           <rng:data type="decimal"/>
         </datatype>
       </attDef>
       <attDef ident="tune.temper" usage="opt">
-        <desc>Provides an indication of the tuning system, 'just', for example.</desc>
+        <desc xml:lang="en">Provides an indication of the tuning system, 'just', for example.</desc>
         <datatype>
           <rng:ref name="data.TEMPERAMENT"/>
         </datatype>
@@ -632,10 +632,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.section.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <attList>
       <attDef ident="attacca">
-        <desc>Indicates that the performance of the next section should begin immediately following
+        <desc xml:lang="en">Indicates that the performance of the next section should begin immediately following
           this one.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
@@ -644,20 +644,20 @@
     </attList>
   </classSpec>
   <classSpec ident="att.signifLet.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.slur.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.soundLocation" module="MEI.gestural" type="atts">
-    <desc>Attributes that locate a sound source within 3-D space.</desc>
+    <desc xml:lang="en">Attributes that locate a sound source within 3-D space.</desc>
     <attList>
       <attDef ident="azimuth" usage="opt">
-        <desc>The lateral or left-to-right plane.</desc>
+        <desc xml:lang="en">The lateral or left-to-right plane.</desc>
         <datatype>
           <rng:ref name="data.DEGREES"/>
         </datatype>
@@ -667,7 +667,7 @@
         </remarks>
       </attDef>
       <attDef ident="elevation" usage="opt">
-        <desc>The above-to-below axis.</desc>
+        <desc xml:lang="en">The above-to-below axis.</desc>
         <datatype>
           <rng:ref name="data.DEGREES"/>
         </datatype>
@@ -679,22 +679,22 @@
     </attList>
   </classSpec>
   <classSpec ident="att.sp.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.space.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.staff.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.staffDef.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes for staffDef in the CMN repertoire.</desc>
+    <desc xml:lang="en">Gestural domain attributes for staffDef in the CMN repertoire.</desc>
     <classes>
       <memberOf key="att.instrumentIdent"/>
       <memberOf key="att.stringtab.tuning"/>
@@ -702,53 +702,53 @@
     </classes>
   </classSpec>
   <classSpec ident="att.staffGrp.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.instrumentIdent"/>
     </classes>
   </classSpec>
   <classSpec ident="att.stageDir.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.strophicus.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.syl.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.syllable.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.symbol.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.tempo.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.midiTempo"/>
     </classes>
   </classSpec>
   <classSpec ident="att.tie.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.timestamp.gestural" module="MEI.gestural" type="atts">
-    <desc>Attributes that record a performed (as opposed to notated) time stamp.</desc>
+    <desc xml:lang="en">Attributes that record a performed (as opposed to notated) time stamp.</desc>
     <attList>
       <attDef ident="tstamp.ges" usage="opt">
-        <desc>Encodes the onset time in terms of musical time, <abbr>i.e.</abbr>, beats[.fractional beat part],
+        <desc xml:lang="en">Encodes the onset time in terms of musical time, <abbr>i.e.</abbr>, beats[.fractional beat part],
           as expressed in the written time signature.</desc>
         <datatype>
           <rng:ref name="data.BEAT"/>
         </datatype>
       </attDef>
       <attDef ident="tstamp.real" usage="opt">
-        <desc>Records the onset time in terms of ISO time.</desc>
+        <desc xml:lang="en">Records the onset time in terms of ISO time.</desc>
         <datatype>
           <rng:ref name="data.ISOTIME"/>
         </datatype>
@@ -756,18 +756,18 @@
     </attList>
   </classSpec>
   <classSpec ident="att.timestamp2.gestural" module="MEI.gestural" type="atts">
-    <desc>Attributes that record a performed (as opposed to notated) time stamp for the end of an
+    <desc xml:lang="en">Attributes that record a performed (as opposed to notated) time stamp for the end of an
       event.</desc>
     <attList>
       <attDef ident="tstamp2.ges" usage="opt">
-        <desc>Encodes the ending point of an event, <abbr>i.e.</abbr>, a count of measures plus a beat location
+        <desc xml:lang="en">Encodes the ending point of an event, <abbr>i.e.</abbr>, a count of measures plus a beat location
           in the ending measure.</desc>
         <datatype>
           <rng:ref name="data.MEASUREBEAT"/>
         </datatype>
       </attDef>
       <attDef ident="tstamp2.real" usage="opt">
-        <desc>Records the ending point of an event in terms of ISO time.</desc>
+        <desc xml:lang="en">Records the ending point of an event in terms of ISO time.</desc>
         <datatype>
           <rng:ref name="data.ISOTIME"/>
         </datatype>
@@ -775,32 +775,32 @@
     </attList>
   </classSpec>
   <classSpec ident="att.trill.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
       <memberOf key="att.timestamp2.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.tuplet.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.gestural"/>
     </classes>
   </classSpec>
   <classSpec ident="att.tupletSpan.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.timestamp2.gestural"/>
       <memberOf key="att.tuplet.ges"/>
     </classes>
   </classSpec>
   <classSpec ident="att.turn.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.verse.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.volta.ges" module="MEI.gestural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
 </specGrp>

--- a/source/modules/MEI.harmony.xml
+++ b/source/modules/MEI.harmony.xml
@@ -83,7 +83,8 @@
     </classes>
   </classSpec>
   <elementSpec ident="chordDef" module="MEI.harmony">
-    <desc xml:lang="en">(chord definition) – Chord tablature definition.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">chord definition</gloss>
+    <desc xml:lang="en">Chord tablature definition.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.chordDef.anl"/>
@@ -145,7 +146,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="f" module="MEI.harmony">
-    <desc xml:lang="en">(figure) – Single element of a figured bass indication.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">figure</gloss>
+    <desc xml:lang="en">Single element of a figured bass indication.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -167,7 +169,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="fb" module="MEI.harmony">
-    <desc xml:lang="en">(figured bass) – Symbols added to a bass line that indicate harmony. Used to improvise a
+    <gloss versionDate="2022-05-18" xml:lang="en">figured bass</gloss>
+    <desc xml:lang="en">Symbols added to a bass line that indicate harmony. Used to improvise a
       chordal accompaniment. Sometimes called Generalbass, thoroughbass, or basso continuo.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -185,7 +188,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="harm" module="MEI.harmony">
-    <desc xml:lang="en">(harmony) – An indication of harmony, <abbr>e.g.</abbr>, chord names, tablature grids, harmonic
+    <gloss versionDate="2022-05-18" xml:lang="en">harmony</gloss>
+    <desc xml:lang="en">An indication of harmony, <abbr>e.g.</abbr>, chord names, tablature grids, harmonic
       analysis, figured bass.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.harmony.xml
+++ b/source/modules/MEI.harmony.xml
@@ -99,7 +99,7 @@
         <rng:ref name="barre"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>An <att>xml:id</att> attribute, while not required by the schema, is needed so that <gi
         scheme="MEI">harm</gi> elements can reference a particular chord definition. The
         <att>pos</att> (position) attribute is provided in order to create displayable chord
@@ -120,7 +120,7 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>string</att>, <att>fret</att>, and <att>fing</att> attributes are provided in
         order to create displayable chord tablature grids. The <att>inth</att> (harmonic interval)
         attribute may be used to facilitate automated performance of a chord. It gives the number of
@@ -139,7 +139,7 @@
         <rng:ref name="chordDef"/>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>A chordTable may be shared between MEI instances through the use of an external parsed
         entity containing the look-up table to be shared.</p>
     </remarks>

--- a/source/modules/MEI.harmony.xml
+++ b/source/modules/MEI.harmony.xml
@@ -5,24 +5,24 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.harmony">
   <moduleSpec ident="MEI.harmony">
-    <desc>Harmony component declarations.</desc>
+    <desc xml:lang="en">Harmony component declarations.</desc>
   </moduleSpec>
   <classSpec ident="att.chordDef.log" module="MEI.harmony" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.stringtab.position"/>
       <memberOf key="att.stringtab.tuning"/>
     </classes>
   </classSpec>
   <classSpec ident="att.chordMember.log" module="MEI.harmony" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.pitched"/>
       <memberOf key="att.stringtab"/>
     </classes>
   </classSpec>
   <classSpec ident="att.f.log" module="MEI.harmony" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
@@ -31,7 +31,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.harm.log" module="MEI.harmony" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
@@ -40,7 +40,7 @@
     </classes>
     <attList>
       <attDef ident="chordref" usage="opt">
-        <desc>Contains a reference to a <gi scheme="MEI">chordDef</gi> element elsewhere in the
+        <desc xml:lang="en">Contains a reference to a <gi scheme="MEI">chordDef</gi> element elsewhere in the
           document.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
@@ -61,29 +61,29 @@
     </attList>
   </classSpec>
   <classSpec ident="model.chordTableLike" module="MEI.harmony" type="model">
-    <desc>Groups elements that group playable chord definitions.</desc>
+    <desc xml:lang="en">Groups elements that group playable chord definitions.</desc>
   </classSpec>
   <classSpec ident="model.controlEventLike.harmony" module="MEI.harmony" type="model">
-    <desc>Groups harmonic elements that function as control events; that is, those events that
+    <desc xml:lang="en">Groups harmonic elements that function as control events; that is, those events that
       modify or otherwise depend on the existence of notated events.</desc>
     <classes>
       <memberOf key="model.controlEventLike"/>
     </classes>
   </classSpec>
   <classSpec ident="model.figbassLike" module="MEI.harmony" type="model">
-    <desc>Groups elements that record figured bass.</desc>
+    <desc xml:lang="en">Groups elements that record figured bass.</desc>
   </classSpec>
   <classSpec ident="model.fLike" module="MEI.harmony" type="model">
-    <desc>Groups elements that represent single figured bass elements.</desc>
+    <desc xml:lang="en">Groups elements that represent single figured bass elements.</desc>
   </classSpec>
   <classSpec ident="model.harmLike" module="MEI.harmony" type="model">
-    <desc>Groups elements that record indications of harmony.</desc>
+    <desc xml:lang="en">Groups elements that record indications of harmony.</desc>
     <classes>
       <memberOf key="model.controlEventLike.harmony"/>
     </classes>
   </classSpec>
   <elementSpec ident="chordDef" module="MEI.harmony">
-    <desc>(chord definition) – Chord tablature definition.</desc>
+    <desc xml:lang="en">(chord definition) – Chord tablature definition.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.chordDef.anl"/>
@@ -109,7 +109,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="chordMember" module="MEI.harmony">
-    <desc>An individual pitch in a chord defined by a <gi scheme="MEI">chordDef</gi> element.</desc>
+    <desc xml:lang="en">An individual pitch in a chord defined by a <gi scheme="MEI">chordDef</gi> element.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.chordMember.anl"/>
@@ -129,7 +129,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="chordTable" module="MEI.harmony">
-    <desc>Chord/tablature look-up table.</desc>
+    <desc xml:lang="en">Chord/tablature look-up table.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="model.chordTableLike"/>
@@ -145,7 +145,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="f" module="MEI.harmony">
-    <desc>(figure) – Single element of a figured bass indication.</desc>
+    <desc xml:lang="en">(figure) – Single element of a figured bass indication.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -167,7 +167,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="fb" module="MEI.harmony">
-    <desc>(figured bass) – Symbols added to a bass line that indicate harmony. Used to improvise a
+    <desc xml:lang="en">(figured bass) – Symbols added to a bass line that indicate harmony. Used to improvise a
       chordal accompaniment. Sometimes called Generalbass, thoroughbass, or basso continuo.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -185,7 +185,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="harm" module="MEI.harmony">
-    <desc>(harmony) – An indication of harmony, <abbr>e.g.</abbr>, chord names, tablature grids, harmonic
+    <desc xml:lang="en">(harmony) – An indication of harmony, <abbr>e.g.</abbr>, chord names, tablature grids, harmonic
       analysis, figured bass.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -158,7 +158,7 @@
         </valList>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>recordtype</att> attribute may be used to determine the appropriateness and
         validity of certain data elements in the description.</p>
       <p>
@@ -299,13 +299,13 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>May indicate the nature of restrictions or the lack of restrictions. Do not confuse this
         element with <gi scheme="MEI">useRestrict</gi> (usage restrictions), which captures
         information about limitations on the <hi rend="bold">use</hi> of material, such as those
         afforded by copyright.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
@@ -322,7 +322,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -343,7 +343,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>One or the other of <gi scheme="MEI">altId</gi> or the <att>id</att> attribute on <gi
         scheme="MEI">mei</gi> is required when applicable.</p>
     </remarks>
@@ -363,7 +363,7 @@
         <rng:ref name="application"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -396,7 +396,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -461,11 +461,11 @@
     <content>
       <rng:ref name="macro.availabilityPart"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>When used within the <gi scheme="MEI">fileDesc</gi> element, <gi scheme="MEI"
         >availability</gi> indicates access to the MEI-encoded document itself.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -650,7 +650,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Additions, deletions, and significant recoding should be noted, but not correction of minor
         typographical errors. It is recommended that revisions should be entered in reverse
         chronological order, with the most recent <gi scheme="MEI">change</gi> first. The
@@ -659,7 +659,7 @@
         to designate an MEI encoding that has been so substantively changed that it constitutes a
         new version that supersedes earlier versions.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
@@ -691,7 +691,7 @@
         <rng:ref name="taxonomy"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Although the use of names and terms from locally controlled vocabularies is possible, best
         practice suggests that terms should come from standard national or international
         vocabularies whenever they are available in order to enable searches in systems that include
@@ -716,7 +716,7 @@
         </rng:choice>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Although the use of names and terms from locally controlled vocabularies is possible, best
         practice suggests that terms should come from standard national or international
         vocabularies whenever they are available in order to enable searches in systems that include
@@ -773,7 +773,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The child elements of this element are treated as components of the bibliographic entity
         containing the <gi scheme="MEI">componentList</gi>. Although this is an implicit way of
         expressing FRBR's hasPart and isPartOf relationships, it avoids this terminology in order to
@@ -798,7 +798,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
@@ -880,7 +880,7 @@
 <contents target="http://www.contentProvider.org/toc/toc01.html"/>
             </egXML>
     </exemplum>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Use this element to provide an enumeration of the contents of a bibliographic entity, like
         that often found in a table of contents. When a detailed bibliographic description of
         included material is desired, use the <gi scheme="MEI">componentList</gi> element
@@ -939,7 +939,7 @@
         </valList>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -1001,7 +1001,7 @@
         </valList>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The dimensions (@width, @height) of the parent element (<abbr>e.g.</abbr>, <gi scheme="MEI">folium</gi>)
         indicate the size of the bounding box of the remaining part of the page. That is, if the
         complete lower half of a page has been cut, the @width and @height attributes describe the
@@ -1009,7 +1009,7 @@
         cut, these attributes still indicate the size of the full page (assuming that the removed
         section was a regular rectangle).</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The dimensions (@width, @height) on <gi scheme="MEI">cutout</gi> itself are only to be used
         when there is a "gap" in the manuscript that allows to specify the dimensions of that
         missing part. In this case, the bounding box dimensions are given, together with @x and @y
@@ -1047,7 +1047,7 @@
         </rng:zeroOrMore>
       </rng:choice>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element uses a variant of the content model provided by
         macro.struc-unstrucContent.</p>
     </remarks>
@@ -1098,7 +1098,7 @@
         </rng:zeroOrMore>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -1131,7 +1131,7 @@
         </rng:group>
       </rng:choice>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -1170,7 +1170,7 @@
         <rng:ref name="classDecls"/>
       </rng:optional>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -1204,7 +1204,7 @@
         </rng:zeroOrMore>
       </rng:choice>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
@@ -1266,10 +1266,10 @@
         <rng:ref name="sourceDesc"/>
       </rng:optional>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Extent in this context represents file size.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -1294,7 +1294,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The purpose of <gi scheme="MEI">foliaDesc</gi> is to transcribe the addition and removal of
         pages as part of physical modifications to a document. Missing pages may be indicated using
         the <gi scheme="MEI">gap</gi> element. The <gi scheme="MEI">folium</gi> and <gi scheme="MEI"
@@ -1316,7 +1316,7 @@
         <rng:ref name="model.paperModLike"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>When the exact folium setup can't be identified, it is advised to use <gi scheme="MEI"
         >folium</gi> elements only (and not guess about the presence of <gi scheme="MEI"
         >bifolium</gi>s in the document).</p>
@@ -1347,7 +1347,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>initial</att> attribute indicates whether this is the first or main hand of the
         document. The <att>medium</att> attribute describes the writing medium, <abbr>e.g.</abbr>, 
         <val>pencil</val>, or the tint or type of ink, <abbr>e.g.</abbr>, <val>brown</val>. 
@@ -1357,7 +1357,7 @@
         <val>thick</val>, etc. may be described within the content of the <gi scheme="MEI">hand</gi> 
         element.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -1387,7 +1387,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -1422,7 +1422,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>To facilitate efficient data interchange, basic information about the circumstances
         surrounding the creation of bibliographic resources should be recorded within the <gi
         scheme="MEI">creation</gi> element, while the record of ownership and custody should be
@@ -1521,7 +1521,7 @@
         <rng:ref name="model.pLike"/>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -1545,7 +1545,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is used exclusively within bibliographic descriptions. Do not confuse this
         element with <gi scheme="MEI">keySig</gi>, which is used within the body of an MEI file to
         record this data.</p>
@@ -1567,14 +1567,14 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>A textual element may be related to this element by setting its <att>xml:lang</att>
         attribute, which normally takes the form of a code drawn from a coded list, such as
         ISO639-2b, to the same value as this element’s codedval attribute. The name and web location
         of the authorizing list may be encoded in the <att>auth</att> attribute and the
         <att>auth.uri</att> attribute, respectively.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -1595,7 +1595,7 @@
         <rng:ref name="language"/>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -1666,7 +1666,7 @@
         </valList>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>In order to encourage uniformity in the provision of metadata across document types, this
         element is modelled on an element in the Text Encoding Initiative (TEI) standard. This
         information is often essential in a machine-readable environment. Five sub-elements must be
@@ -1706,7 +1706,7 @@
     <content>
       <rng:text/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is used exclusively within bibliographic descriptions. Do not confuse <gi
         scheme="MEI">meter</gi> with the <gi scheme="MEI">meterSig</gi> or <gi scheme="MEI"
         >meterSigGrp</gi> or attributes used by staffDef and scoreDef to record this data within the
@@ -1747,7 +1747,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -1770,7 +1770,7 @@
         <rng:ref name="model.pLike"/>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -1789,7 +1789,7 @@
         <rng:ref name="model.annotLike"/>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -1881,13 +1881,13 @@
         </valList>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>A patch must always contain a <gi scheme="MEI">folium</gi> or <gi scheme="MEI"
         >bifolium</gi> element. The @x and @y attributes are used to position the patch on its
         parent surface by indicating the upper left corner of the patch. The size of the patch is
         encoded using the @height and @width attributes on the child folium (or bifolium).</p>
     </remarks>
-    <!--<remarks>
+    <!--<remarks xml:lang="en">
             <p>TODO: It remains unclear how to specify which part of the patch is attached to the
               underlying surface. Right now, the assumption is that it is always attached with the
               patch’s verso (or outer.verso) side, but what about patches that can be folded up or
@@ -1917,7 +1917,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p/>
     </remarks>
   </elementSpec>
@@ -1944,7 +1944,7 @@
         <rng:ref name="model.annotLike"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p> Arrangements are coded for the medium of the work being described, not for the original
         medium.</p>
     </remarks>
@@ -2013,7 +2013,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The function of instrumentalists or vocalists is represented by the choice of <gi
         scheme="MEI">perfRes</gi> and <gi scheme="MEI">perfResList</gi> child elements. Arrangements
         are coded for the medium of the work being described, not for the original medium.</p>
@@ -2038,12 +2038,12 @@
         <rng:ref name="model.physDescPart"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Dedicatory text and title page features may also be encoded here when they are not
         transcribed as part of the front or back matter; <abbr>i.e.</abbr>, when they are considered to be
         meta-data rather than a transcription.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
@@ -2061,11 +2061,11 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>All materials may be described in a single <gi scheme="MEI">physMedium</gi> element or
         multiple elements may be used, one for each medium.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Encoded Archival Description (EAD) standard. It
         has the same function as the material element in the Text Encoding Initiative (TEI)
         standard.</p>
@@ -2085,7 +2085,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>While it is often called a "plate number", it does not always contain numbers. The
         <att>facs</att> attribute may be used to record the location of the plate number in a
         facsimile image.</p>
@@ -2140,7 +2140,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Best practice suggests the use of controlled vocabulary for the currency attribute, such as
         the ISO 4217 list of currency designators.</p>
     </remarks>
@@ -2164,7 +2164,7 @@
         <rng:ref name="model.pLike"/>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -2197,7 +2197,7 @@
         </rng:zeroOrMore>
       </rng:choice>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Encoded Archival Description (EAD) and Text
         Encoding Initiative (TEI) standards.</p>
     </remarks>
@@ -2223,10 +2223,10 @@
         </rng:zeroOrMore>
       </rng:choice>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>When an item is unpublished, use only the <gi scheme="MEI">unpub</gi> sub-element.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -2245,11 +2245,11 @@
         <rng:ref name="change"/>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>It is recommended that changes be recorded in reverse chronological order, with the most
         recent alteration first.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -2271,7 +2271,7 @@
         <rng:ref name="model.pLike"/>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -2307,7 +2307,7 @@
         <rng:ref name="model.pLike"/>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -2340,7 +2340,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <gi scheme="MEI">title</gi> sub-element records the series title, the <gi scheme="MEI"
         >respStmt</gi> element records the person or group responsible for the series, and the <gi
         scheme="MEI">identifier</gi> element contains a series identifier. The <gi scheme="MEI"
@@ -2348,7 +2348,7 @@
         series, but not describe each component. The <gi scheme="MEI">seriesStmt</gi> element is
         provided within seriesStmt for the description of a sub-series.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -2378,7 +2378,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The number of apparent playback channels can differ from the number of physical channels of
         the recording medium, <abbr>i.e.</abbr>, 2-track monophonic recordings. In this example, the soundChan
         element should record the fact that there is a single output channel, while the <gi
@@ -2428,7 +2428,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element contains, or references via its <att>target</att> attribute, a description of
         a source used in the creation of the electronic file. For description of a physical
         embodiment of an expression of a work use the <gi scheme="MEI">manifestation</gi>
@@ -2436,7 +2436,7 @@
       <p>The <att>data</att> attribute may be used to reference one or more musical features found
         in the content of this particular source.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -2455,7 +2455,7 @@
         <rng:ref name="source"/>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is recommended where the MEI file is a transcription of existing music, but is
         not required when the data is originally created in MEI form.</p>
     </remarks>
@@ -2492,7 +2492,7 @@
         <rng:ref name="model.pLike"/>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -2526,7 +2526,7 @@
         <rng:ref name="namespace"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -2579,7 +2579,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -2634,7 +2634,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>An external taxonomy from which all the descendant <gi scheme="MEI">term</gi> elements are
         drawn may be referred to using the <att>target</att> attribute.</p>
     </remarks>
@@ -2658,7 +2658,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -2683,7 +2683,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The number of apparent playback channels can differ from the number of physical channels of
         the recording medium, <abbr>i.e.</abbr>, 2-track monophonic recordings. In this example, the trackConfig
         element should record the fact that there are two physical tracks on the sound medium, while
@@ -2722,11 +2722,11 @@
         </rng:zeroOrMore>
       </rng:choice>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Treatment history may also comprise details of the treatment process (<abbr>e.g.</abbr>, chemical
         solutions used, techniques applied, etc.), the date the treatment was applied, etc.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
@@ -2761,7 +2761,7 @@
         </rng:zeroOrMore>
       </rng:choice>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
@@ -2777,7 +2777,7 @@
     <content>
       <rng:text/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>A short phrase indicating the nature of or the reason for the unpublished status may be
         given as the element’s content.</p>
     </remarks>
@@ -2795,7 +2795,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p> <gi scheme="MEI">useRestrict</gi> may indicate limitations imposed by an owner,
         repository, or legal statute (for example, copyright law) regarding the reproduction,
         publication, or quotation of the item. It may also indicate the absence of restrictions,
@@ -2803,7 +2803,7 @@
         the <gi scheme="MEI">accessRestrict</gi> element, which holds information about conditions
         affecting the availability of the material.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
@@ -2821,11 +2821,11 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>facs</att> attribute may be used to record the location of the watermark in a
         facsimile image.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -2907,7 +2907,7 @@
         <rng:ref name="extMeta"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <gi scheme="MEI">perfDuration</gi> element captures the <emph>intended duration</emph>
         of the work.</p>
     </remarks>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -5,10 +5,10 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.header">
   <moduleSpec ident="MEI.header">
-    <desc>Metadata header component declarations.</desc>
+    <desc xml:lang="en">Metadata header component declarations.</desc>
   </moduleSpec>
   <macroSpec ident="macro.availabilityPart" module="MEI.header" type="pe">
-    <desc>Groups elements that may appear as part of a description of the availability of and access
+    <desc xml:lang="en">Groups elements that may appear as part of a description of the availability of and access
       to a bibliographic item.</desc>
     <content>
       <rng:choice>
@@ -34,7 +34,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="macro.bibldescPart" module="MEI.header" type="pe">
-    <desc>Groups manifestation- and item-specific elements that may appear as part of a
+    <desc xml:lang="en">Groups manifestation- and item-specific elements that may appear as part of a
       bibliographic description.</desc>
     <content>
       <rng:optional>
@@ -55,32 +55,32 @@
     </content>
   </macroSpec>
   <classSpec ident="att.bifoliumSurfaces" module="MEI.header" type="atts">
-    <desc>Attributes that link a bifolium element with a <gi scheme="MEI">surface</gi>
+    <desc xml:lang="en">Attributes that link a bifolium element with a <gi scheme="MEI">surface</gi>
       element.</desc>
     <attList>
       <attDef ident="outer.recto" usage="opt">
-        <desc>A reference to a <gi scheme="MEI">surface</gi> element positioned on the outer recto
+        <desc xml:lang="en">A reference to a <gi scheme="MEI">surface</gi> element positioned on the outer recto
           side of a (folded) sheet.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
       </attDef>
       <attDef ident="inner.verso" usage="opt">
-        <desc>A reference to a <gi scheme="MEI">surface</gi> element positioned on the inner verso
+        <desc xml:lang="en">A reference to a <gi scheme="MEI">surface</gi> element positioned on the inner verso
           side of a (folded) sheet.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
       </attDef>
       <attDef ident="inner.recto" usage="opt">
-        <desc>A reference to a <gi scheme="MEI">surface</gi> element positioned on the inner recto
+        <desc xml:lang="en">A reference to a <gi scheme="MEI">surface</gi> element positioned on the inner recto
           side of a (folded) sheet.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
       </attDef>
       <attDef ident="outer.verso" usage="opt">
-        <desc>A reference to a <gi scheme="MEI">surface</gi> element positioned on the outer verso
+        <desc xml:lang="en">A reference to a <gi scheme="MEI">surface</gi> element positioned on the outer verso
           side of a (folded) sheet.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
@@ -89,17 +89,17 @@
     </attList>
   </classSpec>
   <classSpec ident="att.foliumSurfaces" module="MEI.header" type="atts">
-    <desc>Attributes that link a folium element with a <gi scheme="MEI">surface</gi> element.</desc>
+    <desc xml:lang="en">Attributes that link a folium element with a <gi scheme="MEI">surface</gi> element.</desc>
     <attList>
       <attDef ident="recto" usage="opt">
-        <desc>A reference to a <gi scheme="MEI">surface</gi> element positioned on the recto side of
+        <desc xml:lang="en">A reference to a <gi scheme="MEI">surface</gi> element positioned on the recto side of
           the sheet.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
       </attDef>
       <attDef ident="verso" usage="opt">
-        <desc>A reference to a <gi scheme="MEI">surface</gi> element positioned on the verso side of
+        <desc xml:lang="en">A reference to a <gi scheme="MEI">surface</gi> element positioned on the verso side of
           the sheet.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
@@ -108,52 +108,52 @@
     </attList>
   </classSpec>
   <classSpec ident="att.recordType" type="atts" module="MEI.header">
-    <desc>Attributes that define the characteristics and components of the bibliographic
+    <desc xml:lang="en">Attributes that define the characteristics and components of the bibliographic
       description.</desc>
     <attList>
       <attDef ident="recordtype">
         <valList type="closed">
           <valItem ident="a">
-            <desc>Language material.</desc>
+            <desc xml:lang="en">Language material.</desc>
           </valItem>
           <valItem ident="c">
-            <desc>Notated music.</desc>
+            <desc xml:lang="en">Notated music.</desc>
           </valItem>
           <valItem ident="d">
-            <desc>Manuscript notated music.</desc>
+            <desc xml:lang="en">Manuscript notated music.</desc>
           </valItem>
           <valItem ident="e">
-            <desc>Non-manuscript cartographic material.</desc>
+            <desc xml:lang="en">Non-manuscript cartographic material.</desc>
           </valItem>
           <valItem ident="f">
-            <desc>Manuscript cartographic material.</desc>
+            <desc xml:lang="en">Manuscript cartographic material.</desc>
           </valItem>
           <valItem ident="g">
-            <desc>Projected medium.</desc>
+            <desc xml:lang="en">Projected medium.</desc>
           </valItem>
           <valItem ident="i">
-            <desc>Nonmusical sound recording.</desc>
+            <desc xml:lang="en">Nonmusical sound recording.</desc>
           </valItem>
           <valItem ident="j">
-            <desc>Musical sound recording.</desc>
+            <desc xml:lang="en">Musical sound recording.</desc>
           </valItem>
           <valItem ident="k">
-            <desc>Two-dimensional nonprojectable graphic.</desc>
+            <desc xml:lang="en">Two-dimensional nonprojectable graphic.</desc>
           </valItem>
           <valItem ident="m">
-            <desc>Computer file.</desc>
+            <desc xml:lang="en">Computer file.</desc>
           </valItem>
           <valItem ident="o">
-            <desc>Kit.</desc>
+            <desc xml:lang="en">Kit.</desc>
           </valItem>
           <valItem ident="p">
-            <desc>Mixed materials.</desc>
+            <desc xml:lang="en">Mixed materials.</desc>
           </valItem>
           <valItem ident="r">
-            <desc>Three-dimensional artifact or naturally occurring object.</desc>
+            <desc xml:lang="en">Three-dimensional artifact or naturally occurring object.</desc>
           </valItem>
           <valItem ident="t">
-            <desc>Manuscript language material. </desc>
+            <desc xml:lang="en">Manuscript language material. </desc>
           </valItem>
         </valList>
       </attDef>
@@ -228,66 +228,66 @@
     </remarks>
   </classSpec>
   <classSpec ident="att.regularMethod" module="MEI.header" type="atts">
-    <desc>Attributes that describe correction and normalization methods.</desc>
+    <desc xml:lang="en">Attributes that describe correction and normalization methods.</desc>
     <attList>
       <attDef ident="method" usage="opt">
-        <desc>Indicates the method employed to mark corrections and normalizations.</desc>
+        <desc xml:lang="en">Indicates the method employed to mark corrections and normalizations.</desc>
         <valList type="closed">
           <valItem ident="silent">
-            <desc>Corrections and normalizations made silently.</desc>
+            <desc xml:lang="en">Corrections and normalizations made silently.</desc>
           </valItem>
           <valItem ident="tags">
-            <desc>Corrections and normalizations indicated using elements.</desc>
+            <desc xml:lang="en">Corrections and normalizations indicated using elements.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="model.bifoliumLike" type="model" module="MEI.header">
-    <desc>Collects bifoliumlike elements.</desc>
+    <desc xml:lang="en">Collects bifoliumlike elements.</desc>
   </classSpec>
   <classSpec ident="model.editorialDeclPart" module="MEI.header" type="model">
-    <desc>Groups elements that may appear as part of a description of the editorial process applied
+    <desc xml:lang="en">Groups elements that may appear as part of a description of the editorial process applied
       to the encoding of notation.</desc>
   </classSpec>
   <classSpec ident="model.encodingPart" module="MEI.header" type="model">
-    <desc>Groups elements that may appear as part of the description of the encoding process.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of the description of the encoding process.</desc>
   </classSpec>
   <classSpec ident="model.eventPart" type="model" module="MEI.header">
-    <desc>Groups elements that may be used to provide a structured description of an event.</desc>
+    <desc xml:lang="en">Groups elements that may be used to provide a structured description of an event.</desc>
   </classSpec>
   <classSpec ident="model.foliumLike" type="model" module="MEI.header">
-    <desc>Collects foliumlike elements.</desc>
+    <desc xml:lang="en">Collects foliumlike elements.</desc>
   </classSpec>
   <classSpec ident="model.frontAndBackPart" module="MEI.header" type="model">
-    <desc>Groups elements that may appear as part of auxiliary material preceding or following the
+    <desc xml:lang="en">Groups elements that may appear as part of auxiliary material preceding or following the
       text proper.</desc>
   </classSpec>
   <classSpec ident="model.headerPart" module="MEI.header" type="model">
-    <desc>Groups elements that may appear as part of the MEI metadata header.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of the MEI metadata header.</desc>
   </classSpec>
   <classSpec ident="model.paperModLike" type="model" module="MEI.header">
-    <desc>Groups elements dealing with modifications of document pages.</desc>
+    <desc xml:lang="en">Groups elements dealing with modifications of document pages.</desc>
   </classSpec>
   <classSpec ident="model.physDescPart" module="MEI.header" type="model">
-    <desc>Groups elements that may appear as part of the physical description of a bibliographic
+    <desc xml:lang="en">Groups elements that may appear as part of the physical description of a bibliographic
       item.</desc>
   </classSpec>
   <classSpec ident="model.pubStmtPart" module="MEI.header" type="model">
-    <desc>Groups elements that may appear as part of the publication statement for a bibliographic
+    <desc xml:lang="en">Groups elements that may appear as part of the publication statement for a bibliographic
       item.</desc>
   </classSpec>
   <classSpec ident="model.startLike.header" module="MEI.header" type="model">
-    <desc>Groups elements that may be document elements when the header module is invoked.</desc>
+    <desc xml:lang="en">Groups elements that may be document elements when the header module is invoked.</desc>
   </classSpec>
   <classSpec ident="model.workIdent" module="MEI.header" type="model">
-    <desc>Groups elements that assist in the identification of a work.</desc>
+    <desc xml:lang="en">Groups elements that assist in the identification of a work.</desc>
   </classSpec>
   <classSpec ident="model.workLike" type="model" module="MEI.header">
-    <desc>Collects work-like elements.</desc>
+    <desc xml:lang="en">Collects work-like elements.</desc>
   </classSpec>
   <elementSpec ident="accessRestrict" module="MEI.header">
-    <desc>(access restriction) – Describes the conditions that affect the accessibility of
+    <desc xml:lang="en">(access restriction) – Describes the conditions that affect the accessibility of
       material.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -311,7 +311,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="acquisition" module="MEI.header">
-    <desc>Records information concerning the process by which an item was acquired by the holding
+    <desc xml:lang="en">Records information concerning the process by which an item was acquired by the holding
       institution.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -327,7 +327,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="altId" module="MEI.header">
-    <desc>(alternative identifier) – May contain a bibliographic identifier that does not fit within
+    <desc xml:lang="en">(alternative identifier) – May contain a bibliographic identifier that does not fit within
       the meiHead element’s id attribute, for example because the identifier does not fit the
       definition of an XML id or because multiple identifiers are needed.</desc>
     <classes>
@@ -349,7 +349,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="appInfo" module="MEI.header">
-    <desc>(application information) – Groups information about applications which have acted upon
+    <desc xml:lang="en">(application information) – Groups information about applications which have acted upon
       the MEI file.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -368,7 +368,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="application" module="MEI.header">
-    <desc>Provides information about an application which has acted upon the current
+    <desc xml:lang="en">Provides information about an application which has acted upon the current
       document.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -389,7 +389,7 @@
     </content>
     <attList>
       <attDef ident="version" usage="opt">
-        <desc>Supplies a version number for an application, independent of its identifier or display
+        <desc xml:lang="en">Supplies a version number for an application, independent of its identifier or display
           name.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
@@ -401,7 +401,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="attUsage" module="MEI.header">
-    <desc>Documents the usage of a specific attribute of the element.</desc>
+    <desc xml:lang="en">Documents the usage of a specific attribute of the element.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -421,13 +421,13 @@
     </constraintSpec>
     <attList>
       <attDef ident="name" usage="req">
-        <desc>Name of the attribute.</desc>
+        <desc xml:lang="en">Name of the attribute.</desc>
         <datatype>
           <rng:ref name="data.NMTOKEN"/>
         </datatype>
       </attDef>
       <attDef ident="context" usage="opt">
-        <desc>Circumstances in which the element appears, an XPath expression.</desc>
+        <desc xml:lang="en">Circumstances in which the element appears, an XPath expression.</desc>
         <datatype>
           <rng:data type="string"/>
         </datatype>
@@ -435,7 +435,7 @@
     </attList>
   </elementSpec>
   <elementSpec ident="audience" module="MEI.header">
-    <desc>Defines the class of user for which the work is intended, as defined by age group (<abbr>e.g.</abbr>,
+    <desc xml:lang="en">Defines the class of user for which the work is intended, as defined by age group (<abbr>e.g.</abbr>,
       children, young adults, adults, etc.), educational level (<abbr>e.g.</abbr>, primary, secondary, etc.), or
       other categorization.</desc>
     <classes>
@@ -449,7 +449,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="availability" module="MEI.header">
-    <desc>Groups elements that describe the availability of and access to a bibliographic item,
+    <desc xml:lang="en">Groups elements that describe the availability of and access to a bibliographic item,
       including an MEI-encoded document.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -471,7 +471,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="bifolium" module="MEI.header">
-    <desc>Describes a folded sheet of paper.</desc>
+    <desc xml:lang="en">Describes a folded sheet of paper.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.dimensions"/>
@@ -495,7 +495,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="byline" module="MEI.header">
-    <desc>Contains the primary statement of responsibility given for a work on its title
+    <desc xml:lang="en">Contains the primary statement of responsibility given for a work on its title
       page.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -515,7 +515,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="captureMode" module="MEI.header">
-    <desc>(capture mode) – The means used to record notation, sound, or images in the production of
+    <desc xml:lang="en">(capture mode) – The means used to record notation, sound, or images in the production of
       a source/manifestation (<abbr>e.g.</abbr>, analogue, acoustic, electric, digital, optical etc.).</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -529,7 +529,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="carrierForm" module="MEI.header">
-    <desc>(carrier form) – The specific class of material to which the physical carrier of the
+    <desc xml:lang="en">(carrier form) – The specific class of material to which the physical carrier of the
       source/manifestation belongs (<abbr>e.g.</abbr>, sound cassette, videodisc, microfilm cartridge,
       transparency, etc.). The carrier for a manifestation comprising multiple physical components
       may include more than one form (<abbr>e.g.</abbr>, a filmstrip with an accompanying booklet, a separate
@@ -546,7 +546,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="category" module="MEI.header">
-    <desc>Contains an individual descriptive category in a user-defined taxonomy, possibly nested
+    <desc xml:lang="en">Contains an individual descriptive category in a user-defined taxonomy, possibly nested
       within a superordinate category.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -581,7 +581,7 @@
     </constraintSpec>
   </elementSpec>
   <elementSpec ident="catRel" module="MEI.header">
-    <desc>(category relationship) – Contains the name of a related category.</desc>
+    <desc xml:lang="en">(category relationship) – Contains the name of a related category.</desc>
     <classes>
       <memberOf key="att.authorized"/>
       <memberOf key="att.basic"/>
@@ -601,21 +601,21 @@
     </content>
     <attList>
       <attDef ident="type" usage="req">
-        <desc>Provides a description of the relationship between the current and the target
+        <desc xml:lang="en">Provides a description of the relationship between the current and the target
           categories.</desc>
         <valList type="closed">
           <valItem ident="broader">
-            <desc>Category to which the current category is hierarchically subordinate.</desc>
+            <desc xml:lang="en">Category to which the current category is hierarchically subordinate.</desc>
           </valItem>
           <valItem ident="narrower">
-            <desc>Category which is hierarchically subordinate to the current category.</desc>
+            <desc xml:lang="en">Category which is hierarchically subordinate to the current category.</desc>
           </valItem>
           <valItem ident="related">
-            <desc>Category that is associatively but not hierarchically linked to the current
+            <desc xml:lang="en">Category that is associatively but not hierarchically linked to the current
               category.</desc>
           </valItem>
           <valItem ident="usefor">
-            <desc>Non-preferred category; often a synonym or near-synonym for the preferred category
+            <desc xml:lang="en">Non-preferred category; often a synonym or near-synonym for the preferred category
               label.</desc>
           </valItem>
         </valList>
@@ -623,7 +623,7 @@
     </attList>
   </elementSpec>
   <elementSpec ident="change" module="MEI.header">
-    <desc>Individual change within the revision description.</desc>
+    <desc xml:lang="en">Individual change within the revision description.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -665,7 +665,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="changeDesc" module="MEI.header">
-    <desc>(change description) – Description of a revision of the MEI file.</desc>
+    <desc xml:lang="en">(change description) – Description of a revision of the MEI file.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -678,7 +678,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="classDecls" module="MEI.header">
-    <desc>Groups information which describes the nature or topic of an entity.</desc>
+    <desc xml:lang="en">Groups information which describes the nature or topic of an entity.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -700,7 +700,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="classification" module="MEI.header">
-    <desc>Groups information which describes the nature or topic of an entity.</desc>
+    <desc xml:lang="en">Groups information which describes the nature or topic of an entity.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -725,7 +725,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="componentList" module="MEI.header">
-    <desc>Container for intellectual or physical component parts of a bibliographic entity.</desc>
+    <desc xml:lang="en">Container for intellectual or physical component parts of a bibliographic entity.</desc>
     <classes>
       <memberOf key="att.common"/>
     </classes>
@@ -786,7 +786,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="condition" module="MEI.header">
-    <desc>The physical condition of an item, particularly any variances between the physical make-up
+    <desc xml:lang="en">The physical condition of an item, particularly any variances between the physical make-up
       of the item and that of other copies of the same item (<abbr>e.g.</abbr>, missing pages or plates,
       brittleness, faded images, etc.).</desc>
     <classes>
@@ -804,7 +804,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="contentItem" module="MEI.header">
-    <desc>Contains a single entry within a content description element.</desc>
+    <desc xml:lang="en">Contains a single entry within a content description element.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -823,7 +823,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="contents" module="MEI.header">
-    <desc>List of the material contained within a resource.</desc>
+    <desc xml:lang="en">List of the material contained within a resource.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -888,7 +888,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="context" module="MEI.header">
-    <desc>The historical, social, intellectual, artistic, or other context within which the work was
+    <desc xml:lang="en">The historical, social, intellectual, artistic, or other context within which the work was
       originally conceived (<abbr>e.g.</abbr>, the 17th century restoration of the monarchy in England, the
       aesthetic movement of the late 19th century, etc.) or the historical, social, intellectual,
       artistic, or other context within which the expression was realized.</desc>
@@ -903,7 +903,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="correction" module="MEI.header">
-    <desc>States how and under what circumstances corrections have been made in the text.</desc>
+    <desc xml:lang="en">States how and under what circumstances corrections have been made in the text.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -922,19 +922,19 @@
     </content>
     <attList>
       <attDef ident="corrlevel" usage="opt">
-        <desc>Indicates the degree of correction applied to the text.</desc>
+        <desc xml:lang="en">Indicates the degree of correction applied to the text.</desc>
         <valList type="closed">
           <valItem ident="high">
-            <desc>The text has been thoroughly checked and proofread.</desc>
+            <desc xml:lang="en">The text has been thoroughly checked and proofread.</desc>
           </valItem>
           <valItem ident="medium">
-            <desc>The text has been checked at least once.</desc>
+            <desc xml:lang="en">The text has been checked at least once.</desc>
           </valItem>
           <valItem ident="low">
-            <desc>The text has not been checked.</desc>
+            <desc xml:lang="en">The text has not been checked.</desc>
           </valItem>
           <valItem ident="unknown">
-            <desc>The correction status of the text is unknown.</desc>
+            <desc xml:lang="en">The correction status of the text is unknown.</desc>
           </valItem>
         </valList>
       </attDef>
@@ -944,7 +944,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="cutout" module="MEI.header">
-    <desc>A cutout is a section of a document sheet that has been removed and is now missing.</desc>
+    <desc xml:lang="en">A cutout is a section of a document sheet that has been removed and is now missing.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.dimensions"/>
@@ -964,39 +964,39 @@
     </content>
     <attList>
       <attDef ident="removed.from" usage="req">
-        <desc>Describes the position of the cutout on the parent folium / bifolium.</desc>
+        <desc xml:lang="en">Describes the position of the cutout on the parent folium / bifolium.</desc>
         <valList type="closed">
           <valItem ident="outer.recto">
-            <desc>removed from outer recto side of bifolium.</desc>
+            <desc xml:lang="en">removed from outer recto side of bifolium.</desc>
           </valItem>
           <valItem ident="inner.verso">
-            <desc>removed from inner verso side of bifolium.</desc>
+            <desc xml:lang="en">removed from inner verso side of bifolium.</desc>
           </valItem>
           <valItem ident="inner.recto">
-            <desc>removed from inner recto side of bifolium.</desc>
+            <desc xml:lang="en">removed from inner recto side of bifolium.</desc>
           </valItem>
           <valItem ident="outer.verso">
-            <desc>removed from outer verso side of bifolium.</desc>
+            <desc xml:lang="en">removed from outer verso side of bifolium.</desc>
           </valItem>
           <valItem ident="recto">
-            <desc>removed from recto side of folium.</desc>
+            <desc xml:lang="en">removed from recto side of folium.</desc>
           </valItem>
           <valItem ident="verso">
-            <desc>removed from verso side of folium.</desc>
+            <desc xml:lang="en">removed from verso side of folium.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="removed.by" usage="opt">
-        <desc>Describes the method of removing the cutout.</desc>
+        <desc xml:lang="en">Describes the method of removing the cutout.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="cut">
-            <desc>section is cleanly cut by a knife, scissor or other sharp blade.</desc>
+            <desc xml:lang="en">section is cleanly cut by a knife, scissor or other sharp blade.</desc>
           </valItem>
           <valItem ident="rip">
-            <desc>section is ripped off the page, leaving a rough edge.</desc>
+            <desc xml:lang="en">section is ripped off the page, leaving a rough edge.</desc>
           </valItem>
         </valList>
       </attDef>
@@ -1021,7 +1021,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="dedication" module="MEI.header">
-    <desc>Contains a dedicatory statement.</desc>
+    <desc xml:lang="en">Contains a dedicatory statement.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -1053,7 +1053,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="domainsDecl" module="MEI.header">
-    <desc>(domains declaration) – Indicates which domains are included in the encoding.</desc>
+    <desc xml:lang="en">(domains declaration) – Indicates which domains are included in the encoding.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -1077,7 +1077,7 @@
     </attList>
   </elementSpec>
   <elementSpec ident="editionStmt" module="MEI.header">
-    <desc>(edition statement) – Container for meta-data pertaining to a particular edition of the
+    <desc xml:lang="en">(edition statement) – Container for meta-data pertaining to a particular edition of the
       material being described.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1104,7 +1104,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="editorialDecl" module="MEI.header">
-    <desc>(editorial declaration) – Used to provide details of editorial principles and practices
+    <desc xml:lang="en">(editorial declaration) – Used to provide details of editorial principles and practices
       applied during the encoding of musical text.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1136,7 +1136,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="encodingDesc" module="MEI.header">
-    <desc>(encoding description) – Documents the relationship between an electronic file and the
+    <desc xml:lang="en">(encoding description) – Documents the relationship between an electronic file and the
       source or sources from which it was derived as well as applications used in the
       encoding/editing process.</desc>
     <classes>
@@ -1175,7 +1175,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="exhibHist" module="MEI.header">
-    <desc>(exhibition history) – A record of public exhibitions, including dates, venues,
+    <desc xml:lang="en">(exhibition history) – A record of public exhibitions, including dates, venues,
       etc.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1210,7 +1210,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="extMeta" module="MEI.header">
-    <desc>(extended metadata) – Provides a container element for non-MEI metadata formats.</desc>
+    <desc xml:lang="en">(extended metadata) – Provides a container element for non-MEI metadata formats.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -1228,7 +1228,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="fileChar" module="MEI.header">
-    <desc>(file characteristics) – Standards or schemes used to encode the file (<abbr>e.g.</abbr>, ASCII, SGML,
+    <desc xml:lang="en">(file characteristics) – Standards or schemes used to encode the file (<abbr>e.g.</abbr>, ASCII, SGML,
       etc.), physical characteristics of the file (<abbr>e.g.</abbr>, recording density, parity, blocking, etc.),
       and other characteristics that have a bearing on how the file can be processed.</desc>
     <classes>
@@ -1242,7 +1242,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="fileDesc" module="MEI.header">
-    <desc>(file description) – Contains a full bibliographic description of the MEI file.</desc>
+    <desc xml:lang="en">(file description) – Contains a full bibliographic description of the MEI file.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -1275,7 +1275,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="foliaDesc" module="MEI.header">
-    <desc>Describes the order of folia and bifolia making up the text block of a manuscript or
+    <desc xml:lang="en">Describes the order of folia and bifolia making up the text block of a manuscript or
       print.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1303,7 +1303,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="folium" module="MEI.header">
-    <desc>Describes a single leaf of paper.</desc>
+    <desc xml:lang="en">Describes a single leaf of paper.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.dimensions"/>
@@ -1323,7 +1323,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="hand" module="MEI.header">
-    <desc>Defines a distinct scribe or handwriting style.</desc>
+    <desc xml:lang="en">Defines a distinct scribe or handwriting style.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -1341,7 +1341,7 @@
     </content>
     <attList>
       <attDef ident="initial" usage="opt">
-        <desc>Marks this hand as the first one of the document.</desc>
+        <desc xml:lang="en">Marks this hand as the first one of the document.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
@@ -1362,7 +1362,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="handList" module="MEI.header">
-    <desc>Container for one or more hand elements.</desc>
+    <desc xml:lang="en">Container for one or more hand elements.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -1392,7 +1392,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="history" module="MEI.header">
-    <desc>Provides a container for information about the history of a resource other than the
+    <desc xml:lang="en">Provides a container for information about the history of a resource other than the
       circumstances of its creation.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1430,7 +1430,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="incipCode" module="MEI.header">
-    <desc>Incipit coded in a non-XML, plain text format, such as Plaine &amp; Easie Code.</desc>
+    <desc xml:lang="en">Incipit coded in a non-XML, plain text format, such as Plaine &amp; Easie Code.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -1451,26 +1451,26 @@
     </constraintSpec>
     <attList>
       <attDef ident="form" usage="opt">
-        <desc>Form of the encoded incipit.</desc>
+        <desc xml:lang="en">Form of the encoded incipit.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="plaineAndEasie">
-            <desc>Plaine &amp; Easie Code.</desc>
+            <desc xml:lang="en">Plaine &amp; Easie Code.</desc>
           </valItem>
           <valItem ident="humdrumKern">
-            <desc>Humdrum Kern format.</desc>
+            <desc xml:lang="en">Humdrum Kern format.</desc>
           </valItem>
           <valItem ident="parsons">
-            <desc>Parsons code.</desc>
+            <desc xml:lang="en">Parsons code.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </elementSpec>
   <elementSpec ident="incipText" module="MEI.header">
-    <desc>Opening words of a musical composition.</desc>
+    <desc xml:lang="en">Opening words of a musical composition.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -1491,7 +1491,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="inscription" module="MEI.header">
-    <desc>An inscription added to an item, such as a bookplate, a note designating the item as a
+    <desc xml:lang="en">An inscription added to an item, such as a bookplate, a note designating the item as a
       gift, and/or the author’s signature.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1504,7 +1504,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="interpretation" module="MEI.header">
-    <desc>Describes the scope of any analytic or interpretive information added to the transcription
+    <desc xml:lang="en">Describes the scope of any analytic or interpretive information added to the transcription
       of the music.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1526,7 +1526,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="key" module="MEI.header">
-    <desc>Key captures information about tonal center and mode.</desc>
+    <desc xml:lang="en">Key captures information about tonal center and mode.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.accidental"/>
@@ -1539,7 +1539,7 @@
     </content>
     <attList>
       <attDef ident="mode" usage="opt">
-        <desc>Indicates major, minor, or other tonality.</desc>
+        <desc xml:lang="en">Indicates major, minor, or other tonality.</desc>
         <datatype>
           <rng:ref name="data.MODE"/>
         </datatype>
@@ -1552,7 +1552,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="language" module="MEI.header">
-    <desc>Description of a language used in the document.</desc>
+    <desc xml:lang="en">Description of a language used in the document.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.authorized"/>
@@ -1580,7 +1580,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="langUsage" module="MEI.header">
-    <desc>(language usage) – Groups elements describing the languages, sub-languages, dialects,
+    <desc xml:lang="en">(language usage) – Groups elements describing the languages, sub-languages, dialects,
       etc., represented within the encoded resource.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1600,7 +1600,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="meiHead" module="MEI.header">
-    <desc>(MEI header) – Supplies the descriptive and declarative metadata prefixed to every
+    <desc xml:lang="en">(MEI header) – Supplies the descriptive and declarative metadata prefixed to every
       MEI-conformant text.</desc>
     <classes>
       <memberOf key="att.basic"/>
@@ -1650,17 +1650,17 @@
     </constraintSpec>
     <attList>
       <attDef ident="type" usage="opt">
-        <desc>Specifies the kind of document to which the header is attached, for example whether it
+        <desc xml:lang="en">Specifies the kind of document to which the header is attached, for example whether it
           is a corpus or individual text.</desc>
         <valList type="closed">
           <valItem ident="music">
-            <desc>Header is attached to a music document.</desc>
+            <desc xml:lang="en">Header is attached to a music document.</desc>
           </valItem>
           <valItem ident="corpus">
-            <desc>Header is attached to a corpus.</desc>
+            <desc xml:lang="en">Header is attached to a corpus.</desc>
           </valItem>
           <valItem ident="independent">
-            <desc>Header is independent; <abbr>i.e.</abbr>, not attached to either a music or a corpus
+            <desc xml:lang="en">Header is independent; <abbr>i.e.</abbr>, not attached to either a music or a corpus
               document.</desc>
           </valItem>
         </valList>
@@ -1681,7 +1681,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="mensuration" module="MEI.header">
-    <desc>Captures information about mensuration within bibliographic descriptions.</desc>
+    <desc xml:lang="en">Captures information about mensuration within bibliographic descriptions.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -1695,7 +1695,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="meter" module="MEI.header">
-    <desc>Captures information about the time signature within bibliographic descriptions.</desc>
+    <desc xml:lang="en">Captures information about the time signature within bibliographic descriptions.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -1714,7 +1714,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="namespace" module="MEI.header">
-    <desc>Supplies the formal name of the namespace to which the elements documented by its children
+    <desc xml:lang="en">Supplies the formal name of the namespace to which the elements documented by its children
       belong.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1735,13 +1735,13 @@
     </content>
     <attList>
       <attDef ident="name" usage="req">
-        <desc>Formal namespace identifier; that is, a uniform resource identifier (URI).</desc>
+        <desc xml:lang="en">Formal namespace identifier; that is, a uniform resource identifier (URI).</desc>
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
       </attDef>
       <attDef ident="prefix" usage="opt">
-        <desc>Prefix associated with the formal identifier.</desc>
+        <desc xml:lang="en">Prefix associated with the formal identifier.</desc>
         <datatype>
           <rng:ref name="data.NMTOKEN"/>
         </datatype>
@@ -1752,7 +1752,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="normalization" module="MEI.header">
-    <desc>Indicates the extent of normalization or regularization of the original source carried out
+    <desc xml:lang="en">Indicates the extent of normalization or regularization of the original source carried out
       in converting it to electronic form.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1775,7 +1775,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="notesStmt" module="MEI.header">
-    <desc>(notes statement)– Collects any notes providing information about a text additional to
+    <desc xml:lang="en">(notes statement)– Collects any notes providing information about a text additional to
       that recorded in other parts of the bibliographic description.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1794,7 +1794,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="otherChar" module="MEI.header">
-    <desc>(other distinguishing characteristic) – Any characteristic that serves to differentiate a
+    <desc xml:lang="en">(other distinguishing characteristic) – Any characteristic that serves to differentiate a
       work or expression from another.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1806,7 +1806,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="patch" module="MEI.header">
-    <desc>Describes a physical writing surface attached to the original document.</desc>
+    <desc xml:lang="en">Describes a physical writing surface attached to the original document.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.evidence"/>
@@ -1835,48 +1835,48 @@
     </constraintSpec>
     <attList>
       <attDef ident="attached.to" usage="req">
-        <desc>Describes the position of the patch on the parent folium / bifolium.</desc>
+        <desc xml:lang="en">Describes the position of the patch on the parent folium / bifolium.</desc>
         <valList type="closed">
           <valItem ident="outer.recto">
-            <desc>patch attached to outer recto side of bifolium.</desc>
+            <desc xml:lang="en">patch attached to outer recto side of bifolium.</desc>
           </valItem>
           <valItem ident="inner.verso">
-            <desc>patch attached to inner verso side of bifolium.</desc>
+            <desc xml:lang="en">patch attached to inner verso side of bifolium.</desc>
           </valItem>
           <valItem ident="inner.recto">
-            <desc>patch attached to inner recto side of bifolium.</desc>
+            <desc xml:lang="en">patch attached to inner recto side of bifolium.</desc>
           </valItem>
           <valItem ident="outer.verso">
-            <desc>patch attached to outer verso side of bifolium.</desc>
+            <desc xml:lang="en">patch attached to outer verso side of bifolium.</desc>
           </valItem>
           <valItem ident="recto">
-            <desc>patch attached to recto side of folium.</desc>
+            <desc xml:lang="en">patch attached to recto side of folium.</desc>
           </valItem>
           <valItem ident="verso">
-            <desc>patch attached to verso side of folium.</desc>
+            <desc xml:lang="en">patch attached to verso side of folium.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="attached.by" usage="opt">
-        <desc>Describes the method of attachment of the patch.</desc>
+        <desc xml:lang="en">Describes the method of attachment of the patch.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="glue">
-            <desc>patch is glued on surface beneath.</desc>
+            <desc xml:lang="en">patch is glued on surface beneath.</desc>
           </valItem>
           <valItem ident="thread">
-            <desc>patch is sewn on surface beneath.</desc>
+            <desc xml:lang="en">patch is sewn on surface beneath.</desc>
           </valItem>
           <valItem ident="needle">
-            <desc>patch is pinned to the surface beneath.</desc>
+            <desc xml:lang="en">patch is pinned to the surface beneath.</desc>
           </valItem>
           <valItem ident="tape">
-            <desc>patch is taped on surface beneath using an adhesive strip.</desc>
+            <desc xml:lang="en">patch is taped on surface beneath using an adhesive strip.</desc>
           </valItem>
           <valItem ident="staple">
-            <desc>patch is attached on surface beneath using a staple.</desc>
+            <desc xml:lang="en">patch is attached on surface beneath using a staple.</desc>
           </valItem>
         </valList>
       </attDef>
@@ -1895,7 +1895,7 @@
           </remarks>-->
   </elementSpec>
   <elementSpec ident="perfDuration" module="MEI.header">
-    <desc>(performance duration) – Used to express the duration of performance of printed or
+    <desc xml:lang="en">(performance duration) – Used to express the duration of performance of printed or
       manuscript music or the playing time for a sound recording, videorecording, etc.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1911,7 +1911,7 @@
     </content>
     <attList>
       <attDef ident="isodur" usage="opt">
-        <desc>Holds a W3C duration value, <abbr>e.g.</abbr>, "PT2H34M45.67S".</desc>
+        <desc xml:lang="en">Holds a W3C duration value, <abbr>e.g.</abbr>, "PT2H34M45.67S".</desc>
         <datatype>
           <rng:data type="duration"/>
         </datatype>
@@ -1922,7 +1922,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="perfMedium" module="MEI.header">
-    <desc>(performance medium) – Indicates the number and character of the performing forces used in
+    <desc xml:lang="en">(performance medium) – Indicates the number and character of the performing forces used in
       a musical composition.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1950,7 +1950,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="perfRes" module="MEI.header">
-    <desc>(performance resource) – Name of an instrument on which a performer plays, a performer's
+    <desc xml:lang="en">(performance resource) – Name of an instrument on which a performer plays, a performer's
       voice range, or a standard performing ensemble designation.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1970,13 +1970,13 @@
     </content>
     <attList>
       <attDef ident="count" usage="opt">
-        <desc>Indicates the number of performers.</desc>
+        <desc xml:lang="en">Indicates the number of performers.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
       </attDef>
       <attDef ident="solo" usage="opt">
-        <desc>Marks this instrument or vocal part as a soloist. Do not use this attribute for a solo
+        <desc xml:lang="en">Marks this instrument or vocal part as a soloist. Do not use this attribute for a solo
           instrument which is not accompanied.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
@@ -1985,7 +1985,7 @@
     </attList>
   </elementSpec>
   <elementSpec ident="perfResList" module="MEI.header">
-    <desc>Several instrumental or vocal resources treated as a group.</desc>
+    <desc xml:lang="en">Several instrumental or vocal resources treated as a group.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.authorized"/>
@@ -2007,7 +2007,7 @@
     </content>
     <attList>
       <attDef ident="count" usage="opt">
-        <desc>Indicates the number of performers.</desc>
+        <desc xml:lang="en">Indicates the number of performers.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
@@ -2020,7 +2020,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="physDesc" module="MEI.header">
-    <desc>(physical description) – Container for information about the appearance, construction, or
+    <desc xml:lang="en">(physical description) – Container for information about the appearance, construction, or
       handling of physical materials, such as their dimension, quantity, color, style, and technique
       of creation.</desc>
     <classes>
@@ -2049,7 +2049,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="physMedium" module="MEI.header">
-    <desc>(physical medium) – Records the physical materials used in the source, such as ink and
+    <desc xml:lang="en">(physical medium) – Records the physical materials used in the source, such as ink and
       paper.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2072,7 +2072,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="plateNum" module="MEI.header">
-    <desc>(plate number) – Designation assigned to a resource by a music publisher, usually printed
+    <desc xml:lang="en">(plate number) – Designation assigned to a resource by a music publisher, usually printed
       at the bottom of each page, and sometimes appearing also on the title page.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2092,7 +2092,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="playingSpeed" module="MEI.header">
-    <desc>Playing speed for a sound recording is the speed at which the carrier must be operated to
+    <desc xml:lang="en">Playing speed for a sound recording is the speed at which the carrier must be operated to
       produce the sound intended (<abbr>e.g.</abbr>, 33 1/3 rpm, 19 cm/s, etc.).</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2105,7 +2105,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="price" module="MEI.header">
-    <desc>The cost of access to a bibliographic item.</desc>
+    <desc xml:lang="en">The cost of access to a bibliographic item.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -2125,7 +2125,7 @@
     </content>
     <attList>
       <attDef ident="amount" usage="opt">
-        <desc>Numeric value capturing a cost. Can only be interpreted in combination with the
+        <desc xml:lang="en">Numeric value capturing a cost. Can only be interpreted in combination with the
           currency attribute.</desc>
         <datatype>
           <rng:data type="decimal">
@@ -2134,7 +2134,7 @@
         </datatype>
       </attDef>
       <attDef ident="currency" usage="opt">
-        <desc>Monetary unit.</desc>
+        <desc xml:lang="en">Monetary unit.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
@@ -2146,7 +2146,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="projectDesc" module="MEI.header">
-    <desc>(project description) – Project-level meta-data describing the aim or purpose for which
+    <desc xml:lang="en">(project description) – Project-level meta-data describing the aim or purpose for which
       the electronic file was encoded, funding agencies, etc. together with any other relevant
       information concerning the process by which it was assembled or collected.</desc>
     <classes>
@@ -2169,7 +2169,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="provenance" module="MEI.header">
-    <desc>The record of ownership or custodianship of an item.</desc>
+    <desc xml:lang="en">The record of ownership or custodianship of an item.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -2203,7 +2203,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pubStmt" module="MEI.header">
-    <desc>(publication statement) – Container for information regarding the publication or
+    <desc xml:lang="en">(publication statement) – Container for information regarding the publication or
       distribution of a bibliographic item, including the publisher’s name and address, the date of
       publication, and other relevant details.</desc>
     <classes>
@@ -2231,7 +2231,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="revisionDesc" module="MEI.header">
-    <desc>(revision description) – Container for information about alterations that have been made
+    <desc xml:lang="en">(revision description) – Container for information about alterations that have been made
       to an MEI file.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2254,7 +2254,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="samplingDecl" module="MEI.header">
-    <desc>(sampling declaration) – Contains a prose description of the rationale and methods used in
+    <desc xml:lang="en">(sampling declaration) – Contains a prose description of the rationale and methods used in
       sampling texts in the creation of a corpus or collection.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2276,7 +2276,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="scoreFormat" module="MEI.header">
-    <desc>Describes the type of score used to represent a musical composition (<abbr>e.g.</abbr>, short score,
+    <desc xml:lang="en">Describes the type of score used to represent a musical composition (<abbr>e.g.</abbr>, short score,
       full score, condensed score, close score, etc.).</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2290,7 +2290,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="segmentation" module="MEI.header">
-    <desc>Describes the principles according to which the musical text has been segmented, for
+    <desc xml:lang="en">Describes the principles according to which the musical text has been segmented, for
       example into movements, sections, etc.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2312,7 +2312,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="seriesStmt" module="MEI.header">
-    <desc>(series statement) – Groups information about the series, if any, to which a publication
+    <desc xml:lang="en">(series statement) – Groups information about the series, if any, to which a publication
       belongs.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2353,7 +2353,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="soundChan" module="MEI.header">
-    <desc>(sound channels) – Reflects the number of apparent sound channels in the playback of a
+    <desc xml:lang="en">(sound channels) – Reflects the number of apparent sound channels in the playback of a
       recording (monaural, stereophonic, quadraphonic, etc.).</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2372,7 +2372,7 @@
     </content>
     <attList>
       <attDef ident="num" usage="opt">
-        <desc>Records the channel configuration in numeric form.</desc>
+        <desc xml:lang="en">Records the channel configuration in numeric form.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
@@ -2387,7 +2387,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="source" module="MEI.header">
-    <desc>A bibliographic description of a source used in the creation of the electronic
+    <desc xml:lang="en">A bibliographic description of a source used in the creation of the electronic
       file.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2442,7 +2442,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="sourceDesc" module="MEI.header">
-    <desc>(source description) – A container for the descriptions of the source(s) used in the
+    <desc xml:lang="en">(source description) – A container for the descriptions of the source(s) used in the
       creation of the electronic file.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2461,7 +2461,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="specRepro" module="MEI.header">
-    <desc>(special reproduction characteristic) – The equalization system, noise reduction system,
+    <desc xml:lang="en">(special reproduction characteristic) – The equalization system, noise reduction system,
       etc. used in making the recording (<abbr>e.g.</abbr>, NAB, DBX, Dolby, etc.).</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2475,7 +2475,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="stdVals" module="MEI.header">
-    <desc>(standard values) – Specifies the format used when standardized date or number values are
+    <desc xml:lang="en">(standard values) – Specifies the format used when standardized date or number values are
       supplied.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2497,7 +2497,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="sysReq" module="MEI.header">
-    <desc>(system requirements) – System requirements for using the electronic item.</desc>
+    <desc xml:lang="en">(system requirements) – System requirements for using the electronic item.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -2509,7 +2509,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="tagsDecl" module="MEI.header">
-    <desc>(tagging declaration) – Provides detailed information about the tagging applied to a
+    <desc xml:lang="en">(tagging declaration) – Provides detailed information about the tagging applied to a
       document.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2531,7 +2531,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="tagUsage" module="MEI.header">
-    <desc>Documents the usage of a specific element within the document.</desc>
+    <desc xml:lang="en">Documents the usage of a specific element within the document.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -2554,25 +2554,25 @@
     </constraintSpec>
     <attList>
       <attDef ident="name" usage="req">
-        <desc>Name of the element.</desc>
+        <desc xml:lang="en">Name of the element.</desc>
         <datatype>
           <rng:ref name="data.NMTOKEN"/>
         </datatype>
       </attDef>
       <attDef ident="context" usage="opt">
-        <desc>Circumstances in which the element appears, an XPath expression.</desc>
+        <desc xml:lang="en">Circumstances in which the element appears, an XPath expression.</desc>
         <datatype>
           <rng:data type="string"/>
         </datatype>
       </attDef>
       <attDef ident="occurs" usage="opt">
-        <desc>Number of occurrences in the defined context.</desc>
+        <desc xml:lang="en">Number of occurrences in the defined context.</desc>
         <datatype>
           <rng:data type="nonNegativeInteger"/>
         </datatype>
       </attDef>
       <attDef ident="withid" usage="opt">
-        <desc>Number of occurrences in the defined context that have an <att>xml:id</att>
+        <desc xml:lang="en">Number of occurrences in the defined context that have an <att>xml:id</att>
           attribute.</desc>
         <datatype>
           <rng:data type="nonNegativeInteger"/>
@@ -2584,7 +2584,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="taxonomy" module="MEI.header">
-    <desc>Defines a typology either implicitly, by means of a bibliographic citation, or explicitly
+    <desc xml:lang="en">Defines a typology either implicitly, by means of a bibliographic citation, or explicitly
       by a structured taxonomy.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2609,7 +2609,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="termList" module="MEI.header">
-    <desc>Collection of text phrases which describe a resource.</desc>
+    <desc xml:lang="en">Collection of text phrases which describe a resource.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -2640,7 +2640,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="titleStmt" module="MEI.header">
-    <desc>(title statement) – Container for title and responsibility meta-data.</desc>
+    <desc xml:lang="en">(title statement) – Container for title and responsibility meta-data.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -2663,7 +2663,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="trackConfig" module="MEI.header">
-    <desc>(track configuration) – Number of physical/input tracks on a sound medium (<abbr>e.g.</abbr>, eight
+    <desc xml:lang="en">(track configuration) – Number of physical/input tracks on a sound medium (<abbr>e.g.</abbr>, eight
       track, twelve track).</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2677,7 +2677,7 @@
     </content>
     <attList>
       <attDef ident="num" usage="opt">
-        <desc>Records the track configuration in numeric form.</desc>
+        <desc xml:lang="en">Records the track configuration in numeric form.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
@@ -2693,7 +2693,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="treatHist" module="MEI.header">
-    <desc>(treatment history) – A record of the treatment the item has undergone (<abbr>e.g.</abbr>,
+    <desc xml:lang="en">(treatment history) – A record of the treatment the item has undergone (<abbr>e.g.</abbr>,
       de-acidification, restoration, etc.).</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2732,7 +2732,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="treatSched" module="MEI.header">
-    <desc>(treatment scheduled) – Scheduled treatment, <abbr>e.g.</abbr>, de-acidification, restoration, etc., for
+    <desc xml:lang="en">(treatment scheduled) – Scheduled treatment, <abbr>e.g.</abbr>, de-acidification, restoration, etc., for
       an item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2767,7 +2767,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="unpub" module="MEI.header">
-    <desc>(unpublished) – Used to explicitly indicate that a bibliographic resource is
+    <desc xml:lang="en">(unpublished) – Used to explicitly indicate that a bibliographic resource is
       unpublished.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2783,7 +2783,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="useRestrict" module="MEI.header">
-    <desc>(usage restrictions) – Container for information about the conditions that affect use of a
+    <desc xml:lang="en">(usage restrictions) – Container for information about the conditions that affect use of a
       bibliographic item after access has been granted.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2809,7 +2809,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="watermark" module="MEI.header">
-    <desc>Contains a description of a watermark or similar device.</desc>
+    <desc xml:lang="en">Contains a description of a watermark or similar device.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -2830,7 +2830,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="work" module="MEI.header">
-    <desc>Provides a detailed description of a work — a distinct intellectual or artistic creation —
+    <desc xml:lang="en">Provides a detailed description of a work — a distinct intellectual or artistic creation —
       specifically its history, language use, and high-level musical attributes (<abbr>e.g.</abbr>, key, tempo,
       meter, medium of performance, and intended duration).</desc>
     <classes>
@@ -2913,7 +2913,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="workList" module="MEI.header">
-    <desc>(work list) – Grouping mechanism for information describing non-bibliographic aspects of a
+    <desc xml:lang="en">(work list) – Grouping mechanism for information describing non-bibliographic aspects of a
       text.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -287,7 +287,8 @@
     <desc xml:lang="en">Collects work-like elements.</desc>
   </classSpec>
   <elementSpec ident="accessRestrict" module="MEI.header">
-    <desc xml:lang="en">(access restriction) – Describes the conditions that affect the accessibility of
+    <gloss versionDate="2022-05-18" xml:lang="en">access restriction</gloss>
+    <desc xml:lang="en">Describes the conditions that affect the accessibility of
       material.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -327,7 +328,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="altId" module="MEI.header">
-    <desc xml:lang="en">(alternative identifier) – May contain a bibliographic identifier that does not fit within
+    <gloss versionDate="2022-05-18" xml:lang="en">alternative identifier</gloss>
+    <desc xml:lang="en">May contain a bibliographic identifier that does not fit within
       the meiHead element’s id attribute, for example because the identifier does not fit the
       definition of an XML id or because multiple identifiers are needed.</desc>
     <classes>
@@ -349,7 +351,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="appInfo" module="MEI.header">
-    <desc xml:lang="en">(application information) – Groups information about applications which have acted upon
+    <gloss versionDate="2022-05-18" xml:lang="en">application information</gloss>
+    <desc xml:lang="en">Groups information about applications which have acted upon
       the MEI file.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -515,7 +518,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="captureMode" module="MEI.header">
-    <desc xml:lang="en">(capture mode) – The means used to record notation, sound, or images in the production of
+    <gloss versionDate="2022-05-18" xml:lang="en">capture mode</gloss>
+    <desc xml:lang="en">The means used to record notation, sound, or images in the production of
       a source/manifestation (<abbr>e.g.</abbr>, analogue, acoustic, electric, digital, optical etc.).</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -529,7 +533,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="carrierForm" module="MEI.header">
-    <desc xml:lang="en">(carrier form) – The specific class of material to which the physical carrier of the
+    <gloss versionDate="2022-05-18" xml:lang="en">carrier form</gloss>
+    <desc xml:lang="en">The specific class of material to which the physical carrier of the
       source/manifestation belongs (<abbr>e.g.</abbr>, sound cassette, videodisc, microfilm cartridge,
       transparency, etc.). The carrier for a manifestation comprising multiple physical components
       may include more than one form (<abbr>e.g.</abbr>, a filmstrip with an accompanying booklet, a separate
@@ -581,7 +586,8 @@
     </constraintSpec>
   </elementSpec>
   <elementSpec ident="catRel" module="MEI.header">
-    <desc xml:lang="en">(category relationship) – Contains the name of a related category.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">category relationship</gloss>
+    <desc xml:lang="en">Contains the name of a related category.</desc>
     <classes>
       <memberOf key="att.authorized"/>
       <memberOf key="att.basic"/>
@@ -665,7 +671,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="changeDesc" module="MEI.header">
-    <desc xml:lang="en">(change description) – Description of a revision of the MEI file.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">change description</gloss>
+    <desc xml:lang="en">Description of a revision of the MEI file.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -776,7 +783,7 @@
     <remarks xml:lang="en">
       <p>The child elements of this element are treated as components of the bibliographic entity
         containing the <gi scheme="MEI">componentList</gi>. Although this is an implicit way of
-        expressing FRBR's hasPart and isPartOf relationships, it avoids this terminology in order to
+        expressing FRBR’s hasPart and isPartOf relationships, it avoids this terminology in order to
         prevent confusion with musical terminology. Work, expression, and item components must be
         the same type as the parent of componentList: <gi scheme="MEI">work</gi> children are
         allowed within <gi scheme="MEI">work</gi>, etc. Manifestations; <abbr>i.e.</abbr>, sources, may have
@@ -1053,7 +1060,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="domainsDecl" module="MEI.header">
-    <desc xml:lang="en">(domains declaration) – Indicates which domains are included in the encoding.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">domains declaration</gloss>
+    <desc xml:lang="en">Indicates which domains are included in the encoding.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -1077,7 +1085,8 @@
     </attList>
   </elementSpec>
   <elementSpec ident="editionStmt" module="MEI.header">
-    <desc xml:lang="en">(edition statement) – Container for meta-data pertaining to a particular edition of the
+    <gloss versionDate="2022-05-18" xml:lang="en">edition statement</gloss>
+    <desc xml:lang="en">Container for meta-data pertaining to a particular edition of the
       material being described.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1104,7 +1113,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="editorialDecl" module="MEI.header">
-    <desc xml:lang="en">(editorial declaration) – Used to provide details of editorial principles and practices
+    <gloss versionDate="2022-05-18" xml:lang="en">editorial declaration</gloss>
+    <desc xml:lang="en">Used to provide details of editorial principles and practices
       applied during the encoding of musical text.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1136,7 +1146,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="encodingDesc" module="MEI.header">
-    <desc xml:lang="en">(encoding description) – Documents the relationship between an electronic file and the
+    <gloss versionDate="2022-05-18" xml:lang="en">encoding description</gloss>
+    <desc xml:lang="en">Documents the relationship between an electronic file and the
       source or sources from which it was derived as well as applications used in the
       encoding/editing process.</desc>
     <classes>
@@ -1175,7 +1186,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="exhibHist" module="MEI.header">
-    <desc xml:lang="en">(exhibition history) – A record of public exhibitions, including dates, venues,
+    <gloss versionDate="2022-05-18" xml:lang="en">exhibition history</gloss>
+    <desc xml:lang="en">A record of public exhibitions, including dates, venues,
       etc.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1210,7 +1222,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="extMeta" module="MEI.header">
-    <desc xml:lang="en">(extended metadata) – Provides a container element for non-MEI metadata formats.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">extended metadata</gloss>
+    <desc xml:lang="en">Provides a container element for non-MEI metadata formats.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -1228,7 +1241,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="fileChar" module="MEI.header">
-    <desc xml:lang="en">(file characteristics) – Standards or schemes used to encode the file (<abbr>e.g.</abbr>, ASCII, SGML,
+    <gloss versionDate="2022-05-18" xml:lang="en">file characteristics</gloss>
+    <desc xml:lang="en">Standards or schemes used to encode the file (<abbr>e.g.</abbr>, ASCII, SGML,
       etc.), physical characteristics of the file (<abbr>e.g.</abbr>, recording density, parity, blocking, etc.),
       and other characteristics that have a bearing on how the file can be processed.</desc>
     <classes>
@@ -1242,7 +1256,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="fileDesc" module="MEI.header">
-    <desc xml:lang="en">(file description) – Contains a full bibliographic description of the MEI file.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">file description</gloss>
+    <desc xml:lang="en">Contains a full bibliographic description of the MEI file.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -1580,7 +1595,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="langUsage" module="MEI.header">
-    <desc xml:lang="en">(language usage) – Groups elements describing the languages, sub-languages, dialects,
+    <gloss versionDate="2022-05-18" xml:lang="en">language usage</gloss>
+    <desc xml:lang="en">Groups elements describing the languages, sub-languages, dialects,
       etc., represented within the encoded resource.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1600,7 +1616,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="meiHead" module="MEI.header">
-    <desc xml:lang="en">(MEI header) – Supplies the descriptive and declarative metadata prefixed to every
+    <gloss versionDate="2022-05-18" xml:lang="en">MEI header</gloss>
+    <desc xml:lang="en">Supplies the descriptive and declarative metadata prefixed to every
       MEI-conformant text.</desc>
     <classes>
       <memberOf key="att.basic"/>
@@ -1794,7 +1811,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="otherChar" module="MEI.header">
-    <desc xml:lang="en">(other distinguishing characteristic) – Any characteristic that serves to differentiate a
+    <gloss versionDate="2022-05-18" xml:lang="en">other distinguishing characteristic</gloss>
+    <desc xml:lang="en">Any characteristic that serves to differentiate a
       work or expression from another.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1895,7 +1913,8 @@
           </remarks>-->
   </elementSpec>
   <elementSpec ident="perfDuration" module="MEI.header">
-    <desc xml:lang="en">(performance duration) – Used to express the duration of performance of printed or
+    <gloss versionDate="2022-05-18" xml:lang="en">performance duration</gloss>
+    <desc xml:lang="en">Used to express the duration of performance of printed or
       manuscript music or the playing time for a sound recording, videorecording, etc.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1922,7 +1941,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="perfMedium" module="MEI.header">
-    <desc xml:lang="en">(performance medium) – Indicates the number and character of the performing forces used in
+    <gloss versionDate="2022-05-18" xml:lang="en">performance medium</gloss>
+    <desc xml:lang="en">Indicates the number and character of the performing forces used in
       a musical composition.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1950,7 +1970,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="perfRes" module="MEI.header">
-    <desc xml:lang="en">(performance resource) – Name of an instrument on which a performer plays, a performer's
+    <gloss versionDate="2022-05-18" xml:lang="en">performance resource</gloss>
+    <desc xml:lang="en">Name of an instrument on which a performer plays, a performer's
       voice range, or a standard performing ensemble designation.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2020,7 +2041,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="physDesc" module="MEI.header">
-    <desc xml:lang="en">(physical description) – Container for information about the appearance, construction, or
+    <gloss versionDate="2022-05-18" xml:lang="en">physical description</gloss>
+    <desc xml:lang="en">Container for information about the appearance, construction, or
       handling of physical materials, such as their dimension, quantity, color, style, and technique
       of creation.</desc>
     <classes>
@@ -2049,7 +2071,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="physMedium" module="MEI.header">
-    <desc xml:lang="en">(physical medium) – Records the physical materials used in the source, such as ink and
+    <gloss versionDate="2022-05-18" xml:lang="en">physical medium</gloss>
+    <desc xml:lang="en">Records the physical materials used in the source, such as ink and
       paper.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2072,7 +2095,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="plateNum" module="MEI.header">
-    <desc xml:lang="en">(plate number) – Designation assigned to a resource by a music publisher, usually printed
+    <gloss versionDate="2022-05-18" xml:lang="en">plate number</gloss>
+    <desc xml:lang="en">Designation assigned to a resource by a music publisher, usually printed
       at the bottom of each page, and sometimes appearing also on the title page.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2146,7 +2170,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="projectDesc" module="MEI.header">
-    <desc xml:lang="en">(project description) – Project-level meta-data describing the aim or purpose for which
+    <gloss versionDate="2022-05-18" xml:lang="en">project description</gloss>
+    <desc xml:lang="en">Project-level meta-data describing the aim or purpose for which
       the electronic file was encoded, funding agencies, etc. together with any other relevant
       information concerning the process by which it was assembled or collected.</desc>
     <classes>
@@ -2203,7 +2228,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pubStmt" module="MEI.header">
-    <desc xml:lang="en">(publication statement) – Container for information regarding the publication or
+    <gloss versionDate="2022-05-18" xml:lang="en">publication statement</gloss>
+    <desc xml:lang="en">Container for information regarding the publication or
       distribution of a bibliographic item, including the publisher’s name and address, the date of
       publication, and other relevant details.</desc>
     <classes>
@@ -2231,7 +2257,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="revisionDesc" module="MEI.header">
-    <desc xml:lang="en">(revision description) – Container for information about alterations that have been made
+    <gloss versionDate="2022-05-18" xml:lang="en">revision description</gloss>
+    <desc xml:lang="en">Container for information about alterations that have been made
       to an MEI file.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2254,7 +2281,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="samplingDecl" module="MEI.header">
-    <desc xml:lang="en">(sampling declaration) – Contains a prose description of the rationale and methods used in
+    <gloss versionDate="2022-05-18" xml:lang="en">sampling declaration</gloss>
+    <desc xml:lang="en">Contains a prose description of the rationale and methods used in
       sampling texts in the creation of a corpus or collection.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2312,7 +2340,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="seriesStmt" module="MEI.header">
-    <desc xml:lang="en">(series statement) – Groups information about the series, if any, to which a publication
+    <gloss versionDate="2022-05-18" xml:lang="en">series statement</gloss>
+    <desc xml:lang="en">Groups information about the series, if any, to which a publication
       belongs.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2353,7 +2382,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="soundChan" module="MEI.header">
-    <desc xml:lang="en">(sound channels) – Reflects the number of apparent sound channels in the playback of a
+    <gloss versionDate="2022-05-18" xml:lang="en">sound channels</gloss>
+    <desc xml:lang="en">Reflects the number of apparent sound channels in the playback of a
       recording (monaural, stereophonic, quadraphonic, etc.).</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2442,7 +2472,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="sourceDesc" module="MEI.header">
-    <desc xml:lang="en">(source description) – A container for the descriptions of the source(s) used in the
+    <gloss versionDate="2022-05-18" xml:lang="en">source description</gloss>
+    <desc xml:lang="en">A container for the descriptions of the source(s) used in the
       creation of the electronic file.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2461,7 +2492,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="specRepro" module="MEI.header">
-    <desc xml:lang="en">(special reproduction characteristic) – The equalization system, noise reduction system,
+    <gloss versionDate="2022-05-18" xml:lang="en">special reproduction characteristic</gloss>
+    <desc xml:lang="en">The equalization system, noise reduction system,
       etc. used in making the recording (<abbr>e.g.</abbr>, NAB, DBX, Dolby, etc.).</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2475,7 +2507,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="stdVals" module="MEI.header">
-    <desc xml:lang="en">(standard values) – Specifies the format used when standardized date or number values are
+    <gloss versionDate="2022-05-18" xml:lang="en">standard values</gloss>
+    <desc xml:lang="en">Specifies the format used when standardized date or number values are
       supplied.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2497,7 +2530,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="sysReq" module="MEI.header">
-    <desc xml:lang="en">(system requirements) – System requirements for using the electronic item.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">system requirements</gloss>
+    <desc xml:lang="en">System requirements for using the electronic item.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -2509,7 +2543,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="tagsDecl" module="MEI.header">
-    <desc xml:lang="en">(tagging declaration) – Provides detailed information about the tagging applied to a
+    <gloss versionDate="2022-05-18" xml:lang="en">tagging declaration</gloss>
+    <desc xml:lang="en">Provides detailed information about the tagging applied to a
       document.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2640,7 +2675,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="titleStmt" module="MEI.header">
-    <desc xml:lang="en">(title statement) – Container for title and responsibility meta-data.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">title statement</gloss>
+    <desc xml:lang="en">Container for title and responsibility meta-data.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -2663,7 +2699,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="trackConfig" module="MEI.header">
-    <desc xml:lang="en">(track configuration) – Number of physical/input tracks on a sound medium (<abbr>e.g.</abbr>, eight
+    <gloss versionDate="2022-05-18" xml:lang="en">track configuration</gloss>
+    <desc xml:lang="en">Number of physical/input tracks on a sound medium (<abbr>e.g.</abbr>, eight
       track, twelve track).</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2693,7 +2730,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="treatHist" module="MEI.header">
-    <desc xml:lang="en">(treatment history) – A record of the treatment the item has undergone (<abbr>e.g.</abbr>,
+    <gloss versionDate="2022-05-18" xml:lang="en">treatment history</gloss>
+    <desc xml:lang="en">A record of the treatment the item has undergone (<abbr>e.g.</abbr>,
       de-acidification, restoration, etc.).</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2732,7 +2770,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="treatSched" module="MEI.header">
-    <desc xml:lang="en">(treatment scheduled) – Scheduled treatment, <abbr>e.g.</abbr>, de-acidification, restoration, etc., for
+    <gloss versionDate="2022-05-18" xml:lang="en">treatment scheduled</gloss>
+    <desc xml:lang="en">Scheduled treatment, <abbr>e.g.</abbr>, de-acidification, restoration, etc., for
       an item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2767,7 +2806,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="unpub" module="MEI.header">
-    <desc xml:lang="en">(unpublished) – Used to explicitly indicate that a bibliographic resource is
+    <gloss versionDate="2022-05-18" xml:lang="en">unpublished</gloss>
+    <desc xml:lang="en">Used to explicitly indicate that a bibliographic resource is
       unpublished.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2783,7 +2823,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="useRestrict" module="MEI.header">
-    <desc xml:lang="en">(usage restrictions) – Container for information about the conditions that affect use of a
+    <gloss versionDate="2022-05-18" xml:lang="en">usage restrictions</gloss>
+    <desc xml:lang="en">Container for information about the conditions that affect use of a
       bibliographic item after access has been granted.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2913,7 +2954,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="workList" module="MEI.header">
-    <desc xml:lang="en">(work list) – Grouping mechanism for information describing non-bibliographic aspects of a
+    <gloss versionDate="2022-05-18" xml:lang="en">work list</gloss>
+    <desc xml:lang="en">Grouping mechanism for information describing non-bibliographic aspects of a
       text.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.lyrics.xml
+++ b/source/modules/MEI.lyrics.xml
@@ -69,7 +69,7 @@
         <rng:ref name="model.lbLike"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <gi scheme="MEI">lb</gi> element is allowed here in order to facilitate karaoke
         applications. The <att>func</att> attribute on <gi scheme="MEI">lb</gi> may be used to
         distinguish true line endings from those of line groups for these applications.</p>
@@ -115,7 +115,7 @@
         <rng:ref name="model.lbLike"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <gi scheme="MEI">lb</gi> element is allowed here in order to facilitate karaoke
         applications. The <att>func</att> attribute on <gi scheme="MEI">lb</gi> may be used to
         distinguish true line endings from those of line groups for these applications.</p>
@@ -154,7 +154,7 @@
         <rng:ref name="model.lbLike"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The volta element is intended for those cases where the musical notation is repeated, but
         the accompanying lyrics are not.</p>
     </remarks>

--- a/source/modules/MEI.lyrics.xml
+++ b/source/modules/MEI.lyrics.xml
@@ -5,10 +5,10 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.lyrics">
   <moduleSpec ident="MEI.lyrics">
-    <desc>Lyrics component declarations.</desc>
+    <desc xml:lang="en">Lyrics component declarations.</desc>
   </moduleSpec>
   <classSpec ident="att.lyrics.log" module="MEI.lyrics" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.layerIdent"/>
       <memberOf key="att.partIdent"/>
@@ -16,19 +16,19 @@
     </classes>
   </classSpec>
   <classSpec ident="att.refrain.log" module="MEI.lyrics" type="atts">
-    <desc>Logical domain attributes. The n attribute should be used for verse numbers. Numbers need
+    <desc xml:lang="en">Logical domain attributes. The n attribute should be used for verse numbers. Numbers need
       not be consecutive; they may also be expressed as ranges, <abbr>e.g.</abbr>, 2-3,6.</desc>
   </classSpec>
   <classSpec ident="att.verse.log" module="MEI.lyrics" type="atts">
-    <desc>Logical domain attributes. The n attribute should be used for verse numbers. Numbers need
+    <desc xml:lang="en">Logical domain attributes. The n attribute should be used for verse numbers. Numbers need
       not be consecutive; they may also be expressed as ranges, <abbr>e.g.</abbr>, 2-3,6.</desc>
   </classSpec>
   <classSpec ident="att.volta.log" module="MEI.lyrics" type="atts">
-    <desc>Logical domain attributes. The n attribute should be used for repetition numbers. Numbers
+    <desc xml:lang="en">Logical domain attributes. The n attribute should be used for repetition numbers. Numbers
       need not be consecutive; they may also be expressed as ranges, <abbr>e.g.</abbr>, 2-3,6.</desc>
   </classSpec>
   <classSpec ident="model.verseLike" module="MEI.lyrics" type="model">
-    <desc>Groups elements that contain a lyric verse.</desc>
+    <desc xml:lang="en">Groups elements that contain a lyric verse.</desc>
     <classes>
       <memberOf key="model.syllablePart"/>
       <memberOf key="model.rdgPart.music"/>
@@ -36,7 +36,7 @@
     </classes>
   </classSpec>
   <elementSpec ident="refrain" module="MEI.lyrics">
-    <desc>Recurring lyrics, especially at the end of each verse or stanza of a poem or song lyrics;
+    <desc xml:lang="en">Recurring lyrics, especially at the end of each verse or stanza of a poem or song lyrics;
       a chorus.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -76,7 +76,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="verse" module="MEI.lyrics">
-    <desc>Division of a poem or song lyrics, sometimes having a fixed length, meter or rhyme scheme;
+    <desc xml:lang="en">Division of a poem or song lyrics, sometimes having a fixed length, meter or rhyme scheme;
       a stanza.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -122,7 +122,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="volta" module="MEI.lyrics">
-    <desc>Sung text for a specific iteration of a repeated section of music.</desc>
+    <desc xml:lang="en">Sung text for a specific iteration of a repeated section of music.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -5,54 +5,54 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.mensural">
   <moduleSpec ident="MEI.mensural">
-    <desc>Mensural repertoire component declarations.</desc>
+    <desc xml:lang="en">Mensural repertoire component declarations.</desc>
   </moduleSpec>
   <macroSpec ident="data.DURATION.mensural" module="MEI.mensural" type="dt">
-    <desc>Logical, that is, written, note-shape (or note symbol) attribute values for the mensural repertoire.</desc>
+    <desc xml:lang="en">Logical, that is, written, note-shape (or note symbol) attribute values for the mensural repertoire.</desc>
     <content>
       <valList type="closed">
         <valItem ident="maxima">
-          <desc>Two or three times as long as a longa.</desc>
+          <desc xml:lang="en">Two or three times as long as a longa.</desc>
         </valItem>
         <valItem ident="longa">
-          <desc>Two or three times as long as a brevis.</desc>
+          <desc xml:lang="en">Two or three times as long as a brevis.</desc>
         </valItem>
         <valItem ident="brevis">
-          <desc>Two or three times as long as a semibreve.</desc>
+          <desc xml:lang="en">Two or three times as long as a semibreve.</desc>
         </valItem>
         <valItem ident="semibrevis">
-          <desc>Half or one-third as long as a breve/brevis.</desc>
+          <desc xml:lang="en">Half or one-third as long as a breve/brevis.</desc>
         </valItem>
         <valItem ident="minima">
-          <desc>Half or one-third as long as a semibreve/semibrevis.</desc>
+          <desc xml:lang="en">Half or one-third as long as a semibreve/semibrevis.</desc>
         </valItem>
         <valItem ident="semiminima">
-          <desc>Half as long as a minima.</desc>
+          <desc xml:lang="en">Half as long as a minima.</desc>
         </valItem>
         <valItem ident="fusa">
-          <desc>Half as long as a semiminima.</desc>
+          <desc xml:lang="en">Half as long as a semiminima.</desc>
         </valItem>
         <valItem ident="semifusa">
-          <desc>Half as long as a fusa.</desc>
+          <desc xml:lang="en">Half as long as a fusa.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.MULTIBREVERESTS.mensural" module="MEI.mensural" type="dt">
-    <desc>Logical, that is, written, duration attribute values for multi-breve rests in the mensural repertoire.</desc>
+    <desc xml:lang="en">Logical, that is, written, duration attribute values for multi-breve rests in the mensural repertoire.</desc>
     <content>
       <valList type="closed">
         <valItem ident="2B">
-          <desc>A two-breve rest.</desc>
+          <desc xml:lang="en">A two-breve rest.</desc>
         </valItem>
         <valItem ident="3B">
-          <desc>A three-breve rest.</desc>
+          <desc xml:lang="en">A three-breve rest.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.DURATIONRESTS.mensural" module="MEI.mensural" type="dt">
-    <desc>Logical, that is, written, duration attribute values for mensural rests.</desc>
+    <desc xml:lang="en">Logical, that is, written, duration attribute values for mensural rests.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.MULTIBREVERESTS.mensural"/>
@@ -61,51 +61,51 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.DURQUALITY.mensural" module="MEI.mensural" type="dt">
-    <desc>Duration attribute values of a given note symbol for the mensural repertoire.</desc>
+    <desc xml:lang="en">Duration attribute values of a given note symbol for the mensural repertoire.</desc>
     <content>
       <valList type="closed">
         <valItem ident="perfecta">
-          <desc>Three times the duration of the note in the next smaller degree.</desc>
+          <desc xml:lang="en">Three times the duration of the note in the next smaller degree.</desc>
         </valItem>
         <valItem ident="imperfecta">
-          <desc>Two times the duration of the note in the next smaller degree.</desc>
+          <desc xml:lang="en">Two times the duration of the note in the next smaller degree.</desc>
         </valItem>
         <valItem ident="altera">
-          <desc>Twice the original duration of the note (only usable in perfect mensurations).</desc>
+          <desc xml:lang="en">Twice the original duration of the note (only usable in perfect mensurations).</desc>
         </valItem>
         <valItem ident="minor">
-          <desc>Category of a regular semibrevis in Ars antiqua, equivalent to a third of a brevis.</desc>
+          <desc xml:lang="en">Category of a regular semibrevis in Ars antiqua, equivalent to a third of a brevis.</desc>
         </valItem>
         <valItem ident="maior">
-          <desc>Category of an altered semibrevis in Ars antiqua, equivalent to two minor semibrevis.</desc>
+          <desc xml:lang="en">Category of an altered semibrevis in Ars antiqua, equivalent to two minor semibrevis.</desc>
         </valItem>
         <valItem ident="duplex">
-          <desc>One of the three categories of a longa in Ars antiqua ('duplex', 'perfecta', and 'imperfecta'). A duplex longa is twice as long as a regular longa.</desc>
+          <desc xml:lang="en">One of the three categories of a longa in Ars antiqua ('duplex', 'perfecta', and 'imperfecta'). A duplex longa is twice as long as a regular longa.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.FLAGFORM.mensural" module="MEI.mensural" type="dt">
-    <desc>Form of the flag.</desc>
+    <desc xml:lang="en">Form of the flag.</desc>
     <content>
       <valList type="closed">
         <valItem ident="straight">
-          <desc>Flag is a straight horizontal line.</desc>
+          <desc xml:lang="en">Flag is a straight horizontal line.</desc>
         </valItem>
         <valItem ident="angled">
-          <desc>Flag is a straight line at an angle.</desc>
+          <desc xml:lang="en">Flag is a straight line at an angle.</desc>
         </valItem>
         <valItem ident="curled">
-          <desc>Flag is curled.</desc>
+          <desc xml:lang="en">Flag is curled.</desc>
         </valItem>
         <valItem ident="flared">
-          <desc>Flag is flared.</desc>
+          <desc xml:lang="en">Flag is flared.</desc>
         </valItem>
         <valItem ident="extended">
-          <desc>Flag looks extended.</desc>
+          <desc xml:lang="en">Flag looks extended.</desc>
         </valItem>
         <valItem ident="hooked">
-          <desc>Flag is hooked-form.</desc>
+          <desc xml:lang="en">Flag is hooked-form.</desc>
         </valItem>
       </valList>
     </content>
@@ -117,52 +117,52 @@
     </remarks>
   </macroSpec>
   <macroSpec ident="data.FLAGPOS.mensural" module="MEI.mensural" type="dt">
-    <desc>Position of the flag relative to the stem.</desc>
+    <desc xml:lang="en">Position of the flag relative to the stem.</desc>
     <content>
       <valList type="closed">
         <valItem ident="left">
-          <desc>Flag lies at the left side of the stem.</desc>
+          <desc xml:lang="en">Flag lies at the left side of the stem.</desc>
         </valItem>
         <valItem ident="right">
-          <desc>Flag lies at the right side of the stem.</desc>
+          <desc xml:lang="en">Flag lies at the right side of the stem.</desc>
         </valItem>
         <valItem ident="center">
-          <desc>Flag is centered in the stem.</desc>
+          <desc xml:lang="en">Flag is centered in the stem.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.STAFFITEM.mensural" module="MEI.mensural" type="dt">
-    <desc>Items in the Mensural repertoire that may be printed near a staff.</desc>
+    <desc xml:lang="en">Items in the Mensural repertoire that may be printed near a staff.</desc>
     <content>
       <valList type="closed">
         <valItem ident="ligature">
-          <desc>Ligatures.</desc>
+          <desc xml:lang="en">Ligatures.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.STEMFORM.mensural" module="MEI.mensural" type="dt">
-    <desc>Form of the stem attached to the note.</desc>
+    <desc xml:lang="en">Form of the stem attached to the note.</desc>
     <content>
       <valList type="closed">
         <valItem ident="circle">
-          <desc>Stem has a circular form.</desc>
+          <desc xml:lang="en">Stem has a circular form.</desc>
         </valItem>
         <valItem ident="oblique">
-          <desc>Stem has an oblique form.</desc>
+          <desc xml:lang="en">Stem has an oblique form.</desc>
         </valItem>
         <valItem ident="swallowtail">
-          <desc>Stem has a swallowtail form.</desc>
+          <desc xml:lang="en">Stem has a swallowtail form.</desc>
         </valItem>
         <valItem ident="virgula">
-          <desc>Stem has a virgula-like form.</desc>
+          <desc xml:lang="en">Stem has a virgula-like form.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <classSpec ident="att.duration.quality" module="MEI.mensural" type="atts">
-    <desc>Attribute that expresses duration for a given mensural note symbol.</desc>
+    <desc xml:lang="en">Attribute that expresses duration for a given mensural note symbol.</desc>
     <constraintSpec ident="check_duplex_quality" scheme="isoschematron">
       <constraint>
         <sch:rule context="(mei:note|mei:space)[@dur.quality='duplex']">
@@ -183,7 +183,7 @@
     </constraintSpec>
     <attList>
       <attDef ident="dur.quality" usage="rec">
-        <desc>Encodes the durational quality of a mensural note using the values provided by the data.DURQUALITY.mensural datatype (<abbr>i.e.</abbr>, the perfect / imperfect / altered / major / minor / duplex quality of a note).</desc>
+        <desc xml:lang="en">Encodes the durational quality of a mensural note using the values provided by the data.DURQUALITY.mensural datatype (<abbr>i.e.</abbr>, the perfect / imperfect / altered / major / minor / duplex quality of a note).</desc>
         <datatype>
           <rng:ref name="data.DURQUALITY.mensural"/>
         </datatype>
@@ -191,10 +191,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.ligature.log" module="MEI.mensural" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.mensural.log" module="MEI.mensural" type="atts">
-    <desc>Used by staffDef and scoreDef to provide default values for attributes in the logical
+    <desc xml:lang="en">Used by staffDef and scoreDef to provide default values for attributes in the logical
       domain related to mensuration. The tempus, prolatio, modusmaior, and modusminor attributes
       (from the att.mensural.shared class) specify the relationship between the four principle
       levels of note value, <abbr>i.e.</abbr>, the long, breve, semibreve and minim, in mensural notation.
@@ -207,14 +207,14 @@
     </classes>
     <attList>
       <attDef ident="proport.num" usage="opt">
-        <desc>Together, proport.num and proport.numbase specify a proportional change as a ratio,
+        <desc xml:lang="en">Together, proport.num and proport.numbase specify a proportional change as a ratio,
           <abbr>e.g.</abbr>, 1:3. Proport.num is for the first value in the ratio.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
       </attDef>
       <attDef ident="proport.numbase" usage="opt">
-        <desc>Together, proport.num and proport.numbase specify a proportional change as a ratio,
+        <desc xml:lang="en">Together, proport.num and proport.numbase specify a proportional change as a ratio,
           <abbr>e.g.</abbr>, 1:3. Proport.numbase is for the second value in the ratio.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
@@ -223,7 +223,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.mensural.shared" module="MEI.mensural" type="atts">
-    <desc>Shared attributes in the mensural repertoire.</desc>
+    <desc xml:lang="en">Shared attributes in the mensural repertoire.</desc>
     <constraintSpec ident="mensuration_conflicting_attributes" scheme="isoschematron">
       <constraint>
         <sch:rule context="mei:mensur[@divisio]">
@@ -235,31 +235,31 @@
     </constraintSpec>
     <attList>
       <attDef ident="modusmaior" usage="opt">
-        <desc>Describes the maxima-long relationship.</desc>
+        <desc xml:lang="en">Describes the maxima-long relationship.</desc>
         <datatype>
           <rng:ref name="data.MODUSMAIOR"/>
         </datatype>
       </attDef>
       <attDef ident="modusminor" usage="opt">
-        <desc>Describes the long-breve relationship.</desc>
+        <desc xml:lang="en">Describes the long-breve relationship.</desc>
         <datatype>
           <rng:ref name="data.MODUSMINOR"/>
         </datatype>
       </attDef>
       <attDef ident="prolatio" usage="opt">
-        <desc>Describes the semibreve-minim relationship.</desc>
+        <desc xml:lang="en">Describes the semibreve-minim relationship.</desc>
         <datatype>
           <rng:ref name="data.PROLATIO"/>
         </datatype>
       </attDef>
       <attDef ident="tempus" usage="opt">
-        <desc>Describes the breve-semibreve relationship.</desc>
+        <desc xml:lang="en">Describes the breve-semibreve relationship.</desc>
         <datatype>
           <rng:ref name="data.TEMPUS"/>
         </datatype>
       </attDef>
       <attDef ident="divisio" usage="opt">
-        <desc>Describes the divisions of the breve in use in 14th-century Italy.</desc>
+        <desc xml:lang="en">Describes the divisions of the breve in use in 14th-century Italy.</desc>
         <datatype>
           <rng:ref name="data.DIVISIO"/>
         </datatype>
@@ -267,22 +267,22 @@
     </attList>
   </classSpec>
   <classSpec ident="att.note.anl.mensural" module="MEI.mensural" type="atts">
-    <desc>Analytical domain attributes in the Mensural repertoire.</desc>
+    <desc xml:lang="en">Analytical domain attributes in the Mensural repertoire.</desc>
   </classSpec>
   <classSpec ident="att.note.ges.mensural" module="MEI.mensural" type="atts">
-    <desc>Gestural domain attributes in the Mensural repertoire.</desc>
+    <desc xml:lang="en">Gestural domain attributes in the Mensural repertoire.</desc>
     <classes>
       <memberOf key="att.duration.ratio"/>
     </classes>
   </classSpec>
   <classSpec ident="att.note.log.mensural" module="MEI.mensural" type="atts">
-    <desc>Logical domain attributes in the Mensural repertoire.</desc>
+    <desc xml:lang="en">Logical domain attributes in the Mensural repertoire.</desc>
   </classSpec>
   <classSpec ident="att.note.vis.mensural" module="MEI.mensural" type="atts">
-    <desc>Visual domain attributes in the Mensural repertoire.</desc>
+    <desc xml:lang="en">Visual domain attributes in the Mensural repertoire.</desc>
     <attList>
       <attDef ident="lig" usage="opt">
-        <desc>Indicates this element’s participation in a ligature.</desc>
+        <desc xml:lang="en">Indicates this element’s participation in a ligature.</desc>
         <datatype>
           <rng:ref name="data.LIGATUREFORM"/>
         </datatype>
@@ -290,25 +290,25 @@
     </attList>
   </classSpec>
   <classSpec ident="att.plica.anl" module="MEI.mensural" type="atts">
-    <desc>Analytical domain attributes that describe the properties of a plica in the mensural repertoire.</desc>
+    <desc xml:lang="en">Analytical domain attributes that describe the properties of a plica in the mensural repertoire.</desc>
   </classSpec>
   <classSpec ident="att.plica.ges" module="MEI.mensural" type="atts">
-    <desc>Gestural domain attributes that describe the properties of a plica in the mensural repertoire.</desc>
+    <desc xml:lang="en">Gestural domain attributes that describe the properties of a plica in the mensural repertoire.</desc>
   </classSpec>
   <classSpec ident="att.plica.log" module="MEI.mensural" type="atts">
-    <desc>Logical domain attributes that describe the properties of a plica in the mensural repertoire.</desc>
+    <desc xml:lang="en">Logical domain attributes that describe the properties of a plica in the mensural repertoire.</desc>
   </classSpec>
   <classSpec ident="att.plica.vis" module="MEI.mensural" type="atts">
-    <desc>Visual domain attributes that describe the properties of a plica stem in the mensural repertoire.</desc>
+    <desc xml:lang="en">Visual domain attributes that describe the properties of a plica stem in the mensural repertoire.</desc>
     <attList>
       <attDef ident="dir" usage="opt">
-        <desc>Describes the direction of a stem.</desc>
+        <desc xml:lang="en">Describes the direction of a stem.</desc>
         <datatype>
           <rng:ref name="data.STEMDIRECTION.basic"/>
         </datatype>
       </attDef>
       <attDef ident="len" usage="opt">
-        <desc>Encodes the stem length.</desc>
+        <desc xml:lang="en">Encodes the stem length.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTABS"/>
         </datatype>
@@ -316,23 +316,23 @@
     </attList>
   </classSpec>
   <classSpec ident="att.proport.log" module="MEI.mensural" type="atts">
-    <desc>Logical domain attributes. These attributes describe augmentation or diminution of the
+    <desc xml:lang="en">Logical domain attributes. These attributes describe augmentation or diminution of the
       normal value of the notes in mensural notation as a ratio.</desc>
     <classes>
       <memberOf key="att.duration.ratio"/>
     </classes>
   </classSpec>
   <classSpec ident="att.rest.ges.mensural" module="MEI.mensural" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.ratio"/>
     </classes>
   </classSpec>
   <classSpec ident="att.rest.vis.mensural" module="MEI.mensural" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <attList>
       <attDef ident="spaces" usage="opt">
-        <desc>States how many spaces are covered by the rest.</desc>
+        <desc xml:lang="en">States how many spaces are covered by the rest.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
@@ -340,7 +340,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.scoreDef.log.mensural" module="MEI.mensural" type="atts">
-    <desc>Logical domain attributes for a score in the mensural repertoire. The values set in these
+    <desc xml:lang="en">Logical domain attributes for a score in the mensural repertoire. The values set in these
       attributes act as score-wide defaults for attributes that are not set in descendant
       elements.</desc>
     <classes>
@@ -348,71 +348,71 @@
     </classes>
   </classSpec>
   <classSpec ident="att.scoreDef.vis.mensural" module="MEI.mensural" type="atts">
-    <desc>Visual domain attributes for scoreDef in the mensural repertoire.</desc>
+    <desc xml:lang="en">Visual domain attributes for scoreDef in the mensural repertoire.</desc>
     <classes>
       <memberOf key="att.mensural.vis"/>
     </classes>
   </classSpec>
   <classSpec ident="att.staffDef.log.mensural" module="MEI.mensural" type="atts">
-    <desc>Logical domain attributes for staffDef in the mensural repertoire.</desc>
+    <desc xml:lang="en">Logical domain attributes for staffDef in the mensural repertoire.</desc>
     <classes>
       <memberOf key="att.mensural.log"/>
     </classes>
   </classSpec>
   <classSpec ident="att.staffDef.vis.mensural" module="MEI.mensural" type="atts">
-    <desc>Visual domain attributes for the mensural repertoire.</desc>
+    <desc xml:lang="en">Visual domain attributes for the mensural repertoire.</desc>
     <classes>
       <memberOf key="att.mensural.vis"/>
     </classes>
   </classSpec>
   <classSpec ident="att.stem.anl" module="MEI.mensural" type="atts">
-    <desc>Analytical domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
+    <desc xml:lang="en">Analytical domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
   </classSpec>
   <classSpec ident="att.stem.ges" module="MEI.mensural" type="atts">
-    <desc>Gestural domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
+    <desc xml:lang="en">Gestural domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
   </classSpec>
   <classSpec ident="att.stem.log" module="MEI.mensural" type="atts">
-    <desc>Logical domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
+    <desc xml:lang="en">Logical domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
   </classSpec>
   <classSpec ident="att.stem.vis" module="MEI.mensural" type="atts">
-    <desc>Visual domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
+    <desc xml:lang="en">Visual domain attributes that describe the properties of a stem in the mensural repertoire.</desc>
     <classes>
         <memberOf key="att.xy"/>
         <memberOf key="att.color"/>
     </classes>
     <attList>
       <attDef ident="pos" usage="opt">
-        <desc>Records the position of the stem in relation to the note head(s).</desc>
+        <desc xml:lang="en">Records the position of the stem in relation to the note head(s).</desc>
         <datatype>
           <rng:ref name="data.STEMPOSITION"/>
         </datatype>
       </attDef>
       <attDef ident="len" usage="opt">
-        <desc>Encodes the stem length.</desc>
+        <desc xml:lang="en">Encodes the stem length.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTABS"/>
         </datatype>
       </attDef>
       <attDef ident="form" usage="opt">
-        <desc>Encodes the form of the stem using the values provided by the data.STEMFORM.mensural datatype.</desc>
+        <desc xml:lang="en">Encodes the form of the stem using the values provided by the data.STEMFORM.mensural datatype.</desc>
         <datatype>
           <rng:ref name="data.STEMFORM.mensural"/>
         </datatype>
       </attDef>
       <attDef ident="dir" usage="opt">
-        <desc>Describes the direction of a stem.</desc>
+        <desc xml:lang="en">Describes the direction of a stem.</desc>
         <datatype>
           <rng:ref name="data.STEMDIRECTION"/>
         </datatype>
       </attDef>
       <attDef ident="flag.pos" usage="opt">
-        <desc>Records the position of the flag using the values provided by the data.FLAGPOS.mensural datatype.</desc>
+        <desc xml:lang="en">Records the position of the flag using the values provided by the data.FLAGPOS.mensural datatype.</desc>
         <datatype>
           <rng:ref name="data.FLAGPOS.mensural"/>
         </datatype>
       </attDef>
       <attDef ident="flag.form" usage="opt">
-        <desc>Encodes the form of the flag using the values provided by the data.FLAGFORM.mensural datatype.</desc>
+        <desc xml:lang="en">Encodes the form of the flag using the values provided by the data.FLAGFORM.mensural datatype.</desc>
         <datatype>
           <rng:ref name="data.FLAGFORM.mensural"/>
         </datatype>
@@ -420,10 +420,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.stems.mensural" module="MEI.mensural" type="atts">
-      <desc>Attributes that describe the properties of stemmed features specific to mensural repertoires.</desc>
+      <desc xml:lang="en">Attributes that describe the properties of stemmed features specific to mensural repertoires.</desc>
       <attList>
           <attDef ident="stem.form" usage="opt">
-              <desc>Records the form of the stem.</desc>
+              <desc xml:lang="en">Records the form of the stem.</desc>
               <datatype maxOccurs="1" minOccurs="1">
                   <rng:ref name="data.STEMFORM.mensural"/>
               </datatype>
@@ -431,41 +431,41 @@
       </attList>
   </classSpec>
   <classSpec ident="model.eventLike.mensural" module="MEI.mensural" type="model">
-    <desc>Groups event elements that occur in the mensural repertoire.</desc>
+    <desc xml:lang="en">Groups event elements that occur in the mensural repertoire.</desc>
     <classes>
       <memberOf key="model.layerPart.mensural"/>
     </classes>
   </classSpec>
   <classSpec ident="model.layerPart.mensural" module="MEI.mensural" type="model">
-    <desc>Groups notated events that may appear at the layer level in the mensural
+    <desc xml:lang="en">Groups notated events that may appear at the layer level in the mensural
       repertoire.</desc>
     <classes>
       <memberOf key="model.layerPart.mensuralAndNeumes"/>
     </classes>
   </classSpec>
   <classSpec ident="model.scorePart.mensural" module="MEI.mensural" type="model">
-    <desc>Groups elements that may appear as part of a score in the mensural repertoire.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of a score in the mensural repertoire.</desc>
   </classSpec>
   <classSpec ident="model.sectionPart.mensural" module="MEI.mensural" type="model">
-    <desc>Groups elements that may appear as part of a section in the mensural repertoire.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of a section in the mensural repertoire.</desc>
     <classes>
       <memberOf key="model.sectionPart.mensuralAndNeumes"/>
     </classes>
   </classSpec>
   <classSpec ident="model.staffDefPart.mensural" module="MEI.mensural" type="model">
-    <desc>Groups elements that may appear in the declaration of staff features.</desc>
+    <desc xml:lang="en">Groups elements that may appear in the declaration of staff features.</desc>
     <classes>
       <memberOf key="model.staffDefPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.staffPart.mensural" module="MEI.mensural" type="model">
-    <desc>Groups elements that are components of a staff in the mensural repertoire.</desc>
+    <desc xml:lang="en">Groups elements that are components of a staff in the mensural repertoire.</desc>
     <classes>
       <memberOf key="model.staffPart.mensuralAndNeumes"/>
     </classes>
   </classSpec>
   <elementSpec ident="ligature" module="MEI.mensural">
-    <desc>A mensural notation symbol that combines two or more notes into a single sign.</desc>
+    <desc xml:lang="en">A mensural notation symbol that combines two or more notes into a single sign.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -497,7 +497,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="mensur" module="MEI.mensural">
-    <desc>(mensuration) – Collects information about the metrical relationship between a note value
+    <desc xml:lang="en">(mensuration) – Collects information about the metrical relationship between a note value
       and the next smaller value; that is, either triple or duple.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -519,7 +519,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="plica" module="MEI.mensural">
-    <desc>Plica</desc>
+    <desc xml:lang="en">Plica</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -537,7 +537,7 @@
     </constraintSpec>
   </elementSpec>
   <elementSpec ident="proport" module="MEI.mensural">
-    <desc>(proportion) – Description of note duration as arithmetic ratio.</desc>
+    <desc xml:lang="en">(proportion) – Description of note duration as arithmetic ratio.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -559,7 +559,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="stem" module="MEI.mensural">
-    <desc>A stem element.</desc>
+    <desc xml:lang="en">A stem element.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -109,7 +109,7 @@
         </valItem>
       </valList>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
         <p>
             <!-- TODO: Add samples for all values here  -->
             <!--<graphic url="ExampleImages/accid-20100510.png" height="50%" width="50%"/>-->
@@ -487,7 +487,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The rhythmic meaning of the components of a ligature is typically contextual, not absolute;
         therefore, an interpretative duration may be encoded on each of the components using either
         the <att>dur.ges</att> attribute or the <att>num</att> and <att>numbase</att> attribute
@@ -512,7 +512,7 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <gi scheme="MEI">mensur</gi> element is provided for the encoding of mensural notation.
         The <att>slash</att> attribute indicates the number lines added to the mensuration sign. For
         example, one slash is added for what we now call 'alla breve'.</p>
@@ -551,7 +551,7 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The proport element is provided for the encoding of mensural notation. It allows the
         description of note durations as arithmetic ratios. While mensuration refers to the normal
         relationships between note durations, proportion affects the relations of the note durations
@@ -578,7 +578,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Mensural notes can have multiple stems and these may have various forms, directions, and types of flags.
         Multiple stem elements can be encoded as children of a single note. The attributes <att>pos</att>,
         <att>length</att>, <att>form</att>, and <att>dir</att> allow to encode different positions, lengths,

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -497,7 +497,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="mensur" module="MEI.mensural">
-    <desc xml:lang="en">(mensuration) – Collects information about the metrical relationship between a note value
+    <gloss versionDate="2022-05-18" xml:lang="en">mensuration</gloss>
+    <desc xml:lang="en">Collects information about the metrical relationship between a note value
       and the next smaller value; that is, either triple or duple.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -537,7 +538,8 @@
     </constraintSpec>
   </elementSpec>
   <elementSpec ident="proport" module="MEI.mensural">
-    <desc xml:lang="en">(proportion) – Description of note duration as arithmetic ratio.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">proportion</gloss>
+    <desc xml:lang="en">Description of note duration as arithmetic ratio.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>

--- a/source/modules/MEI.midi.xml
+++ b/source/modules/MEI.midi.xml
@@ -5,31 +5,31 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.midi">
   <moduleSpec ident="MEI.midi">
-    <desc>MIDI component declarations.</desc>
+    <desc xml:lang="en">MIDI component declarations.</desc>
   </moduleSpec>
   <classSpec ident="att.channelized" module="MEI.midi" type="atts">
-    <desc>Attributes that record MIDI channel information.</desc>
+    <desc xml:lang="en">Attributes that record MIDI channel information.</desc>
     <attList>
       <attDef ident="midi.channel" usage="opt">
-        <desc>Records a MIDI channel value.</desc>
+        <desc xml:lang="en">Records a MIDI channel value.</desc>
         <datatype>
           <rng:ref name="data.MIDICHANNEL"/>
         </datatype>
       </attDef>
       <attDef ident="midi.duty" usage="opt">
-        <desc>Specifies the 'on' part of the duty cycle as a percentage of a note’s duration.</desc>
+        <desc xml:lang="en">Specifies the 'on' part of the duty cycle as a percentage of a note’s duration.</desc>
         <datatype>
           <rng:ref name="data.PERCENT.LIMITED"/>
         </datatype>
       </attDef>
       <attDef ident="midi.port" usage="opt">
-        <desc>Sets the MIDI port value.</desc>
+        <desc xml:lang="en">Sets the MIDI port value.</desc>
         <datatype>
           <rng:ref name="data.MIDIVALUE_NAME"/>
         </datatype>
       </attDef>
       <attDef ident="midi.track" usage="opt">
-        <desc>Sets the MIDI track.</desc>
+        <desc xml:lang="en">Sets the MIDI track.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
@@ -37,13 +37,13 @@
     </attList>
   </classSpec>
   <classSpec ident="att.instrDef.log" module="MEI.midi" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.instrumentIdent" module="MEI.midi" type="atts">
-    <desc>Attributes which identify a MIDI instrument.</desc>
+    <desc xml:lang="en">Attributes which identify a MIDI instrument.</desc>
     <attList>
       <attDef ident="instr" usage="opt">
-        <desc>Provides a way of pointing to a MIDI instrument definition. It must contain the ID of
+        <desc xml:lang="en">Provides a way of pointing to a MIDI instrument definition. It must contain the ID of
           an <gi scheme="MEI">instrDef</gi> element elsewhere in the document.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
@@ -64,7 +64,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.midi.event" module="MEI.midi" type="atts">
-    <desc>Attributes common to MIDI events.</desc>
+    <desc xml:lang="en">Attributes common to MIDI events.</desc>
     <classes>
       <memberOf key="att.layerIdent"/>
       <memberOf key="att.partIdent"/>
@@ -74,7 +74,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.midi.log" module="MEI.midi" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.layerIdent"/>
       <memberOf key="att.partIdent"/>
@@ -82,7 +82,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.midiInstrument" module="MEI.midi" type="atts">
-    <desc>Attributes that record MIDI instrument information.</desc>
+    <desc xml:lang="en">Attributes that record MIDI instrument information.</desc>
     <constraintSpec ident="One_of_instrname_or_instrnum" scheme="isoschematron">
       <constraint>
         <sch:rule context="mei:*[@midi.instrname]">
@@ -101,20 +101,20 @@
     </constraintSpec>
     <attList>
       <attDef ident="midi.instrnum" usage="opt">
-        <desc>Captures the General MIDI instrument number. Use an integer for a 0-based value. An
+        <desc xml:lang="en">Captures the General MIDI instrument number. Use an integer for a 0-based value. An
           integer preceded by "in" indicates a 1-based value.</desc>
         <datatype>
           <rng:ref name="data.MIDIVALUE"/>
         </datatype>
       </attDef>
       <attDef ident="midi.instrname" usage="opt">
-        <desc>Provides a General MIDI label for the MIDI instrument.</desc>
+        <desc xml:lang="en">Provides a General MIDI label for the MIDI instrument.</desc>
         <datatype>
           <rng:ref name="data.MIDINAMES"/>
         </datatype>
       </attDef>
       <attDef ident="midi.pan" usage="opt">
-        <desc>Sets the instrument’s position in a stereo field. MIDI values of 0 and 1 both pan
+        <desc xml:lang="en">Sets the instrument’s position in a stereo field. MIDI values of 0 and 1 both pan
           left, 127 or 128 pans right, and 63 or 64 pans to the center. Positve percentage values
           pan to the right, negative ones to the left. 0% is centered.</desc>
         <datatype>
@@ -122,19 +122,19 @@
         </datatype>
       </attDef>
       <attDef ident="midi.patchname" usage="opt">
-        <desc>Records a non-General MIDI patch/instrument name.</desc>
+        <desc xml:lang="en">Records a non-General MIDI patch/instrument name.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
       </attDef>
       <attDef ident="midi.patchnum" usage="opt">
-        <desc>Records a non-General MIDI patch/instrument number.</desc>
+        <desc xml:lang="en">Records a non-General MIDI patch/instrument number.</desc>
         <datatype>
           <rng:ref name="data.MIDIVALUE"/>
         </datatype>
       </attDef>
       <attDef ident="midi.volume" usage="opt">
-        <desc>Sets the instrument’s volume.</desc>
+        <desc xml:lang="en">Sets the instrument’s volume.</desc>
         <datatype>
           <rng:ref name="data.MIDIVALUE_PERCENT"/>
         </datatype>
@@ -142,10 +142,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.midiNumber" module="MEI.midi" type="atts">
-    <desc>Attributes that record MIDI numbers.</desc>
+    <desc xml:lang="en">Attributes that record MIDI numbers.</desc>
     <attList>
       <attDef ident="num" usage="req">
-        <desc>MIDI number in the range set by data.MIDIVALUE.</desc>
+        <desc xml:lang="en">MIDI number in the range set by data.MIDIVALUE.</desc>
         <datatype>
           <rng:ref name="data.MIDIVALUE"/>
         </datatype>
@@ -153,10 +153,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.midiTempo" module="MEI.midi" type="atts">
-    <desc>Attributes that record MIDI tempo information.</desc>
+    <desc xml:lang="en">Attributes that record MIDI tempo information.</desc>
     <attList>
       <attDef ident="midi.bpm" usage="opt">
-        <desc>Captures the number of *quarter notes* per minute. In MIDI, a beat is always defined
+        <desc xml:lang="en">Captures the number of *quarter notes* per minute. In MIDI, a beat is always defined
           as a quarter note, *not the numerator of the time signature or the metronomic
           indication*.</desc>
         <datatype>
@@ -164,7 +164,7 @@
         </datatype>
       </attDef>
       <attDef ident="midi.mspb" usage="opt">
-        <desc>Records the number of microseconds per *quarter note*. In MIDI, a beat is always
+        <desc xml:lang="en">Records the number of microseconds per *quarter note*. In MIDI, a beat is always
           defined as a quarter note, *not the numerator of the time signature or the metronomic
           indication*. At 120 quarter notes per minute, each quarter note will last 500,000
           microseconds.</desc>
@@ -175,10 +175,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.midiValue" module="MEI.midi" type="atts">
-    <desc>Attributes that record MIDI values.</desc>
+    <desc xml:lang="en">Attributes that record MIDI values.</desc>
     <attList>
       <attDef ident="val" usage="opt">
-        <desc>MIDI number.</desc>
+        <desc xml:lang="en">MIDI number.</desc>
         <datatype>
           <rng:ref name="data.MIDIVALUE"/>
         </datatype>
@@ -186,10 +186,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.midiValue2" module="MEI.midi" type="atts">
-    <desc>Attributes that record terminal MIDI values.</desc>
+    <desc xml:lang="en">Attributes that record terminal MIDI values.</desc>
     <attList>
       <attDef ident="val2" usage="opt">
-        <desc>MIDI number.</desc>
+        <desc xml:lang="en">MIDI number.</desc>
         <datatype>
           <rng:ref name="data.MIDIVALUE"/>
         </datatype>
@@ -197,10 +197,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.midiVelocity" module="MEI.midi" type="atts">
-    <desc>MIDI attributes pertaining to key velocity.</desc>
+    <desc xml:lang="en">MIDI attributes pertaining to key velocity.</desc>
     <attList>
       <attDef ident="vel" usage="opt">
-        <desc>MIDI Note-on/off velocity.</desc>
+        <desc xml:lang="en">MIDI Note-on/off velocity.</desc>
         <datatype>
           <rng:ref name="data.MIDIVALUE"/>
         </datatype>
@@ -208,10 +208,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.timeBase" module="MEI.midi" type="atts">
-    <desc>Attributes that record time-base information.</desc>
+    <desc xml:lang="en">Attributes that record time-base information.</desc>
     <attList>
       <attDef ident="ppq" usage="opt">
-        <desc>Indicates the number of pulses (sometimes referred to as ticks or divisions) per
+        <desc xml:lang="en">Indicates the number of pulses (sometimes referred to as ticks or divisions) per
           quarter note. Unlike MIDI, MEI permits different values for a score and individual
           staves.</desc>
         <datatype>
@@ -221,7 +221,7 @@
     </attList>
   </classSpec>
   <classSpec ident="model.midiLike" module="MEI.midi" type="model">
-    <desc>Groups elements which group MIDI-like elements.</desc>
+    <desc xml:lang="en">Groups elements which group MIDI-like elements.</desc>
     <classes>
       <memberOf key="model.layerPart.mensuralAndNeumes"/>
       <memberOf key="model.measurePart"/>
@@ -229,7 +229,7 @@
     </classes>
   </classSpec>
   <elementSpec ident="cc" module="MEI.midi">
-    <desc>(control change) – MIDI parameter/control change.</desc>
+    <desc xml:lang="en">(control change) – MIDI parameter/control change.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.midi.event"/>
@@ -245,7 +245,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="chan" module="MEI.midi">
-    <desc>(channel) – MIDI channel assignment.</desc>
+    <desc xml:lang="en">(channel) – MIDI channel assignment.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.midi.event"/>
@@ -255,7 +255,7 @@
     </content>
     <attList>
       <attDef ident="num" usage="req">
-        <desc>MIDI number in the range set by data.MIDICHANNEL.</desc>
+        <desc xml:lang="en">MIDI number in the range set by data.MIDICHANNEL.</desc>
         <datatype>
           <rng:ref name="data.MIDICHANNEL"/>
         </datatype>
@@ -263,7 +263,7 @@
     </attList>
   </elementSpec>
   <elementSpec ident="chanPr" module="MEI.midi">
-    <desc>(channel pressure) – MIDI channel pressure/after touch.</desc>
+    <desc xml:lang="en">(channel pressure) – MIDI channel pressure/after touch.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.midi.event"/>
@@ -277,7 +277,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="cue" module="MEI.midi">
-    <desc>MIDI cue point.</desc>
+    <desc xml:lang="en">MIDI cue point.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.lang"/>
@@ -288,7 +288,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="hex" module="MEI.midi">
-    <desc>Arbitrary MIDI data in hexadecimal form.</desc>
+    <desc xml:lang="en">Arbitrary MIDI data in hexadecimal form.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.midi.event"/>
@@ -301,7 +301,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="instrDef" module="MEI.midi">
-    <desc>(instrument definition) – MIDI instrument declaration.</desc>
+    <desc xml:lang="en">(instrument definition) – MIDI instrument declaration.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.instrDef.anl"/>
@@ -320,7 +320,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="instrGrp" module="MEI.midi">
-    <desc>(instrument group) – Collects MIDI instrument definitions.</desc>
+    <desc xml:lang="en">(instrument group) – Collects MIDI instrument definitions.</desc>
     <classes>
       <memberOf key="att.common"/>
     </classes>
@@ -331,7 +331,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="marker" module="MEI.midi">
-    <desc>MIDI marker meta-event.</desc>
+    <desc xml:lang="en">MIDI marker meta-event.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.lang"/>
@@ -342,7 +342,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="metaText" module="MEI.midi">
-    <desc>MIDI text meta-event.</desc>
+    <desc xml:lang="en">MIDI text meta-event.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.lang"/>
@@ -353,7 +353,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="midi" module="MEI.midi">
-    <desc>Container for elements that contain information useful when generating MIDI output.</desc>
+    <desc xml:lang="en">Container for elements that contain information useful when generating MIDI output.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.midi.log"/>
@@ -387,7 +387,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="noteOff" module="MEI.midi">
-    <desc>MIDI note-off event.</desc>
+    <desc xml:lang="en">MIDI note-off event.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.midi.event"/>
@@ -398,7 +398,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="noteOn" module="MEI.midi">
-    <desc>MIDI note-on event.</desc>
+    <desc xml:lang="en">MIDI note-on event.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.midi.event"/>
@@ -409,7 +409,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="port" module="MEI.midi">
-    <desc>MIDI port.</desc>
+    <desc xml:lang="en">MIDI port.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.midi.event"/>
@@ -420,7 +420,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="prog" module="MEI.midi">
-    <desc>(program) – MIDI program change.</desc>
+    <desc xml:lang="en">(program) – MIDI program change.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.midi.event"/>
@@ -431,7 +431,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="seqNum" module="MEI.midi">
-    <desc>(sequence number) – MIDI sequence number.</desc>
+    <desc xml:lang="en">(sequence number) – MIDI sequence number.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.midi.event"/>
@@ -441,7 +441,7 @@
     </content>
     <attList>
       <attDef ident="num" usage="req">
-        <desc>Number in the range 0-65535.</desc>
+        <desc xml:lang="en">Number in the range 0-65535.</desc>
         <datatype>
           <rng:data type="nonNegativeInteger">
             <rng:param name="maxInclusive">65535</rng:param>
@@ -451,7 +451,7 @@
     </attList>
   </elementSpec>
   <elementSpec ident="trkName" module="MEI.midi">
-    <desc>(track name) – MIDI track/sequence name.</desc>
+    <desc xml:lang="en">(track name) – MIDI track/sequence name.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.lang"/>
@@ -462,7 +462,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="vel" module="MEI.midi">
-    <desc>(velocity) – MIDI Note-on/off velocity.</desc>
+    <desc xml:lang="en">(velocity) – MIDI Note-on/off velocity.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.midi.event"/>
@@ -473,13 +473,13 @@
     </content>
     <attList>
       <attDef ident="form" usage="req">
-        <desc>Indicates whether this is note-on or note-off velocity data.</desc>
+        <desc xml:lang="en">Indicates whether this is note-on or note-off velocity data.</desc>
         <valList type="closed">
           <valItem ident="on">
-            <desc>Note-on velocity.</desc>
+            <desc xml:lang="en">Note-on velocity.</desc>
           </valItem>
           <valItem ident="off">
-            <desc>Note-off velocity.</desc>
+            <desc xml:lang="en">Note-off velocity.</desc>
           </valItem>
         </valList>
       </attDef>

--- a/source/modules/MEI.midi.xml
+++ b/source/modules/MEI.midi.xml
@@ -229,7 +229,8 @@
     </classes>
   </classSpec>
   <elementSpec ident="cc" module="MEI.midi">
-    <desc xml:lang="en">(control change) – MIDI parameter/control change.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">control change</gloss>
+    <desc xml:lang="en">MIDI parameter/control change.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.midi.event"/>
@@ -245,7 +246,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="chan" module="MEI.midi">
-    <desc xml:lang="en">(channel) – MIDI channel assignment.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">channel</gloss>
+    <desc xml:lang="en">MIDI channel assignment.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.midi.event"/>
@@ -263,7 +265,8 @@
     </attList>
   </elementSpec>
   <elementSpec ident="chanPr" module="MEI.midi">
-    <desc xml:lang="en">(channel pressure) – MIDI channel pressure/after touch.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">channel pressure</gloss>
+    <desc xml:lang="en">MIDI channel pressure/after touch.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.midi.event"/>
@@ -301,7 +304,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="instrDef" module="MEI.midi">
-    <desc xml:lang="en">(instrument definition) – MIDI instrument declaration.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">instrument definition</gloss>
+    <desc xml:lang="en">MIDI instrument declaration.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.instrDef.anl"/>
@@ -320,7 +324,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="instrGrp" module="MEI.midi">
-    <desc xml:lang="en">(instrument group) – Collects MIDI instrument definitions.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">instrument group</gloss>
+    <desc xml:lang="en">Collects MIDI instrument definitions.</desc>
     <classes>
       <memberOf key="att.common"/>
     </classes>
@@ -420,7 +425,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="prog" module="MEI.midi">
-    <desc xml:lang="en">(program) – MIDI program change.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">program</gloss>
+    <desc xml:lang="en">MIDI program change.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.midi.event"/>
@@ -431,7 +437,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="seqNum" module="MEI.midi">
-    <desc xml:lang="en">(sequence number) – MIDI sequence number.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">sequence number</gloss>
+    <desc xml:lang="en">MIDI sequence number.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.midi.event"/>
@@ -451,7 +458,8 @@
     </attList>
   </elementSpec>
   <elementSpec ident="trkName" module="MEI.midi">
-    <desc xml:lang="en">(track name) – MIDI track/sequence name.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">track name</gloss>
+    <desc xml:lang="en">MIDI track/sequence name.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.lang"/>
@@ -462,7 +470,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="vel" module="MEI.midi">
-    <desc xml:lang="en">(velocity) – MIDI Note-on/off velocity.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">velocity</gloss>
+    <desc xml:lang="en">MIDI Note-on/off velocity.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.midi.event"/>

--- a/source/modules/MEI.midi.xml
+++ b/source/modules/MEI.midi.xml
@@ -239,7 +239,7 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>num</att> attribute specifies a MIDI parameter number, while <att>val</att>
         contains the parameter value. Each must fall in the range 0-127.</p>
     </remarks>
@@ -272,7 +272,7 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The value of the <att>num</att> attribute must be in the range 0-127.</p>
     </remarks>
   </elementSpec>
@@ -296,7 +296,7 @@
     <content>
       <rng:text/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The element’s content must be wrapped in a CDATA section to avoid parsing errors.</p>
     </remarks>
   </elementSpec>
@@ -313,7 +313,7 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element provides a starting or default instrument declaration for a staff, a group of
         staves, or a layer. Following scoreDef, staffDef, layerDef, or MIDI prog elements may then
         change the instrument as necessary.</p>
@@ -381,7 +381,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>label</att> attribute can be used to differentiate between multiple MIDI data
         streams, <abbr>e.g.</abbr>, quantized/unquantized, straight/swing, ornamented/as notated, etc.</p>
     </remarks>

--- a/source/modules/MEI.msDesc.xml
+++ b/source/modules/MEI.msDesc.xml
@@ -5,10 +5,10 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.msDesc">
   <moduleSpec ident="MEI.msDesc">
-    <desc>Manuscript description component declarations.</desc>
+    <desc xml:lang="en">Manuscript description component declarations.</desc>
   </moduleSpec>
   <classSpec ident="att.componentType" type="atts" module="MEI.msDesc">
-    <desc>Attributes that express the relationship between a component and its host.</desc>
+    <desc xml:lang="en">Attributes that express the relationship between a component and its host.</desc>
     <attList>
       <attDef ident="comptype" usage="opt">
         <constraintSpec ident="checkComponentType" scheme="isoschematron">
@@ -23,27 +23,27 @@
         </constraintSpec>
         <valList type="closed">
           <valItem ident="constituent">
-            <desc>A physical and logical part of entity.</desc>
+            <desc xml:lang="en">A physical and logical part of entity.</desc>
           </valItem>
           <valItem ident="boundwith">
-            <desc>A physical, but not logical component of the entity, usually included as part of
+            <desc xml:lang="en">A physical, but not logical component of the entity, usually included as part of
               the binding process.</desc>
           </valItem>
           <valItem ident="separated">
-            <desc>A logical component of the entity physically held elsewhere.</desc>
+            <desc xml:lang="en">A logical component of the entity physically held elsewhere.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="model.msInline" type="model" module="MEI.msDesc">
-    <desc>Groups elements that may appear inline when the msdesc module is active.</desc>
+    <desc xml:lang="en">Groups elements that may appear inline when the msdesc module is active.</desc>
     <classes>
       <memberOf key="model.textPhraseLike.limited"/>
     </classes>
   </classSpec>
   <elementSpec ident="accMat" module="MEI.msDesc">
-    <desc>Holds a description of any additional material bound with an item, such as
+    <desc xml:lang="en">Holds a description of any additional material bound with an item, such as
       non-contemporaneous documents or fragments.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -59,7 +59,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="addDesc" module="MEI.msDesc">
-    <desc>(addition description) – Provides a description of significant additions found within an
+    <desc xml:lang="en">(addition description) – Provides a description of significant additions found within an
       item, such as marginalia or other annotations.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -75,7 +75,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="binding" module="MEI.msDesc">
-    <desc>(binding) – Contains a description of one binding, <abbr>i.e.</abbr>, type of covering, boards, etc.
+    <desc xml:lang="en">(binding) – Contains a description of one binding, <abbr>i.e.</abbr>, type of covering, boards, etc.
       applied to an item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -108,7 +108,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="bindingDesc" module="MEI.msDesc">
-    <desc>(binding description) – Describes the present and former bindings of an item.</desc>
+    <desc xml:lang="en">(binding description) – Describes the present and former bindings of an item.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -145,7 +145,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="catchwords" module="MEI.msDesc">
-    <desc>Describes the system used to ensure correct ordering of the quires making up an item,
+    <desc xml:lang="en">Describes the system used to ensure correct ordering of the quires making up an item,
       typically by means of annotations at the foot of the page.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -162,7 +162,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="collation" module="MEI.msDesc">
-    <desc>Records a description of how the leaves or bifolia of an item are physically
+    <desc xml:lang="en">Records a description of how the leaves or bifolia of an item are physically
       arranged.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -177,7 +177,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="colophon" module="MEI.msDesc">
-    <desc>Contains a statement providing information regarding the date, place, agency, or reason
+    <desc xml:lang="en">Contains a statement providing information regarding the date, place, agency, or reason
       for production of the item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -194,7 +194,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="decoDesc" module="MEI.msDesc">
-    <desc>(decoration description) – Contains a description of the decoration of an item.</desc>
+    <desc xml:lang="en">(decoration description) – Contains a description of the decoration of an item.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -228,7 +228,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="decoNote" module="MEI.msDesc">
-    <desc>(decoration note) – Contains a description of one or more decorative features of an
+    <desc xml:lang="en">(decoration note) – Contains a description of one or more decorative features of an
       item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -262,7 +262,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="explicit" module="MEI.msDesc">
-    <desc>Contains the explicit of a manuscript item; that is, the closing words of the text proper,
+    <desc xml:lang="en">Contains the explicit of a manuscript item; that is, the closing words of the text proper,
       exclusive of any rubric or colophon which might follow it.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -279,7 +279,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="foliation" module="MEI.msDesc">
-    <desc>Describes the numbering system or systems used to count the leaves or pages in a
+    <desc xml:lang="en">Describes the numbering system or systems used to count the leaves or pages in a
       codex.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -294,7 +294,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="heraldry" module="MEI.msDesc">
-    <desc>Contains a heraldic formula or phrase, typically found as part of a blazon, coat of arms,
+    <desc xml:lang="en">Contains a heraldic formula or phrase, typically found as part of a blazon, coat of arms,
       etc.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -312,7 +312,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="layout" module="MEI.msDesc">
-    <desc>Describes how text is laid out on the page, including information about any ruling,
+    <desc xml:lang="en">Describes how text is laid out on the page, including information about any ruling,
       pricking, or other evidence of page-preparation techniques.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -324,7 +324,7 @@
     </content>
     <attList>
       <attDef ident="cols" usage="opt">
-        <desc>Specifies the number of columns per page.</desc>
+        <desc xml:lang="en">Specifies the number of columns per page.</desc>
         <datatype minOccurs="1" maxOccurs="2">
           <rng:data type="nonNegativeInteger"/>
         </datatype>
@@ -334,7 +334,7 @@
         </remarks>
       </attDef>
       <attDef ident="ruledlines" usage="opt">
-        <desc>Specifies the number of ruled text lines per column.</desc>
+        <desc xml:lang="en">Specifies the number of ruled text lines per column.</desc>
         <datatype minOccurs="1" maxOccurs="2">
           <rng:data type="nonNegativeInteger"/>
         </datatype>
@@ -345,7 +345,7 @@
         </remarks>
       </attDef>
       <attDef ident="writtenlines" usage="opt">
-        <desc>Specifies the number of written text lines per column.</desc>
+        <desc xml:lang="en">Specifies the number of written text lines per column.</desc>
         <datatype minOccurs="1" maxOccurs="2">
           <rng:data type="nonNegativeInteger"/>
         </datatype>
@@ -356,7 +356,7 @@
         </remarks>
       </attDef>
       <attDef ident="ruledstaves" usage="opt">
-        <desc>Specifies the number of ruled staves per column.</desc>
+        <desc xml:lang="en">Specifies the number of ruled staves per column.</desc>
         <datatype minOccurs="1" maxOccurs="2">
           <rng:data type="nonNegativeInteger"/>
         </datatype>
@@ -367,7 +367,7 @@
         </remarks>
       </attDef>
       <attDef ident="writtenstaves" usage="opt">
-        <desc>Specifies the number of written staves per column.</desc>
+        <desc xml:lang="en">Specifies the number of written staves per column.</desc>
         <datatype minOccurs="1" maxOccurs="2">
           <rng:data type="nonNegativeInteger"/>
         </datatype>
@@ -383,7 +383,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="layoutDesc" module="MEI.msDesc">
-    <desc>(layout description) – Collects layout descriptions.</desc>
+    <desc xml:lang="en">(layout description) – Collects layout descriptions.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -416,7 +416,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="locus" module="MEI.msDesc">
-    <desc>Defines a location within a manuscript or manuscript component, usually as a (possibly
+    <desc xml:lang="en">Defines a location within a manuscript or manuscript component, usually as a (possibly
       discontinuous) sequence of folio references.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -436,7 +436,7 @@
     </content>
     <attList>
       <attDef ident="scheme" usage="opt">
-        <desc>Identifies the foliation scheme in terms of which the location is being specified by
+        <desc xml:lang="en">Identifies the foliation scheme in terms of which the location is being specified by
           pointing to some foliation element defining it, or to some other equivalent
           resource.</desc>
         <datatype>
@@ -444,13 +444,13 @@
         </datatype>
       </attDef>
       <attDef ident="from" usage="opt">
-        <desc>Specifies the starting point of the location in a normalized form.</desc>
+        <desc xml:lang="en">Specifies the starting point of the location in a normalized form.</desc>
         <datatype>
           <rng:ref name="data.WORD"/>
         </datatype>
       </attDef>
       <attDef ident="to" usage="opt">
-        <desc>Specifies the end-point of the location in a normalized form.</desc>
+        <desc xml:lang="en">Specifies the end-point of the location in a normalized form.</desc>
         <datatype>
           <rng:ref name="data.WORD"/>
         </datatype>
@@ -461,7 +461,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="locusGrp" module="MEI.msDesc">
-    <desc>(locus group) – Groups locations which together form a distinct but discontinuous item
+    <desc xml:lang="en">(locus group) – Groups locations which together form a distinct but discontinuous item
       within a manuscript or manuscript part, according to a specific foliation.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -476,7 +476,7 @@
     </content>
     <attList>
       <attDef ident="scheme" usage="opt">
-        <desc>Identifies the foliation scheme in terms of which the location is being specified by
+        <desc xml:lang="en">Identifies the foliation scheme in terms of which the location is being specified by
           pointing to some foliation element defining it, or to some other equivalent
           resource.</desc>
         <datatype>
@@ -489,7 +489,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="rubric" module="MEI.msDesc">
-    <desc>Contains a string of words through which a manuscript signals the beginning or end of a
+    <desc xml:lang="en">Contains a string of words through which a manuscript signals the beginning or end of a
       text division, often with an assertion as to its author and title, which is in some way set
       off from the text itself, usually in red ink, or by use of different size or type of script,
       or some other such visual device.</desc>
@@ -507,10 +507,10 @@
       <attDef ident="func">
         <valList type="closed">
           <valItem ident="initial">
-            <desc>Signals beginning of a text division.</desc>
+            <desc xml:lang="en">Signals beginning of a text division.</desc>
           </valItem>
           <valItem ident="final">
-            <desc>Makrs the end of a text division.</desc>
+            <desc xml:lang="en">Makrs the end of a text division.</desc>
           </valItem>
         </valList>
       </attDef>
@@ -520,7 +520,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="scriptDesc" module="MEI.msDesc">
-    <desc>(script description) – Contains a description of the letters or characters used in an
+    <desc xml:lang="en">(script description) – Contains a description of the letters or characters used in an
       autographic item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -554,7 +554,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="scriptNote" module="MEI.msDesc">
-    <desc>(script note) – Describes a particular script distinguished within the description of an
+    <desc xml:lang="en">(script note) – Describes a particular script distinguished within the description of an
       autographic item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -569,7 +569,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="seal" module="MEI.msDesc">
-    <desc>A single seal or similar attachment.</desc>
+    <desc xml:lang="en">A single seal or similar attachment.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -610,7 +610,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="sealDesc" module="MEI.msDesc">
-    <desc>(seal description) – Describes the seals or similar external attachments applied to an
+    <desc xml:lang="en">(seal description) – Describes the seals or similar external attachments applied to an
       item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -650,7 +650,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="secFolio" module="MEI.msDesc">
-    <desc>(second folio) – Marks the word or words taken from a fixed point in a codex (typically
+    <desc xml:lang="en">(second folio) – Marks the word or words taken from a fixed point in a codex (typically
       the beginning of the second leaf) in order to provide a unique identifier for the item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -668,7 +668,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="signatures" module="MEI.msDesc">
-    <desc>Provides a description of the leaf or quire signatures found within a codex.</desc>
+    <desc xml:lang="en">Provides a description of the leaf or quire signatures found within a codex.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -684,7 +684,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="stamp" module="MEI.msDesc">
-    <desc>Contains a word or phrase describing an official mark indicating ownership, genuineness,
+    <desc xml:lang="en">Contains a word or phrase describing an official mark indicating ownership, genuineness,
       validity, etc.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -703,7 +703,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="support" module="MEI.msDesc">
-    <desc>Provides a description of the physical support material of a written item.</desc>
+    <desc xml:lang="en">Provides a description of the physical support material of a written item.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -727,7 +727,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="supportDesc" module="MEI.msDesc">
-    <desc>(support description) – Groups elements describing the physical support material of an
+    <desc xml:lang="en">(support description) – Groups elements describing the physical support material of an
       item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -771,20 +771,20 @@
     </content>
     <attList>
       <attDef ident="material" usage="opt">
-        <desc>Short, project-defined name for the material composing the majority of the
+        <desc xml:lang="en">Short, project-defined name for the material composing the majority of the
           support.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="paper">
-            <desc>Paper.</desc>
+            <desc xml:lang="en">Paper.</desc>
           </valItem>
           <valItem ident="parch">
-            <desc>Parchment.</desc>
+            <desc xml:lang="en">Parchment.</desc>
           </valItem>
           <valItem ident="mixed">
-            <desc>Mixed materials.</desc>
+            <desc xml:lang="en">Mixed materials.</desc>
           </valItem>
         </valList>
       </attDef>
@@ -794,7 +794,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="typeDesc" module="MEI.msDesc">
-    <desc>(type description) – Contains a description of the typefaces or other aspects of the
+    <desc xml:lang="en">(type description) – Contains a description of the typefaces or other aspects of the
       printing of a printed source.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -828,7 +828,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="typeNote" module="MEI.msDesc">
-    <desc>(type note) – Describes a particular font or other significant typographic feature of a
+    <desc xml:lang="en">(type note) – Describes a particular font or other significant typographic feature of a
       printed resource.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.msDesc.xml
+++ b/source/modules/MEI.msDesc.xml
@@ -59,7 +59,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="addDesc" module="MEI.msDesc">
-    <desc xml:lang="en">(addition description) – Provides a description of significant additions found within an
+    <gloss versionDate="2022-05-18" xml:lang="en">addition description</gloss>
+    <desc xml:lang="en">Provides a description of significant additions found within an
       item, such as marginalia or other annotations.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -75,7 +76,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="binding" module="MEI.msDesc">
-    <desc xml:lang="en">(binding) – Contains a description of one binding, <abbr>i.e.</abbr>, type of covering, boards, etc.
+    <gloss versionDate="2022-05-18" xml:lang="en">binding</gloss>
+    <desc xml:lang="en">Contains a description of one binding, <abbr>i.e.</abbr>, type of covering, boards, etc.
       applied to an item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -108,7 +110,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="bindingDesc" module="MEI.msDesc">
-    <desc xml:lang="en">(binding description) – Describes the present and former bindings of an item.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">binding description</gloss>
+    <desc xml:lang="en">Describes the present and former bindings of an item.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -194,7 +197,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="decoDesc" module="MEI.msDesc">
-    <desc xml:lang="en">(decoration description) – Contains a description of the decoration of an item.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">decoration description</gloss>
+    <desc xml:lang="en">Contains a description of the decoration of an item.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -228,7 +232,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="decoNote" module="MEI.msDesc">
-    <desc xml:lang="en">(decoration note) – Contains a description of one or more decorative features of an
+    <gloss versionDate="2022-05-18" xml:lang="en">decoration note</gloss>
+    <desc xml:lang="en">Contains a description of one or more decorative features of an
       item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -383,7 +388,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="layoutDesc" module="MEI.msDesc">
-    <desc xml:lang="en">(layout description) – Collects layout descriptions.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">layout description</gloss>
+    <desc xml:lang="en">Collects layout descriptions.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -461,7 +467,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="locusGrp" module="MEI.msDesc">
-    <desc xml:lang="en">(locus group) – Groups locations which together form a distinct but discontinuous item
+    <gloss versionDate="2022-05-18" xml:lang="en">locus group</gloss>
+    <desc xml:lang="en">Groups locations which together form a distinct but discontinuous item
       within a manuscript or manuscript part, according to a specific foliation.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -520,7 +527,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="scriptDesc" module="MEI.msDesc">
-    <desc xml:lang="en">(script description) – Contains a description of the letters or characters used in an
+    <gloss versionDate="2022-05-18" xml:lang="en">script description</gloss>
+    <desc xml:lang="en">Contains a description of the letters or characters used in an
       autographic item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -554,7 +562,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="scriptNote" module="MEI.msDesc">
-    <desc xml:lang="en">(script note) – Describes a particular script distinguished within the description of an
+    <gloss versionDate="2022-05-18" xml:lang="en">script note</gloss>
+    <desc xml:lang="en">Describes a particular script distinguished within the description of an
       autographic item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -610,7 +619,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="sealDesc" module="MEI.msDesc">
-    <desc xml:lang="en">(seal description) – Describes the seals or similar external attachments applied to an
+    <gloss versionDate="2022-05-18" xml:lang="en">seal description</gloss>
+    <desc xml:lang="en">Describes the seals or similar external attachments applied to an
       item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -650,7 +660,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="secFolio" module="MEI.msDesc">
-    <desc xml:lang="en">(second folio) – Marks the word or words taken from a fixed point in a codex (typically
+    <gloss versionDate="2022-05-18" xml:lang="en">second folio</gloss>
+    <desc xml:lang="en">Marks the word or words taken from a fixed point in a codex (typically
       the beginning of the second leaf) in order to provide a unique identifier for the item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -727,7 +738,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="supportDesc" module="MEI.msDesc">
-    <desc xml:lang="en">(support description) – Groups elements describing the physical support material of an
+    <gloss versionDate="2022-05-18" xml:lang="en">support description</gloss>
+    <desc xml:lang="en">Groups elements describing the physical support material of an
       item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -794,7 +806,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="typeDesc" module="MEI.msDesc">
-    <desc xml:lang="en">(type description) – Contains a description of the typefaces or other aspects of the
+    <gloss versionDate="2022-05-18" xml:lang="en">type description</gloss>
+    <desc xml:lang="en">Contains a description of the typefaces or other aspects of the
       printing of a printed source.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -828,7 +841,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="typeNote" module="MEI.msDesc">
-    <desc xml:lang="en">(type note) – Describes a particular font or other significant typographic feature of a
+    <gloss versionDate="2022-05-18" xml:lang="en">type note</gloss>
+    <desc xml:lang="en">Describes a particular font or other significant typographic feature of a
       printed resource.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.msDesc.xml
+++ b/source/modules/MEI.msDesc.xml
@@ -54,7 +54,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -70,7 +70,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -103,7 +103,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -140,7 +140,7 @@
         </rng:zeroOrMore>
       </rng:choice>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -157,7 +157,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -172,7 +172,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -189,7 +189,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -223,7 +223,7 @@
         </rng:zeroOrMore>
       </rng:choice>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -257,7 +257,7 @@
         </rng:zeroOrMore>
       </rng:choice>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -274,7 +274,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -289,7 +289,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -307,7 +307,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -328,7 +328,7 @@
         <datatype minOccurs="1" maxOccurs="2">
           <rng:data type="nonNegativeInteger"/>
         </datatype>
-        <remarks>
+        <remarks xml:lang="en">
           <p>A single number indicates that all pages have this number of columns. Two numbers mean
             that the number of columns per page varies between the values supplied.</p>
         </remarks>
@@ -338,7 +338,7 @@
         <datatype minOccurs="1" maxOccurs="2">
           <rng:data type="nonNegativeInteger"/>
         </datatype>
-        <remarks>
+        <remarks xml:lang="en">
           <p> A single number indicates that all columns have this number of ruled lines. Two
             numbers mean that the number of text lines per column varies between the values
             supplied.</p>
@@ -349,7 +349,7 @@
         <datatype minOccurs="1" maxOccurs="2">
           <rng:data type="nonNegativeInteger"/>
         </datatype>
-        <remarks>
+        <remarks xml:lang="en">
           <p>A single number indicates that all columns have this number of written text lines. Two
             numbers mean that the number of text lines per column varies between the values
             supplied.</p>
@@ -360,7 +360,7 @@
         <datatype minOccurs="1" maxOccurs="2">
           <rng:data type="nonNegativeInteger"/>
         </datatype>
-        <remarks>
+        <remarks xml:lang="en">
           <p>A single number indicates that all columns have this number of ruled staves. Two
             numbers mean that the number of ruled staves per column varies between the values
             supplied.</p>
@@ -371,14 +371,14 @@
         <datatype minOccurs="1" maxOccurs="2">
           <rng:data type="nonNegativeInteger"/>
         </datatype>
-        <remarks>
+        <remarks xml:lang="en">
           <p>A single number indicates that all columns have this number of written staves. Two
             numbers mean that the number of written staves per column varies between the values
             supplied.</p>
         </remarks>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -411,7 +411,7 @@
         </rng:zeroOrMore>
       </rng:choice>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -456,7 +456,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -484,7 +484,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -515,7 +515,7 @@
         </valList>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -549,7 +549,7 @@
         </rng:zeroOrMore>
       </rng:choice>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -564,7 +564,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -605,7 +605,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -645,7 +645,7 @@
         </rng:zeroOrMore>
       </rng:choice>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -663,7 +663,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -679,7 +679,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -698,7 +698,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -722,7 +722,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -789,7 +789,7 @@
         </valList>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -823,7 +823,7 @@
         </rng:zeroOrMore>
       </rng:choice>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -838,7 +838,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>

--- a/source/modules/MEI.namesdates.xml
+++ b/source/modules/MEI.namesdates.xml
@@ -49,7 +49,8 @@
     <desc xml:lang="en">Groups elements which form part of a personal name.</desc>
   </classSpec>
   <elementSpec ident="addName" module="MEI.namesdates">
-    <desc xml:lang="en">(additional name) – Contains an additional name component, such as a nickname, epithet, or
+    <gloss versionDate="2022-05-18" xml:lang="en">additional name</gloss>
+    <desc xml:lang="en">Contains an additional name component, such as a nickname, epithet, or
       alias, or any other descriptive phrase used within a personal name.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -101,7 +102,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="corpName" module="MEI.namesdates">
-    <desc xml:lang="en">(corporate name) – Identifies an organization or group of people that acts as a single
+    <gloss versionDate="2022-05-18" xml:lang="en">corporate name</gloss>
+    <desc xml:lang="en">Identifies an organization or group of people that acts as a single
       entity.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -189,7 +191,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="famName" module="MEI.namesdates">
-    <desc xml:lang="en">(family name) – Contains a family (inherited) name, as opposed to a given, baptismal, or
+    <gloss versionDate="2022-05-18" xml:lang="en">family name</gloss>
+    <desc xml:lang="en">Contains a family (inherited) name, as opposed to a given, baptismal, or
       nick name.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -238,7 +241,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="genName" module="MEI.namesdates">
-    <desc xml:lang="en">(generational name component) – Contains a name component used to distinguish otherwise
+    <gloss versionDate="2022-05-18" xml:lang="en">generational name component</gloss>
+    <desc xml:lang="en">Contains a name component used to distinguish otherwise
       similar names on the basis of the relative ages or generations of the persons named.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -264,7 +268,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="geogFeat" module="MEI.namesdates">
-    <desc xml:lang="en">(geographical feature name) – Contains a common noun identifying a geographical
+    <gloss versionDate="2022-05-18" xml:lang="en">geographical feature name</gloss>
+    <desc xml:lang="en">Contains a common noun identifying a geographical
       feature.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -290,7 +295,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="geogName" module="MEI.namesdates">
-    <desc xml:lang="en">(geographic name) – The proper noun designation for a place, natural feature, or political
+    <gloss versionDate="2022-05-18" xml:lang="en">geographic name</gloss>
+    <desc xml:lang="en">The proper noun designation for a place, natural feature, or political
       jurisdiction.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -326,7 +332,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="nameLink" module="MEI.namesdates">
-    <desc xml:lang="en">(name link) – Contains a connecting phrase or link used within a name but not regarded as
+    <gloss versionDate="2022-05-18" xml:lang="en">name link</gloss>
+    <desc xml:lang="en">Contains a connecting phrase or link used within a name but not regarded as
       part of it, such as "van der" or "of", "from", etc.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -352,7 +359,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="periodName" module="MEI.namesdates">
-    <desc xml:lang="en">(period name) – A label that describes a period of time, such as 'Baroque' or '3rd Style
+    <gloss versionDate="2022-05-18" xml:lang="en">period name</gloss>
+    <desc xml:lang="en">A label that describes a period of time, such as 'Baroque' or '3rd Style
       period'.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -379,7 +387,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="persName" module="MEI.namesdates">
-    <desc xml:lang="en">(personal name) – Designation for an individual, including any or all of that individual's
+    <gloss versionDate="2022-05-18" xml:lang="en">personal name</gloss>
+    <desc xml:lang="en">Designation for an individual, including any or all of that individual's
       forenames, surnames, honorific titles, and added names.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -483,7 +492,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="roleName" module="MEI.namesdates">
-    <desc xml:lang="en">(role name) – Contains a name component which indicates that the referent has a particular
+    <gloss versionDate="2022-05-18" xml:lang="en">role name</gloss>
+    <desc xml:lang="en">Contains a name component which indicates that the referent has a particular
       role or position in society, such as an official title or rank.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -558,7 +568,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="styleName" module="MEI.namesdates">
-    <desc xml:lang="en">(style name) – A label for a characteristic style of writing or performance, such as
+    <gloss versionDate="2022-05-18" xml:lang="en">style name</gloss>
+    <desc xml:lang="en">A label for a characteristic style of writing or performance, such as
       'bebop' or 'rock-n-roll'.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.namesdates.xml
+++ b/source/modules/MEI.namesdates.xml
@@ -70,7 +70,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -96,7 +96,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -122,7 +122,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Examples of corporate entities include names of associations, institutions, business firms,
         non-profit enterprises, governments, government agencies, projects, programs, religious
         bodies, churches, conferences, athletic contests, exhibitions, expeditions, fairs, and
@@ -130,7 +130,7 @@
         sub-elements. The name of the list from which a controlled value is taken may be recorded
         using the <att>auth</att> attribute.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
@@ -158,7 +158,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -184,7 +184,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -233,7 +233,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -259,7 +259,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -285,7 +285,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -311,7 +311,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Examples include Black Forest; Baltimore, Maryland; and Quartier Latin, Paris. Geographic
         name parts can be encoded using <gi scheme="MEI">geogName</gi> sub-elements. For greater
         specificity, however, use <gi scheme="MEI">district</gi>, <gi scheme="MEI">settlement</gi>,
@@ -320,7 +320,7 @@
         Thesaurus of Geographic Names (TGN), may be recorded using the <att>auth</att>
         attribute.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
@@ -347,7 +347,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -373,7 +373,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The name of the list from which a controlled value is taken may be recorded using the
         <att>auth</att> attribute.</p>
     </remarks>
@@ -401,13 +401,13 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Parts of a personal name may be captured using <gi scheme="MEI">persName</gi> sub-elements.
         For greater specificity, however, use foreName, famName, genName, addName, genName,
         nameLink, and roleName elements. The name of the list from which a controlled value for
         persName is taken may be recorded using the <att>auth</att> attribute.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
@@ -430,7 +430,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -452,7 +452,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -478,7 +478,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -504,7 +504,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -530,7 +530,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -553,7 +553,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -579,7 +579,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Do not confuse this element with the <gi scheme="MEI">periodName</gi> element. The name of
         the list from which a controlled value is taken may be recorded using the <att>auth</att>
         attribute.</p>

--- a/source/modules/MEI.namesdates.xml
+++ b/source/modules/MEI.namesdates.xml
@@ -5,51 +5,51 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.namesdates">
   <moduleSpec ident="MEI.namesdates">
-    <desc>Names and dates component declarations.</desc>
+    <desc xml:lang="en">Names and dates component declarations.</desc>
   </moduleSpec>
   <classSpec ident="model.addressPart" module="MEI.namesdates" type="model">
-    <desc>Groups elements used as part of a physical address.</desc>
+    <desc xml:lang="en">Groups elements used as part of a physical address.</desc>
     <classes>
       <memberOf key="model.textPhraseLike.limited"/>
     </classes>
   </classSpec>
   <classSpec ident="model.geogNamePart" module="MEI.namesdates" type="model">
-    <desc>Groups elements which form part of a geographic name.</desc>
+    <desc xml:lang="en">Groups elements which form part of a geographic name.</desc>
     <classes>
       <memberOf key="model.addressPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.nameLike.agent" module="MEI.namesdates" type="model">
-    <desc>Groups elements which contain names of individuals or corporate bodies.</desc>
+    <desc xml:lang="en">Groups elements which contain names of individuals or corporate bodies.</desc>
     <classes>
       <memberOf key="model.eventPart"/>
       <memberOf key="model.nameLike"/>
     </classes>
   </classSpec>
   <classSpec ident="model.nameLike.geogName" module="MEI.namesdates" type="model">
-    <desc>Groups geographic name elements.</desc>
+    <desc xml:lang="en">Groups geographic name elements.</desc>
     <classes>
       <memberOf key="model.eventPart"/>
       <memberOf key="model.nameLike.place"/>
     </classes>
   </classSpec>
   <classSpec ident="model.nameLike.label" module="MEI.namesdates" type="model">
-    <desc>Groups elements that serve as stylistic labels.</desc>
+    <desc xml:lang="en">Groups elements that serve as stylistic labels.</desc>
     <classes>
       <memberOf key="model.textPhraseLike.limited"/>
     </classes>
   </classSpec>
   <classSpec ident="model.nameLike.place" module="MEI.namesdates" type="model">
-    <desc>Groups place name elements.</desc>
+    <desc xml:lang="en">Groups place name elements.</desc>
     <classes>
       <memberOf key="model.nameLike"/>
     </classes>
   </classSpec>
   <classSpec ident="model.persNamePart" module="MEI.namesdates" type="model">
-    <desc>Groups elements which form part of a personal name.</desc>
+    <desc xml:lang="en">Groups elements which form part of a personal name.</desc>
   </classSpec>
   <elementSpec ident="addName" module="MEI.namesdates">
-    <desc>(additional name) – Contains an additional name component, such as a nickname, epithet, or
+    <desc xml:lang="en">(additional name) – Contains an additional name component, such as a nickname, epithet, or
       alias, or any other descriptive phrase used within a personal name.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -75,7 +75,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="bloc" module="MEI.namesdates">
-    <desc>Contains the name of a geopolitical unit consisting of two or more nation states or
+    <desc xml:lang="en">Contains the name of a geopolitical unit consisting of two or more nation states or
       countries.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -101,7 +101,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="corpName" module="MEI.namesdates">
-    <desc>(corporate name) – Identifies an organization or group of people that acts as a single
+    <desc xml:lang="en">(corporate name) – Identifies an organization or group of people that acts as a single
       entity.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -136,7 +136,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="country" module="MEI.namesdates">
-    <desc>Contains the name of a geopolitical unit, such as a nation, country, colony, or
+    <desc xml:lang="en">Contains the name of a geopolitical unit, such as a nation, country, colony, or
       commonwealth, larger than or administratively superior to a region and smaller than a
       bloc.</desc>
     <classes>
@@ -163,7 +163,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="district" module="MEI.namesdates">
-    <desc>Contains the name of any kind of subdivision of a settlement, such as a parish, ward, or
+    <desc xml:lang="en">Contains the name of any kind of subdivision of a settlement, such as a parish, ward, or
       other administrative or geographic unit.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -189,7 +189,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="famName" module="MEI.namesdates">
-    <desc>(family name) – Contains a family (inherited) name, as opposed to a given, baptismal, or
+    <desc xml:lang="en">(family name) – Contains a family (inherited) name, as opposed to a given, baptismal, or
       nick name.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -213,7 +213,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="foreName" module="MEI.namesdates">
-    <desc>Contains a forename, given or baptismal name.</desc>
+    <desc xml:lang="en">Contains a forename, given or baptismal name.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -238,7 +238,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="genName" module="MEI.namesdates">
-    <desc>(generational name component) – Contains a name component used to distinguish otherwise
+    <desc xml:lang="en">(generational name component) – Contains a name component used to distinguish otherwise
       similar names on the basis of the relative ages or generations of the persons named.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -264,7 +264,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="geogFeat" module="MEI.namesdates">
-    <desc>(geographical feature name) – Contains a common noun identifying a geographical
+    <desc xml:lang="en">(geographical feature name) – Contains a common noun identifying a geographical
       feature.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -290,7 +290,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="geogName" module="MEI.namesdates">
-    <desc>(geographic name) – The proper noun designation for a place, natural feature, or political
+    <desc xml:lang="en">(geographic name) – The proper noun designation for a place, natural feature, or political
       jurisdiction.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -326,7 +326,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="nameLink" module="MEI.namesdates">
-    <desc>(name link) – Contains a connecting phrase or link used within a name but not regarded as
+    <desc xml:lang="en">(name link) – Contains a connecting phrase or link used within a name but not regarded as
       part of it, such as "van der" or "of", "from", etc.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -352,7 +352,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="periodName" module="MEI.namesdates">
-    <desc>(period name) – A label that describes a period of time, such as 'Baroque' or '3rd Style
+    <desc xml:lang="en">(period name) – A label that describes a period of time, such as 'Baroque' or '3rd Style
       period'.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -379,7 +379,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="persName" module="MEI.namesdates">
-    <desc>(personal name) – Designation for an individual, including any or all of that individual's
+    <desc xml:lang="en">(personal name) – Designation for an individual, including any or all of that individual's
       forenames, surnames, honorific titles, and added names.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -413,7 +413,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="postBox" module="MEI.namesdates">
-    <desc>(postal box or post office box) contains a number or other identifier for some postal
+    <desc xml:lang="en">(postal box or post office box) contains a number or other identifier for some postal
       delivery point other than a street address.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -435,7 +435,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="postCode" module="MEI.namesdates">
-    <desc>(postal code) contains a numerical or alphanumeric code used as part of a postal address
+    <desc xml:lang="en">(postal code) contains a numerical or alphanumeric code used as part of a postal address
       to simplify sorting or delivery of mail.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -457,7 +457,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="region" module="MEI.namesdates">
-    <desc>Contains the name of an administrative unit such as a state, province, or county, larger
+    <desc xml:lang="en">Contains the name of an administrative unit such as a state, province, or county, larger
       than a settlement, but smaller than a country.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -483,7 +483,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="roleName" module="MEI.namesdates">
-    <desc>(role name) – Contains a name component which indicates that the referent has a particular
+    <desc xml:lang="en">(role name) – Contains a name component which indicates that the referent has a particular
       role or position in society, such as an official title or rank.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -509,7 +509,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="settlement" module="MEI.namesdates">
-    <desc>Contains the name of a settlement such as a city, town, or village identified as a single
+    <desc xml:lang="en">Contains the name of a settlement such as a city, town, or village identified as a single
       geopolitical or administrative unit.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -535,7 +535,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="street" module="MEI.namesdates">
-    <desc>full street address including any name or number identifying a building as well as the
+    <desc xml:lang="en">full street address including any name or number identifying a building as well as the
       name of the street or route on which it is located.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -558,7 +558,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="styleName" module="MEI.namesdates">
-    <desc>(style name) – A label for a characteristic style of writing or performance, such as
+    <desc xml:lang="en">(style name) – A label for a characteristic style of writing or performance, such as
       'bebop' or 'rock-n-roll'.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.neumes.xml
+++ b/source/modules/MEI.neumes.xml
@@ -5,13 +5,13 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.neumes">
   <moduleSpec ident="MEI.neumes">
-    <desc>Neume repertoire component declarations.</desc>
+    <desc xml:lang="en">Neume repertoire component declarations.</desc>
   </moduleSpec>
   <macroSpec ident="data.STAFFITEM.neumes" module="MEI.neumes" type="dt">
-    <desc>Items in the Neume repertoire that may be printed near a staff.</desc>
+    <desc xml:lang="en">Items in the Neume repertoire that may be printed near a staff.</desc>
   </macroSpec>
   <classSpec ident="att.episema.log" module="MEI.neumes" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <!-- att.controlEvent class expanded here in order to disallow att.timestamp.* -->
       <memberOf key="att.alignment"/>
@@ -23,7 +23,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.hispanTick.log" module="MEI.neumes" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <!-- att.controlEvent class expanded here in order to disallow att.timestamp.* -->
       <memberOf key="att.alignment"/>
@@ -35,10 +35,10 @@
     </classes>
   </classSpec>
   <classSpec ident="att.liquescent.log" module="MEI.neumes" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.nc.log" module="MEI.neumes" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <!-- att.event restricted -->
       <memberOf key="att.alignment"/>
@@ -48,7 +48,7 @@
     <attList>
       <!-- pname and oct are re-defined locally to allow indefinite pitch -->
       <attDef ident="oct" usage="opt">
-        <desc>Captures written octave information.</desc>
+        <desc xml:lang="en">Captures written octave information.</desc>
         <datatype>
           <rng:choice>
             <rng:data type="nonNegativeInteger">
@@ -61,7 +61,7 @@
         </datatype>
       </attDef>
       <attDef ident="pname" usage="opt">
-        <desc>Contains a written pitch name.</desc>
+        <desc xml:lang="en">Contains a written pitch name.</desc>
         <datatype>
           <rng:data type="token">
             <rng:param name="pattern">[a-g]|unknown</rng:param>
@@ -71,7 +71,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.ncForm" module="MEI.neumes" type="atts">
-    <desc>Attributes that record visual details of neume notation.</desc>
+    <desc xml:lang="en">Attributes that record visual details of neume notation.</desc>
     <attList>
       <attDef ident="angled" usage="opt">
         <desc/>
@@ -80,57 +80,57 @@
         </datatype>
       </attDef>
       <attDef ident="con" usage="opt">
-        <desc>Connection to the previous component within the same neume; this attribute should not
+        <desc xml:lang="en">Connection to the previous component within the same neume; this attribute should not
           be used for the first component of a neume.</desc>
         <valList type="closed">
           <valItem ident="g">
-            <desc>Gapped; not connected.</desc>
+            <desc xml:lang="en">Gapped; not connected.</desc>
           </valItem>
           <valItem ident="l">
-            <desc>Looped.</desc>
+            <desc xml:lang="en">Looped.</desc>
           </valItem>
           <valItem ident="e">
-            <desc>Extended.</desc>
+            <desc xml:lang="en">Extended.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="curve" usage="opt">
-        <desc>Records direction of curvature.</desc>
+        <desc xml:lang="en">Records direction of curvature.</desc>
         <valList type="closed">
           <valItem ident="a">
-            <desc>Anti-clockwise curvature.</desc>
+            <desc xml:lang="en">Anti-clockwise curvature.</desc>
           </valItem>
           <valItem ident="c">
-            <desc>Clockwise curvature.</desc>
+            <desc xml:lang="en">Clockwise curvature.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="hooked" usage="opt">
-        <desc>Pen stroke has an extension; specific to Hispanic notation.</desc>
+        <desc xml:lang="en">Pen stroke has an extension; specific to Hispanic notation.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
       </attDef>
       <attDef ident="ligated" usage="opt">
-        <desc>Indicates participation in a ligature.</desc>
+        <desc xml:lang="en">Indicates participation in a ligature.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
       </attDef>
       <attDef ident="rellen" usage="opt">
-        <desc>Length of the pen stroke relative to the previous component within the same neume;
+        <desc xml:lang="en">Length of the pen stroke relative to the previous component within the same neume;
           this attribute should not be used for the first component of a neume.</desc>
         <valList type="closed">
           <valItem ident="l">
-            <desc>Longer.</desc>
+            <desc xml:lang="en">Longer.</desc>
           </valItem>
           <valItem ident="s">
-            <desc>Shorter.</desc>
+            <desc xml:lang="en">Shorter.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="s-shape" usage="opt">
-        <desc>Direction of the initial direction for an s-shaped pen stroke; <abbr>i.e.</abbr>, "w" for the
+        <desc xml:lang="en">Direction of the initial direction for an s-shaped pen stroke; <abbr>i.e.</abbr>, "w" for the
           standard letter S, "e" for its mirror image, "s" for the letter S turned 90-degrees
           anti-clockwise, and "n" for its mirror image.</desc>
         <datatype>
@@ -138,7 +138,7 @@
         </datatype>
       </attDef>
       <attDef ident="tilt" usage="opt">
-        <desc>Direction of the pen stroke.</desc>
+        <desc xml:lang="en">Direction of the pen stroke.</desc>
         <datatype>
           <rng:ref name="data.COMPASSDIRECTION"/>
         </datatype>
@@ -146,7 +146,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.ncGrp.log" module="MEI.neumes" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <!-- att.event restricted -->
       <memberOf key="att.alignment"/>
@@ -156,7 +156,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.neume.log" module="MEI.neumes" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <!-- att.event restricted -->
       <memberOf key="att.alignment"/>
@@ -166,13 +166,13 @@
     </classes>
   </classSpec>
   <classSpec ident="att.oriscus.log" module="MEI.neumes" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.quilisma.log" module="MEI.neumes" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.signifLet.log" module="MEI.neumes" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <!-- att.controlEvent class expanded here in order to disallow att.timestamp.* -->
       <memberOf key="att.alignment"/>
@@ -184,62 +184,62 @@
     </classes>
   </classSpec>
   <classSpec ident="att.strophicus.log" module="MEI.neumes" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.syllable.log" module="MEI.neumes" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.alignment"/>
     </classes>
   </classSpec>
   <classSpec ident="model.eventLike.neumes" module="MEI.neumes" type="model">
-    <desc>Groups event elements that occur in the neume repertoire.</desc>
+    <desc xml:lang="en">Groups event elements that occur in the neume repertoire.</desc>
     <classes>
       <memberOf key="model.layerPart.neumes"/>
       <memberOf key="model.syllablePart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.layerPart.neumes" module="MEI.neumes" type="model">
-    <desc>Groups notated events that may appear at the layer level in the neume repertoire.</desc>
+    <desc xml:lang="en">Groups notated events that may appear at the layer level in the neume repertoire.</desc>
     <classes>
       <memberOf key="model.layerPart.mensuralAndNeumes"/>
     </classes>
   </classSpec>
   <classSpec ident="model.neumeComponentModifierLike" module="MEI.neumes" type="model">
-    <desc>Groups elements that modify neume components.</desc>
+    <desc xml:lang="en">Groups elements that modify neume components.</desc>
   </classSpec>
   <classSpec ident="model.neumeModifierLike" module="MEI.neumes" type="model">
-    <desc>Groups elements that modify neume-like features.</desc>
+    <desc xml:lang="en">Groups elements that modify neume-like features.</desc>
   </classSpec>
   <classSpec ident="model.neumePart" module="MEI.neumes" type="model">
-    <desc>Groups elements that may occur within a neume.</desc>
+    <desc xml:lang="en">Groups elements that may occur within a neume.</desc>
   </classSpec>
   <classSpec ident="model.scorePart.neumes" module="MEI.neumes" type="model">
-    <desc>Groups elements that may appear as part of a score in the neume repertoire.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of a score in the neume repertoire.</desc>
   </classSpec>
   <classSpec ident="model.sectionPart.neumes" module="MEI.neumes" type="model">
-    <desc>Groups elements that may appear as part of a section in the neume repertoire.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of a section in the neume repertoire.</desc>
     <classes>
       <memberOf key="model.sectionPart.mensuralAndNeumes"/>
     </classes>
   </classSpec>
   <classSpec ident="model.staffPart.neumes" module="MEI.neumes" type="model">
-    <desc>Groups elements that are components of a staff in the neume repertoire.</desc>
+    <desc xml:lang="en">Groups elements that are components of a staff in the neume repertoire.</desc>
     <classes>
       <memberOf key="model.staffPart.mensuralAndNeumes"/>
     </classes>
   </classSpec>
   <classSpec ident="model.syllableLike" module="MEI.neumes" type="model">
-    <desc>Groups elements that accommodate neumed text.</desc>
+    <desc xml:lang="en">Groups elements that accommodate neumed text.</desc>
     <classes>
       <memberOf key="model.layerPart.neumes"/>
     </classes>
   </classSpec>
   <classSpec ident="model.syllablePart" module="MEI.neumes" type="model">
-    <desc>Groups elements that may appear as part of the content of a syllable.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of the content of a syllable.</desc>
   </classSpec>
   <elementSpec ident="episema" module="MEI.neumes">
-    <desc>Episema.</desc>
+    <desc xml:lang="en">Episema.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -251,7 +251,7 @@
     </classes>
   </elementSpec>
   <elementSpec ident="hispanTick" module="MEI.neumes">
-    <desc>Hispanic tick.</desc>
+    <desc xml:lang="en">Hispanic tick.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -266,7 +266,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="liquescent" module="MEI.neumes">
-    <desc>Liquescent.</desc>
+    <desc xml:lang="en">Liquescent.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -278,7 +278,7 @@
     </classes>
   </elementSpec>
   <elementSpec ident="nc" module="MEI.neumes">
-    <desc>Sign representing a single pitched event, although the exact pitch may not be
+    <desc xml:lang="en">Sign representing a single pitched event, although the exact pitch may not be
       known.</desc>
     <classes>
       <memberOf key="att.basic"/>
@@ -307,7 +307,7 @@
     </content>
     <attList>
       <attDef ident="type" usage="opt">
-        <desc>Designation which characterizes the element in some sense, using any convenient
+        <desc xml:lang="en">Designation which characterizes the element in some sense, using any convenient
           classification scheme or typology that employs single-token labels.</desc>
         <datatype maxOccurs="unbounded">
           <rng:data type="NMTOKEN"/>
@@ -340,7 +340,7 @@
     </attList>
   </elementSpec>
   <elementSpec ident="ncGrp" module="MEI.neumes">
-    <desc>Collection of one or more neume components.</desc>
+    <desc xml:lang="en">Collection of one or more neume components.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -364,7 +364,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="neume" module="MEI.neumes">
-    <desc>Sign representing one or more musical pitches.</desc>
+    <desc xml:lang="en">Sign representing one or more musical pitches.</desc>
     <classes>
       <memberOf key="att.basic"/>
       <memberOf key="att.classed"/>
@@ -392,7 +392,7 @@
     </content>
     <attList>
       <attDef ident="type" usage="opt">
-        <desc>Designation which characterizes the element in some sense, using any convenient
+        <desc xml:lang="en">Designation which characterizes the element in some sense, using any convenient
           classification scheme or typology that employs single-token labels.</desc>
         <datatype maxOccurs="unbounded">
           <rng:data type="NMTOKEN"/>
@@ -425,7 +425,7 @@
     </attList>
   </elementSpec>
   <elementSpec ident="oriscus" module="MEI.neumes">
-    <desc>Oriscus.</desc>
+    <desc xml:lang="en">Oriscus.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -437,7 +437,7 @@
     </classes>
   </elementSpec>
   <elementSpec ident="quilisma" module="MEI.neumes">
-    <desc>Quilisma.</desc>
+    <desc xml:lang="en">Quilisma.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -449,7 +449,7 @@
     </classes>
   </elementSpec>
   <elementSpec ident="signifLet" module="MEI.neumes">
-    <desc>Significantive letter(s).</desc>
+    <desc xml:lang="en">Significantive letter(s).</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -472,7 +472,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="strophicus" module="MEI.neumes">
-    <desc>Strophicus.</desc>
+    <desc xml:lang="en">Strophicus.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -484,7 +484,7 @@
     </classes>
   </elementSpec>
   <elementSpec ident="syllable" module="MEI.neumes">
-    <desc>Neume notation can be thought of as "neumed text". Therefore, the syllable element
+    <desc xml:lang="en">Neume notation can be thought of as "neumed text". Therefore, the syllable element
       provides high-level organization in this repertoire.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -515,7 +515,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="divLine" module="MEI.neumes">
-    <desc>Represents a division (divisio) in neume notation. Divisions indicate short, medium, or long pauses
+    <desc xml:lang="en">Represents a division (divisio) in neume notation. Divisions indicate short, medium, or long pauses
     similar to breath marks in modern notation.</desc>
     <classes>
       <memberOf key="att.basic"/>
@@ -535,7 +535,7 @@
     </classes>
     <attList>
       <attDef ident="form" usage="opt">
-        <desc>Identifies the different kinds of division.</desc>
+        <desc xml:lang="en">Identifies the different kinds of division.</desc>
         <datatype maxOccurs="unbounded">
           <rng:data type="NMTOKEN"/>
         </datatype>

--- a/source/modules/MEI.performance.xml
+++ b/source/modules/MEI.performance.xml
@@ -54,7 +54,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is analogous to the <gi scheme="MEI">graphic</gi> element in the figtable
         module.</p>
     </remarks>
@@ -85,7 +85,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is analogous to the <gi scheme="MEI">zone</gi> element in the facsimile
         module.</p>
     </remarks>
@@ -102,7 +102,7 @@
         <rng:ref name="recording"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>decls</att> attribute may be used to link the collection with a particular source
         described in the header. This element is analogous to the <gi scheme="MEI">facsimile</gi>
         element in the facsimile module.</p>
@@ -136,7 +136,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>startid</att> attribute may be used to hold a reference to the first feature
         occurring in this performance. This element is analogous to the <gi scheme="MEI"
         >surface</gi> element in the facsimile module.</p>
@@ -235,11 +235,11 @@
         </constraintSpec>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>data</att> attribute may be used to reference one or more features that occur at
         this point in time.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>

--- a/source/modules/MEI.performance.xml
+++ b/source/modules/MEI.performance.xml
@@ -32,7 +32,8 @@
     </attList>
   </classSpec>
   <elementSpec ident="avFile" module="MEI.performance">
-    <desc xml:lang="en">(audio/video file) – References an external digital audio or video file.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">audio/video file</gloss>
+    <desc xml:lang="en">References an external digital audio or video file.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>

--- a/source/modules/MEI.performance.xml
+++ b/source/modules/MEI.performance.xml
@@ -5,10 +5,10 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.performance">
   <moduleSpec ident="MEI.performance">
-    <desc>Performance component declarations.</desc>
+    <desc xml:lang="en">Performance component declarations.</desc>
   </moduleSpec>
   <classSpec ident="att.alignment" module="MEI.performance" type="atts">
-    <desc>Temporal alignment attributes.</desc>
+    <desc xml:lang="en">Temporal alignment attributes.</desc>
     <constraintSpec ident="check_whenTarget" scheme="isoschematron">
       <constraint>
         <sch:rule context="@when">
@@ -23,7 +23,7 @@
     </constraintSpec>
     <attList>
       <attDef ident="when" usage="opt">
-        <desc>Indicates the point of occurrence of this feature along a time line. Its value must be
+        <desc xml:lang="en">Indicates the point of occurrence of this feature along a time line. Its value must be
           the ID of a <gi scheme="MEI">when</gi> element elsewhere in the document.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
@@ -32,7 +32,7 @@
     </attList>
   </classSpec>
   <elementSpec ident="avFile" module="MEI.performance">
-    <desc>(audio/video file) – References an external digital audio or video file.</desc>
+    <desc xml:lang="en">(audio/video file) – References an external digital audio or video file.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -60,7 +60,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="clip" module="MEI.performance">
-    <desc>Defines a time segment of interest within a recording or within a digital audio or video
+    <desc xml:lang="en">Defines a time segment of interest within a recording or within a digital audio or video
       file.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -91,7 +91,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="performance" module="MEI.performance">
-    <desc>A presentation of one or more musical works.</desc>
+    <desc xml:lang="en">A presentation of one or more musical works.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.metadataPointing"/>
@@ -109,7 +109,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="recording" module="MEI.performance">
-    <desc>A recorded performance.</desc>
+    <desc xml:lang="en">A recorded performance.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.dataPointing"/>
@@ -143,7 +143,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="when" module="MEI.performance">
-    <desc>Indicates a point in time either absolutely (using the absolute attribute), or relative to
+    <desc xml:lang="en">Indicates a point in time either absolutely (using the absolute attribute), or relative to
       another when element (using the since, interval and inttype attributes).</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -182,13 +182,13 @@
     </constraintSpec>
     <attList>
       <attDef ident="absolute" usage="opt">
-        <desc>Provides an absolute value for the time point.</desc>
+        <desc xml:lang="en">Provides an absolute value for the time point.</desc>
         <datatype>
           <rng:text/>
         </datatype>
       </attDef>
       <attDef ident="interval" usage="opt">
-        <desc>Specifies the time interval between this time point and the one designated by the
+        <desc xml:lang="en">Specifies the time interval between this time point and the one designated by the
           since attribute. This attribute can only be interpreted meaningfully in conjunction with
           the inttype attribute.</desc>
         <datatype>
@@ -201,19 +201,19 @@
         </datatype>
       </attDef>
       <attDef ident="abstype" usage="opt">
-        <desc>Specifies the kind of values used in the absolute attribute.</desc>
+        <desc xml:lang="en">Specifies the kind of values used in the absolute attribute.</desc>
         <datatype>
           <rng:ref name="data.BETYPE"/>
         </datatype>
       </attDef>
       <attDef ident="inttype" usage="opt">
-        <desc>Specifies the kind of values used in the interval attribute.</desc>
+        <desc xml:lang="en">Specifies the kind of values used in the interval attribute.</desc>
         <datatype>
           <rng:ref name="data.BETYPE"/>
         </datatype>
       </attDef>
       <attDef ident="since" usage="opt">
-        <desc>Identifies the reference point for determining the time of the current when element,
+        <desc xml:lang="en">Identifies the reference point for determining the time of the current when element,
           which is obtained by adding the interval to the time of the reference point. The value
           should be the ID of another when element within the same parent element. If the since
           attribute is omitted and the absolute attribute is not specified, then the reference point

--- a/source/modules/MEI.ptrref.xml
+++ b/source/modules/MEI.ptrref.xml
@@ -5,16 +5,16 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.ptrref">
   <moduleSpec ident="MEI.ptrref">
-    <desc>Pointer and reference component declarations.</desc>
+    <desc xml:lang="en">Pointer and reference component declarations.</desc>
   </moduleSpec>
   <classSpec ident="model.locrefLike" module="MEI.ptrref" type="model">
-    <desc>Groups elements used for purposes of location and reference.</desc>
+    <desc xml:lang="en">Groups elements used for purposes of location and reference.</desc>
     <classes>
       <memberOf key="model.textPhraseLike.limited"/>
     </classes>
   </classSpec>
   <elementSpec ident="ptr" module="MEI.ptrref">
-    <desc>(pointer) – Defines a traversible pointer to another location, using only attributes to
+    <desc xml:lang="en">(pointer) – Defines a traversible pointer to another location, using only attributes to
       describe the destination.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -37,7 +37,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="ref" module="MEI.ptrref">
-    <desc>(reference) – Defines a traversible reference to another location. May contain text and
+    <desc xml:lang="en">(reference) – Defines a traversible reference to another location. May contain text and
       sub-elements that describe the destination.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.ptrref.xml
+++ b/source/modules/MEI.ptrref.xml
@@ -14,7 +14,8 @@
     </classes>
   </classSpec>
   <elementSpec ident="ptr" module="MEI.ptrref">
-    <desc xml:lang="en">(pointer) – Defines a traversible pointer to another location, using only attributes to
+    <gloss versionDate="2022-05-18" xml:lang="en">pointer</gloss>
+    <desc xml:lang="en">Defines a traversible pointer to another location, using only attributes to
       describe the destination.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -37,7 +38,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="ref" module="MEI.ptrref">
-    <desc xml:lang="en">(reference) – Defines a traversible reference to another location. May contain text and
+    <gloss versionDate="2022-05-18" xml:lang="en">reference</gloss>
+    <desc xml:lang="en">Defines a traversible reference to another location. May contain text and
       sub-elements that describe the destination.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.ptrref.xml
+++ b/source/modules/MEI.ptrref.xml
@@ -27,11 +27,11 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Unlike the <gi scheme="MEI">ref</gi> element, <gi scheme="MEI">ptr</gi> cannot contain text
         or sub-elements to describe the referenced object.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Encoded Archival Description (EAD) and Text
         Encoding Initiative (TEI) standards.</p>
     </remarks>
@@ -56,11 +56,11 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Unlike the <gi scheme="MEI">ptr</gi> element, <gi scheme="MEI">ref</gi> may contain text
         and sub-elements to describe the destination.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Encoded Archival Description (EAD) and TEI
         standards.</p>
     </remarks>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -323,7 +323,7 @@
         </constraintSpec>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>dots</att> attribute records the number of augmentation dots necessary to
         represent a non-power-of-two duration. This is usually, but not always, the number of dots
         displayed. For example, a note with this attribute will result in displayed dots, while a
@@ -380,7 +380,7 @@
             <rng:param name="minExclusive">0</rng:param>
           </rng:data>
         </datatype>
-        <remarks>
+        <remarks xml:lang="en">
           <p>This attribute is ignored if the value of the bar.style attribute is <val>mensur</val>.</p>
         </remarks>
       </attDef>
@@ -404,7 +404,7 @@
         <datatype>
           <rng:ref name="data.STAFFLOC"/>
         </datatype>
-        <remarks>
+        <remarks xml:lang="en">
           <p>The location may include staff lines, the spaces between the lines, and the spaces
             directly above and below the staff. The value ranges between 0 (just below the staff) to
             2 * number of staff lines (directly above the staff). For example, on a 5-line staff the
@@ -442,7 +442,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Mapping elements from one system to another via <att>analog</att> may help a repository
         harvest selected data from the MEI file to build a basic catalog record. The encoding system
         from which fields are taken must be specified. When possible, subfields as well as fields
@@ -699,7 +699,7 @@
           <rng:ref name="data.DEGREES"/>
         </datatype>
         <defaultVal>0</defaultVal>
-        <remarks>
+        <remarks xml:lang="en">
           <p>This attribute is based on the TEI attribute of the same name.</p>
         </remarks>
       </attDef>
@@ -1318,7 +1318,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Mixed key signatures, <abbr>e.g.</abbr>, those consisting of a mixture of flats and sharps (Read, p. 143,
         ex. 9-39), and key signatures with unorthodox placement of the accidentals (Read, p. 141)
         can be encoded using the <gi scheme="MEI">keySig</gi> element.</p>
@@ -1335,7 +1335,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Mixed key signatures, <abbr>e.g.</abbr>, those consisting of a mixture of flats and sharps (Read, p. 143,
         ex. 9-39), and key signatures with unorthodox placement of the accidentals (Read, p. 141)
         can be encoded using the <gi scheme="MEI">keySig</gi> element.</p>
@@ -1350,7 +1350,7 @@
         <datatype>
           <rng:data type="string"/>
         </datatype>
-        <remarks>
+        <remarks xml:lang="en">
           <p> <att>label</att> is used to provide a display label for an element’s contents, for
             example in the form of a "tool tip" or as the "name" when the element’s contents are
             treated as the "value" in a "name-value pair". Unlike <att>n</att>, <att>label</att> may
@@ -1379,12 +1379,12 @@
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
-        <remarks>
+        <remarks xml:lang="en">
           <p>There is no standard list of transliteration schemes.</p>
         </remarks>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>BCP 47 is described at <ref target="https://tools.ietf.org/html/bcp47"
         >https://tools.ietf.org/html/bcp47</ref>. The IANA Subtag Registry, from which BCP 47
         language tags are constructed, may be found at <ref
@@ -2049,7 +2049,7 @@
         <datatype>
           <rng:text/>
         </datatype>
-        <remarks>
+        <remarks xml:lang="en">
           <p>When applicable, values from the <abbr>MARC</abbr> relator term list (<ref
             target="http://www.loc.gov/marc/relators/relaterm.html"
             >http://www.loc.gov/marc/relators/relaterm.html</ref>) or code list (<ref
@@ -3308,7 +3308,7 @@
               element(s) specified in plist or target attribute.</desc>
           </valItem>
         </valList>
-        <remarks>
+        <remarks xml:lang="en">
           <p>If no value is given, the application program is responsible for deciding (possibly on
             the basis of user input) how far to trace a chain of pointers.</p>
         </remarks>
@@ -3463,7 +3463,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Diatonic transposition requires both <att>trans.diat</att> and <att>trans.semi</att>
         attributes in order to distinguish the difference, for example, between a transposition from
         C to C♯ and one from C to D♭.</p>
@@ -3496,7 +3496,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>When appropriate, values from an established typology should be used.</p>
     </remarks>
   </classSpec>
@@ -3748,7 +3748,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The width attribute may be used to capture measure width data for interchange with music
         printing systems that utilize this information for printing. On &lt;barLine&gt; the width
         attribute captures the width of the preceding measure.</p>
@@ -4171,7 +4171,7 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>An accidental may raise a pitch by one or two semitones or it may cancel a previous
         accidental or part of a key signature. This element provides an alternative to the
         <att>accid</att> and <att>accid.ges</att> attributes on the <gi scheme="MEI">note</gi>
@@ -4196,7 +4196,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -4221,7 +4221,7 @@
         </rng:oneOrMore>
       </rng:choice>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -4243,11 +4243,11 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p> <gi scheme="MEI">addrLine</gi> may be repeated as many times as necessary to enter all
         lines of an address.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -4357,7 +4357,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <gi scheme="MEI">annot</gi> element can be used for both general comments and for
         annotations of the musical text. It provides a way to group participating *events* and/or
         *control events*, for example, the notes that form a descending bass line, and provide a
@@ -4407,7 +4407,7 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Articulations typically affect duration, such as staccato marks, or the force of attack,
         such as accents. This element provides an alternative to the <att>artic</att> attribute on
         the <gi scheme="MEI">note</gi> and <gi scheme="MEI">chord</gi> elements. It may be used when
@@ -4434,7 +4434,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -4456,7 +4456,7 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is provided for repertoires, such as mensural notation, that lack measures.
         Because the <gi scheme="MEI">barLine</gi> element’s attributes, from which the logical and
         visual characteristics of the bar line can be discerned, largely duplicate those of measure,
@@ -4500,14 +4500,14 @@
               </rng:choice>
             </rng:zeroOrMore>
            </content> -->
-    <remarks>
+    <remarks xml:lang="en">
       <p> <gi scheme="MEI">bibl</gi> may contain a mix of text and more specific elements such as
         <gi scheme="MEI">title</gi>, <gi scheme="MEI">edition</gi>, <gi scheme="MEI">persName</gi>,
         and <gi scheme="MEI">corpName</gi>. This element may also function as a hypertext reference
         to an external electronic resource. Do not confuse this element with <gi scheme="MEI"
         >ref</gi>, which does not provide special bibliographic sub-elements.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -4545,7 +4545,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -4580,7 +4580,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Use the <att>from</att> and <att>to</att> attributes to regularize the beginning and ending
         values provided in the element content.</p>
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
@@ -4635,7 +4635,7 @@
         </rng:choice>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>When the music can be broken into high-level, discrete, linear segments, such as movements
         of a symphony, there may be multiple <gi scheme="MEI">mdiv</gi> elements within <gi
         scheme="MEI">body</gi>. This is the highest level indication of the structure of the
@@ -4669,7 +4669,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The caesura often indicates an abrupt interruption in the performance followed by an
         equally sudden resumption. Its duration is typically shorter than a grand pause (G.P.) or
         long pause (L.P.), but longer than that indicated by a <gi scheme="MEI">breath</gi> mark.
@@ -4720,7 +4720,7 @@
         </rng:choice>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -4744,7 +4744,7 @@
         </rng:choice>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -4768,7 +4768,7 @@
         </rng:choice>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -4809,7 +4809,7 @@
         </constraintSpec>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -4878,7 +4878,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element can be used as an alternative to the <gi scheme="MEI">staff</gi> element's
         clef.* attributes. It should be used when specific display info, such as size or color,
         needs to be recorded for the clef or when multiple, simultaneous clefs occur on a single
@@ -4981,7 +4981,7 @@
         <datatype>
           <rng:text/>
         </datatype>
-        <remarks>
+        <remarks xml:lang="en">
           <p>When applicable, values from the <abbr>MARC</abbr> relator term list (<ref
             target="http://www.loc.gov/marc/relators/relaterm.html"
             >http://www.loc.gov/marc/relators/relaterm.html</ref>) or code list (<ref
@@ -5016,7 +5016,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI).</p>
     </remarks>
   </elementSpec>
@@ -5038,7 +5038,7 @@
         <rng:ref name="accid"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The most common visual form is a sign resembling a mordent. Other graphical forms may be
         indicated by the <att>altsym</att> attribute. Together the <att>pname</att> and
         <att>oct</att> attributes identify the location where the custos appears.</p>
@@ -5064,7 +5064,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -5134,7 +5134,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -5205,7 +5205,7 @@
         </valList>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <gi scheme="MEI">height</gi>, <gi scheme="MEI">width</gi>, and <gi scheme="MEI"
         >depth</gi> elements are preferred when appropriate.</p>
     </remarks>
@@ -5236,14 +5236,14 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The elements <gi scheme="MEI">height</gi>, <gi scheme="MEI">width</gi>, <gi scheme="MEI"
         >depth</gi>, and <gi scheme="MEI">dim</gi> are available for circumstances that require the
         capture of the individual dimensions of an object. Do not confuse this element with the <gi
         scheme="MEI">extent</gi> element, which is used to indicate the quantity of described
         materials.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -5282,7 +5282,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Examples include text strings, such as 'affettuoso', and music symbols, such as segno and
         coda symbols, fermatas over a bar line, etc. Directives can be control elements. That is,
         they can be linked via their attributes to other events. The starting point of the directive
@@ -5311,7 +5311,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -5406,7 +5406,7 @@
         </valList>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Often, the <gi scheme="MEI">head</gi> sub-element identifies the <gi scheme="MEI"
         >div</gi>’s purpose. This element is modelled on an element in the Text Encoding Initiative
         (TEI) standard.</p>
@@ -5427,7 +5427,7 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element provides an alternative to the <att>dots</att> attribute on <gi scheme="MEI"
         >note</gi> and <gi scheme="MEI">rest</gi> elements. It should be used when specific display
         info, such as size or color, needs to be recorded for the dot. This element may also be used
@@ -5472,7 +5472,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element may be used for instantaneous or continuous <emph>textual</emph> dynamics,
         <abbr>e.g.</abbr>, 'p', 'mf', or 'cresc. poco a poco'. The <gi scheme="MEI">hairpin</gi> element should be
         used for <emph>graphical</emph>, <abbr>i.e.</abbr>, crescendo and diminuendo, dynamic markings. The
@@ -5507,7 +5507,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -5531,7 +5531,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -5570,7 +5570,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <gi scheme="MEI">scoreDef</gi> element is allowed as a sub-element so that an ending
         may have its own meta-data without the overhead of child <gi scheme="MEI">section</gi>
         elements. <gi scheme="MEI">div</gi> sub-elements are not allowed within ending. They may,
@@ -5655,7 +5655,7 @@
         <rng:ref name="biblList"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>An <gi scheme="MEI">eventList</gi> contains <gi scheme="MEI">event</gi> elements that
         capture a brief description of the associated event, including dates and locations where the
         event took place. An <gi scheme="MEI">eventList</gi> describes events associated with a work
@@ -5679,7 +5679,7 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>plist</att> attribute contains an ordered list of identifiers of descendant <gi
         scheme="MEI">section</gi>, <gi scheme="MEI">ending</gi>, <gi scheme="MEI">lem</gi>, or <gi
         scheme="MEI">rdg</gi> elements. For example, the sequence "#A #End1 #A #End2" indicates that
@@ -5707,12 +5707,12 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Use the <gi scheme="MEI">dimensions</gi> element when it is necessary to specify the <hi
         rend="bold">physical</hi> size of materials being described, for example, height and
         width.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -5737,7 +5737,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -5782,11 +5782,11 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Because its model contains the music element, each of the subordinate MEI documents can
         have its own front and back matter.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -5822,7 +5822,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element provides an alternative to the <gi scheme="MEI">staffGrp</gi> element's
         <att>symbol</att> attribute. It may be used when exact placement or editorial details for
         the grouping symbol must be recorded.</p>
@@ -5848,11 +5848,11 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>One or more <gi scheme="MEI">head</gi> elements usually identify the parent element and/or
         its purpose.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in Encoded Archival Description (EAD), Text Encoding
         Initiative (TEI), and HTML standards.</p>
     </remarks>
@@ -5894,7 +5894,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Examples include an International Standard Book/Music Number, Library of Congress Control
         Number, publisher’s number, a personal identification number, an entry in a bibliography or
         catalog, etc. The <att>type</att> attribute may be used to indicate the system from which
@@ -5921,7 +5921,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -5977,7 +5977,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <gi scheme="MEI">incipText</gi> element may be used to capture a text incipit, while
         <gi scheme="MEI">score</gi> is available to provide an MEI-encoded musical incipit. Images
         of an incipit may be referenced using the <gi scheme="MEI">graphic</gi> element. An incipit
@@ -6021,7 +6021,7 @@
         </valList>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>It is a semantic error not to provide one of the following: the <att>x</att> and
         <att>y</att> pair of attributes, the <att>pname</att> and <att>oct</att> pair of attributes,
         or the <att>loc</att> attribute.</p>
@@ -6085,7 +6085,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
       <p>Don't confuse this element, which is used to capture labelling text appearing in the
         document, with the <att>label</att> attribute, which records text to be used to generate a
@@ -6143,7 +6143,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The term 'layer' is used instead of 'voice' in order to avoid confusion between 'voice' and
         'voice leading' and 'voicing'. The <att>def</att> attribute may be used to create a
         connection with a <gi scheme="MEI">layerDef</gi> element where logical and visual
@@ -6197,13 +6197,13 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>n</att> attribute should be used to record a number associated with this textual
         line. See comment on <gi scheme="MEI">verse</gi> element for description of <att>func</att>
         attribute. Do not confuse this element with the <gi scheme="MEI">sb</gi> element, which
         performs a similar function for musical notation.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -6237,7 +6237,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -6306,7 +6306,7 @@
         </rng:zeroOrMore>
       </rng:choice>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <gi scheme="MEI">mdiv</gi> element may contain one or both of 2 possible views of the
         music. The score view is the traditional full and open score while the parts view contains
         each performer’s view of the score; that is, his part. These 2 views are necessary because
@@ -6342,7 +6342,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <gi scheme="MEI">mei</gi> element defines an instance of a document encoded with the
         MEI schema. It is the document element for a single document containing a header and data.
         The name of this element should not be changed by any customization in order to assure an
@@ -6507,7 +6507,7 @@
         </valList>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Contains the name of an entity that is difficult to tag more specifically, for example, as
         a <gi scheme="MEI">corpName</gi>, <gi scheme="MEI">geogName</gi>, <gi scheme="MEI"
         >persName</gi>, or <gi scheme="MEI">title</gi>. The <gi scheme="MEI">name</gi> element may
@@ -6528,7 +6528,7 @@
         its electronically-available location may be recorded using the <att>auth</att> and
         <att>auth.uri</att> attributes.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
@@ -6559,7 +6559,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <gi scheme="MEI">accid</gi> and <gi scheme="MEI">artic</gi> sub-elements may be used
         instead of the note element’s attributes when accid and artic represent first-class objects,
         <abbr>e.g.</abbr>, when they require attributes, such as <att>x</att> and <att>y</att> location
@@ -6601,7 +6601,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Use this element only when it is necessary to display a number in a special way or to
         identify it with a <att>type</att> attribute.</p>
     </remarks>
@@ -6636,7 +6636,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>If it is not textual, the glyph of the ornament may be indicated with the <att>altsym</att>
         attribute, and it is recommended to provide an expansion of the ornament on the staff content.
         The starting point of the ornament may be indicated by either a <att>startid</att>,
@@ -6662,11 +6662,11 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>A paragraph is usually typographically distinct: The text usually begins on a new line and
         the first letter of the content is often indented, enlarged, or both.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Encoded Archival Description, Text Encoding
         Initiative (TEI), and HTML standards.</p>
     </remarks>
@@ -6713,7 +6713,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p> <gi scheme="MEI">part</gi> elements are not used in MEI to indicate voice leading.
         <att>next</att> attributes on event elements should be used for this purpose. <gi
         scheme="MEI">part</gi> elements are useful for encoding individual parts when there is no
@@ -6759,13 +6759,13 @@
     <content>
       <rng:ref name="macro.metaLike.page"/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>n</att> attribute should be used to record the page number displayed in the
         source. It need not be an integer, <abbr>e.g.</abbr>, 'iv', or 'p17-3'. The logical page number can be
         calculated by counting previous <gi scheme="MEI">pb</gi> ancestor elements. When used in a
         score context, a page beginning implies an accompanying system beginning.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -6788,7 +6788,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Best practice suggests the use of controlled vocabulary. Don't confuse this element with a
         figure caption. A caption is text primarily intended for display with an illustration. It
         may or may not function as a description of the illustration.</p>
@@ -6823,7 +6823,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is used to capture the textual data that often appears on the first page of
         printed music. It may also be used for similarly formatted material in manuscripts. When
         used within <gi scheme="MEI">pb</gi>, it records a temporary suspension of the pattern of
@@ -6862,7 +6862,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is used to capture the textual data that often appears on the second and
         succeeding pages of printed music. It may also be used for similarly formatted material in
         manuscripts. Auto-generated page numbers may be indicated with a processing instruction. The
@@ -6899,7 +6899,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is used to capture the textual data that often appears on the first page of
         printed music. It may also be used for similarly formatted material in manuscripts. When
         used within <gi scheme="MEI">pb</gi>, it records a temporary suspension of the pattern of
@@ -6938,7 +6938,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is used to capture the textual data that often appears at the top of the
         second and succeeding pages of printed music. It may also be used for similarly formatted
         material in manuscripts. Auto-generated page numbers may be indicated with a processing
@@ -6985,7 +6985,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Historically, the term "slur" indicated two notes performed legato, while the term "phrase"
         was used for a "unified melodic idea". Nowadays, however, "slur" often has the same meaning
         as "phrase" (See Read, p. 265-266), since the visual rendition of the two concepts is the
@@ -7030,7 +7030,7 @@
         <rng:ref name="history"/>
       </rng:optional>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
@@ -7053,7 +7053,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -7075,7 +7075,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -7213,7 +7213,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>plist</att> and <att>target</att> attributes identify the participants in a
         relationship, while the <att>rel</att> attribute describes the nature of their relationship.
         A mutual relationship can be described using only the <att>plist</att> attribute – the
@@ -7272,7 +7272,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>When an entire element should be rendered in a special way, a style sheet function should
         be used instead of the <gi scheme="MEI">rend</gi> element.</p>
     </remarks>
@@ -7295,12 +7295,12 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Sub-units of the holding institution may be marked with <gi scheme="MEI">repository</gi>
         sub-elements. The name of the list from which a controlled value is taken may be recorded
         using the <att>auth</att> attribute.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
@@ -7323,11 +7323,11 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The name of the list from which a controlled value is taken may be recorded using the
         <att>auth</att> attribute.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -7366,7 +7366,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -7402,7 +7402,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>See (Read, p. 96-102). Do not confuse this element with the <gi scheme="MEI">space</gi>
         element, which is used as an aid for visual alignment.</p>
     </remarks>
@@ -7422,7 +7422,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -7441,7 +7441,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -7461,7 +7461,7 @@
     <content>
       <rng:empty/>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Do not confuse this element with the <gi scheme="MEI">lb</gi> element, which performs a
         similar function in prose.</p>
     </remarks>
@@ -7494,7 +7494,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Since the <gi scheme="MEI">measure</gi> element is optional, a score may consist entirely
         of page beginnings, each of which points to a page image. <gi scheme="MEI">div</gi> elements
         are allowed preceding and following sections of music data in order to accommodate blocks of
@@ -7593,7 +7593,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element functions as a container for actual music data. Pointing attributes make it
         possible to connect this element to other internal or external entities, such as media
         objects or annotations.</p>
@@ -7625,7 +7625,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -7664,7 +7664,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -7688,7 +7688,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -7792,7 +7792,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>def</att> attribute may be used to create a connection with a <gi scheme="MEI"
         >staffDef</gi> element where logical and visual information about the staff is recorded.
         Alternatively, the <att>n</att> attribute may be used as a reference to a <gi scheme="MEI"
@@ -7993,7 +7993,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>System is the more proper name for this concept (Read, p. 37-38). Bracketed staff groups
         may contain other bracketed or braced staff groups or single staves. See Read, p. 35-38,
         examples p. 434, 438.</p>
@@ -8022,7 +8022,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Do not confuse this element with the <gi scheme="MEI">syllable</gi> element, which is used
         to organize neume notation.</p>
     </remarks>
@@ -8052,7 +8052,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The starting point, <abbr>e.g.</abbr>, "hotspot", of the symbol may be identified in absolute output
         coordinate terms using the <att>x</att> and <att>y</att> attributes or relative to another
         element using the <att>startid</att> attribute. Attributes in the att.visualOffset class may
@@ -8134,7 +8134,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <gi scheme="MEI">term</gi> element may include other <gi scheme="MEI">term</gi>
         elements in order to allow the creation of coordinated terms; <abbr>i.e.</abbr>, terms created from a
         combination of other, independent terms.</p>
@@ -8144,7 +8144,7 @@
         taxonomy, <att>class</att> must contain an absolute URI, which may include the fragment
         identifier of the element containing the category label.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -8276,7 +8276,7 @@
         </valList>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>type</att> attribute may be used to classify the title according to some
         convenient typology. Sample values include: main (main title), subordinate (subtitle, title
         of part), abbreviated (abbreviated form of title), alternative (alternate title by which the
@@ -8291,7 +8291,7 @@
         as those constituting an article or preposition) that should not be used for sorting a title
         or name may be indicated in the <att>nonfiling</att> attribute.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -8320,11 +8320,11 @@
         </rng:choice>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element may be used within the <gi scheme="MEI">physDesc</gi> element when no other
         transcription is provided.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in Encoded Archival Description (EAD) standard.</p>
     </remarks>
   </elementSpec>
@@ -8412,7 +8412,7 @@
         </valList>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -5,10 +5,10 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.shared">
   <moduleSpec ident="MEI.shared">
-    <desc>Component declarations that are shared between two or more modules.</desc>
+    <desc xml:lang="en">Component declarations that are shared between two or more modules.</desc>
   </moduleSpec>
   <macroSpec ident="macro.anyXML" module="MEI.shared" type="pe">
-    <desc>Permits any XML elements except those from the MEI or SVG namespace.</desc>
+    <desc xml:lang="en">Permits any XML elements except those from the MEI or SVG namespace.</desc>
     <content>
       <rng:element>
         <rng:anyName>
@@ -32,7 +32,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="macro.metaLike.page" module="MEI.shared" type="pe">
-    <desc>Groups elements that contain meta-data about a single page.</desc>
+    <desc xml:lang="en">Groups elements that contain meta-data about a single page.</desc>
     <content>
       <rng:optional>
         <rng:ref name="pgHead"/>
@@ -46,7 +46,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="macro.musicPart" module="MEI.shared" type="pe">
-    <desc>Groups elements that may appear as part of the music element.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of the music element.</desc>
     <content>
       <rng:optional>
         <rng:ref name="model.frontLike"/>
@@ -63,7 +63,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="macro.struc-unstrucContent" module="MEI.shared" type="pe">
-    <desc>Provides a choice between structured and unstructured/mixed content.</desc>
+    <desc xml:lang="en">Provides a choice between structured and unstructured/mixed content.</desc>
     <content>
       <rng:choice>
         <rng:group>
@@ -84,7 +84,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="macro.titlePart" module="MEI.shared" type="pe">
-    <desc>Groups elements that may appear as part of a bibliographic title.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of a bibliographic title.</desc>
     <content>
       <rng:zeroOrMore>
         <rng:choice>
@@ -109,76 +109,76 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.BETYPE" module="MEI.shared" type="dt">
-    <desc>Datatypes for values in begin, end, abstype and inttype attributes.</desc>
+    <desc xml:lang="en">Datatypes for values in begin, end, abstype and inttype attributes.</desc>
     <content>
       <valList type="closed">
         <valItem ident="byte">
-          <desc>Bytes.</desc>
+          <desc xml:lang="en">Bytes.</desc>
         </valItem>
         <valItem ident="smil">
-          <desc>Synchronized Multimedia Integration Language.</desc>
+          <desc xml:lang="en">Synchronized Multimedia Integration Language.</desc>
         </valItem>
         <valItem ident="midi">
-          <desc>MIDI clicks.</desc>
+          <desc xml:lang="en">MIDI clicks.</desc>
         </valItem>
         <valItem ident="mmc">
-          <desc>MIDI machine code.</desc>
+          <desc xml:lang="en">MIDI machine code.</desc>
         </valItem>
         <valItem ident="mtc">
-          <desc>MIDI time code.</desc>
+          <desc xml:lang="en">MIDI time code.</desc>
         </valItem>
         <valItem ident="smpte-25">
-          <desc>SMPTE 25 EBU.</desc>
+          <desc xml:lang="en">SMPTE 25 EBU.</desc>
         </valItem>
         <valItem ident="smpte-24">
-          <desc>SMPTE 24 Film Sync.</desc>
+          <desc xml:lang="en">SMPTE 24 Film Sync.</desc>
         </valItem>
         <valItem ident="smpte-df30">
-          <desc>SMPTE 30 Drop.</desc>
+          <desc xml:lang="en">SMPTE 30 Drop.</desc>
         </valItem>
         <valItem ident="smpte-ndf30">
-          <desc>SMPTE 30 Non-Drop.</desc>
+          <desc xml:lang="en">SMPTE 30 Non-Drop.</desc>
         </valItem>
         <valItem ident="smpte-df29.97">
-          <desc>SMPTE 29.97 Drop.</desc>
+          <desc xml:lang="en">SMPTE 29.97 Drop.</desc>
         </valItem>
         <valItem ident="smpte-ndf29.97">
-          <desc>SMPTE 29.97 Non-Drop.</desc>
+          <desc xml:lang="en">SMPTE 29.97 Non-Drop.</desc>
         </valItem>
         <valItem ident="tcf">
-          <desc>AES Time-code character format.</desc>
+          <desc xml:lang="en">AES Time-code character format.</desc>
         </valItem>
         <valItem ident="time">
-          <desc>ISO 24-hour time format: HH:MM:SS.ss.</desc>
+          <desc xml:lang="en">ISO 24-hour time format: HH:MM:SS.ss.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <classSpec ident="att.accid.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.accidental"/>
       <memberOf key="att.controlEvent"/>
     </classes>
     <attList>
       <attDef ident="func" usage="opt">
-        <desc>Records the function of an accidental.</desc>
+        <desc xml:lang="en">Records the function of an accidental.</desc>
         <valList type="closed">
           <valItem ident="caution">
-            <desc>Cautionary accidental.</desc>
+            <desc xml:lang="en">Cautionary accidental.</desc>
           </valItem>
           <valItem ident="edit">
-            <desc>Editorial accidental.</desc>
+            <desc xml:lang="en">Editorial accidental.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.accidental" module="MEI.shared" type="atts">
-    <desc>Attributes for capturing momentary pitch inflection.</desc>
+    <desc xml:lang="en">Attributes for capturing momentary pitch inflection.</desc>
     <attList>
       <attDef ident="accid" usage="opt">
-        <desc>Captures a written accidental.</desc>
+        <desc xml:lang="en">Captures a written accidental.</desc>
         <datatype>
           <rng:ref name="data.ACCIDENTAL.WRITTEN"/>
         </datatype>
@@ -186,22 +186,22 @@
     </attList>
   </classSpec>
   <classSpec ident="att.ambitus.anl" module="MEI.shared" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
     <classes>
       <memberOf key="att.intervalHarmonic"/>
     </classes>
   </classSpec>
   <classSpec ident="att.ambitus.ges" module="MEI.shared" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.ambitus.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.ambitus.vis" module="MEI.shared" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.ambNote.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.accidental"/>
       <memberOf key="att.coloration"/>
@@ -210,20 +210,20 @@
     </classes>
   </classSpec>
   <classSpec ident="att.anchoredText.anl" module="MEI.shared" type="atts">
-    <desc>Analytical domain attributes.</desc>
+    <desc xml:lang="en">Analytical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.anchoredText.ges" module="MEI.shared" type="atts">
-    <desc>Gestural domain attributes.</desc>
+    <desc xml:lang="en">Gestural domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.anchoredText.vis" module="MEI.shared" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>
   </classSpec>
   <classSpec ident="att.annot.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes for annot. Values for the type attribute can be taken from any
+    <desc xml:lang="en">Logical domain attributes for annot. Values for the type attribute can be taken from any
       convenient typology of annotation suitable to the work in hand; <abbr>e.g.</abbr>, annotation, gloss,
       citation, digression, preliminary, temporary, etc.</desc>
     <!-- Some attributes defined in att.controlEvent (att.timestamp.logical, att.timestamp.gestural,
@@ -241,17 +241,17 @@
     </classes>
   </classSpec>
   <classSpec ident="att.artic.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.articulation"/>
       <memberOf key="att.controlEvent"/>
     </classes>
   </classSpec>
   <classSpec ident="att.articulation" module="MEI.shared" type="atts">
-    <desc>Attributes for capturing the written signs that describe the method of performance.</desc>
+    <desc xml:lang="en">Attributes for capturing the written signs that describe the method of performance.</desc>
     <attList>
       <attDef ident="artic" usage="opt">
-        <desc>Encodes the written articulation(s). Articulations are normally encoded in order from
+        <desc xml:lang="en">Encodes the written articulation(s). Articulations are normally encoded in order from
           the note head outward; that is, away from the stem. See additional notes at att.vis.note.
           Only articulations should be encoded in the artic attribute; for example, fingerings
           should be encoded using the <gi scheme="MEI">fing</gi> element.</desc>
@@ -262,7 +262,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.attacca.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.startEndId"/>
@@ -270,7 +270,7 @@
     </classes>
     <attList>
       <attDef ident="target" usage="opt">
-        <desc>Indicates the next section or movement to be performed.</desc>
+        <desc xml:lang="en">Indicates the next section or movement to be performed.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
@@ -290,26 +290,26 @@
     </attList>
   </classSpec>
   <classSpec ident="att.audience" module="MEI.shared" type="atts">
-    <desc>Attributes that describe the intended audience.</desc>
+    <desc xml:lang="en">Attributes that describe the intended audience.</desc>
     <attList>
       <attDef ident="audience" usage="opt">
-        <desc>The intended audience.</desc>
+        <desc xml:lang="en">The intended audience.</desc>
         <valList type="closed">
           <valItem ident="private">
-            <desc>Internal use only.</desc>
+            <desc xml:lang="en">Internal use only.</desc>
           </valItem>
           <valItem ident="public">
-            <desc>Available to all audiences.</desc>
+            <desc xml:lang="en">Available to all audiences.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.augmentDots" module="MEI.shared" type="atts">
-    <desc>Attributes that record the number of dots of augmentation.</desc>
+    <desc xml:lang="en">Attributes that record the number of dots of augmentation.</desc>
     <attList>
       <attDef ident="dots" usage="opt">
-        <desc>Records the number of augmentation dots required by a written dotted duration.</desc>
+        <desc xml:lang="en">Records the number of augmentation dots required by a written dotted duration.</desc>
         <datatype>
           <rng:ref name="data.AUGMENTDOT"/>
         </datatype>
@@ -331,20 +331,20 @@
     </remarks>
   </classSpec>
   <classSpec ident="att.authorized" module="MEI.shared" type="atts">
-    <desc>Attributes that describe the source of a controlled value.</desc>
+    <desc xml:lang="en">Attributes that describe the source of a controlled value.</desc>
     <classes>
       <memberOf key="att.canonical"/>
     </classes>
     <attList>
       <attDef ident="auth" usage="opt">
-        <desc>A name or label associated with a controlled vocabulary or other authoritative source
+        <desc xml:lang="en">A name or label associated with a controlled vocabulary or other authoritative source
           for this element or its content.</desc>
         <datatype>
           <rng:data type="string"/>
         </datatype>
       </attDef>
       <attDef ident="auth.uri" usage="opt">
-        <desc>A web-accessible location of the controlled vocabulary or other authoritative source
+        <desc xml:lang="en">A web-accessible location of the controlled vocabulary or other authoritative source
           of identification or definition for this element or its content. This attribute may
           contain a complete URI or a partial URI which is completed by the value of the codedval
           attribute.</desc>
@@ -355,13 +355,13 @@
     </attList>
   </classSpec>
   <classSpec ident="att.barLine.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.meterConformance.bar"/>
     </classes>
     <attList>
       <attDef ident="form" usage="opt">
-        <desc>Records the appearance and usually the function of the bar line.</desc>
+        <desc xml:lang="en">Records the appearance and usually the function of the bar line.</desc>
         <datatype>
           <rng:ref name="data.BARRENDITION"/>
         </datatype>
@@ -369,10 +369,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.barring" module="MEI.shared" type="atts">
-    <desc>Attributes that capture the placement of bar lines.</desc>
+    <desc xml:lang="en">Attributes that capture the placement of bar lines.</desc>
     <attList>
       <attDef ident="bar.len" usage="opt">
-        <desc>States the length of barlines in virtual units. The value must be greater than 0 and
+        <desc xml:lang="en">States the length of barlines in virtual units. The value must be greater than 0 and
           is typically equal to 2 times (the number of staff lines - 1); <abbr>e.g.</abbr>, a value of <val>8</val> for a
           5-line staff.</desc>
         <datatype>
@@ -385,7 +385,7 @@
         </remarks>
       </attDef>
       <attDef ident="bar.method" usage="opt">
-        <desc>Records the method of barring.</desc>
+        <desc xml:lang="en">Records the method of barring.</desc>
         <datatype>
           <rng:ref name="data.BARMETHOD"/>
         </datatype>
@@ -399,7 +399,7 @@
         </constraintSpec>
       </attDef>
       <attDef ident="bar.place" usage="opt">
-        <desc>Denotes the staff location of bar lines, if the length is non-standard; that is, not
+        <desc xml:lang="en">Denotes the staff location of bar lines, if the length is non-standard; that is, not
           equal to 2 times (the number of staff lines - 1).</desc>
         <datatype>
           <rng:ref name="data.STAFFLOC"/>
@@ -416,14 +416,14 @@
     </attList>
   </classSpec>
   <classSpec ident="att.basic" module="MEI.shared" type="atts">
-    <desc>Attributes that form the basis of the att.common class.</desc>
+    <desc xml:lang="en">Attributes that form the basis of the att.common class.</desc>
     <classes>
       <memberOf key="att.id"/>
     </classes>
     <attList>
       <!--<attDef ident="base" ns="http://www.w3.org/XML/1998/namespace" usage="opt">-->
       <attDef ident="xml:base" usage="opt">
-        <desc>Provides a base URI reference with which applications can resolve relative URI
+        <desc xml:lang="en">Provides a base URI reference with which applications can resolve relative URI
           references into absolute URI references.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
@@ -432,10 +432,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.bibl" module="MEI.shared" type="atts">
-    <desc>Bibliographic attributes.</desc>
+    <desc xml:lang="en">Bibliographic attributes.</desc>
     <attList>
       <attDef ident="analog" usage="opt">
-        <desc>Contains a reference to a field or element in another descriptive encoding system to
+        <desc xml:lang="en">Contains a reference to a field or element in another descriptive encoding system to
           which this MEI element is comparable.</desc>
         <datatype>
           <rng:data type="string"/>
@@ -450,7 +450,7 @@
     </remarks>
   </classSpec>
   <classSpec ident="att.caesura.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.layerIdent"/>
       <memberOf key="att.partIdent"/>
@@ -460,10 +460,10 @@
     </classes>
   </classSpec>
   <classSpec ident="att.calendared" module="MEI.shared" type="atts">
-    <desc>Attributes that indicate the calendar system of a date or other datable element.</desc>
+    <desc xml:lang="en">Attributes that indicate the calendar system of a date or other datable element.</desc>
     <attList>
       <attDef ident="calendar" usage="opt">
-        <desc>Indicates the calendar system to which a date belongs, for example, Gregorian, Julian,
+        <desc xml:lang="en">Indicates the calendar system to which a date belongs, for example, Gregorian, Julian,
           Roman, Mosaic, Revolutionary, Islamic, etc.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
@@ -472,11 +472,11 @@
     </attList>
   </classSpec>
   <classSpec ident="att.canonical" module="MEI.shared" type="atts">
-    <desc>Attributes that can be used to associate a representation such as a name or title with
+    <desc xml:lang="en">Attributes that can be used to associate a representation such as a name or title with
       canonical information about the object being named or referenced.</desc>
     <attList>
       <attDef ident="codedval" usage="opt">
-        <desc>A value that represents or identifies other data. Often, it is a primary key in the
+        <desc xml:lang="en">A value that represents or identifies other data. Often, it is a primary key in the
           database or a unique value in the coded list identified by the <att>auth</att> or
           <att>auth.uri</att> attributes.</desc>
         <datatype maxOccurs="unbounded">
@@ -486,7 +486,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.chord.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes for chord. The artic, dots, and dur attributes encode the
+    <desc xml:lang="en">Logical domain attributes for chord. The artic, dots, and dur attributes encode the
       written articulations, augmentation dots, and duration values. The beam, fermata, lv, slur,
       syl, tie, and tuplet attributes may be used to indicate the attachment of these things to this
       chord. If visual information about these things needs to be recorded, then either the elements
@@ -503,10 +503,10 @@
     </classes>
   </classSpec>
   <classSpec ident="att.classed" module="MEI.shared" type="atts">
-    <desc>Attributes which can be used to classify features.</desc>
+    <desc xml:lang="en">Attributes which can be used to classify features.</desc>
     <attList>
       <attDef ident="class" usage="opt">
-        <desc>Contains one or more URIs which denote classification terms that apply to the entity
+        <desc xml:lang="en">Contains one or more URIs which denote classification terms that apply to the entity
           bearing this attribute.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
@@ -525,7 +525,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.clef.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.clefShape"/>
       <memberOf key="att.lineLoc"/>
@@ -534,7 +534,7 @@
     </classes>
     <attList>
       <attDef ident="cautionary" usage="opt">
-        <desc>Records the function of the clef. A "cautionary" clef does not change the following
+        <desc xml:lang="en">Records the function of the clef. A "cautionary" clef does not change the following
           pitches.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
@@ -543,7 +543,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.cleffing.log" module="MEI.shared" type="atts">
-    <desc>Used by staffDef and scoreDef to provide default values for attributes in the logical
+    <desc xml:lang="en">Used by staffDef and scoreDef to provide default values for attributes in the logical
       domain related to clefs.</desc>
     <constraintSpec ident="clef_shape_requires_clef_line" scheme="isoschematron">
       <constraint>
@@ -559,13 +559,13 @@
     </constraintSpec>
     <attList>
       <attDef ident="clef.shape" usage="opt">
-        <desc>Encodes a value for the clef symbol.</desc>
+        <desc xml:lang="en">Encodes a value for the clef symbol.</desc>
         <datatype>
           <rng:ref name="data.CLEFSHAPE"/>
         </datatype>
       </attDef>
       <attDef ident="clef.line" usage="opt">
-        <desc>Contains a default value for the position of the clef. The value must be in the range
+        <desc xml:lang="en">Contains a default value for the position of the clef. The value must be in the range
           between 1 and the number of lines on the staff. The numbering of lines starts with the
           lowest line of the staff.</desc>
         <datatype>
@@ -573,13 +573,13 @@
         </datatype>
       </attDef>
       <attDef ident="clef.dis" usage="opt">
-        <desc>Records the amount of octave displacement to be applied to the clef.</desc>
+        <desc xml:lang="en">Records the amount of octave displacement to be applied to the clef.</desc>
         <datatype>
           <rng:ref name="data.OCTAVE.DIS"/>
         </datatype>
       </attDef>
       <attDef ident="clef.dis.place" usage="opt">
-        <desc>Records the direction of octave displacement to be applied to the clef.</desc>
+        <desc xml:lang="en">Records the direction of octave displacement to be applied to the clef.</desc>
         <datatype>
           <rng:ref name="data.STAFFREL.basic"/>
         </datatype>
@@ -587,10 +587,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.clefGrp.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.clefShape" module="MEI.shared" type="atts">
-    <desc>Attributes that record the shape of a clef.</desc>
+    <desc xml:lang="en">Attributes that record the shape of a clef.</desc>
     <constraintSpec ident="shape_requires_line" scheme="isoschematron">
       <constraint>
         <sch:rule context="mei:clef[matches(@shape, '[FCG]')]">
@@ -601,7 +601,7 @@
     </constraintSpec>
     <attList>
       <attDef ident="shape" usage="opt">
-        <desc>Describes a clef’s shape.</desc>
+        <desc xml:lang="en">Describes a clef’s shape.</desc>
         <datatype>
           <rng:ref name="data.CLEFSHAPE"/>
         </datatype>
@@ -609,10 +609,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.color" module="MEI.shared" type="atts">
-    <desc>Visual color attributes.</desc>
+    <desc xml:lang="en">Visual color attributes.</desc>
     <attList>
       <attDef ident="color" usage="opt">
-        <desc>Used to indicate visual appearance. Do not confuse this with the musical term 'color'
+        <desc xml:lang="en">Used to indicate visual appearance. Do not confuse this with the musical term 'color'
           as used in pre-CMN notation.</desc>
         <datatype>
           <rng:ref name="data.COLOR"/>
@@ -621,10 +621,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.coloration" module="MEI.shared" type="atts">
-    <desc>Indication of coloration.</desc>
+    <desc xml:lang="en">Indication of coloration.</desc>
     <attList>
       <attDef ident="colored" usage="opt">
-        <desc>Indicates this feature is 'colored'; that is, it is a participant in a change in
+        <desc xml:lang="en">Indicates this feature is 'colored'; that is, it is a participant in a change in
           rhythmic values. In mensural notation, coloration is indicated by colored notes (red,
           black, etc.) where void notes would otherwise occur. In CMN, coloration is indicated by an
           inverse color; that is, the note head is void when it would otherwise be filled and vice
@@ -636,7 +636,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.common" module="MEI.shared" type="atts">
-    <desc>Attributes common to many elements.</desc>
+    <desc xml:lang="en">Attributes common to many elements.</desc>
     <classes>
       <memberOf key="att.basic"/>
       <memberOf key="att.labelled"/>
@@ -647,7 +647,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.controlEvent" module="MEI.shared" type="atts">
-    <desc>Attributes shared by events which rely on other events for their existence. For example, a
+    <desc xml:lang="en">Attributes shared by events which rely on other events for their existence. For example, a
       slur/phrase marking must be drawn between or over a group of notes. The slur is therefore a
       control event.</desc>
     <classes>
@@ -662,35 +662,35 @@
     </classes>
   </classSpec>
   <classSpec ident="att.coordinated" module="MEI.shared" type="atts">
-    <desc>This attribute class records the position of a feature within a two-dimensional coordinate
+    <desc xml:lang="en">This attribute class records the position of a feature within a two-dimensional coordinate
       system.</desc>
     <attList>
       <attDef ident="ulx" usage="opt">
-        <desc>Indicates the upper-left corner x coordinate.</desc>
+        <desc xml:lang="en">Indicates the upper-left corner x coordinate.</desc>
         <datatype>
           <rng:data type="nonNegativeInteger"/>
         </datatype>
       </attDef>
       <attDef ident="uly" usage="opt">
-        <desc>Indicates the upper-left corner y coordinate.</desc>
+        <desc xml:lang="en">Indicates the upper-left corner y coordinate.</desc>
         <datatype>
           <rng:data type="nonNegativeInteger"/>
         </datatype>
       </attDef>
       <attDef ident="lrx" usage="opt">
-        <desc>Indicates the lower-right corner x coordinate.</desc>
+        <desc xml:lang="en">Indicates the lower-right corner x coordinate.</desc>
         <datatype>
           <rng:data type="nonNegativeInteger"/>
         </datatype>
       </attDef>
       <attDef ident="lry" usage="opt">
-        <desc>Indicates the lower-left corner x coordinate.</desc>
+        <desc xml:lang="en">Indicates the lower-left corner x coordinate.</desc>
         <datatype>
           <rng:data type="nonNegativeInteger"/>
         </datatype>
       </attDef>
       <attDef ident="rotate">
-        <desc>
+        <desc xml:lang="en">
           Indicates the amount by which the contents of this element have been rotated clockwise or, if applicable, how the orientation of
           the element self should be interpreted, with respect to the normal orientation of the parent surface.
           The orientation is expressed in arc degrees.
@@ -706,7 +706,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.cue" module="MEI.shared" type="atts">
-    <desc>Attributes that describe "cue-ness".</desc>
+    <desc xml:lang="en">Attributes that describe "cue-ness".</desc>
     <attList>
       <attDef ident="cue" usage="opt">
         <datatype>
@@ -716,10 +716,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.curvature" module="MEI.shared" type="atts">
-    <desc>Attributes that describe curvature.</desc>
+    <desc xml:lang="en">Attributes that describe curvature.</desc>
     <attList>
       <attDef ident="bezier" usage="opt">
-        <desc>Records the placement of Bezier control points as a series of pairs of space-separated
+        <desc xml:lang="en">Records the placement of Bezier control points as a series of pairs of space-separated
           values; <abbr>e.g.</abbr>, <val>19 45 -32 118.</val></desc>
         <datatype>
           <rng:list>
@@ -731,7 +731,7 @@
         </datatype>
       </attDef>
       <attDef ident="bulge" usage="opt">
-        <desc>Describes a curve as one or more pairs of values with respect to an imaginary line
+        <desc xml:lang="en">Describes a curve as one or more pairs of values with respect to an imaginary line
           connecting the starting and ending points of the curve. The first value captures a
           distance to the left (positive value) or right (negative value) of the line, expressed in
           virtual units. The second value of each pair represents a point along the line, expressed
@@ -748,32 +748,32 @@
         </datatype>
       </attDef>
       <attDef ident="curvedir" usage="opt">
-        <desc>Describes a curve with a generic term indicating the direction of curvature.</desc>
+        <desc xml:lang="en">Describes a curve with a generic term indicating the direction of curvature.</desc>
         <valList type="closed">
           <valItem ident="above">
-            <desc>Upward curve.</desc>
+            <desc xml:lang="en">Upward curve.</desc>
           </valItem>
           <valItem ident="below">
-            <desc>Downward curve.</desc>
+            <desc xml:lang="en">Downward curve.</desc>
           </valItem>
           <valItem ident="mixed">
-            <desc>A "meandering" curve, both above and below the items it pertains to.</desc>
+            <desc xml:lang="en">A "meandering" curve, both above and below the items it pertains to.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.curveRend" module="MEI.shared" type="atts">
-    <desc>Attributes that record the visual rendition of curves.</desc>
+    <desc xml:lang="en">Attributes that record the visual rendition of curves.</desc>
     <attList>
       <attDef ident="lform" usage="opt">
-        <desc>Describes the line style of a curve.</desc>
+        <desc xml:lang="en">Describes the line style of a curve.</desc>
         <datatype>
           <rng:ref name="data.LINEFORM"/>
         </datatype>
       </attDef>
       <attDef ident="lwidth" usage="opt">
-        <desc>Width of a curved line.</desc>
+        <desc xml:lang="en">Width of a curved line.</desc>
         <datatype>
           <rng:ref name="data.LINEWIDTH"/>
         </datatype>
@@ -781,14 +781,14 @@
     </attList>
   </classSpec>
   <classSpec ident="att.custos.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.accidental"/>
       <memberOf key="att.pitched"/>
     </classes>
     <attList>
       <attDef ident="target" usage="opt">
-        <desc>Encodes the target note when its pitch differs from the pitch at which the custos
+        <desc xml:lang="en">Encodes the target note when its pitch differs from the pitch at which the custos
           appears.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
@@ -809,34 +809,34 @@
     </attList>
   </classSpec>
   <classSpec ident="att.datable" module="MEI.shared" type="atts">
-    <desc>Attributes common to dates.</desc>
+    <desc xml:lang="en">Attributes common to dates.</desc>
     <attList>
       <attDef ident="enddate" usage="opt">
-        <desc>Contains the end point of a date range in standard ISO form.</desc>
+        <desc xml:lang="en">Contains the end point of a date range in standard ISO form.</desc>
         <datatype>
           <rng:ref name="data.ISODATE"/>
         </datatype>
       </attDef>
       <attDef ident="isodate" usage="opt">
-        <desc>Provides the value of a textual date in standard ISO form.</desc>
+        <desc xml:lang="en">Provides the value of a textual date in standard ISO form.</desc>
         <datatype>
           <rng:ref name="data.ISODATE"/>
         </datatype>
       </attDef>
       <attDef ident="notafter" usage="opt">
-        <desc>Contains an upper boundary for an uncertain date in standard ISO form.</desc>
+        <desc xml:lang="en">Contains an upper boundary for an uncertain date in standard ISO form.</desc>
         <datatype>
           <rng:ref name="data.ISODATE"/>
         </datatype>
       </attDef>
       <attDef ident="notbefore" usage="opt">
-        <desc>Contains a lower boundary, in standard ISO form, for an uncertain date.</desc>
+        <desc xml:lang="en">Contains a lower boundary, in standard ISO form, for an uncertain date.</desc>
         <datatype>
           <rng:ref name="data.ISODATE"/>
         </datatype>
       </attDef>
       <attDef ident="startdate" usage="opt">
-        <desc>Contains the starting point of a date range in standard ISO form.</desc>
+        <desc xml:lang="en">Contains the starting point of a date range in standard ISO form.</desc>
         <datatype>
           <rng:ref name="data.ISODATE"/>
         </datatype>
@@ -844,10 +844,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.dataPointing" module="MEI.shared" type="atts">
-    <desc>Attributes for linking metadata to data.</desc>
+    <desc xml:lang="en">Attributes for linking metadata to data.</desc>
     <attList>
       <attDef ident="data" usage="opt">
-        <desc>Used to link metadata elements to one or more data-containing elements.</desc>
+        <desc xml:lang="en">Used to link metadata elements to one or more data-containing elements.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
         </datatype>
@@ -867,17 +867,17 @@
     </attList>
   </classSpec>
   <classSpec ident="att.mdiv.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.alignment"/>
     </classes>
   </classSpec>
   <classSpec ident="att.metadataPointing" module="MEI.shared" type="atts">
-    <desc>Provides attributes for elements which may be associated with particular contextual
+    <desc xml:lang="en">Provides attributes for elements which may be associated with particular contextual
       elements within the header.</desc>
     <attList>
       <attDef ident="decls" usage="opt">
-        <desc>Identifies one or more metadata elements (other than classification terms) within the
+        <desc xml:lang="en">Identifies one or more metadata elements (other than classification terms) within the
           header, which are understood to apply to the element bearing this attribute and its
           content.</desc>
         <datatype maxOccurs="unbounded">
@@ -903,14 +903,14 @@
     </attList>
   </classSpec>
   <classSpec ident="att.dimensions" module="MEI.shared" type="atts">
-    <desc>Attributes that capture the dimensions of an entity.</desc>
+    <desc xml:lang="en">Attributes that capture the dimensions of an entity.</desc>
     <classes>
       <memberOf key="att.height"/>
       <memberOf key="att.width"/>
     </classes>
   </classSpec>
   <classSpec ident="att.dir.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
@@ -919,23 +919,23 @@
     </classes>
   </classSpec>
   <classSpec ident="att.distances" module="MEI.shared" type="atts">
-    <desc>Attributes that describe distance from the staff.</desc>
+    <desc xml:lang="en">Attributes that describe distance from the staff.</desc>
     <attList>
       <attDef ident="dynam.dist" usage="opt">
-        <desc>Records the default distance from the staff for dynamic marks.</desc>
+        <desc xml:lang="en">Records the default distance from the staff for dynamic marks.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTREL"/>
         </datatype>
       </attDef>
       <attDef ident="harm.dist" usage="opt">
-        <desc>Records the default distance from the staff of harmonic indications, such as guitar
+        <desc xml:lang="en">Records the default distance from the staff of harmonic indications, such as guitar
           chord grids or functional labels.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTREL"/>
         </datatype>
       </attDef>
       <attDef ident="text.dist" usage="opt">
-        <desc>Determines how far from the staff to render text elements.</desc>
+        <desc xml:lang="en">Determines how far from the staff to render text elements.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTREL"/>
         </datatype>
@@ -943,29 +943,29 @@
     </attList>
   </classSpec>
   <classSpec ident="att.dot.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
     </classes>
     <attList>
       <attDef ident="form" usage="opt">
-        <desc>Records the function of the dot.</desc>
+        <desc xml:lang="en">Records the function of the dot.</desc>
         <valList type="closed">
           <valItem ident="aug">
-            <desc>Augmentation dot.</desc>
+            <desc xml:lang="en">Augmentation dot.</desc>
           </valItem>
           <valItem ident="div">
-            <desc>Dot of division.</desc>
+            <desc xml:lang="en">Dot of division.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.duration.additive" module="MEI.shared" type="atts">
-    <desc>Attributes that permit total duration to be represented by multiple values.</desc>
+    <desc xml:lang="en">Attributes that permit total duration to be represented by multiple values.</desc>
     <attList>
       <attDef ident="dur" usage="opt">
-        <desc>When a duration cannot be represented as a single power-of-two value, multiple
+        <desc xml:lang="en">When a duration cannot be represented as a single power-of-two value, multiple
           space-separated values that add up to the total duration may be used.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.DURATION"/>
@@ -974,24 +974,24 @@
     </attList>
   </classSpec>
   <classSpec ident="att.duration.default" module="MEI.shared" type="atts">
-    <desc>Attributes that provide a durational default value.</desc>
+    <desc xml:lang="en">Attributes that provide a durational default value.</desc>
     <attList>
       <attDef ident="dur.default" usage="opt">
-        <desc>Contains a default duration in those situations when the first note, rest, chord, etc.
+        <desc xml:lang="en">Contains a default duration in those situations when the first note, rest, chord, etc.
           in a measure does not have a duration specified.</desc>
         <datatype>
           <rng:ref name="data.DURATION"/>
         </datatype>
       </attDef>
       <attDef ident="num.default" usage="opt">
-        <desc>Along with numbase.default, describes the default duration as a ratio. num.default is
+        <desc xml:lang="en">Along with numbase.default, describes the default duration as a ratio. num.default is
           the first value in the ratio.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
       </attDef>
       <attDef ident="numbase.default" usage="opt">
-        <desc>Along with num.default, describes the default duration as a ratio. numbase.default is
+        <desc xml:lang="en">Along with num.default, describes the default duration as a ratio. numbase.default is
           the second value in the ratio.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
@@ -1000,10 +1000,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.duration.logical" module="MEI.shared" type="atts">
-    <desc>Attributes that express duration in musical terms.</desc>
+    <desc xml:lang="en">Attributes that express duration in musical terms.</desc>
     <attList>
       <attDef ident="dur" usage="opt">
-        <desc>Records the duration of a feature using the relative durational values provided by the
+        <desc xml:lang="en">Records the duration of a feature using the relative durational values provided by the
           data.DURATION datatype.</desc>
         <datatype>
           <rng:ref name="data.DURATION"/>
@@ -1012,17 +1012,17 @@
     </attList>
   </classSpec>
   <classSpec ident="att.duration.ratio" module="MEI.shared" type="atts">
-    <desc>Attributes that describe duration as a ratio.</desc>
+    <desc xml:lang="en">Attributes that describe duration as a ratio.</desc>
     <attList>
       <attDef ident="num" usage="opt">
-        <desc>Along with numbase, describes duration as a ratio. num is the first value in the
+        <desc xml:lang="en">Along with numbase, describes duration as a ratio. num is the first value in the
           ratio, while numbase is the second.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
       </attDef>
       <attDef ident="numbase" usage="opt">
-        <desc>Along with num, describes duration as a ratio. num is the first value in the ratio,
+        <desc xml:lang="en">Along with num, describes duration as a ratio. num is the first value in the ratio,
           while numbase is the second.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
@@ -1031,7 +1031,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.dynam.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
@@ -1040,11 +1040,11 @@
     </classes>
   </classSpec>
   <classSpec ident="att.enclosingChars" module="MEI.shared" type="atts">
-    <desc>Attributes that capture characters used to enclose symbols having a cautionary or
+    <desc xml:lang="en">Attributes that capture characters used to enclose symbols having a cautionary or
       editorial function.</desc>
     <attList>
       <attDef ident="enclose" usage="opt">
-        <desc>Records the characters often used to mark accidentals, articulations, and sometimes
+        <desc xml:lang="en">Records the characters often used to mark accidentals, articulations, and sometimes
           notes as having a cautionary or editorial function. For an example of cautionary
           accidentals enclosed in parentheses, see Read, p. 131, ex. 9-14.</desc>
         <datatype>
@@ -1054,32 +1054,32 @@
     </attList>
   </classSpec>
   <classSpec ident="att.ending.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.alignment"/>
     </classes>
   </classSpec>
   <classSpec ident="att.endings" module="MEI.shared" type="atts">
-    <desc>Attributes that record ending style information</desc>
+    <desc xml:lang="en">Attributes that record ending style information</desc>
     <attList>
       <attDef ident="ending.rend" usage="opt">
-        <desc>Describes where ending marks should be displayed.</desc>
+        <desc xml:lang="en">Describes where ending marks should be displayed.</desc>
         <valList type="closed">
           <valItem ident="top">
-            <desc>Ending rendered only above top staff.</desc>
+            <desc xml:lang="en">Ending rendered only above top staff.</desc>
           </valItem>
           <valItem ident="barred">
-            <desc>Ending rendered above staves that have bar lines drawn across them.</desc>
+            <desc xml:lang="en">Ending rendered above staves that have bar lines drawn across them.</desc>
           </valItem>
           <valItem ident="grouped">
-            <desc>Endings rendered above staff groups.</desc>
+            <desc xml:lang="en">Endings rendered above staff groups.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.event" module="MEI.shared" type="atts">
-    <desc>Attributes that apply to all written events, <abbr>e.g.</abbr>, note, chord, rest, etc.</desc>
+    <desc xml:lang="en">Attributes that apply to all written events, <abbr>e.g.</abbr>, note, chord, rest, etc.</desc>
     <classes>
       <memberOf key="att.alignment"/>
       <memberOf key="att.layerIdent"/>
@@ -1089,29 +1089,29 @@
     </classes>
   </classSpec>
   <classSpec ident="att.evidence" module="MEI.shared" type="atts">
-    <desc>Attributes describing the support for and the certainty of an assertion.</desc>
+    <desc xml:lang="en">Attributes describing the support for and the certainty of an assertion.</desc>
     <attList>
       <attDef ident="cert" usage="opt">
-        <desc>Signifies the degree of certainty or precision associated with a feature.</desc>
+        <desc xml:lang="en">Signifies the degree of certainty or precision associated with a feature.</desc>
         <datatype>
           <rng:ref name="data.CERTAINTY"/>
         </datatype>
       </attDef>
       <attDef ident="evidence" usage="opt">
-        <desc>Indicates the nature of the evidence supporting the reliability or accuracy of the
+        <desc xml:lang="en">Indicates the nature of the evidence supporting the reliability or accuracy of the
           intervention or interpretation.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="internal">
-            <desc>There is evidence within the document to support the intervention.</desc>
+            <desc xml:lang="en">There is evidence within the document to support the intervention.</desc>
           </valItem>
           <valItem ident="external">
-            <desc>There is evidence outside the document to support the intervention.</desc>
+            <desc xml:lang="en">There is evidence outside the document to support the intervention.</desc>
           </valItem>
           <valItem ident="conjecture">
-            <desc>The assertion has been made by the editor, cataloguer, or scholar on the basis of
+            <desc xml:lang="en">The assertion has been made by the editor, cataloguer, or scholar on the basis of
               their expertise.</desc>
           </valItem>
         </valList>
@@ -1119,14 +1119,14 @@
     </attList>
   </classSpec>
   <classSpec ident="att.extender" module="MEI.shared" type="atts">
-    <desc>Attributes that describe extension symbols, typically lines. Members of this class are
+    <desc xml:lang="en">Attributes that describe extension symbols, typically lines. Members of this class are
       also typically members of the att.lineRend class.</desc>
     <classes>
       <memberOf key="att.lineRend"/>
     </classes>
     <attList>
       <attDef ident="extender" usage="opt">
-        <desc>Indicates the presence of an extension symbol, typically a line.</desc>
+        <desc xml:lang="en">Indicates the presence of an extension symbol, typically a line.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
@@ -1134,14 +1134,14 @@
     </attList>
   </classSpec>
   <classSpec ident="att.extent" module="MEI.shared" type="atts">
-    <desc>Provides attributes for describing the size of an entity.</desc>
+    <desc xml:lang="en">Provides attributes for describing the size of an entity.</desc>
     <classes>
       <memberOf key="att.measurement"/>
       <memberOf key="att.ranging"/>
     </classes>
     <attList>
       <attDef ident="extent" usage="opt">
-        <desc>Captures a measurement, count, or description. When extent contains a numeric value,
+        <desc xml:lang="en">Captures a measurement, count, or description. When extent contains a numeric value,
           use the unit attribute to indicate the measurement unit.</desc>
         <datatype>
           <rng:data type="string"/>
@@ -1162,10 +1162,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.fermataPresent" module="MEI.shared" type="atts">
-    <desc>Attributes indicating the attachment of a fermata to the feature.</desc>
+    <desc xml:lang="en">Attributes indicating the attachment of a fermata to the feature.</desc>
     <attList>
       <attDef ident="fermata" usage="opt">
-        <desc>Indicates the attachment of a fermata to this element. If visual information about the
+        <desc xml:lang="en">Indicates the attachment of a fermata to this element. If visual information about the
           fermata needs to be recorded, then a <gi scheme="MEI">fermata</gi> element should be
           employed instead.</desc>
         <datatype>
@@ -1175,10 +1175,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.filing" module="MEI.shared" type="atts">
-    <desc>Attributes that deal with string filing characteristics.</desc>
+    <desc xml:lang="en">Attributes that deal with string filing characteristics.</desc>
     <attList>
       <attDef ident="nonfiling" usage="opt">
-        <desc>Holds the number of initial characters (such as those constituting an article or
+        <desc xml:lang="en">Holds the number of initial characters (such as those constituting an article or
           preposition) that should not be used for sorting a title or name.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
@@ -1187,14 +1187,14 @@
     </attList>
   </classSpec>
   <classSpec ident="att.grpSym.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.staffGroupingSym"/>
       <memberOf key="att.startEndId"/>
     </classes>
     <attList>
       <attDef ident="level" usage="opt">
-        <desc>Indicates the nesting level of staff grouping symbols.</desc>
+        <desc xml:lang="en">Indicates the nesting level of staff grouping symbols.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
@@ -1202,10 +1202,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.handIdent" module="MEI.shared" type="atts">
-    <desc>Attributes which identify a document hand.</desc>
+    <desc xml:lang="en">Attributes which identify a document hand.</desc>
     <attList>
       <attDef ident="hand" usage="opt">
-        <desc>Signifies the hand responsible for an action. The value must be the ID of a <gi
+        <desc xml:lang="en">Signifies the hand responsible for an action. The value must be the ID of a <gi
           scheme="MEI">hand</gi> element declared in the header.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
@@ -1226,10 +1226,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.height" module="MEI.shared" type="atts">
-    <desc>Attributes that describe vertical size.</desc>
+    <desc xml:lang="en">Attributes that describe vertical size.</desc>
     <attList>
       <attDef ident="height" usage="opt">
-        <desc>Measurement of the vertical dimension of an entity.</desc>
+        <desc xml:lang="en">Measurement of the vertical dimension of an entity.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTABS"/>
         </datatype>
@@ -1237,10 +1237,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.horizontalAlign" module="MEI.shared" type="atts">
-    <desc>Attributes that record horizontal alignment.</desc>
+    <desc xml:lang="en">Attributes that record horizontal alignment.</desc>
     <attList>
       <attDef ident="halign" usage="opt">
-        <desc>Records horizontal alignment.</desc>
+        <desc xml:lang="en">Records horizontal alignment.</desc>
         <datatype>
           <rng:ref name="data.HORIZONTALALIGNMENT"/>
         </datatype>
@@ -1248,11 +1248,11 @@
     </attList>
   </classSpec>
   <classSpec ident="att.id" module="MEI.shared" type="atts">
-    <desc>Attributes that uniquely identify an element.</desc>
+    <desc xml:lang="en">Attributes that uniquely identify an element.</desc>
     <attList>
       <!--<attDef ident="id" ns="http://www.w3.org/XML/1998/namespace" usage="opt">-->
       <attDef ident="xml:id" usage="opt">
-        <desc>Regularizes the naming of an element and thus facilitates building links between it
+        <desc xml:lang="en">Regularizes the naming of an element and thus facilitates building links between it
           and other resources. Each id attribute within a document must have a unique value.</desc>
         <datatype>
           <rng:data type="ID"/>
@@ -1261,10 +1261,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.internetMedia" module="MEI.shared" type="atts">
-    <desc>Attributes which record the type of an electronic resource.</desc>
+    <desc xml:lang="en">Attributes which record the type of an electronic resource.</desc>
     <attList>
       <attDef ident="mimetype" usage="opt">
-        <desc>Specifies the applicable MIME (multimedia internet mail extension) type. The value
+        <desc xml:lang="en">Specifies the applicable MIME (multimedia internet mail extension) type. The value
           should be a valid MIME media type defined by the Internet Engineering Task Force in RFC
           2046.</desc>
         <datatype>
@@ -1274,11 +1274,11 @@
     </attList>
   </classSpec>
   <classSpec ident="att.joined" module="MEI.shared" type="atts">
-    <desc>Attributes indicating that elements are semantically linked; that is, while the parts are
+    <desc xml:lang="en">Attributes indicating that elements are semantically linked; that is, while the parts are
       encoded separately, together they may be thought of as a single intellectual object.</desc>
     <attList>
       <attDef ident="join" usage="opt">
-        <desc>Used for linking visually separate entities that form a single logical entity, for
+        <desc xml:lang="en">Used for linking visually separate entities that form a single logical entity, for
           example, multiple slurs broken across a system break that form a single musical phrase.
           Also used to indicate a measure which metrically completes the current one. Record the
           identifiers of the separately encoded components, excluding the one carrying the
@@ -1302,17 +1302,17 @@
     </attList>
   </classSpec>
   <classSpec ident="att.keyAccid.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.accidental"/>
       <memberOf key="att.pitched"/>
     </classes>
   </classSpec>
   <classSpec ident="att.keySig.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <attList>
       <attDef ident="sig" usage="opt">
-        <desc>Written key signature.</desc>
+        <desc xml:lang="en">Written key signature.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.KEYFIFTHS"/>
         </datatype>
@@ -1325,11 +1325,11 @@
     </remarks>
   </classSpec>
   <classSpec ident="att.keySigDefault.log" module="MEI.shared" type="atts">
-    <desc>Used by staffDef and scoreDef to provide default values for attributes in the logical
+    <desc xml:lang="en">Used by staffDef and scoreDef to provide default values for attributes in the logical
       domain that are related to key signatures.</desc>
     <attList>
       <attDef ident="key.sig" usage="opt">
-        <desc>Written key signature.</desc>
+        <desc xml:lang="en">Written key signature.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.KEYFIFTHS"/>
         </datatype>
@@ -1344,7 +1344,7 @@
   <classSpec ident="att.labelled" module="MEI.shared" type="atts">
     <attList>
       <attDef ident="label" usage="opt">
-        <desc>Captures text to be used to generate a label for the element to which it’s attached, a
+        <desc xml:lang="en">Captures text to be used to generate a label for the element to which it’s attached, a
           "tool tip" or prefatory text, for example. Should not be used to record document
           content.</desc>
         <datatype>
@@ -1362,11 +1362,11 @@
     </attList>
   </classSpec>
   <classSpec ident="att.lang" module="MEI.shared" type="atts">
-    <desc>Language attributes common to text elements.</desc>
+    <desc xml:lang="en">Language attributes common to text elements.</desc>
     <attList>
       <!--<attDef ident="lang" ns="http://www.w3.org/XML/1998/namespace" usage="opt">-->
       <attDef ident="xml:lang" usage="opt">
-        <desc>Identifies the language of the element’s content. The values for this attribute are
+        <desc xml:lang="en">Identifies the language of the element’s content. The values for this attribute are
           language 'tags' as defined in BCP 47. All language tags that make use of private use
           sub-tags must be documented in a corresponding language element in the MEI header whose id
           attribute is the same as the language tag’s value.</desc>
@@ -1375,7 +1375,7 @@
         </datatype>
       </attDef>
       <attDef ident="translit" usage="opt">
-        <desc>Specifies the transliteration technique used.</desc>
+        <desc xml:lang="en">Specifies the transliteration technique used.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
@@ -1395,14 +1395,14 @@
     </remarks>
   </classSpec>
   <classSpec ident="att.layer.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.cue"/>
       <memberOf key="att.meterConformance"/>
     </classes>
     <attList>
       <attDef ident="def" usage="opt">
-        <desc>Provides a mechanism for linking the layer to a layerDef element.</desc>
+        <desc xml:lang="en">Provides a mechanism for linking the layer to a layerDef element.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
@@ -1422,7 +1422,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.layerDef.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.default"/>
       <memberOf key="att.layerDef.log.cmn"/>
@@ -1431,10 +1431,10 @@
     </classes>
   </classSpec>
   <classSpec ident="att.layerIdent" module="MEI.shared" type="atts">
-    <desc>Attributes that identify the layer to which a feature applies.</desc>
+    <desc xml:lang="en">Attributes that identify the layer to which a feature applies.</desc>
     <attList>
       <attDef ident="layer" usage="opt">
-        <desc>Identifies the layer to which a feature applies.</desc>
+        <desc xml:lang="en">Identifies the layer to which a feature applies.</desc>
         <datatype maxOccurs="unbounded">
           <rng:data type="positiveInteger"/>
         </datatype>
@@ -1442,10 +1442,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.lineLoc" module="MEI.shared" type="atts">
-    <desc>Attributes for identifying the staff line with which a feature is associated.</desc>
+    <desc xml:lang="en">Attributes for identifying the staff line with which a feature is associated.</desc>
     <attList>
       <attDef ident="line" usage="opt">
-        <desc>Indicates the line upon which a feature stands. The value must be in the range between
+        <desc xml:lang="en">Indicates the line upon which a feature stands. The value must be in the range between
           1 and the number of lines on the staff. The numbering of lines starts with the lowest line
           of the staff.</desc>
         <datatype>
@@ -1455,32 +1455,32 @@
     </attList>
   </classSpec>
   <classSpec ident="att.lineRend" module="MEI.shared" type="atts">
-    <desc>Attributes that record the visual rendition of lines.</desc>
+    <desc xml:lang="en">Attributes that record the visual rendition of lines.</desc>
     <classes>
       <memberOf key="att.lineRend.base"/>
     </classes>
     <attList>
       <!-- additional visual characteristics of the line -->
       <attDef ident="lendsym" usage="opt">
-        <desc>Symbol rendered at end of line.</desc>
+        <desc xml:lang="en">Symbol rendered at end of line.</desc>
         <datatype>
           <rng:ref name="data.LINESTARTENDSYMBOL"/>
         </datatype>
       </attDef>
       <attDef ident="lendsym.size" usage="opt">
-        <desc>Holds the relative size of the line-end symbol.</desc>
+        <desc xml:lang="en">Holds the relative size of the line-end symbol.</desc>
         <datatype>
           <rng:ref name="data.FONTSIZESCALE"/>
         </datatype>
       </attDef>
       <attDef ident="lstartsym" usage="opt">
-        <desc>Symbol rendered at start of line.</desc>
+        <desc xml:lang="en">Symbol rendered at start of line.</desc>
         <datatype>
           <rng:ref name="data.LINESTARTENDSYMBOL"/>
         </datatype>
       </attDef>
       <attDef ident="lstartsym.size" usage="opt">
-        <desc>Holds the relative size of the line-start symbol.</desc>
+        <desc xml:lang="en">Holds the relative size of the line-start symbol.</desc>
         <datatype>
           <rng:ref name="data.FONTSIZESCALE"/>
         </datatype>
@@ -1488,10 +1488,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.lineRend.base" module="MEI.shared" type="atts">
-    <desc>Attributes that record the basic visual rendition of lines.</desc>
+    <desc xml:lang="en">Attributes that record the basic visual rendition of lines.</desc>
     <attList>
       <attDef ident="lform" usage="opt">
-        <desc>Describes the line style of a line.</desc>
+        <desc xml:lang="en">Describes the line style of a line.</desc>
         <datatype>
           <rng:ref name="data.LINEFORM"/>
         </datatype>
@@ -1501,7 +1501,7 @@
             can't know without establishing an end point, which in turn makes
             @llength redundant. -->
       <attDef ident="lsegs" usage="opt">
-        <desc>Describes the number of segments into which a dashed or dotted line may be divided, or
+        <desc xml:lang="en">Describes the number of segments into which a dashed or dotted line may be divided, or
           the number of "peaks" of a wavy line; a pair of space-separated values (minimum and
           maximum, respectively) provides a range between which a rendering system-supplied value
           may fall, while a single value indicates a fixed amount of space; that is, the minimum and
@@ -1521,14 +1521,14 @@
         </constraintSpec>
       </attDef>
       <attDef ident="lwidth" usage="opt">
-        <desc>Width of a line.</desc>
+        <desc xml:lang="en">Width of a line.</desc>
         <datatype>
           <rng:ref name="data.LINEWIDTH"/>
         </datatype>
       </attDef>
       <!-- Possible addition:
           <attDef ident="lwaveheight" usage="opt">
-            <desc>Captures the height of peaks of a wavy line.</desc>
+            <desc xml:lang="en">Captures the height of peaks of a wavy line.</desc>
             <datatype>
               <rng:ref name="data.MEASUREMENT"/>
             </datatype>
@@ -1537,10 +1537,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.linking" module="MEI.shared" type="atts">
-    <desc>Attributes that specify element-to-element relationships.</desc>
+    <desc xml:lang="en">Attributes that specify element-to-element relationships.</desc>
     <attList>
       <attDef ident="copyof" usage="opt">
-        <desc>Points to an element of which the current element is a copy.</desc>
+        <desc xml:lang="en">Points to an element of which the current element is a copy.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
@@ -1567,7 +1567,7 @@
         </constraintSpec>
       </attDef>
       <attDef ident="corresp" usage="opt">
-        <desc>Used to point to other elements that correspond to this one in a generic
+        <desc xml:lang="en">Used to point to other elements that correspond to this one in a generic
           fashion.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
@@ -1586,7 +1586,7 @@
         </constraintSpec>
       </attDef>
       <attDef ident="follows" usage="opt">
-        <desc>points to one or more events in a user-defined collection that are known to be
+        <desc xml:lang="en">points to one or more events in a user-defined collection that are known to be
           predecessors of the current element.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
@@ -1605,7 +1605,7 @@
         </constraintSpec>
       </attDef>
       <attDef ident="next" usage="opt">
-        <desc>Used to point to the next event(s) in a user-defined collection.</desc>
+        <desc xml:lang="en">Used to point to the next event(s) in a user-defined collection.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
         </datatype>
@@ -1623,7 +1623,7 @@
         </constraintSpec>
       </attDef>
       <attDef ident="precedes" usage="opt">
-        <desc>Points to one or more events in a user-defined collection that are known to be
+        <desc xml:lang="en">Points to one or more events in a user-defined collection that are known to be
           successors of the current element.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
@@ -1642,7 +1642,7 @@
         </constraintSpec>
       </attDef>
       <attDef ident="prev" usage="opt">
-        <desc>Points to the previous event(s) in a user-defined collection.</desc>
+        <desc xml:lang="en">Points to the previous event(s) in a user-defined collection.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
         </datatype>
@@ -1660,7 +1660,7 @@
         </constraintSpec>
       </attDef>
       <attDef ident="sameas" usage="opt">
-        <desc>Points to an element that is the same as the current element but is not a literal copy
+        <desc xml:lang="en">Points to an element that is the same as the current element but is not a literal copy
           of the current element.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
@@ -1679,7 +1679,7 @@
         </constraintSpec>
       </attDef>
       <attDef ident="synch" usage="opt">
-        <desc>Points to elements that are synchronous with the current element.</desc>
+        <desc xml:lang="en">Points to elements that are synchronous with the current element.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
         </datatype>
@@ -1699,40 +1699,40 @@
     </attList>
   </classSpec>
   <classSpec ident="att.lyricStyle" module="MEI.shared" type="atts">
-    <desc>Attributes that describe default typography of lyrics.</desc>
+    <desc xml:lang="en">Attributes that describe default typography of lyrics.</desc>
     <attList>
       <attDef ident="lyric.align" usage="opt">
-        <desc>Describes the alignment of lyric syllables associated with a note or chord.</desc>
+        <desc xml:lang="en">Describes the alignment of lyric syllables associated with a note or chord.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTREL"/>
         </datatype>
       </attDef>
       <attDef ident="lyric.fam" usage="opt">
-        <desc>Sets the font family default value for lyrics.</desc>
+        <desc xml:lang="en">Sets the font family default value for lyrics.</desc>
         <datatype>
           <rng:ref name="data.FONTFAMILY"/>
         </datatype>
       </attDef>
       <attDef ident="lyric.name" usage="opt">
-        <desc>Sets the font name default value for lyrics.</desc>
+        <desc xml:lang="en">Sets the font name default value for lyrics.</desc>
         <datatype>
           <rng:ref name="data.FONTNAME"/>
         </datatype>
       </attDef>
       <attDef ident="lyric.size" usage="opt">
-        <desc>Sets the default font size value for lyrics.</desc>
+        <desc xml:lang="en">Sets the default font size value for lyrics.</desc>
         <datatype>
           <rng:ref name="data.FONTSIZE"/>
         </datatype>
       </attDef>
       <attDef ident="lyric.style" usage="opt">
-        <desc>Sets the default font style value for lyrics.</desc>
+        <desc xml:lang="en">Sets the default font style value for lyrics.</desc>
         <datatype>
           <rng:ref name="data.FONTSTYLE"/>
         </datatype>
       </attDef>
       <attDef ident="lyric.weight" usage="opt">
-        <desc>Sets the default font weight value for lyrics.</desc>
+        <desc xml:lang="en">Sets the default font weight value for lyrics.</desc>
         <datatype>
           <rng:ref name="data.FONTWEIGHT"/>
         </datatype>
@@ -1740,74 +1740,74 @@
     </attList>
   </classSpec>
   <classSpec ident="att.measurement" module="MEI.shared" type="atts">
-    <desc>Attributes that record the unit of measurement in which a value is expressed.</desc>
+    <desc xml:lang="en">Attributes that record the unit of measurement in which a value is expressed.</desc>
     <attList>
       <attDef ident="unit" usage="opt">
-        <desc>Indicates the unit of measurement.</desc>
+        <desc xml:lang="en">Indicates the unit of measurement.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="byte">
-            <desc>Byte.</desc>
+            <desc xml:lang="en">Byte.</desc>
           </valItem>
           <valItem ident="char">
-            <desc>Character.</desc>
+            <desc xml:lang="en">Character.</desc>
           </valItem>
           <valItem ident="cm">
-            <desc>Centimeter.</desc>
+            <desc xml:lang="en">Centimeter.</desc>
           </valItem>
           <valItem ident="deg">
-            <desc>Degree.</desc>
+            <desc xml:lang="en">Degree.</desc>
           </valItem>
           <valItem ident="in">
-            <desc>Inch.</desc>
+            <desc xml:lang="en">Inch.</desc>
           </valItem>
           <valItem ident="issue">
-            <desc>Serial issue.</desc>
+            <desc xml:lang="en">Serial issue.</desc>
           </valItem>
           <valItem ident="ft">
-            <desc>Foot.</desc>
+            <desc xml:lang="en">Foot.</desc>
           </valItem>
           <valItem ident="m">
-            <desc>Meter.</desc>
+            <desc xml:lang="en">Meter.</desc>
           </valItem>
           <valItem ident="mm">
-            <desc>Millimeter.</desc>
+            <desc xml:lang="en">Millimeter.</desc>
           </valItem>
           <valItem ident="page">
-            <desc>Page.</desc>
+            <desc xml:lang="en">Page.</desc>
           </valItem>
           <valItem ident="pc">
-            <desc>Pica.</desc>
+            <desc xml:lang="en">Pica.</desc>
           </valItem>
           <valItem ident="pt">
-            <desc>Point.</desc>
+            <desc xml:lang="en">Point.</desc>
           </valItem>
           <valItem ident="px">
-            <desc>Pixel.</desc>
+            <desc xml:lang="en">Pixel.</desc>
           </valItem>
           <valItem ident="rad">
-            <desc>Radian.</desc>
+            <desc xml:lang="en">Radian.</desc>
           </valItem>
           <valItem ident="record">
-            <desc>Record.</desc>
+            <desc xml:lang="en">Record.</desc>
           </valItem>
           <valItem ident="vol">
-            <desc>Serial volume.</desc>
+            <desc xml:lang="en">Serial volume.</desc>
           </valItem>
           <valItem ident="vu">
-            <desc>MEI virtual unit.</desc>
+            <desc xml:lang="en">MEI virtual unit.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.measureNumbers" module="MEI.shared" type="atts">
-    <desc>Attributes pertaining to measure numbers</desc>
+    <desc xml:lang="en">Attributes pertaining to measure numbers</desc>
     <attList>
       <attDef ident="mnum.visible" usage="opt">
-        <desc>Indicates whether measure numbers should be displayed.</desc>
+        <desc xml:lang="en">Indicates whether measure numbers should be displayed.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
@@ -1815,17 +1815,17 @@
     </attList>
   </classSpec>
   <classSpec ident="att.mediaBounds" module="MEI.shared" type="atts">
-    <desc>Attributes that establish the boundaries of a media object.</desc>
+    <desc xml:lang="en">Attributes that establish the boundaries of a media object.</desc>
     <attList>
       <attDef ident="begin" usage="opt">
-        <desc>Specifies a point where the relevant content begins. A numerical value must be less
+        <desc xml:lang="en">Specifies a point where the relevant content begins. A numerical value must be less
           and a time value must be earlier than that given by the end attribute.</desc>
         <datatype>
           <rng:text/>
         </datatype>
       </attDef>
       <attDef ident="end" usage="opt">
-        <desc>Specifies a point where the relevant content ends. If not specified, the end of the
+        <desc xml:lang="en">Specifies a point where the relevant content ends. If not specified, the end of the
           content is assumed to be the end point. A numerical value must be greater and a time value
           must be later than that given by the begin attribute.</desc>
         <datatype>
@@ -1833,7 +1833,7 @@
         </datatype>
       </attDef>
       <attDef ident="betype" usage="opt">
-        <desc>Type of values used in the begin/end attributes. The begin and end attributes can only
+        <desc xml:lang="en">Type of values used in the begin/end attributes. The begin and end attributes can only
           be interpreted meaningfully in conjunction with this attribute.</desc>
         <datatype>
           <rng:ref name="data.BETYPE"/>
@@ -1842,10 +1842,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.medium" module="MEI.shared" type="atts">
-    <desc>Attributes describing a writing medium, such as pencil or ink.</desc>
+    <desc xml:lang="en">Attributes describing a writing medium, such as pencil or ink.</desc>
     <attList>
       <attDef ident="medium" usage="opt">
-        <desc>Describes the writing medium.</desc>
+        <desc xml:lang="en">Describes the writing medium.</desc>
         <datatype>
           <rng:data type="string"/>
         </datatype>
@@ -1853,60 +1853,60 @@
     </attList>
   </classSpec>
   <classSpec ident="att.meiVersion" module="MEI.shared" type="atts">
-    <desc>Attributes that record the version of MEI in use.</desc>
+    <desc xml:lang="en">Attributes that record the version of MEI in use.</desc>
     <attList>
       <attDef ident="meiversion" usage="opt">
-        <desc>Specifies a generic MEI version label.</desc>
+        <desc xml:lang="en">Specifies a generic MEI version label.</desc>
         <defaultVal>5.0.0-dev</defaultVal>
         <valList type="closed">
           <valItem ident="5.0.0-dev">
-            <desc>Development version of MEI 5.0.0</desc>
+            <desc xml:lang="en">Development version of MEI 5.0.0</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.mensur.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.ratio"/>
       <memberOf key="att.mensural.shared"/>
     </classes>
   </classSpec>
   <classSpec ident="att.meterConformance" module="MEI.shared" type="atts">
-    <desc>Attributes that provide information about a structure’s conformance to the prevailing
+    <desc xml:lang="en">Attributes that provide information about a structure’s conformance to the prevailing
       meter.</desc>
     <attList>
       <attDef ident="metcon" usage="opt">
-        <desc>Indicates the relationship between the content of a staff or layer and the prevailing
+        <desc xml:lang="en">Indicates the relationship between the content of a staff or layer and the prevailing
           meter.</desc>
         <valList type="closed">
           <valItem ident="c">
-            <desc>Complete; <abbr>i.e.</abbr>, conformant with the prevailing meter.</desc>
+            <desc xml:lang="en">Complete; <abbr>i.e.</abbr>, conformant with the prevailing meter.</desc>
           </valItem>
           <valItem ident="i">
-            <desc>Incomplete; <abbr>i.e.</abbr>, not enough beats.</desc>
+            <desc xml:lang="en">Incomplete; <abbr>i.e.</abbr>, not enough beats.</desc>
           </valItem>
           <valItem ident="o">
-            <desc>Overfull; <abbr>i.e.</abbr>, too many beats.</desc>
+            <desc xml:lang="en">Overfull; <abbr>i.e.</abbr>, too many beats.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.meterConformance.bar" module="MEI.shared" type="atts">
-    <desc>Attributes that provide information about a measure’s conformance to the prevailing
+    <desc xml:lang="en">Attributes that provide information about a measure’s conformance to the prevailing
       meter.</desc>
     <attList>
       <attDef ident="metcon" usage="opt">
-        <desc>Indicates the relationship between the content of a measure and the prevailing
+        <desc xml:lang="en">Indicates the relationship between the content of a measure and the prevailing
           meter.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
       </attDef>
       <attDef ident="control" usage="opt">
-        <desc>Indicates whether or not a bar line is "controlling"; that is, if it indicates a point
+        <desc xml:lang="en">Indicates whether or not a bar line is "controlling"; that is, if it indicates a point
           of alignment across all the parts. Bar lines within a score are usually controlling; that
           is, they "line up". Bar lines within parts may or may not be controlling. When applied to
           <gi scheme="MEI">measure</gi>, this attribute indicates the nature of the right barline
@@ -1918,10 +1918,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.meterSig.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <attList>
       <attDef ident="count" usage="opt">
-        <desc>Captures the number of beats in a measure, that is, the top number of the meter
+        <desc xml:lang="en">Captures the number of beats in a measure, that is, the top number of the meter
           signature. It must contain a decimal number or an expression that evaluates to a
           decimal number, such as 2+3 or 3*2.</desc>
         <datatype>
@@ -1931,14 +1931,14 @@
         </datatype>
       </attDef>
       <attDef ident="sym" usage="opt">
-        <desc>Indicates the use of a meter symbol instead of a numeric meter signature, that is, 'C'
+        <desc xml:lang="en">Indicates the use of a meter symbol instead of a numeric meter signature, that is, 'C'
           for common time or 'C' with a slash for cut time.</desc>
         <datatype>
           <rng:ref name="data.METERSIGN"/>
         </datatype>
       </attDef>
       <attDef ident="unit" usage="opt">
-        <desc>Contains the number indicating the beat unit, that is, the bottom number of the meter
+        <desc xml:lang="en">Contains the number indicating the beat unit, that is, the bottom number of the meter
           signature.</desc>
         <datatype>
           <rng:data type="decimal"/>
@@ -1947,11 +1947,11 @@
     </attList>
   </classSpec>
   <classSpec ident="att.meterSigDefault.log" module="MEI.shared" type="atts">
-    <desc>Used by staffDef and scoreDef to provide default values for attributes in the logical
+    <desc xml:lang="en">Used by staffDef and scoreDef to provide default values for attributes in the logical
       domain related to meter signature.</desc>
     <attList>
       <attDef ident="meter.count" usage="opt">
-        <desc>Captures the number of beats in a measure, that is, the top number of the meter
+        <desc xml:lang="en">Captures the number of beats in a measure, that is, the top number of the meter
           signature. It must contain a decimal number or an expression that evaluates to a
           decimal number, such as 2+3 or 3*2.</desc>
         <datatype>
@@ -1961,7 +1961,7 @@
         </datatype>
       </attDef>
       <attDef ident="meter.unit" usage="opt">
-        <desc>Contains the number indicating the beat unit, that is, the bottom number of the meter
+        <desc xml:lang="en">Contains the number indicating the beat unit, that is, the bottom number of the meter
           signature.</desc>
         <datatype>
           <rng:data type="decimal">
@@ -1970,7 +1970,7 @@
         </datatype>
       </attDef>
       <attDef ident="meter.sym" usage="opt">
-        <desc>Indicates the use of a meter symbol instead of a numeric meter signature, that is, 'C'
+        <desc xml:lang="en">Indicates the use of a meter symbol instead of a numeric meter signature, that is, 'C'
           for common time or 'C' with a slash for cut time.</desc>
         <datatype>
           <rng:ref name="data.METERSIGN"/>
@@ -1979,10 +1979,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.mmTempo" module="MEI.shared" type="atts">
-    <desc>Attributes that record tempo in terms of beats per minute.</desc>
+    <desc xml:lang="en">Attributes that record tempo in terms of beats per minute.</desc>
     <attList>
       <attDef ident="mm" usage="opt">
-        <desc>Used to describe tempo in terms of beats (often the meter signature denominator) per
+        <desc xml:lang="en">Used to describe tempo in terms of beats (often the meter signature denominator) per
           minute, ala M.M. (Maelzel’s Metronome). Do not confuse this attribute with midi.bpm or
           midi.mspb. In MIDI, a beat is always defined as a quarter note, *not the numerator of the
           time signature or the metronomic indication*.</desc>
@@ -1991,13 +1991,13 @@
         </datatype>
       </attDef>
       <attDef ident="mm.unit" usage="opt">
-        <desc>Captures the metronomic unit.</desc>
+        <desc xml:lang="en">Captures the metronomic unit.</desc>
         <datatype>
           <rng:ref name="data.DURATION"/>
         </datatype>
       </attDef>
       <attDef ident="mm.dots" usage="opt">
-        <desc>Records the number of augmentation dots required by a dotted metronome unit.</desc>
+        <desc xml:lang="en">Records the number of augmentation dots required by a dotted metronome unit.</desc>
         <datatype>
           <rng:ref name="data.AUGMENTDOT"/>
         </datatype>
@@ -2005,10 +2005,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.multinumMeasures" module="MEI.shared" type="atts">
-    <desc>Attributes that indicate programmatic numbering.</desc>
+    <desc xml:lang="en">Attributes that indicate programmatic numbering.</desc>
     <attList>
       <attDef ident="multi.number" usage="opt">
-        <desc>Indicates whether programmatically calculated counts of multiple measures of rest
+        <desc xml:lang="en">Indicates whether programmatically calculated counts of multiple measures of rest
           (mRest) and whole measure repeats (mRpt) in parts should be rendered.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
@@ -2017,7 +2017,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.name" module="MEI.shared" type="atts">
-    <desc>Attributes shared by names.</desc>
+    <desc xml:lang="en">Attributes shared by names.</desc>
     <classes>
       <memberOf key="att.authorized"/>
       <memberOf key="att.datable"/>
@@ -2025,7 +2025,7 @@
     </classes>
     <attList>
       <attDef ident="nymref" usage="opt">
-        <desc>Used to record a pointer to the regularized form of the name elsewhere in the
+        <desc xml:lang="en">Used to record a pointer to the regularized form of the name elsewhere in the
           document.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
@@ -2044,7 +2044,7 @@
         </constraintSpec>
       </attDef>
       <attDef ident="role" usage="opt">
-        <desc>Used to specify further information about the entity referenced by this name, for
+        <desc xml:lang="en">Used to specify further information about the entity referenced by this name, for
           example, the occupation of a person or the status of a place.</desc>
         <datatype>
           <rng:text/>
@@ -2061,10 +2061,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.nInteger" module="MEI.shared" type="atts">
-    <desc>Attributes used to supply an integer number designation for an element.</desc>
+    <desc xml:lang="en">Attributes used to supply an integer number designation for an element.</desc>
     <attList>
       <attDef ident="n" usage="opt">
-        <desc>Provides a numeric designation that indicates an element’s position in a sequence of
+        <desc xml:lang="en">Provides a numeric designation that indicates an element’s position in a sequence of
           similar elements. Its value must be a non-negative integer.</desc>
         <datatype>
           <rng:data type="nonNegativeInteger"/>
@@ -2073,10 +2073,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.nNumberLike" module="MEI.shared" type="atts">
-    <desc>Attributes used to supply a number-like designation for an element.</desc>
+    <desc xml:lang="en">Attributes used to supply a number-like designation for an element.</desc>
     <attList>
       <attDef ident="n" usage="opt">
-        <desc>Provides a number-like designation that indicates an element’s position in a sequence
+        <desc xml:lang="en">Provides a number-like designation that indicates an element’s position in a sequence
           of similar elements. May not contain space characters.</desc>
         <datatype>
           <rng:ref name="data.WORD"/>
@@ -2085,16 +2085,16 @@
     </attList>
   </classSpec>
   <classSpec ident="att.notationStyle" module="MEI.shared" type="atts">
-    <desc>Attributes that capture music font name and size.</desc>
+    <desc xml:lang="en">Attributes that capture music font name and size.</desc>
     <attList>
       <attDef ident="music.name" usage="opt">
-        <desc>Sets the default music font name.</desc>
+        <desc xml:lang="en">Sets the default music font name.</desc>
         <datatype>
           <rng:ref name="data.MUSICFONT"/>
         </datatype>
       </attDef>
       <attDef ident="music.size" usage="opt">
-        <desc>Sets the default music font size.</desc>
+        <desc xml:lang="en">Sets the default music font size.</desc>
         <datatype>
           <rng:ref name="data.FONTSIZE"/>
         </datatype>
@@ -2102,7 +2102,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.note.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.augmentDots"/>
       <memberOf key="att.coloration"/>
@@ -2116,10 +2116,10 @@
     </classes>
   </classSpec>
   <classSpec ident="att.noteHeads" module="MEI.shared" type="atts">
-    <desc>Attributes pertaining to the notehead part of a note.</desc>
+    <desc xml:lang="en">Attributes pertaining to the notehead part of a note.</desc>
     <attList>
       <attDef ident="head.altsym" usage="opt">
-        <desc>Provides a way of pointing to a user-defined symbol. It must contain a reference to an
+        <desc xml:lang="en">Provides a way of pointing to a user-defined symbol. It must contain a reference to an
           ID of a <gi scheme="MEI">symbolDef</gi> element elsewhere in the document.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
@@ -2138,7 +2138,7 @@
         </constraintSpec>
       </attDef>
       <attDef ident="head.auth" usage="opt">
-        <desc>A name or label associated with the controlled vocabulary from which a numerical value
+        <desc xml:lang="en">A name or label associated with the controlled vocabulary from which a numerical value
           of <att>head.shape</att> is taken.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
@@ -2154,36 +2154,36 @@
         </constraintSpec>
         <valList type="semi">
           <valItem ident="smufl">
-            <desc>Standard Music Font Layout.</desc>
+            <desc xml:lang="en">Standard Music Font Layout.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="head.color" usage="opt">
-        <desc>Captures the overall color of a notehead.</desc>
+        <desc xml:lang="en">Captures the overall color of a notehead.</desc>
         <datatype>
           <rng:ref name="data.COLOR"/>
         </datatype>
       </attDef>
       <attDef ident="head.fill" usage="opt">
-        <desc>Describes how/if the notehead is filled.</desc>
+        <desc xml:lang="en">Describes how/if the notehead is filled.</desc>
         <datatype>
           <rng:ref name="data.FILL"/>
         </datatype>
       </attDef>
       <attDef ident="head.fillcolor" usage="opt">
-        <desc>Captures the fill color of a notehead if different from the overall note color.</desc>
+        <desc xml:lang="en">Captures the fill color of a notehead if different from the overall note color.</desc>
         <datatype>
           <rng:ref name="data.COLOR"/>
         </datatype>
       </attDef>
       <attDef ident="head.mod" usage="opt">
-        <desc>Records any additional symbols applied to the notehead.</desc>
+        <desc xml:lang="en">Records any additional symbols applied to the notehead.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.NOTEHEADMODIFIER"/>
         </datatype>
       </attDef>
       <attDef ident="head.rotation" usage="opt">
-        <desc>Describes rotation applied to the basic notehead shape. A positive value rotates the
+        <desc xml:lang="en">Describes rotation applied to the basic notehead shape. A positive value rotates the
           notehead in a counter-clockwise fashion, while negative values produce clockwise
           rotation.</desc>
         <datatype>
@@ -2191,7 +2191,7 @@
         </datatype>
       </attDef>
       <attDef ident="head.shape" usage="opt">
-        <desc>Used to override the head shape normally used for the given duration.</desc>
+        <desc xml:lang="en">Used to override the head shape normally used for the given duration.</desc>
         <datatype>
           <rng:ref name="data.HEADSHAPE"/>
         </datatype>
@@ -2207,7 +2207,7 @@
         </constraintSpec>
       </attDef>
       <attDef ident="head.visible" usage="opt">
-        <desc>Indicates if a feature should be rendered when the notation is presented graphically
+        <desc xml:lang="en">Indicates if a feature should be rendered when the notation is presented graphically
           or sounded when it is presented in an aural form.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
@@ -2216,10 +2216,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.octave" module="MEI.shared" type="atts">
-    <desc>Attributes that record written octave.</desc>
+    <desc xml:lang="en">Attributes that record written octave.</desc>
     <attList>
       <attDef ident="oct" usage="opt">
-        <desc>Captures written octave information.</desc>
+        <desc xml:lang="en">Captures written octave information.</desc>
         <datatype>
           <rng:ref name="data.OCTAVE"/>
         </datatype>
@@ -2227,10 +2227,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.octaveDefault" module="MEI.shared" type="atts">
-    <desc>Attributes that record a default value for octave.</desc>
+    <desc xml:lang="en">Attributes that record a default value for octave.</desc>
     <attList>
       <attDef ident="oct.default" usage="opt">
-        <desc>Contains a default octave specification for use when the first note, rest, chord, etc.
+        <desc xml:lang="en">Contains a default octave specification for use when the first note, rest, chord, etc.
           in a measure does not have an octave value specified.</desc>
         <datatype>
           <rng:ref name="data.OCTAVE"/>
@@ -2239,16 +2239,16 @@
     </attList>
   </classSpec>
   <classSpec ident="att.octaveDisplacement" module="MEI.shared" type="atts">
-    <desc>Attributes describing the amount and direction of octave displacement.</desc>
+    <desc xml:lang="en">Attributes describing the amount and direction of octave displacement.</desc>
     <attList>
       <attDef ident="dis" usage="opt">
-        <desc>Records the amount of octave displacement.</desc>
+        <desc xml:lang="en">Records the amount of octave displacement.</desc>
         <datatype>
           <rng:ref name="data.OCTAVE.DIS"/>
         </datatype>
       </attDef>
       <attDef ident="dis.place" usage="opt">
-        <desc>Records the direction of octave displacement.</desc>
+        <desc xml:lang="en">Records the direction of octave displacement.</desc>
         <datatype>
           <rng:ref name="data.STAFFREL.basic"/>
         </datatype>
@@ -2256,10 +2256,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.oneLineStaff" module="MEI.shared" type="atts">
-    <desc>Attributes that record placement of notes on a single-line staff.</desc>
+    <desc xml:lang="en">Attributes that record placement of notes on a single-line staff.</desc>
     <attList>
       <attDef ident="ontheline" usage="opt">
-        <desc>Determines the placement of notes on a 1-line staff. A value of '<val>true</val>' places all
+        <desc xml:lang="en">Determines the placement of notes on a 1-line staff. A value of '<val>true</val>' places all
           notes on the line, while a value of '<val>false</val>' places stems-up notes above the line and
           stems-down notes below the line.</desc>
         <datatype>
@@ -2269,10 +2269,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.optimization" module="MEI.shared" type="atts">
-    <desc>Attributes pertaining to layout optimization.</desc>
+    <desc xml:lang="en">Attributes pertaining to layout optimization.</desc>
     <attList>
       <attDef ident="optimize" usage="opt">
-        <desc>Indicates whether staves without notes, rests, etc. should be displayed. When the
+        <desc xml:lang="en">Indicates whether staves without notes, rests, etc. should be displayed. When the
           value is 'true', empty staves are displayed.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
@@ -2281,10 +2281,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.origin.layerIdent" module="MEI.shared" type="atts">
-    <desc>Attributes that identify the layer associated with a distant feature.</desc>
+    <desc xml:lang="en">Attributes that identify the layer associated with a distant feature.</desc>
     <attList>
       <attDef ident="origin.layer" usage="opt">
-        <desc>identifies the layer on which referenced notation occurs.</desc>
+        <desc xml:lang="en">identifies the layer on which referenced notation occurs.</desc>
         <datatype>
           <rng:list>
             <rng:oneOrMore>
@@ -2296,10 +2296,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.origin.staffIdent" module="MEI.shared" type="atts">
-    <desc>Attributes for identifying the staff associated with a distant feature.</desc>
+    <desc xml:lang="en">Attributes for identifying the staff associated with a distant feature.</desc>
     <attList>
       <attDef ident="origin.staff" usage="rec">
-        <desc>signifies the staff on which referenced notation occurs. Defaults to the same value as
+        <desc xml:lang="en">signifies the staff on which referenced notation occurs. Defaults to the same value as
           the local staff. Mandatory when applicable.</desc>
         <datatype>
           <rng:list>
@@ -2312,17 +2312,17 @@
     </attList>
   </classSpec>
   <classSpec ident="att.origin.startEndId" module="MEI.shared" type="atts">
-    <desc>Attributes recording the identifiers of the first and last elements of a sequence of
+    <desc xml:lang="en">Attributes recording the identifiers of the first and last elements of a sequence of
       distant elements.</desc>
     <attList>
       <attDef ident="origin.startid" usage="opt">
-        <desc>indicates the first element in a sequence of events.</desc>
+        <desc xml:lang="en">indicates the first element in a sequence of events.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
       </attDef>
       <attDef ident="origin.endid" usage="opt">
-        <desc>indicates the final element in a sequence of events.</desc>
+        <desc xml:lang="en">indicates the final element in a sequence of events.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
@@ -2330,17 +2330,17 @@
     </attList>
   </classSpec>
   <classSpec ident="att.origin.timestamp.logical" module="MEI.shared" type="atts">
-    <desc>Attributes that identify a musical range in terms of musical time.</desc>
+    <desc xml:lang="en">Attributes that identify a musical range in terms of musical time.</desc>
     <attList>
       <attDef ident="origin.tstamp" usage="opt">
-        <desc>encodes the starting point of musical material in terms of musical time, <abbr>i.e.</abbr>, a
+        <desc xml:lang="en">encodes the starting point of musical material in terms of musical time, <abbr>i.e.</abbr>, a
           (potentially negative) count of measures plus a beat location.</desc>
         <datatype>
           <rng:ref name="data.MEASUREBEATOFFSET"/>
         </datatype>
       </attDef>
       <attDef ident="origin.tstamp2" usage="rec">
-        <desc>encodes the ending point of musical material in terms of musical time, <abbr>i.e.</abbr>, a count
+        <desc xml:lang="en">encodes the ending point of musical material in terms of musical time, <abbr>i.e.</abbr>, a count
           of measures plus a beat location. The values are relative to the measure identified by
           <att>origin.tstamp</att>.</desc>
         <datatype>
@@ -2358,7 +2358,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.ornam.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
@@ -2368,61 +2368,61 @@
     </classes>
   </classSpec>
   <classSpec ident="att.pad.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.event"/>
       <memberOf key="att.width"/>
     </classes>
   </classSpec>
   <classSpec ident="att.pages" module="MEI.shared" type="atts">
-    <desc>Attributes that record page-level layout information.</desc>
+    <desc xml:lang="en">Attributes that record page-level layout information.</desc>
     <attList>
       <attDef ident="page.height" usage="opt">
-        <desc>Specifies the height of the page; may be expressed in real-world units or staff
+        <desc xml:lang="en">Specifies the height of the page; may be expressed in real-world units or staff
           steps.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTABS"/>
         </datatype>
       </attDef>
       <attDef ident="page.width" usage="opt">
-        <desc>Describes the width of the page; may be expressed in real-world units or staff
+        <desc xml:lang="en">Describes the width of the page; may be expressed in real-world units or staff
           steps.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTABS"/>
         </datatype>
       </attDef>
       <attDef ident="page.topmar" usage="opt">
-        <desc>Indicates the amount of whitespace at the top of a page.</desc>
+        <desc xml:lang="en">Indicates the amount of whitespace at the top of a page.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTABS"/>
         </datatype>
       </attDef>
       <attDef ident="page.botmar" usage="opt">
-        <desc>Indicates the amount of whitespace at the bottom of a page.</desc>
+        <desc xml:lang="en">Indicates the amount of whitespace at the bottom of a page.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTABS"/>
         </datatype>
       </attDef>
       <attDef ident="page.leftmar" usage="opt">
-        <desc>Indicates the amount of whitespace at the left side of a page.</desc>
+        <desc xml:lang="en">Indicates the amount of whitespace at the left side of a page.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTABS"/>
         </datatype>
       </attDef>
       <attDef ident="page.rightmar" usage="opt">
-        <desc>Indicates the amount of whitespace at the right side of a page.</desc>
+        <desc xml:lang="en">Indicates the amount of whitespace at the right side of a page.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTABS"/>
         </datatype>
       </attDef>
       <attDef ident="page.panels" usage="opt">
-        <desc>Indicates the number of logical pages to be rendered on a single physical page.</desc>
+        <desc xml:lang="en">Indicates the number of logical pages to be rendered on a single physical page.</desc>
         <datatype>
           <rng:ref name="data.PAGE.PANELS"/>
         </datatype>
       </attDef>
       <attDef ident="page.scale" usage="opt">
-        <desc>Indicates how the page should be scaled when rendered.</desc>
+        <desc xml:lang="en">Indicates how the page should be scaled when rendered.</desc>
         <datatype>
           <rng:ref name="data.PGSCALE"/>
         </datatype>
@@ -2430,13 +2430,13 @@
     </attList>
   </classSpec>
   <classSpec ident="att.part.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.partIdent" module="MEI.shared" type="atts">
-    <desc>Attributes for identifying the part in which the current feature appears.</desc>
+    <desc xml:lang="en">Attributes for identifying the part in which the current feature appears.</desc>
     <attList>
       <attDef ident="part" usage="opt">
-        <desc>Indicates the part in which the current feature should appear. Use '%all' when the
+        <desc xml:lang="en">Indicates the part in which the current feature should appear. Use '%all' when the
           feature should occur in every part.</desc>
         <datatype maxOccurs="unbounded">
           <rng:data type="token">
@@ -2454,7 +2454,7 @@
         </constraintSpec>
       </attDef>
       <attDef ident="partstaff" usage="opt">
-        <desc>Signifies the part staff on which a notated feature occurs. Use '%all' when the
+        <desc xml:lang="en">Signifies the part staff on which a notated feature occurs. Use '%all' when the
           feature should occur on every staff.</desc>
         <datatype maxOccurs="unbounded">
           <rng:data type="token">
@@ -2474,16 +2474,16 @@
     </attList>
   </classSpec>
   <classSpec ident="att.parts.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.pb.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.alignment"/>
     </classes>
   </classSpec>
   <classSpec ident="att.phrase.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
@@ -2492,10 +2492,10 @@
     </classes>
   </classSpec>
   <classSpec ident="att.pitch" module="MEI.shared" type="atts">
-    <desc>Attributes that record written pitch name.</desc>
+    <desc xml:lang="en">Attributes that record written pitch name.</desc>
     <attList>
       <attDef ident="pname" usage="opt">
-        <desc>Contains a written pitch name.</desc>
+        <desc xml:lang="en">Contains a written pitch name.</desc>
         <datatype>
           <rng:ref name="data.PITCHNAME"/>
         </datatype>
@@ -2503,17 +2503,17 @@
     </attList>
   </classSpec>
   <classSpec ident="att.pitched" module="MEI.shared" type="atts">
-    <desc>Attributes that record written pitch name and octave number.</desc>
+    <desc xml:lang="en">Attributes that record written pitch name and octave number.</desc>
     <classes>
       <memberOf key="att.pitch"/>
       <memberOf key="att.octave"/>
     </classes>
   </classSpec>
   <classSpec ident="att.placementOnStaff" module="MEI.shared" type="atts">
-    <desc>Attributes capturing placement on a staff.</desc>
+    <desc xml:lang="en">Attributes capturing placement on a staff.</desc>
     <attList>
        <attDef ident="onstaff" usage="opt">
-          <desc>Indicates the placement of the item within the staff. A value of '<val>true</val>' means on the staff, and '<val>false</val>' off the staff.</desc>
+          <desc xml:lang="en">Indicates the placement of the item within the staff. A value of '<val>true</val>' means on the staff, and '<val>false</val>' off the staff.</desc>
           <datatype>
              <rng:ref name="data.BOOLEAN"/>
           </datatype>
@@ -2521,10 +2521,10 @@
     </attList>
   </classSpec>   
   <classSpec ident="att.placementRelEvent" module="MEI.shared" type="atts">
-    <desc>Attributes capturing placement information with respect to an event.</desc>
+    <desc xml:lang="en">Attributes capturing placement information with respect to an event.</desc>
     <attList>
        <attDef ident="place" usage="opt">
-          <desc>Captures the placement of the item with respect to the event with which it is
+          <desc xml:lang="en">Captures the placement of the item with respect to the event with which it is
              associated.</desc>
           <datatype>
              <rng:ref name="data.STAFFREL"/>
@@ -2533,10 +2533,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.placementRelStaff" module="MEI.shared" type="atts">
-    <desc>Attributes capturing placement information with respect to the staff.</desc>
+    <desc xml:lang="en">Attributes capturing placement information with respect to the staff.</desc>
     <attList>
       <attDef ident="place" usage="opt">
-        <desc>Captures the placement of the item with respect to the staff with which it is
+        <desc xml:lang="en">Captures the placement of the item with respect to the staff with which it is
           associated.</desc>
         <datatype>
           <rng:ref name="data.STAFFREL"/>
@@ -2545,10 +2545,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.plist" module="MEI.shared" type="atts">
-    <desc>Attributes listing the active participants in a user-defined collection.</desc>
+    <desc xml:lang="en">Attributes listing the active participants in a user-defined collection.</desc>
     <attList>
       <attDef ident="plist" usage="opt">
-        <desc>When the target attribute is present, plist identifies the active participants; that
+        <desc xml:lang="en">When the target attribute is present, plist identifies the active participants; that
           is, those entities pointed "from", in a relationship with the specified target(s). When
           the target attribute is not present, it identifies participants in a mutual
           relationship.</desc>
@@ -2571,29 +2571,29 @@
     </attList>
   </classSpec>
   <classSpec ident="att.pointing" module="MEI.shared" type="atts">
-    <desc>Attributes common to all pointing/linking elements.</desc>
+    <desc xml:lang="en">Attributes common to all pointing/linking elements.</desc>
     <attList>
       <!--<attDef ident="actuate" ns="http://www.w3.org/1999/xlink" usage="opt">-->
       <attDef ident="xlink:actuate" usage="opt">
-        <desc>Defines whether a link occurs automatically or must be requested by the user.</desc>
+        <desc xml:lang="en">Defines whether a link occurs automatically or must be requested by the user.</desc>
         <valList type="closed">
           <valItem ident="onLoad">
-            <desc>Load the target resource(s) immediately.</desc>
+            <desc xml:lang="en">Load the target resource(s) immediately.</desc>
           </valItem>
           <valItem ident="onRequest">
-            <desc>Load the target resource(s) upon user request.</desc>
+            <desc xml:lang="en">Load the target resource(s) upon user request.</desc>
           </valItem>
           <valItem ident="none">
-            <desc>Do not permit loading of the target resource(s).</desc>
+            <desc xml:lang="en">Do not permit loading of the target resource(s).</desc>
           </valItem>
           <valItem ident="other">
-            <desc>Behavior other than allowed by the other values of this attribute.</desc>
+            <desc xml:lang="en">Behavior other than allowed by the other values of this attribute.</desc>
           </valItem>
         </valList>
       </attDef>
       <!--<attDef ident="role" ns="http://www.w3.org/1999/xlink" usage="opt">-->
       <attDef ident="xlink:role" usage="opt">
-        <desc>Characterization of the relationship between resources. The value of the role
+        <desc xml:lang="en">Characterization of the relationship between resources. The value of the role
           attribute must be a URI.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
@@ -2601,34 +2601,34 @@
       </attDef>
       <!--<attDef ident="show" ns="http://www.w3.org/1999/xlink" usage="opt">-->
       <attDef ident="xlink:show" usage="opt">
-        <desc>Defines how a remote resource is rendered.</desc>
+        <desc xml:lang="en">Defines how a remote resource is rendered.</desc>
         <valList type="closed">
           <valItem ident="new">
-            <desc>Open in a new window.</desc>
+            <desc xml:lang="en">Open in a new window.</desc>
           </valItem>
           <valItem ident="replace">
-            <desc>Load the referenced resource in the same window.</desc>
+            <desc xml:lang="en">Load the referenced resource in the same window.</desc>
           </valItem>
           <valItem ident="embed">
-            <desc>Embed the referenced resource at the point of the link.</desc>
+            <desc xml:lang="en">Embed the referenced resource at the point of the link.</desc>
           </valItem>
           <valItem ident="none">
-            <desc>Do not permit traversal to the referenced resource.</desc>
+            <desc xml:lang="en">Do not permit traversal to the referenced resource.</desc>
           </valItem>
           <valItem ident="other">
-            <desc>Behavior other than permitted by the other values of this attribute.</desc>
+            <desc xml:lang="en">Behavior other than permitted by the other values of this attribute.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="target" usage="opt">
-        <desc>Identifies passive participants in a relationship; that is, the entities pointed
+        <desc xml:lang="en">Identifies passive participants in a relationship; that is, the entities pointed
           "to".</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
         </datatype>
       </attDef>
       <attDef ident="targettype" usage="opt">
-        <desc>Characterization of target resource(s) using any convenient classification scheme or
+        <desc xml:lang="en">Characterization of target resource(s) using any convenient classification scheme or
           typology.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
@@ -2637,7 +2637,7 @@
       <!-- @xlink:title duplicates @label.  Use @label instead! -->
       <!--<attDef ident="title" ns="http://www.w3.org/1999/xlink" usage="opt">-->
       <!--<attDef ident="xlink:title" usage="opt">
-              <desc>Contains a human-readable description of the entire link.</desc>
+              <desc xml:lang="en">Contains a human-readable description of the entire link.</desc>
               <datatype>
                 <rng:data type="string"/>
               </datatype>
@@ -2645,14 +2645,14 @@
     </attList>
   </classSpec>
   <classSpec ident="att.quantity" module="MEI.shared" type="atts">
-    <desc>Attributes that specify a measurement in numerical terms.</desc>
+    <desc xml:lang="en">Attributes that specify a measurement in numerical terms.</desc>
     <classes>
       <memberOf key="att.measurement"/>
       <memberOf key="att.ranging"/>
     </classes>
     <attList>
       <attDef ident="quantity" usage="opt">
-        <desc>Numeric value capturing a measurement or count. Can only be interpreted in combination
+        <desc xml:lang="en">Numeric value capturing a measurement or count. Can only be interpreted in combination
           with the unit attribute.</desc>
         <datatype>
           <rng:data type="decimal">
@@ -2663,36 +2663,36 @@
     </attList>
   </classSpec>
   <classSpec ident="att.ranging" module="MEI.shared" type="atts">
-    <desc>Groups attributes that describe a numerical range.</desc>
+    <desc xml:lang="en">Groups attributes that describe a numerical range.</desc>
     <attList>
       <attDef ident="atleast" usage="opt">
-        <desc>Gives a minimum estimated value for an approximate measurement.</desc>
+        <desc xml:lang="en">Gives a minimum estimated value for an approximate measurement.</desc>
         <datatype>
           <rng:data type="decimal"/>
         </datatype>
       </attDef>
       <attDef ident="atmost" usage="opt">
-        <desc>Gives a maximum estimated value for an approximate measurement.</desc>
+        <desc xml:lang="en">Gives a maximum estimated value for an approximate measurement.</desc>
         <datatype>
           <rng:data type="decimal"/>
         </datatype>
       </attDef>
       <attDef ident="min" usage="opt">
-        <desc>Where the measurement summarizes more than one observation or a range of values,
+        <desc xml:lang="en">Where the measurement summarizes more than one observation or a range of values,
           supplies the minimum value observed.</desc>
         <datatype>
           <rng:data type="decimal"/>
         </datatype>
       </attDef>
       <attDef ident="max" usage="opt">
-        <desc>Where the measurement summarizes more than one observation or a range of values,
+        <desc xml:lang="en">Where the measurement summarizes more than one observation or a range of values,
           supplies the maximum value observed.</desc>
         <datatype>
           <rng:data type="decimal"/>
         </datatype>
       </attDef>
       <attDef ident="confidence" usage="opt">
-        <desc>Specifies the degree of statistical confidence (between zero and one) that a value
+        <desc xml:lang="en">Specifies the degree of statistical confidence (between zero and one) that a value
           falls within the range specified by min and max, or the proportion of observed values that
           fall within that range.</desc>
         <datatype>
@@ -2710,10 +2710,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.regularized" module="MEI.shared" type="atts">
-    <desc>Attributes that hold a controlled value.</desc>
+    <desc xml:lang="en">Attributes that hold a controlled value.</desc>
     <attList>
       <attDef ident="reg" usage="opt">
-        <desc>Provides a regularized, authorized value.</desc>
+        <desc xml:lang="en">Provides a regularized, authorized value.</desc>
         <datatype>
           <rng:data type="string"/>
         </datatype>
@@ -2721,11 +2721,11 @@
     </attList>
   </classSpec>
   <classSpec ident="att.responsibility" module="MEI.shared" type="atts">
-    <desc>Attributes capturing information regarding responsibility for some aspect of the text's
+    <desc xml:lang="en">Attributes capturing information regarding responsibility for some aspect of the text's
       creation, transcription, editing, or encoding.</desc>
     <attList>
       <attDef ident="resp" usage="opt">
-        <desc>Indicates the agent(s) responsible for some aspect of the text’s transcription,
+        <desc xml:lang="en">Indicates the agent(s) responsible for some aspect of the text’s transcription,
           editing, or encoding. Its value must point to one or more identifiers declared in the
           document header.</desc>
         <datatype maxOccurs="unbounded">
@@ -2747,7 +2747,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.rest.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.augmentDots"/>
       <memberOf key="att.cue"/>
@@ -2757,10 +2757,10 @@
     </classes>
   </classSpec>
   <classSpec ident="att.restduration.logical" module="MEI.shared" type="atts">
-    <desc>Attributes that express duration of rests in musical terms.</desc>
+    <desc xml:lang="en">Attributes that express duration of rests in musical terms.</desc>
     <attList>
       <attDef ident="dur" usage="opt">
-        <desc>Records the duration of a rest using the relative durational values provided by the
+        <desc xml:lang="en">Records the duration of a rest using the relative durational values provided by the
           data.DURATIONRESTS datatype.</desc>
         <datatype>
           <rng:ref name="data.DURATIONRESTS"/>
@@ -2769,16 +2769,16 @@
     </attList>
   </classSpec>
   <classSpec ident="att.sb.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.alignment"/>
     </classes>
   </classSpec>
   <classSpec ident="att.scalable" module="MEI.shared" type="atts">
-    <desc>Attributes that describe relative size.</desc>
+    <desc xml:lang="en">Attributes that describe relative size.</desc>
     <attList>
       <attDef ident="scale" usage="opt">
-        <desc>Scale factor to be applied to the feature to make it the desired display size.</desc>
+        <desc xml:lang="en">Scale factor to be applied to the feature to make it the desired display size.</desc>
         <datatype>
           <rng:ref name="data.PERCENT"/>
         </datatype>
@@ -2786,10 +2786,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.score.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.scoreDef.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes for scoreDef in the CMN repertoire. The values set in these
+    <desc xml:lang="en">Logical domain attributes for scoreDef in the CMN repertoire. The values set in these
       attributes act as score-wide defaults for attributes that are not set in descendant
       elements.</desc>
     <classes>
@@ -2804,16 +2804,16 @@
     </classes>
   </classSpec>
   <classSpec ident="att.section.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.alignment"/>
     </classes>
   </classSpec>
   <classSpec ident="att.sequence" module="MEI.shared" type="atts">
-    <desc>Attributes that describe order within a collection of features.</desc>
+    <desc xml:lang="en">Attributes that describe order within a collection of features.</desc>
     <attList>
       <attDef ident="seq" usage="opt">
-        <desc>Used to assign a sequence number related to the order in which the encoded features
+        <desc xml:lang="en">Used to assign a sequence number related to the order in which the encoded features
           carrying this attribute are believed to have occurred.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
@@ -2822,10 +2822,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.slashCount" module="MEI.shared" type="atts">
-    <desc>Attributes for recording the number of slashes that accompany a feature.</desc>
+    <desc xml:lang="en">Attributes for recording the number of slashes that accompany a feature.</desc>
     <attList>
       <attDef ident="slash" usage="opt">
-        <desc>Indicates the number of slashes present.</desc>
+        <desc xml:lang="en">Indicates the number of slashes present.</desc>
         <datatype>
           <rng:ref name="data.SLASH"/>
         </datatype>
@@ -2833,10 +2833,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.slurPresent" module="MEI.shared" type="atts">
-    <desc>Attributes for marking the presence of a slur.</desc>
+    <desc xml:lang="en">Attributes for marking the presence of a slur.</desc>
     <attList>
       <attDef ident="slur" usage="opt">
-        <desc>Indicates that this element participates in a slur. If visual information about the
+        <desc xml:lang="en">Indicates that this element participates in a slur. If visual information about the
           slur needs to be recorded, then a <gi scheme="MEI">slur</gi> element should be
           employed.</desc>
         <datatype maxOccurs="unbounded">
@@ -2846,10 +2846,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.source" module="MEI.shared" type="atts">
-    <desc>Attributes common to elements that may refer to a source.</desc>
+    <desc xml:lang="en">Attributes common to elements that may refer to a source.</desc>
     <attList>
       <attDef ident="source" usage="opt">
-        <desc>Contains a list of one or more pointers indicating the sources which attest to a given
+        <desc xml:lang="en">Contains a list of one or more pointers indicating the sources which attest to a given
           reading. Each value should correspond to the ID of a <gi scheme="MEI">source</gi> or <gi
           scheme="MEI">manifestation</gi>element located in the document header.</desc>
         <datatype maxOccurs="unbounded">
@@ -2871,7 +2871,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.space.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.augmentDots"/>
       <memberOf key="att.duration.logical"/>
@@ -2879,22 +2879,22 @@
     </classes>
   </classSpec>
   <classSpec ident="att.spacing" module="MEI.shared" type="atts">
-    <desc>Attributes that capture notation spacing information.</desc>
+    <desc xml:lang="en">Attributes that capture notation spacing information.</desc>
     <attList>
       <attDef ident="spacing.packexp" usage="opt">
-        <desc>Describes a note’s spacing relative to its time value.</desc>
+        <desc xml:lang="en">Describes a note’s spacing relative to its time value.</desc>
         <datatype>
           <rng:data type="decimal"/>
         </datatype>
       </attDef>
       <attDef ident="spacing.packfact" usage="opt">
-        <desc>Describes the note spacing of output.</desc>
+        <desc xml:lang="en">Describes the note spacing of output.</desc>
         <datatype>
           <rng:data type="decimal"/>
         </datatype>
       </attDef>
       <attDef ident="spacing.staff" usage="opt">
-        <desc>Specifies the minimum amount of space between adjacent staves in the same system;
+        <desc xml:lang="en">Specifies the minimum amount of space between adjacent staves in the same system;
           measured from the bottom line of the staff above to the top line of the staff
           below.</desc>
         <datatype>
@@ -2902,7 +2902,7 @@
         </datatype>
       </attDef>
       <attDef ident="spacing.system" usage="opt">
-        <desc>Describes the space between adjacent systems; a pair of space-separated values
+        <desc xml:lang="en">Describes the space between adjacent systems; a pair of space-separated values
           (minimum and maximum, respectively) provides a range between which a rendering
           system-supplied value may fall, while a single value indicates a fixed amount of space;
           that is, the minimum and maximum values are equal.</desc>
@@ -2913,13 +2913,13 @@
     </attList>
   </classSpec>
   <classSpec ident="att.staff.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.meterConformance"/>
     </classes>
     <attList>
       <attDef ident="def" usage="opt">
-        <desc>Provides a mechanism for linking the staff to a staffDef element.</desc>
+        <desc xml:lang="en">Provides a mechanism for linking the staff to a staffDef element.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
@@ -2939,7 +2939,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.staffDef.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes for staffDef.</desc>
+    <desc xml:lang="en">Logical domain attributes for staffDef.</desc>
     <classes>
       <memberOf key="att.cleffing.log"/>
       <memberOf key="att.duration.default"/>
@@ -2953,7 +2953,7 @@
     </classes>
     <attList>
       <attDef ident="lines" usage="opt">
-        <desc>Indicates the number of staff lines.</desc>
+        <desc xml:lang="en">Indicates the number of staff lines.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
@@ -2961,39 +2961,39 @@
     </attList>
   </classSpec>
   <classSpec ident="att.staffGroupingSym" module="MEI.shared" type="atts">
-    <desc>Attributes that describe the symbol used to group a set of staves.</desc>
+    <desc xml:lang="en">Attributes that describe the symbol used to group a set of staves.</desc>
     <attList>
       <attDef ident="symbol" usage="opt">
-        <desc>Specifies the symbol used to group a set of staves.</desc>
+        <desc xml:lang="en">Specifies the symbol used to group a set of staves.</desc>
         <valList type="closed">
           <valItem ident="brace">
-            <desc>Curved symbol, <abbr>i.e.</abbr>, {.</desc>
+            <desc xml:lang="en">Curved symbol, <abbr>i.e.</abbr>, {.</desc>
           </valItem>
           <valItem ident="bracket">
-            <desc>Square symbol, <abbr>i.e.</abbr>, [, but with curved/angled top and bottom segments.</desc>
+            <desc xml:lang="en">Square symbol, <abbr>i.e.</abbr>, [, but with curved/angled top and bottom segments.</desc>
           </valItem>
           <valItem ident="bracketsq">
-            <desc>Square symbol, <abbr>i.e.</abbr>, [, with horizontal top and bottom segments.</desc>
+            <desc xml:lang="en">Square symbol, <abbr>i.e.</abbr>, [, with horizontal top and bottom segments.</desc>
           </valItem>
           <valItem ident="line">
-            <desc>Line symbol, <abbr>i.e.</abbr>, |, (wide) line without top and bottom curved/horizontal
+            <desc xml:lang="en">Line symbol, <abbr>i.e.</abbr>, |, (wide) line without top and bottom curved/horizontal
               segments.</desc>
           </valItem>
           <valItem ident="none">
-            <desc>Grouping symbol missing.</desc>
+            <desc xml:lang="en">Grouping symbol missing.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.staffGrp.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.staffIdent" module="MEI.shared" type="atts">
-    <desc>Attributes for identifying the staff associated with the current feature.</desc>
+    <desc xml:lang="en">Attributes for identifying the staff associated with the current feature.</desc>
     <attList>
       <attDef ident="staff" usage="rec">
-        <desc>Signifies the staff on which a notated event occurs or to which a control event
+        <desc xml:lang="en">Signifies the staff on which a notated event occurs or to which a control event
           applies. Mandatory when applicable.</desc>
         <datatype maxOccurs="unbounded">
           <rng:data type="positiveInteger"/>
@@ -3002,24 +3002,24 @@
     </attList>
   </classSpec>
   <classSpec ident="att.staffItems" module="MEI.shared" type="atts">
-    <desc>Attributes that describe items printed near (above, below, or between) staves</desc>
+    <desc xml:lang="en">Attributes that describe items printed near (above, below, or between) staves</desc>
     <attList>
       <attDef ident="aboveorder">
-        <desc>Describes vertical order of items printed above a staff, from closest to farthest away
+        <desc xml:lang="en">Describes vertical order of items printed above a staff, from closest to farthest away
           from the staff.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.STAFFITEM"/>
         </datatype>
       </attDef>
       <attDef ident="beloworder">
-        <desc>Describes vertical order of items printed below a staff, from closest to farthest away
+        <desc xml:lang="en">Describes vertical order of items printed below a staff, from closest to farthest away
           from the staff.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.STAFFITEM"/>
         </datatype>
       </attDef>
       <attDef ident="betweenorder">
-        <desc>Describes vertical order of items printed between staves, from top to bottom.</desc>
+        <desc xml:lang="en">Describes vertical order of items printed between staves, from top to bottom.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.STAFFITEM"/>
         </datatype>
@@ -3027,10 +3027,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.staffLoc" module="MEI.shared" type="atts">
-    <desc>Attributes that identify location on a staff in terms of lines and spaces.</desc>
+    <desc xml:lang="en">Attributes that identify location on a staff in terms of lines and spaces.</desc>
     <attList>
       <attDef ident="loc" usage="opt">
-        <desc>Holds the staff location of the feature.</desc>
+        <desc xml:lang="en">Holds the staff location of the feature.</desc>
         <datatype>
           <rng:ref name="data.STAFFLOC"/>
         </datatype>
@@ -3038,16 +3038,16 @@
     </attList>
   </classSpec>
   <classSpec ident="att.staffLoc.pitched" module="MEI.shared" type="atts">
-    <desc>Attributes that identify location on a staff in terms of pitch and octave.</desc>
+    <desc xml:lang="en">Attributes that identify location on a staff in terms of pitch and octave.</desc>
     <attList>
       <attDef ident="ploc" usage="opt">
-        <desc>Captures staff location in terms of written pitch name.</desc>
+        <desc xml:lang="en">Captures staff location in terms of written pitch name.</desc>
         <datatype>
           <rng:ref name="data.PITCHNAME"/>
         </datatype>
       </attDef>
       <attDef ident="oloc" usage="opt">
-        <desc>Records staff location in terms of written octave.</desc>
+        <desc xml:lang="en">Records staff location in terms of written octave.</desc>
         <datatype>
           <rng:ref name="data.OCTAVE"/>
         </datatype>
@@ -3055,14 +3055,14 @@
     </attList>
   </classSpec>
   <classSpec ident="att.startEndId" module="MEI.shared" type="atts">
-    <desc>Attributes recording the identifiers of the first and last elements of a sequence of
+    <desc xml:lang="en">Attributes recording the identifiers of the first and last elements of a sequence of
       elements to which the current element is associated.</desc>
     <classes>
       <memberOf key="att.startId"/>
     </classes>
     <attList>
       <attDef ident="endid" usage="opt">
-        <desc>Indicates the final element in a sequence of events to which the feature
+        <desc xml:lang="en">Indicates the final element in a sequence of events to which the feature
           applies.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
@@ -3083,10 +3083,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.startId" module="MEI.shared" type="atts">
-    <desc>Attributes that identify a relative starting point.</desc>
+    <desc xml:lang="en">Attributes that identify a relative starting point.</desc>
     <attList>
       <attDef ident="startid" usage="opt">
-        <desc>Holds a reference to the first element in a sequence of events to which the feature
+        <desc xml:lang="en">Holds a reference to the first element in a sequence of events to which the feature
           applies.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
@@ -3107,7 +3107,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.stems" module="MEI.shared" type="atts">
-    <desc>Attributes that describe the properties of stemmed features; that is, chords and
+    <desc xml:lang="en">Attributes that describe the properties of stemmed features; that is, chords and
       notes.</desc>
     <classes>
       <memberOf key="att.stems.cmn"/>
@@ -3115,32 +3115,32 @@
     </classes>
     <attList>
       <attDef ident="stem.dir" usage="opt">
-        <desc>Describes the direction of a stem.</desc>
+        <desc xml:lang="en">Describes the direction of a stem.</desc>
         <datatype>
           <rng:ref name="data.STEMDIRECTION"/>
         </datatype>
       </attDef>
       <attDef ident="stem.len" usage="opt">
-        <desc>Encodes the stem length.</desc>
+        <desc xml:lang="en">Encodes the stem length.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTABS"/>
         </datatype>
       </attDef>
       <attDef ident="stem.mod" usage="opt">
-        <desc>Encodes any stem "modifiers"; that is, symbols rendered on the stem, such as tremolo
+        <desc xml:lang="en">Encodes any stem "modifiers"; that is, symbols rendered on the stem, such as tremolo
           or Sprechstimme indicators.</desc>
         <datatype>
           <rng:ref name="data.STEMMODIFIER"/>
         </datatype>
       </attDef>
       <attDef ident="stem.pos" usage="opt">
-        <desc>Records the position of the stem in relation to the note head(s).</desc>
+        <desc xml:lang="en">Records the position of the stem in relation to the note head(s).</desc>
         <datatype>
           <rng:ref name="data.STEMPOSITION"/>
         </datatype>
       </attDef>
       <attDef ident="stem.sameas" usage="opt">
-        <desc>Points to a note element in a different layer whose stem is shared. 
+        <desc xml:lang="en">Points to a note element in a different layer whose stem is shared. 
           The linked notes should be rendered like a chord though they are part of different layers.
         </desc>
         <datatype maxOccurs="1">
@@ -3166,19 +3166,19 @@
         </constraintSpec>
       </attDef>
       <attDef ident="stem.visible" usage="opt">
-        <desc>Determines whether a stem should be displayed.</desc>
+        <desc xml:lang="en">Determines whether a stem should be displayed.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
       </attDef>
       <attDef ident="stem.x" usage="opt">
-        <desc>Records the output x coordinate of the stem’s attachment point.</desc>
+        <desc xml:lang="en">Records the output x coordinate of the stem’s attachment point.</desc>
         <datatype>
           <rng:data type="decimal"/>
         </datatype>
       </attDef>
       <attDef ident="stem.y" usage="opt">
-        <desc>Records the output y coordinate of the stem’s attachment point.</desc>
+        <desc xml:lang="en">Records the output y coordinate of the stem’s attachment point.</desc>
         <datatype>
           <rng:data type="decimal"/>
         </datatype>
@@ -3186,62 +3186,62 @@
     </attList>
   </classSpec>
   <classSpec ident="att.syl.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <attList>
       <attDef ident="con" usage="opt">
-        <desc>Describes the symbols typically used to indicate breaks between syllables and their
+        <desc xml:lang="en">Describes the symbols typically used to indicate breaks between syllables and their
           functions.</desc>
         <valList type="closed">
           <valItem ident="s">
-            <desc>Space (word separator).</desc>
+            <desc xml:lang="en">Space (word separator).</desc>
           </valItem>
           <valItem ident="d">
-            <desc>Dash (syllable separator).</desc>
+            <desc xml:lang="en">Dash (syllable separator).</desc>
           </valItem>
           <valItem ident="u">
-            <desc>Underscore (syllable extension).</desc>
+            <desc xml:lang="en">Underscore (syllable extension).</desc>
           </valItem>
           <valItem ident="t">
-            <desc>Tilde (syllable elision).</desc>
+            <desc xml:lang="en">Tilde (syllable elision).</desc>
           </valItem>
           <valItem ident="c">
-            <desc>Circumflex [angled line above] (syllable elision).</desc>
+            <desc xml:lang="en">Circumflex [angled line above] (syllable elision).</desc>
           </valItem>
           <valItem ident="v">
-            <desc>Caron [angled line below] (syllable elision).</desc>
+            <desc xml:lang="en">Caron [angled line below] (syllable elision).</desc>
           </valItem>
           <valItem ident="i">
-            <desc>Inverted breve [curved line above] (syllable elision).</desc>
+            <desc xml:lang="en">Inverted breve [curved line above] (syllable elision).</desc>
           </valItem>
           <valItem ident="b">
-            <desc>Breve [curved line below] (syllable elision).</desc>
+            <desc xml:lang="en">Breve [curved line below] (syllable elision).</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="wordpos" usage="opt">
-        <desc>Records the position of a syllable within a word.</desc>
+        <desc xml:lang="en">Records the position of a syllable within a word.</desc>
         <valList type="closed">
           <valItem ident="i">
-            <desc>(initial) first syllable.</desc>
+            <desc xml:lang="en">(initial) first syllable.</desc>
           </valItem>
           <valItem ident="m">
-            <desc>(medial) neither first nor last syllable.</desc>
+            <desc xml:lang="en">(medial) neither first nor last syllable.</desc>
           </valItem>
           <valItem ident="s">
-            <desc>(single) single syllable.</desc>
+            <desc xml:lang="en">(single) single syllable.</desc>
           </valItem>
           <valItem ident="t">
-            <desc>(terminal) last syllable.</desc>
+            <desc xml:lang="en">(terminal) last syllable.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.sylText" module="MEI.shared" type="atts">
-    <desc>Attributes that hold associated sung text syllables.</desc>
+    <desc xml:lang="en">Attributes that hold associated sung text syllables.</desc>
     <attList>
       <attDef ident="syl" usage="opt">
-        <desc>Holds an associated sung text syllable.</desc>
+        <desc xml:lang="en">Holds an associated sung text syllable.</desc>
         <datatype>
           <rng:data type="string"/>
         </datatype>
@@ -3249,16 +3249,16 @@
     </attList>
   </classSpec>
   <classSpec ident="att.symbol.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.startId"/>
     </classes>
   </classSpec>
   <classSpec ident="att.systems" module="MEI.shared" type="atts">
-    <desc>Attributes that capture system layout information.</desc>
+    <desc xml:lang="en">Attributes that capture system layout information.</desc>
     <attList>
       <attDef ident="system.leftline" usage="opt">
-        <desc>Indicates whether the system starts with a continuous line connecting all staves,
+        <desc xml:lang="en">Indicates whether the system starts with a continuous line connecting all staves,
           including single-staff systems. Do not confuse this with the heavy vertical line used as a grouping
           symbol.</desc>
         <datatype>
@@ -3266,21 +3266,21 @@
         </datatype>
       </attDef>
       <attDef ident="system.leftmar" usage="opt">
-        <desc>Describes the amount of whitespace at the left system margin relative to
+        <desc xml:lang="en">Describes the amount of whitespace at the left system margin relative to
           page.leftmar.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTABS"/>
         </datatype>
       </attDef>
       <attDef ident="system.rightmar" usage="opt">
-        <desc>Describes the amount of whitespace at the right system margin relative to
+        <desc xml:lang="en">Describes the amount of whitespace at the right system margin relative to
           page.rightmar.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTABS"/>
         </datatype>
       </attDef>
       <attDef ident="system.topmar" usage="opt">
-        <desc>Describes the distance from page’s top edge to the first system; used for first page
+        <desc xml:lang="en">Describes the distance from page’s top edge to the first system; used for first page
           only.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTABS"/>
@@ -3289,22 +3289,22 @@
     </attList>
   </classSpec>
   <classSpec ident="att.targetEval" module="MEI.shared" type="atts">
-    <desc>Attributes that deal with resolution of values in plist or target attributes.</desc>
+    <desc xml:lang="en">Attributes that deal with resolution of values in plist or target attributes.</desc>
     <attList>
       <attDef ident="evaluate" usage="opt">
-        <desc>Specifies the intended meaning when a participant in a relationship is itself a
+        <desc xml:lang="en">Specifies the intended meaning when a participant in a relationship is itself a
           pointer.</desc>
         <valList type="closed">
           <valItem ident="all">
-            <desc>If an element pointed to is itself a pointer, then the target of that pointer will
+            <desc xml:lang="en">If an element pointed to is itself a pointer, then the target of that pointer will
               be taken, and so on, until an element is found which is not a pointer.</desc>
           </valItem>
           <valItem ident="one">
-            <desc>If an element pointed to is itself a pointer, then its target (whether a pointer
+            <desc xml:lang="en">If an element pointed to is itself a pointer, then its target (whether a pointer
               or not) is taken as the target of this pointer.</desc>
           </valItem>
           <valItem ident="none">
-            <desc>No further evaluation of targets is carried out beyond that needed to find the
+            <desc xml:lang="en">No further evaluation of targets is carried out beyond that needed to find the
               element(s) specified in plist or target attribute.</desc>
           </valItem>
         </valList>
@@ -3316,7 +3316,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.tempo.log" module="MEI.shared" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.mmTempo"/>
@@ -3325,22 +3325,22 @@
     </classes>
     <attList>
       <attDef ident="func">
-        <desc>Records the function of a tempo indication.</desc>
+        <desc xml:lang="en">Records the function of a tempo indication.</desc>
         <valList type="closed">
           <valItem ident="continuous">
-            <desc>Marks a gradual change of tempo, such as "accel." or "rit."</desc>
+            <desc xml:lang="en">Marks a gradual change of tempo, such as "accel." or "rit."</desc>
           </valItem>
           <valItem ident="instantaneous">
-            <desc>Represents a static tempo instruction, such as a textual term like "Adagio", a
+            <desc xml:lang="en">Represents a static tempo instruction, such as a textual term like "Adagio", a
               metronome marking like "♩=70", or a combination of text and metronome
               indication.</desc>
           </valItem>
           <valItem ident="metricmod">
-            <desc>Captures a change in pulse rate (tempo) and/or pulse grouping (subdivision) in an
+            <desc xml:lang="en">Captures a change in pulse rate (tempo) and/or pulse grouping (subdivision) in an
               "equation" of the form [tempo before change] = [tempo after change].</desc>
           </valItem>
           <valItem ident="precedente">
-            <desc>Indicates a change in pulse rate (tempo) and/or pulse grouping (subdivision) in an
+            <desc xml:lang="en">Indicates a change in pulse rate (tempo) and/or pulse grouping (subdivision) in an
               "equation" of the form [tempo after change] = [tempo before change]. The term
               "precedente" often appears following the "equation" to distinguish this kind of
               historical usage from the modern metric modulation form.</desc>
@@ -3350,16 +3350,16 @@
     </attList>
   </classSpec>
   <classSpec ident="att.textRendition" module="MEI.shared" type="atts">
-    <desc>Attributes that record renditional characteristics.</desc>
+    <desc xml:lang="en">Attributes that record renditional characteristics.</desc>
     <attList>
       <attDef ident="altrend" usage="opt">
-        <desc>Used to extend the values of the rend attribute.</desc>
+        <desc xml:lang="en">Used to extend the values of the rend attribute.</desc>
         <datatype maxOccurs="unbounded">
           <rng:data type="NMTOKEN"/>
         </datatype>
       </attDef>
       <attDef ident="rend" usage="opt">
-        <desc>Captures the appearance of the element’s contents using MEI-defined
+        <desc xml:lang="en">Captures the appearance of the element’s contents using MEI-defined
           descriptors.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.TEXTRENDITION"/>
@@ -3368,38 +3368,38 @@
     </attList>
   </classSpec>
   <classSpec ident="att.textStyle" module="MEI.shared" type="atts">
-    <desc>Attributes that describe default text typography.</desc>
+    <desc xml:lang="en">Attributes that describe default text typography.</desc>
     <attList>
       <attDef ident="text.fam" usage="opt">
-        <desc>Provides a default value for the font family name of text (other than lyrics) when
+        <desc xml:lang="en">Provides a default value for the font family name of text (other than lyrics) when
           this information is not provided on the individual elements.</desc>
         <datatype>
           <rng:ref name="data.FONTFAMILY"/>
         </datatype>
       </attDef>
       <attDef ident="text.name" usage="opt">
-        <desc>Provides a default value for the font name of text (other than lyrics) when this
+        <desc xml:lang="en">Provides a default value for the font name of text (other than lyrics) when this
           information is not provided on the individual elements.</desc>
         <datatype>
           <rng:ref name="data.FONTNAME"/>
         </datatype>
       </attDef>
       <attDef ident="text.size" usage="opt">
-        <desc>Provides a default value for the font size of text (other than lyrics) when this
+        <desc xml:lang="en">Provides a default value for the font size of text (other than lyrics) when this
           information is not provided on the individual elements.</desc>
         <datatype>
           <rng:ref name="data.FONTSIZE"/>
         </datatype>
       </attDef>
       <attDef ident="text.style" usage="opt">
-        <desc>Provides a default value for the font style of text (other than lyrics) when this
+        <desc xml:lang="en">Provides a default value for the font style of text (other than lyrics) when this
           information is not provided on the individual elements.</desc>
         <datatype>
           <rng:ref name="data.FONTSTYLE"/>
         </datatype>
       </attDef>
       <attDef ident="text.weight" usage="opt">
-        <desc>Provides a default value for the font weight for text (other than lyrics) when this
+        <desc xml:lang="en">Provides a default value for the font weight for text (other than lyrics) when this
           information is not provided on the individual elements.</desc>
         <datatype>
           <rng:ref name="data.FONTWEIGHT"/>
@@ -3408,10 +3408,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.tiePresent" module="MEI.shared" type="atts">
-    <desc>Attributes that indicate the presence of a tie.</desc>
+    <desc xml:lang="en">Attributes that indicate the presence of a tie.</desc>
     <attList>
       <attDef ident="tie" usage="opt">
-        <desc>Indicates that this element participates in a tie. If visual information about the tie
+        <desc xml:lang="en">Indicates that this element participates in a tie. If visual information about the tie
           needs to be recorded, then a <gi scheme="MEI">tie</gi> element should be employed.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.TIE"/>
@@ -3420,11 +3420,11 @@
     </attList>
   </classSpec>
   <classSpec ident="att.timestamp.logical" module="MEI.shared" type="atts">
-    <desc>Attributes that record a time stamp in terms of musical time, <abbr>i.e.</abbr>, beats[.fractional beat
+    <desc xml:lang="en">Attributes that record a time stamp in terms of musical time, <abbr>i.e.</abbr>, beats[.fractional beat
       part].</desc>
     <attList>
       <attDef ident="tstamp" usage="opt">
-        <desc>Encodes the onset time in terms of musical time, <abbr>i.e.</abbr>, beats[.fractional beat part],
+        <desc xml:lang="en">Encodes the onset time in terms of musical time, <abbr>i.e.</abbr>, beats[.fractional beat part],
           as expressed in the written time signature.</desc>
         <datatype>
           <rng:ref name="data.BEAT"/>
@@ -3433,11 +3433,11 @@
     </attList>
   </classSpec>
   <classSpec ident="att.timestamp2.logical" module="MEI.shared" type="atts">
-    <desc>Attributes that record a time stamp for the end of an event in terms of musical
+    <desc xml:lang="en">Attributes that record a time stamp for the end of an event in terms of musical
       time.</desc>
     <attList>
       <attDef ident="tstamp2" usage="opt">
-        <desc>Encodes the ending point of an event, <abbr>i.e.</abbr>, a count of measures plus a beat location
+        <desc xml:lang="en">Encodes the ending point of an event, <abbr>i.e.</abbr>, a count of measures plus a beat location
           in the ending measure.</desc>
         <datatype>
           <rng:ref name="data.MEASUREBEAT"/>
@@ -3446,17 +3446,17 @@
     </attList>
   </classSpec>
   <classSpec ident="att.transposition" module="MEI.shared" type="atts">
-    <desc>Attributes that describe transposition.</desc>
+    <desc xml:lang="en">Attributes that describe transposition.</desc>
     <attList>
       <attDef ident="trans.diat" usage="opt">
-        <desc>Records the amount of diatonic pitch shift, <abbr>e.g.</abbr>, C to C♯ = 0, C to D♭ = 1, necessary
+        <desc xml:lang="en">Records the amount of diatonic pitch shift, <abbr>e.g.</abbr>, C to C♯ = 0, C to D♭ = 1, necessary
           to calculate the sounded pitch from the written one.</desc>
         <datatype>
           <rng:data type="integer"/>
         </datatype>
       </attDef>
       <attDef ident="trans.semi" usage="opt">
-        <desc>Records the amount of pitch shift in semitones, <abbr>e.g.</abbr>, C to C♯ = 1, C to D♭ = 1,
+        <desc xml:lang="en">Records the amount of pitch shift in semitones, <abbr>e.g.</abbr>, C to C♯ = 1, C to D♭ = 1,
           necessary to calculate the sounded pitch from the written one.</desc>
         <datatype>
           <rng:data type="integer"/>
@@ -3470,10 +3470,10 @@
     </remarks>
   </classSpec>
   <classSpec ident="att.tupletPresent" module="MEI.shared" type="atts">
-    <desc>Attributes for indicating the presence of a tuplet.</desc>
+    <desc xml:lang="en">Attributes for indicating the presence of a tuplet.</desc>
     <attList>
       <attDef ident="tuplet" usage="opt">
-        <desc>Indicates that this feature participates in a tuplet. If visual information about the
+        <desc xml:lang="en">Indicates that this feature participates in a tuplet. If visual information about the
           tuplet needs to be recorded, then a <gi scheme="MEI">tuplet</gi> element should be
           employed.</desc>
         <datatype maxOccurs="unbounded">
@@ -3483,13 +3483,13 @@
     </attList>
   </classSpec>
   <classSpec ident="att.typed" module="MEI.shared" type="atts">
-    <desc>Attributes which can be used to classify features.</desc>
+    <desc xml:lang="en">Attributes which can be used to classify features.</desc>
     <classes>
       <memberOf key="att.classed"/>
     </classes>
     <attList>
       <attDef ident="type" usage="opt">
-        <desc>Designation which characterizes the element in some sense, using any convenient
+        <desc xml:lang="en">Designation which characterizes the element in some sense, using any convenient
           classification scheme or typology that employs single-token labels.</desc>
         <datatype maxOccurs="unbounded">
           <rng:data type="NMTOKEN"/>
@@ -3501,22 +3501,22 @@
     </remarks>
   </classSpec>
   <classSpec ident="att.typography" module="MEI.shared" type="atts">
-    <desc>Typographical attributes.</desc>
+    <desc xml:lang="en">Typographical attributes.</desc>
     <attList>
       <attDef ident="fontfam" usage="opt">
-        <desc>Contains the name of a font-family.</desc>
+        <desc xml:lang="en">Contains the name of a font-family.</desc>
         <datatype>
           <rng:ref name="data.FONTFAMILY"/>
         </datatype>
       </attDef>
       <attDef ident="fontname" usage="opt">
-        <desc>Holds the name of a font.</desc>
+        <desc xml:lang="en">Holds the name of a font.</desc>
         <datatype>
           <rng:ref name="data.FONTNAME"/>
         </datatype>
       </attDef>
       <attDef ident="fontsize" usage="opt">
-        <desc>Indicates the size of a font expressed in printers' points, <abbr>i.e.</abbr>, 1/72nd of an inch,
+        <desc xml:lang="en">Indicates the size of a font expressed in printers' points, <abbr>i.e.</abbr>, 1/72nd of an inch,
           relative terms, <abbr>e.g.</abbr>, <val>small</val>, <val>larger</val>, <abbr>etc.</abbr>, or percentage values relative to <val>normal</val>
           size, <abbr>e.g.</abbr>, <val>125%</val>. </desc>
         <datatype>
@@ -3524,13 +3524,13 @@
         </datatype>
       </attDef>
       <attDef ident="fontstyle" usage="opt">
-        <desc>Records the style of a font, <abbr>i.e.</abbr>, <val>italic</val>, <val>oblique</val>, or <val>normal</val>.</desc>
+        <desc xml:lang="en">Records the style of a font, <abbr>i.e.</abbr>, <val>italic</val>, <val>oblique</val>, or <val>normal</val>.</desc>
         <datatype>
           <rng:ref name="data.FONTSTYLE"/>
         </datatype>
       </attDef>
       <attDef ident="fontweight" usage="opt">
-        <desc>Used to indicate bold type.</desc>
+        <desc xml:lang="en">Used to indicate bold type.</desc>
         <datatype>
           <rng:ref name="data.FONTWEIGHT"/>
         </datatype>
@@ -3538,10 +3538,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.verticalAlign" module="MEI.shared" type="atts">
-    <desc>Attributes that record vertical alignment.</desc>
+    <desc xml:lang="en">Attributes that record vertical alignment.</desc>
     <attList>
       <attDef ident="valign" usage="opt">
-        <desc>Records vertical alignment.</desc>
+        <desc xml:lang="en">Records vertical alignment.</desc>
         <datatype>
           <rng:ref name="data.VERTICALALIGNMENT"/>
         </datatype>
@@ -3549,10 +3549,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.verticalGroup" module="MEI.shared" type="atts">
-    <desc>Attributes that record grouping of vertically aligned elements.</desc>
+    <desc xml:lang="en">Attributes that record grouping of vertically aligned elements.</desc>
     <attList>
       <attDef ident="vgrp" usage="opt">
-        <desc>Provides a label for members of a vertically aligned group.</desc>
+        <desc xml:lang="en">Provides a label for members of a vertically aligned group.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
@@ -3560,10 +3560,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.visibility" module="MEI.shared" type="atts">
-    <desc>Attributes describing whether a feature should be displayed.</desc>
+    <desc xml:lang="en">Attributes describing whether a feature should be displayed.</desc>
     <attList>
       <attDef ident="visible" usage="opt">
-        <desc>Indicates if a feature should be rendered when the notation is presented graphically
+        <desc xml:lang="en">Indicates if a feature should be rendered when the notation is presented graphically
           or sounded when it is presented in an aural form.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
@@ -3572,7 +3572,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.visualOffset" module="MEI.shared" type="atts">
-    <desc>Visual offset attributes. Some items may have their location recorded in terms of offsets
+    <desc xml:lang="en">Visual offset attributes. Some items may have their location recorded in terms of offsets
       from their programmatically-determined location. The ho attribute records the horizontal
       offset while vo records the vertical. The to attribute holds a timestamp offset, the most
       common use of which is as an alternative to the ho attribute.</desc>
@@ -3583,10 +3583,10 @@
     </classes>
   </classSpec>
   <classSpec ident="att.visualOffset.ho" module="MEI.shared" type="atts">
-    <desc>Horizontal offset attributes.</desc>
+    <desc xml:lang="en">Horizontal offset attributes.</desc>
     <attList>
       <attDef ident="ho" usage="opt">
-        <desc>Records a horizontal adjustment to a feature’s programmatically-determined location in
+        <desc xml:lang="en">Records a horizontal adjustment to a feature’s programmatically-determined location in
           terms of staff interline distance; that is, in units of 1/2 the distance between adjacent
           staff lines.</desc>
         <datatype>
@@ -3596,10 +3596,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.visualOffset.to" module="MEI.shared" type="atts">
-    <desc>Horizontal offset attributes specified in terms of time.</desc>
+    <desc xml:lang="en">Horizontal offset attributes specified in terms of time.</desc>
     <attList>
       <attDef ident="to" usage="opt">
-        <desc>Records a timestamp adjustment of a feature’s programmatically-determined location in
+        <desc xml:lang="en">Records a timestamp adjustment of a feature’s programmatically-determined location in
           terms of musical time; that is, beats.</desc>
         <datatype>
           <rng:ref name="data.TSTAMPOFFSET"/>
@@ -3608,10 +3608,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.visualOffset.vo" module="MEI.shared" type="atts">
-    <desc>Vertical offset attributes.</desc>
+    <desc xml:lang="en">Vertical offset attributes.</desc>
     <attList>
       <attDef ident="vo" usage="opt">
-        <desc>Records the vertical adjustment of a feature’s programmatically-determined location in
+        <desc xml:lang="en">Records the vertical adjustment of a feature’s programmatically-determined location in
           terms of staff interline distance; that is, in units of 1/2 the distance between adjacent
           staff lines.</desc>
         <datatype>
@@ -3621,7 +3621,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.visualOffset2" module="MEI.shared" type="atts">
-    <desc>Visual offset attributes. Some items may have their location recorded in terms of pairs of
+    <desc xml:lang="en">Visual offset attributes. Some items may have their location recorded in terms of pairs of
       offsets from their programmatically-determined location. The startho and endho attributes
       record the horizontal offsets of the start and end points of the item, respectively.
       Similarly, the startvo and endvo attributes record the vertical offsets of the start and end
@@ -3634,17 +3634,17 @@
     </classes>
   </classSpec>
   <classSpec ident="att.visualOffset2.ho" module="MEI.shared" type="atts">
-    <desc>Horizontal offset requiring a pair of attributes.</desc>
+    <desc xml:lang="en">Horizontal offset requiring a pair of attributes.</desc>
     <attList>
       <attDef ident="startho" usage="opt">
-        <desc>Records the horizontal adjustment of a feature’s programmatically-determined start
+        <desc xml:lang="en">Records the horizontal adjustment of a feature’s programmatically-determined start
           point.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTREL"/>
         </datatype>
       </attDef>
       <attDef ident="endho" usage="opt">
-        <desc>Records the horizontal adjustment of a feature’s programmatically-determined end
+        <desc xml:lang="en">Records the horizontal adjustment of a feature’s programmatically-determined end
           point.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTREL"/>
@@ -3653,18 +3653,18 @@
     </attList>
   </classSpec>
   <classSpec ident="att.visualOffset2.to" module="MEI.shared" type="atts">
-    <desc>Horizontal offset attributes requiring a pair of attributes specified in terms of
+    <desc xml:lang="en">Horizontal offset attributes requiring a pair of attributes specified in terms of
       time.</desc>
     <attList>
       <attDef ident="startto" usage="opt">
-        <desc>Records a timestamp adjustment of a feature’s programmatically-determined start
+        <desc xml:lang="en">Records a timestamp adjustment of a feature’s programmatically-determined start
           point.</desc>
         <datatype>
           <rng:ref name="data.TSTAMPOFFSET"/>
         </datatype>
       </attDef>
       <attDef ident="endto" usage="opt">
-        <desc>Records a timestamp adjustment of a feature’s programmatically-determined end
+        <desc xml:lang="en">Records a timestamp adjustment of a feature’s programmatically-determined end
           point.</desc>
         <datatype>
           <rng:ref name="data.TSTAMPOFFSET"/>
@@ -3673,17 +3673,17 @@
     </attList>
   </classSpec>
   <classSpec ident="att.visualOffset2.vo" module="MEI.shared" type="atts">
-    <desc>Vertical offset attributes requiring a pair of attributes.</desc>
+    <desc xml:lang="en">Vertical offset attributes requiring a pair of attributes.</desc>
     <attList>
       <attDef ident="startvo" usage="opt">
-        <desc>Records a vertical adjustment of a feature’s programmatically-determined start
+        <desc xml:lang="en">Records a vertical adjustment of a feature’s programmatically-determined start
           point.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTREL"/>
         </datatype>
       </attDef>
       <attDef ident="endvo" usage="opt">
-        <desc>Records a vertical adjustment of a feature’s programmatically-determined end
+        <desc xml:lang="en">Records a vertical adjustment of a feature’s programmatically-determined end
           point.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTREL"/>
@@ -3692,46 +3692,46 @@
     </attList>
   </classSpec>
   <classSpec ident="att.voltaGroupingSym" module="MEI.shared" type="atts">
-    <desc>Attributes that describe the symbol used to group volta elements.</desc>
+    <desc xml:lang="en">Attributes that describe the symbol used to group volta elements.</desc>
     <attList>
       <attDef ident="voltasym" usage="opt">
-        <desc>Specifies the symbol used to group lyrics.</desc>
+        <desc xml:lang="en">Specifies the symbol used to group lyrics.</desc>
         <valList type="closed">
           <valItem ident="brace">
-            <desc>Curved symbol, <abbr>i.e.</abbr>, {.</desc>
+            <desc xml:lang="en">Curved symbol, <abbr>i.e.</abbr>, {.</desc>
           </valItem>
           <valItem ident="bracket">
-            <desc>Square symbol, <abbr>i.e.</abbr>, [, but with curved/angled top and bottom segments.</desc>
+            <desc xml:lang="en">Square symbol, <abbr>i.e.</abbr>, [, but with curved/angled top and bottom segments.</desc>
           </valItem>
           <valItem ident="bracketsq">
-            <desc>Square symbol, <abbr>i.e.</abbr>, [, with horizontal top and bottom segments.</desc>
+            <desc xml:lang="en">Square symbol, <abbr>i.e.</abbr>, [, with horizontal top and bottom segments.</desc>
           </valItem>
           <valItem ident="line">
-            <desc>Line symbol, <abbr>i.e.</abbr>, |, (wide) line without top and bottom curved/horizontal
+            <desc xml:lang="en">Line symbol, <abbr>i.e.</abbr>, |, (wide) line without top and bottom curved/horizontal
               segments.</desc>
           </valItem>
           <valItem ident="none">
-            <desc>Grouping symbol missing.</desc>
+            <desc xml:lang="en">Grouping symbol missing.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.whitespace" module="MEI.shared" type="atts">
-    <desc>Attributes that address whitespace processing.</desc>
+    <desc xml:lang="en">Attributes that address whitespace processing.</desc>
     <!--<attDef ident="space" ns="http://www.w3.org/XML/1998/namespace" usage="opt">-->
     <attList>
       <attDef ident="xml:space" usage="opt">
-        <desc>Allows one to signal to an application whether an element’s white space is
+        <desc xml:lang="en">Allows one to signal to an application whether an element’s white space is
           "significant". The behavior of xml:space cascades to all descendant elements, but it can
           be turned off locally by setting the xml:space attribute to the value "default".</desc>
         <valList type="closed">
           <valItem ident="default">
-            <desc>Allows the application to handle white space as necessary. Not including an
+            <desc xml:lang="en">Allows the application to handle white space as necessary. Not including an
               xml:space attribute produces the same result as using the default value.</desc>
           </valItem>
           <valItem ident="preserve">
-            <desc>Instructs the application to maintain white space "as-is", suggesting that it
+            <desc xml:lang="en">Instructs the application to maintain white space "as-is", suggesting that it
               might have meaning.</desc>
           </valItem>
         </valList>
@@ -3739,10 +3739,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.width" module="MEI.shared" type="atts">
-    <desc>Attributes that describe horizontal size.</desc>
+    <desc xml:lang="en">Attributes that describe horizontal size.</desc>
     <attList>
       <attDef ident="width" usage="opt">
-        <desc>Measurement of the horizontal dimension of an entity.</desc>
+        <desc xml:lang="en">Measurement of the horizontal dimension of an entity.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTABS"/>
         </datatype>
@@ -3755,13 +3755,13 @@
     </remarks>
   </classSpec>
   <classSpec ident="att.xy" module="MEI.shared" type="atts">
-    <desc>Output coordinate attributes. Some elements may have their exact rendered *output*
+    <desc xml:lang="en">Output coordinate attributes. Some elements may have their exact rendered *output*
       coordinates recorded. x and y attributes indicate where to place the rendered output.
       Recording the coordinates of a feature in a facsimile requires the use of the facs
       attribute.</desc>
     <attList>
       <attDef ident="x" usage="opt">
-        <desc>Encodes an x coordinate for a feature in an output coordinate system. When it is
+        <desc xml:lang="en">Encodes an x coordinate for a feature in an output coordinate system. When it is
           necessary to record the placement of a feature in a facsimile image, use the facs
           attribute.</desc>
         <datatype>
@@ -3769,7 +3769,7 @@
         </datatype>
       </attDef>
       <attDef ident="y" usage="opt">
-        <desc>Encodes a y coordinate for a feature in an output coordinate system. When it is
+        <desc xml:lang="en">Encodes a y coordinate for a feature in an output coordinate system. When it is
           necessary to record the placement of a feature in a facsimile image, use the facs
           attribute.</desc>
         <datatype>
@@ -3779,19 +3779,19 @@
     </attList>
   </classSpec>
   <classSpec ident="att.xy2" module="MEI.shared" type="atts">
-    <desc>Output coordinate attributes. Some elements may need 2 coordinate pairs to record their
+    <desc xml:lang="en">Output coordinate attributes. Some elements may need 2 coordinate pairs to record their
       rendered *output* coordinates. The attributes indicate where to place the rendered output.
       Recording the coordinates of a feature in a facsimile requires the use of the facs
       attribute.</desc>
     <attList>
       <attDef ident="x2" usage="opt">
-        <desc>Encodes the optional 2nd x coordinate.</desc>
+        <desc xml:lang="en">Encodes the optional 2nd x coordinate.</desc>
         <datatype>
           <rng:data type="decimal"/>
         </datatype>
       </attDef>
       <attDef ident="y2" usage="opt">
-        <desc>Encodes the optional 2nd y coordinate.</desc>
+        <desc xml:lang="en">Encodes the optional 2nd y coordinate.</desc>
         <datatype>
           <rng:data type="decimal"/>
         </datatype>
@@ -3799,7 +3799,7 @@
     </attList>
   </classSpec>
   <classSpec ident="model.addressLike" module="MEI.shared" type="model">
-    <desc>Groups elements used to represent a postal address.</desc>
+    <desc xml:lang="en">Groups elements used to represent a postal address.</desc>
     <classes>
       <memberOf key="model.textPhraseLike.limited"/>
       <memberOf key="model.pubStmtPart"/>
@@ -3807,29 +3807,29 @@
     </classes>
   </classSpec>
   <classSpec ident="model.annotLike" module="MEI.shared" type="model">
-    <desc>Groups annotation-like elements.</desc>
+    <desc xml:lang="en">Groups annotation-like elements.</desc>
     <classes>
       <memberOf key="model.textPhraseLike.limited"/>
     </classes>
   </classSpec>
   <classSpec ident="model.biblLike" module="MEI.shared" type="model">
-    <desc>Groups elements containing a bibliographic description.</desc>
+    <desc xml:lang="en">Groups elements containing a bibliographic description.</desc>
     <classes>
       <memberOf key="model.textPhraseLike.limited"/>
     </classes>
   </classSpec>
   <classSpec ident="model.biblPart" module="MEI.shared" type="model">
-    <desc>Groups elements that may appear as part of a bibliographic description.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of a bibliographic description.</desc>
   </classSpec>
   <classSpec ident="model.captionLike" module="MEI.shared" type="model">
-    <desc>Groups elements that contain the text of a caption or other text displayed along with a
+    <desc xml:lang="en">Groups elements that contain the text of a caption or other text displayed along with a
       figure.</desc>
   </classSpec>
   <classSpec ident="model.chordPart" module="MEI.shared" type="model">
-    <desc>Groups elements that may appear as part of the content of a chord element.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of the content of a chord element.</desc>
   </classSpec>
   <classSpec ident="model.controlEventLike" module="MEI.shared" type="model">
-    <desc>Groups elements, such as dynamics, ties, phrase marks, pedal marks, etc., which depend
+    <desc xml:lang="en">Groups elements, such as dynamics, ties, phrase marks, pedal marks, etc., which depend
       upon other events, such as notes or rests, for their existence.</desc>
     <classes>
       <memberOf key="model.measurePart"/>
@@ -3840,7 +3840,7 @@
     </classes>
   </classSpec>
   <classSpec ident="model.dateLike" module="MEI.shared" type="model">
-    <desc>Groups elements containing date expressions.</desc>
+    <desc xml:lang="en">Groups elements containing date expressions.</desc>
     <classes>
       <memberOf key="model.textPhraseLike.limited"/>
       <memberOf key="model.pubStmtPart"/>
@@ -3849,48 +3849,48 @@
     </classes>
   </classSpec>
   <classSpec ident="model.descLike" module="MEI.shared" type="model">
-    <desc>Groups elements which provide a description of their parent entity.</desc>
+    <desc xml:lang="en">Groups elements which provide a description of their parent entity.</desc>
   </classSpec>
   <classSpec ident="model.dimLike" module="MEI.shared" type="model">
-    <desc>Groups elements which describe a measurement forming part of the physical dimensions of an
+    <desc xml:lang="en">Groups elements which describe a measurement forming part of the physical dimensions of an
       object.</desc>
     <classes>
       <memberOf key="model.textPhraseLike.limited"/>
     </classes>
   </classSpec>
   <classSpec ident="model.editionLike" module="MEI.shared" type="model">
-    <desc>Groups elements containing bibliographic edition information.</desc>
+    <desc xml:lang="en">Groups elements containing bibliographic edition information.</desc>
     <classes>
       <memberOf key="model.biblPart"/>
       <memberOf key="model.titlePagePart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.editorialLike" module="MEI.shared" type="model">
-    <desc>Groups editorial intervention elements.</desc>
+    <desc xml:lang="en">Groups editorial intervention elements.</desc>
     <classes>
       <memberOf key="model.textPhraseLike.limited"/>
       <memberOf key="model.choicePart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.endingLike" module="MEI.shared" type="model">
-    <desc>Groups elements that represent alternative endings.</desc>
+    <desc xml:lang="en">Groups elements that represent alternative endings.</desc>
     <classes>
       <memberOf key="model.scorePart"/>
       <memberOf key="model.sectionPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.eventLike" module="MEI.shared" type="model">
-    <desc>Groups event elements that occur in all notational repertoires.</desc>
+    <desc xml:lang="en">Groups event elements that occur in all notational repertoires.</desc>
     <classes>
       <memberOf key="model.layerPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.headLike" module="MEI.shared" type="model">
-    <desc>Groups elements used to provide a heading at the start of a text division or other markup
+    <desc xml:lang="en">Groups elements used to provide a heading at the start of a text division or other markup
       component.</desc>
   </classSpec>
   <classSpec ident="model.identifierLike" module="MEI.shared" type="model">
-    <desc>Groups identifier-like elements.</desc>
+    <desc xml:lang="en">Groups identifier-like elements.</desc>
     <classes>
       <memberOf key="model.textPhraseLike.limited"/>
       <memberOf key="model.pubStmtPart"/>
@@ -3898,36 +3898,36 @@
     </classes>
   </classSpec>
   <classSpec ident="model.imprintPart" module="MEI.shared" type="model">
-    <desc>Groups elements that may appear as part of a bibliographic imprint.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of a bibliographic imprint.</desc>
   </classSpec>
   <classSpec ident="model.incipLike" module="MEI.shared" type="model">
-    <desc>Groups elements used to represent a textual or musical incipit.</desc>
+    <desc xml:lang="en">Groups elements used to represent a textual or musical incipit.</desc>
     <classes>
       <memberOf key="model.physDescPart"/>
       <memberOf key="model.workIdent"/>
     </classes>
   </classSpec>
   <classSpec ident="model.instrDefLike" module="MEI.shared" type="model">
-    <desc>Groups elements used to declare a MIDI instrument.</desc>
+    <desc xml:lang="en">Groups elements used to declare a MIDI instrument.</desc>
   </classSpec>
   <classSpec ident="model.keyAccidLike" module="MEI.shared" type="model">
-    <desc>Groups elements that represent accidentals in a key signature.</desc>
+    <desc xml:lang="en">Groups elements that represent accidentals in a key signature.</desc>
   </classSpec>
   <classSpec ident="model.keySigLike" module="MEI.shared" type="model">
-    <desc>Groups elements that have the same function as a key signature.</desc>
+    <desc xml:lang="en">Groups elements that have the same function as a key signature.</desc>
     <classes>
       <memberOf key="model.eventLike"/>
       <memberOf key="model.staffDefPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.labelLike" module="MEI.shared" type="model">
-    <desc>Groups elements used to assign a label to other parts of a document.</desc>
+    <desc xml:lang="en">Groups elements used to assign a label to other parts of a document.</desc>
   </classSpec>
   <classSpec ident="model.layerDefLike" module="MEI.shared" type="model">
-    <desc>Groups elements that permit declaration of layer properties.</desc>
+    <desc xml:lang="en">Groups elements that permit declaration of layer properties.</desc>
   </classSpec>
   <classSpec ident="model.layerLike" module="MEI.shared" type="model">
-    <desc>Groups elements that function as notational layers within a staff.</desc>
+    <desc xml:lang="en">Groups elements that function as notational layers within a staff.</desc>
     <classes>
       <memberOf key="model.staffPart"/>
       <memberOf key="model.rdgPart.music"/>
@@ -3935,75 +3935,75 @@
     </classes>
   </classSpec>
   <classSpec ident="model.layerPart" module="MEI.shared" type="model">
-    <desc>Groups notated events that may appear at the layer level in all repertoires.</desc>
+    <desc xml:lang="en">Groups notated events that may appear at the layer level in all repertoires.</desc>
   </classSpec>
   <classSpec ident="model.layerPart.mensuralAndNeumes" module="MEI.shared" type="model">
-    <desc>Groups notated events at the layer level that are shared by the mensural and neume
+    <desc xml:lang="en">Groups notated events at the layer level that are shared by the mensural and neume
       repertoires.</desc>
     <classes>
       <memberOf key="model.layerPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.lbLike" module="MEI.shared" type="model">
-    <desc>Groups elements that function like line beginnings.</desc>
+    <desc xml:lang="en">Groups elements that function like line beginnings.</desc>
     <classes>
       <memberOf key="model.milestoneLike.text"/>
       <memberOf key="model.textPhraseLike.limited"/>
     </classes>
   </classSpec>
   <classSpec ident="model.mdivLike" module="MEI.shared" type="model">
-    <desc>Groups elements used to represent generic structural divisions of music notation.</desc>
+    <desc xml:lang="en">Groups elements used to represent generic structural divisions of music notation.</desc>
   </classSpec>
   <classSpec ident="model.measurementLike" module="MEI.shared" type="model">
-    <desc>Groups elements that represent a measurement.</desc>
+    <desc xml:lang="en">Groups elements that represent a measurement.</desc>
     <classes>
       <memberOf key="model.textPhraseLike.limited"/>
     </classes>
   </classSpec>
   <classSpec ident="model.meterSigLike" module="MEI.shared" type="model">
-    <desc>Groups elements that represent a meter signature.</desc>
+    <desc xml:lang="en">Groups elements that represent a meter signature.</desc>
     <classes>
       <memberOf key="model.eventLike"/>
       <memberOf key="model.staffDefPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.milestoneLike.music" module="MEI.shared" type="model">
-    <desc>Groups milestone-style elements found in music notation.</desc>
+    <desc xml:lang="en">Groups milestone-style elements found in music notation.</desc>
   </classSpec>
   <classSpec ident="model.milestoneLike.text" module="MEI.shared" type="model">
-    <desc>Groups milestone-style elements found in text.</desc>
+    <desc xml:lang="en">Groups milestone-style elements found in text.</desc>
   </classSpec>
   <classSpec ident="model.nameLike" module="MEI.shared" type="model">
-    <desc>Groups elements that contain names.</desc>
+    <desc xml:lang="en">Groups elements that contain names.</desc>
     <classes>
       <memberOf key="model.textPhraseLike.limited"/>
     </classes>
   </classSpec>
   <classSpec ident="model.noteModifierLike" module="MEI.shared" type="model">
-    <desc>Groups elements that modify note-like features.</desc>
+    <desc xml:lang="en">Groups elements that modify note-like features.</desc>
     <classes>
       <!--<memberOf key="model.layerPart.mensuralAndNeumes"/>-->
       <memberOf key="model.layerPart.mensural"/>
     </classes>
   </classSpec>
   <classSpec ident="model.numLike" module="MEI.shared" type="model">
-    <desc>Groups elements that denote a number or a quantity.</desc>
+    <desc xml:lang="en">Groups elements that denote a number or a quantity.</desc>
     <classes>
       <memberOf key="model.measurementLike"/>
     </classes>
   </classSpec>
   <classSpec ident="model.paracontentPart" module="MEI.shared" type="model">
-    <desc>Groups elements which may appear as part of the paragraph content model. A paragraph may
+    <desc xml:lang="en">Groups elements which may appear as part of the paragraph content model. A paragraph may
       contain inline elements and all other block-level elements except itself.</desc>
   </classSpec>
   <classSpec ident="model.partLike" module="MEI.shared" type="model">
-    <desc>Groups elements that represent a separate performer part.</desc>
+    <desc xml:lang="en">Groups elements that represent a separate performer part.</desc>
   </classSpec>
   <classSpec ident="model.partsLike" module="MEI.shared" type="model">
-    <desc>Groups elements that collect separate performer parts.</desc>
+    <desc xml:lang="en">Groups elements that collect separate performer parts.</desc>
   </classSpec>
   <classSpec ident="model.pbLike" module="MEI.shared" type="model">
-    <desc>Groups page beginning-like elements.</desc>
+    <desc xml:lang="en">Groups page beginning-like elements.</desc>
     <classes>
       <memberOf key="model.milestoneLike.music"/>
       <memberOf key="model.milestoneLike.text"/>
@@ -4011,41 +4011,41 @@
     </classes>
   </classSpec>
   <classSpec ident="model.pLike" module="MEI.shared" type="model">
-    <desc>Groups paragraph-like elements.</desc>
+    <desc xml:lang="en">Groups paragraph-like elements.</desc>
     <classes>
       <memberOf key="model.textComponentLike"/>
     </classes>
   </classSpec>
   <classSpec ident="model.relationLike" type="model" module="MEI.shared">
-    <desc>Collects elements that express a relationship.</desc>
+    <desc xml:lang="en">Collects elements that express a relationship.</desc>
     <classes>
       <memberOf key="model.textPhraseLike.limited"/>
     </classes>
   </classSpec>
   <classSpec ident="model.rendLike" module="MEI.shared" type="model">
-    <desc>Groups elements that mark typographical features.</desc>
+    <desc xml:lang="en">Groups elements that mark typographical features.</desc>
     <classes>
       <memberOf key="model.textPhraseLike.limited"/>
     </classes>
   </classSpec>
   <classSpec ident="model.repositoryLike" module="MEI.shared" type="model">
-    <desc>Groups elements that denote a corporate entity that holds a bibliographic item.</desc>
+    <desc xml:lang="en">Groups elements that denote a corporate entity that holds a bibliographic item.</desc>
     <classes>
       <memberOf key="model.nameLike.place"/>
     </classes>
   </classSpec>
   <classSpec ident="model.resourceLike" module="MEI.shared" type="model">
-    <desc>Groups non-text components that represent the content of the musical text.</desc>
+    <desc xml:lang="en">Groups non-text components that represent the content of the musical text.</desc>
   </classSpec>
   <classSpec ident="model.respLike" module="MEI.shared" type="model">
-    <desc>Groups elements that are used to indicate intellectual or other significant
+    <desc xml:lang="en">Groups elements that are used to indicate intellectual or other significant
       responsibility, for example within a bibliographic citation.</desc>
     <classes>
       <memberOf key="model.biblPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.respLikePart" module="MEI.shared" type="model">
-    <desc>Groups elements that delineate particular responsibilities as opposed to the respStmt
+    <desc xml:lang="en">Groups elements that delineate particular responsibilities as opposed to the respStmt
       element that provides for generic statements of responsibility.</desc>
     <classes>
       <memberOf key="model.respLike"/>
@@ -4053,72 +4053,72 @@
     </classes>
   </classSpec>
   <classSpec ident="model.scoreDefLike" module="MEI.shared" type="model">
-    <desc>Groups elements that provide score meta-information.</desc>
+    <desc xml:lang="en">Groups elements that provide score meta-information.</desc>
     <classes>
       <memberOf key="model.sectionPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.scoreLike" module="MEI.shared" type="model">
-    <desc>Groups elements that represent a score.</desc>
+    <desc xml:lang="en">Groups elements that represent a score.</desc>
   </classSpec>
   <classSpec ident="model.scorePart" module="MEI.shared" type="model">
-    <desc>Groups elements that may appear as part of a score.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of a score.</desc>
   </classSpec>
   <classSpec ident="model.scorePart.mensuralAndNeumes" module="MEI.shared" type="model">
-    <desc>Groups elements that may appear as part of a score in the mensural and neumes
+    <desc xml:lang="en">Groups elements that may appear as part of a score in the mensural and neumes
       repertoires.</desc>
     <classes>
       <memberOf key="model.scorePart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.sectionLike" module="MEI.shared" type="model">
-    <desc>Groups elements that represent a segment of music notation.</desc>
+    <desc xml:lang="en">Groups elements that represent a segment of music notation.</desc>
     <classes>
       <memberOf key="model.scorePart"/>
       <memberOf key="model.sectionPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.sectionPart" module="MEI.shared" type="model">
-    <desc>Groups elements that may appear as part of a section.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of a section.</desc>
   </classSpec>
   <classSpec ident="model.sectionPart.mensuralAndNeumes" module="MEI.shared" type="model">
-    <desc>Groups elements that may appear as part of a section in the mensural and neume
+    <desc xml:lang="en">Groups elements that may appear as part of a section in the mensural and neume
       repertoires.</desc>
     <classes>
       <memberOf key="model.sectionPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.staffDefLike" module="MEI.shared" type="model">
-    <desc>Groups elements that permit declaration of staff properties.</desc>
+    <desc xml:lang="en">Groups elements that permit declaration of staff properties.</desc>
     <classes>
       <memberOf key="model.sectionPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.staffDefPart" module="MEI.shared" type="model">
-    <desc>Groups elements that may appear in the declaration of staff features.</desc>
+    <desc xml:lang="en">Groups elements that may appear in the declaration of staff features.</desc>
   </classSpec>
   <classSpec ident="model.staffGrpLike" module="MEI.shared" type="model">
-    <desc>Groups elements that permit declaration of staff group properties.</desc>
+    <desc xml:lang="en">Groups elements that permit declaration of staff group properties.</desc>
   </classSpec>
   <classSpec ident="model.staffLike" module="MEI.shared" type="model">
-    <desc>Groups elements that function like staves.</desc>
+    <desc xml:lang="en">Groups elements that function like staves.</desc>
     <classes>
       <memberOf key="model.sectionPart.mensuralAndNeumes"/>
       <memberOf key="model.measurePart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.staffPart" module="MEI.shared" type="model">
-    <desc>Groups elements that are components of a staff.</desc>
+    <desc xml:lang="en">Groups elements that are components of a staff.</desc>
   </classSpec>
   <classSpec ident="model.staffPart.mensuralAndNeumes" module="MEI.shared" type="model">
-    <desc>Groups elements that are components of a staff in the mensural and neume
+    <desc xml:lang="en">Groups elements that are components of a staff in the mensural and neume
       repertoires.</desc>
     <classes>
       <memberOf key="model.staffPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.sylLike" module="MEI.shared" type="model">
-    <desc>Groups elements that contain a lyric syllable.</desc>
+    <desc xml:lang="en">Groups elements that contain a lyric syllable.</desc>
     <classes>
       <memberOf key="model.editTransPart"/>
       <memberOf key="model.rdgPart"/>
@@ -4126,20 +4126,20 @@
     </classes>
   </classSpec>
   <classSpec ident="model.textComponentLike" module="MEI.shared" type="model">
-    <desc>Groups block-level text elements.</desc>
+    <desc xml:lang="en">Groups block-level text elements.</desc>
     <classes>
       <memberOf key="model.rdgPart.text"/>
       <memberOf key="model.editTransPart.text"/>
     </classes>
   </classSpec>
   <classSpec ident="model.textPhraseLike" module="MEI.shared" type="model">
-    <desc>Groups textual elements that occur at the level of individual words or phrases.</desc>
+    <desc xml:lang="en">Groups textual elements that occur at the level of individual words or phrases.</desc>
     <classes>
       <memberOf key="model.paracontentPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.textPhraseLike.limited" module="MEI.shared" type="model">
-    <desc>Groups textual elements that occur at the level of individual words or phrases. This class
+    <desc xml:lang="en">Groups textual elements that occur at the level of individual words or phrases. This class
       is equivalent to the model.textPhraseLike class without the pb element.</desc>
     <classes>
       <memberOf key="model.rdgPart.text"/>
@@ -4148,17 +4148,17 @@
     </classes>
   </classSpec>
   <classSpec ident="model.titleLike" module="MEI.shared" type="model">
-    <desc>Groups elements that denote the name of a bibliographic item.</desc>
+    <desc xml:lang="en">Groups elements that denote the name of a bibliographic item.</desc>
     <classes>
       <memberOf key="model.textPhraseLike.limited"/>
       <memberOf key="model.titlePagePart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.titlePagePart" module="MEI.shared" type="model">
-    <desc>Groups elements that may appear as part of a title page transcription.</desc>
+    <desc xml:lang="en">Groups elements that may appear as part of a title page transcription.</desc>
   </classSpec>
   <elementSpec ident="accid" module="MEI.shared">
-    <desc>(accidental) – Records a temporary alteration to the pitch of a note.</desc>
+    <desc xml:lang="en">(accidental) – Records a temporary alteration to the pitch of a note.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -4182,7 +4182,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="actor" module="MEI.shared">
-    <desc>Name of an actor appearing within a cast list.</desc>
+    <desc xml:lang="en">Name of an actor appearing within a cast list.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -4201,7 +4201,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="address" module="MEI.shared">
-    <desc>Contains a postal address, for example of a publisher, an organization, or an
+    <desc xml:lang="en">Contains a postal address, for example of a publisher, an organization, or an
       individual.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4227,7 +4227,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="addrLine" module="MEI.shared">
-    <desc>(address line) – Single line of a postal address.</desc>
+    <desc xml:lang="en">(address line) – Single line of a postal address.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -4253,7 +4253,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="ambitus" module="MEI.shared">
-    <desc>Range of a voice, instrument or piece.</desc>
+    <desc xml:lang="en">Range of a voice, instrument or piece.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -4269,7 +4269,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="ambNote" module="MEI.shared">
-    <desc>Highest or lowest pitch in a score, staff, or layer.</desc>
+    <desc xml:lang="en">Highest or lowest pitch in a score, staff, or layer.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -4283,7 +4283,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="analytic" module="MEI.shared">
-    <desc>(analytic level) – Contains bibliographic elements describing an item (<abbr>e.g.</abbr>, an article or
+    <desc xml:lang="en">(analytic level) – Contains bibliographic elements describing an item (<abbr>e.g.</abbr>, an article or
       poem) published within a monograph or journal and not as an independent publication.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4311,7 +4311,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="annot" module="MEI.shared">
-    <desc>(annotation) – Provides a statement explaining the text or indicating the basis for an
+    <desc xml:lang="en">(annotation) – Provides a statement explaining the text or indicating the basis for an
       assertion.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4372,7 +4372,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="arranger" module="MEI.shared">
-    <desc>A person or organization who transcribes a musical composition, usually for a different
+    <desc xml:lang="en">A person or organization who transcribes a musical composition, usually for a different
       medium from that of the original; in an arrangement the musical substance remains essentially
       unchanged.</desc>
     <classes>
@@ -4393,7 +4393,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="artic" module="MEI.shared">
-    <desc>(articulation) – An indication of how to play a note or chord.</desc>
+    <desc xml:lang="en">(articulation) – An indication of how to play a note or chord.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -4416,7 +4416,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="author" module="MEI.shared">
-    <desc>The name of the creator of the intellectual content of a non-musical, literary
+    <desc xml:lang="en">The name of the creator of the intellectual content of a non-musical, literary
       work.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4440,7 +4440,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="barLine" module="MEI.shared">
-    <desc>Vertical line drawn through one or more staves that divides musical notation into metrical
+    <desc xml:lang="en">Vertical line drawn through one or more staves that divides musical notation into metrical
       units.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4465,7 +4465,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="bibl" module="MEI.shared">
-    <desc>(bibliographic reference) – Provides a loosely-structured bibliographic citation in which
+    <desc xml:lang="en">(bibliographic reference) – Provides a loosely-structured bibliographic citation in which
       the sub-components may or may not be explicitly marked.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4513,7 +4513,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="biblList" module="MEI.shared">
-    <desc>List of bibliographic references.</desc>
+    <desc xml:lang="en">List of bibliographic references.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -4550,7 +4550,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="biblScope" module="MEI.shared">
-    <desc>(scope of citation) – Defines the scope of a bibliographic reference, for example as a
+    <desc xml:lang="en">(scope of citation) – Defines the scope of a bibliographic reference, for example as a
       list of page numbers, or a named subdivision of a larger work.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4587,7 +4587,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="biblStruct" module="MEI.shared">
-    <desc>(structured bibliographic citation) – Contains a bibliographic citation in which
+    <desc xml:lang="en">(structured bibliographic citation) – Contains a bibliographic citation in which
       bibliographic sub-elements must appear in a specified order.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4621,7 +4621,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="body" module="MEI.shared">
-    <desc>Contains the whole of a single musical text, excluding any front or back matter.</desc>
+    <desc xml:lang="en">Contains the whole of a single musical text, excluding any front or back matter.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.metadataPointing"/>
@@ -4647,7 +4647,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="caesura" module="MEI.shared">
-    <desc>Break, pause, or interruption in the normal tempo of a composition. Typically indicated by
+    <desc xml:lang="en">Break, pause, or interruption in the normal tempo of a composition. Typically indicated by
       "railroad tracks", <abbr>i.e.</abbr>, two diagonal slashes.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4686,7 +4686,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="caption" module="MEI.shared">
-    <desc>A label which accompanies an illustration or a table.</desc>
+    <desc xml:lang="en">A label which accompanies an illustration or a table.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -4705,7 +4705,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="castGrp" module="MEI.shared">
-    <desc>(cast group) – Groups one or more individual castItem elements within a cast list.</desc>
+    <desc xml:lang="en">(cast group) – Groups one or more individual castItem elements within a cast list.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -4725,7 +4725,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="castItem" module="MEI.shared">
-    <desc>Contains a single entry within a cast list, describing either a single role or a list of
+    <desc xml:lang="en">Contains a single entry within a cast list, describing either a single role or a list of
       non-speaking roles.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4749,7 +4749,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="castList" module="MEI.shared">
-    <desc>Contains a single cast list or dramatis personae.</desc>
+    <desc xml:lang="en">Contains a single cast list or dramatis personae.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -4773,7 +4773,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="cb" module="MEI.shared">
-    <desc>(column beginning) – An empty formatting element that forces text to begin in a new
+    <desc xml:lang="en">(column beginning) – An empty formatting element that forces text to begin in a new
       column.</desc>
     <classes>
       <memberOf key="att.basic"/>
@@ -4791,7 +4791,7 @@
     </content>
     <attList>
       <attDef ident="n" usage="req">
-        <desc>Records the column number.</desc>
+        <desc xml:lang="en">Records the column number.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
@@ -4814,7 +4814,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="chord" module="MEI.shared">
-    <desc>A simultaneous sounding of two or more notes in the same layer *with the same
+    <desc xml:lang="en">A simultaneous sounding of two or more notes in the same layer *with the same
       duration*.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4839,7 +4839,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="clef" module="MEI.shared">
-    <desc>Indication of the exact location of a particular note on the staff and, therefore, the
+    <desc xml:lang="en">Indication of the exact location of a particular note on the staff and, therefore, the
       other notes as well.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4887,7 +4887,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="clefGrp" module="MEI.shared">
-    <desc>(clef group) – A set of simultaneously-occurring clefs.</desc>
+    <desc xml:lang="en">(clef group) – A set of simultaneously-occurring clefs.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.event"/>
@@ -4906,7 +4906,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="colLayout" module="MEI.shared">
-    <desc>(column layout) – An empty formatting element that signals the start of columnar
+    <desc xml:lang="en">(column layout) – An empty formatting element that signals the start of columnar
       layout.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4919,7 +4919,7 @@
     </content>
     <attList>
       <attDef ident="cols" usage="req">
-        <desc>Records the number of columns.</desc>
+        <desc xml:lang="en">Records the number of columns.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
@@ -4927,7 +4927,7 @@
     </attList>
   </elementSpec>
   <elementSpec ident="composer" module="MEI.shared">
-    <desc>The name of the creator of the intellectual content of a musical work.</desc>
+    <desc xml:lang="en">The name of the creator of the intellectual content of a musical work.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -4946,7 +4946,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="contributor" module="MEI.shared">
-    <desc>Names of individuals, institutions, or organizations responsible for contributions to the
+    <desc xml:lang="en">Names of individuals, institutions, or organizations responsible for contributions to the
       intellectual content of a work, where the specialized elements for authors, editors, etc. do
       not suffice or do not apply.</desc>
     <classes>
@@ -4977,7 +4977,7 @@
     </constraintSpec>
     <attList>
       <attDef ident="role" usage="rec">
-        <desc>Used to specify the contributor’s function.</desc>
+        <desc xml:lang="en">Used to specify the contributor’s function.</desc>
         <datatype>
           <rng:text/>
         </datatype>
@@ -4993,7 +4993,7 @@
     </attList>
   </elementSpec>
   <elementSpec ident="creation" module="MEI.shared">
-    <desc>Non-bibliographic details of the creation of an intellectual entity, in narrative form,
+    <desc xml:lang="en">Non-bibliographic details of the creation of an intellectual entity, in narrative form,
       such as the date, place, and circumstances of its composition. More detailed information may
       be captured within the history element.</desc>
     <classes>
@@ -5021,7 +5021,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="custos" module="MEI.shared">
-    <desc>Symbol placed at the end of a line of music to indicate the first note of the next line.
+    <desc xml:lang="en">Symbol placed at the end of a line of music to indicate the first note of the next line.
       Sometimes called a "direct".</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -5045,7 +5045,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="date" module="MEI.shared">
-    <desc>A string identifying a point in time or the time period between two such points.</desc>
+    <desc xml:lang="en">A string identifying a point in time or the time period between two such points.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -5070,7 +5070,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="dedicatee" module="MEI.shared">
-    <desc>Entity to whom a creative work is formally offered.</desc>
+    <desc xml:lang="en">Entity to whom a creative work is formally offered.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -5096,7 +5096,7 @@
     </constraintSpec>
   </elementSpec>
   <elementSpec ident="depth" module="MEI.shared">
-    <desc>Description of a measurement taken through a three-dimensional object.</desc>
+    <desc xml:lang="en">Description of a measurement taken through a three-dimensional object.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -5114,7 +5114,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="desc" module="MEI.shared">
-    <desc>(description) – Container for text that briefly describes the feature to which it is
+    <desc xml:lang="en">(description) – Container for text that briefly describes the feature to which it is
       attached, including its intended usage, purpose, or application as appropriate.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -5139,7 +5139,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="dim" module="MEI.shared">
-    <desc>(dimension) – Any single dimensional specification.</desc>
+    <desc xml:lang="en">(dimension) – Any single dimensional specification.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -5157,50 +5157,50 @@
     </content>
     <attList>
       <attDef ident="form" usage="req">
-        <desc>Aspect of the object being measured.</desc>
+        <desc xml:lang="en">Aspect of the object being measured.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="alt">
-            <desc>Altitude. Refers to the distance above a given level, commonly mean sea
+            <desc xml:lang="en">Altitude. Refers to the distance above a given level, commonly mean sea
               level.</desc>
           </valItem>
           <valItem ident="angle">
-            <desc>Angle. Amount of rotation needed to bring one line or plane into coincidence with
+            <desc xml:lang="en">Angle. Amount of rotation needed to bring one line or plane into coincidence with
               another.</desc>
           </valItem>
           <valItem ident="circum">
-            <desc>Circumference of a circular area.</desc>
+            <desc xml:lang="en">Circumference of a circular area.</desc>
           </valItem>
           <valItem ident="depth">
-            <desc>Dimension taken through an object or body of material, usually downward from an
+            <desc xml:lang="en">Dimension taken through an object or body of material, usually downward from an
               upper surface, horizontally inward from an outer surface, or from top to bottom of
               something regarded as one of several layers.</desc>
           </valItem>
           <valItem ident="diameter">
-            <desc>Length of a straight line passing through the center of a circle or sphere and
+            <desc xml:lang="en">Length of a straight line passing through the center of a circle or sphere and
               meeting the circumference or surface at each end.</desc>
           </valItem>
           <valItem ident="elevation">
-            <desc>Distance to which something has been raised or uplifted above a level, <abbr>e.g.</abbr>, a
+            <desc xml:lang="en">Distance to which something has been raised or uplifted above a level, <abbr>e.g.</abbr>, a
               hill’s elevation above the surrounding country.</desc>
           </valItem>
           <valItem ident="height">
-            <desc>Denotes extent upward (as from foot to head) as well as any measurable distance
+            <desc xml:lang="en">Denotes extent upward (as from foot to head) as well as any measurable distance
               above a given level.</desc>
           </valItem>
           <valItem ident="length">
-            <desc>Measure of the greatest dimension of a plane or solid figure.</desc>
+            <desc xml:lang="en">Measure of the greatest dimension of a plane or solid figure.</desc>
           </valItem>
           <valItem ident="radius">
-            <desc>Half the diameter of a circular, spherical, or cylindrical object.</desc>
+            <desc xml:lang="en">Half the diameter of a circular, spherical, or cylindrical object.</desc>
           </valItem>
           <valItem ident="relief">
-            <desc>Projection of a figure or part from the plane on which it is formed.</desc>
+            <desc xml:lang="en">Projection of a figure or part from the plane on which it is formed.</desc>
           </valItem>
           <valItem ident="width">
-            <desc>Extent from side to side; breadth.</desc>
+            <desc xml:lang="en">Extent from side to side; breadth.</desc>
           </valItem>
         </valList>
       </attDef>
@@ -5211,7 +5211,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="dimensions" module="MEI.shared">
-    <desc>Information about the physical size of an entity; usually includes numerical data.</desc>
+    <desc xml:lang="en">Information about the physical size of an entity; usually includes numerical data.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -5249,7 +5249,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="dir" module="MEI.shared">
-    <desc>(directive) – An instruction expressed as a combination of text and symbols — such as
+    <desc xml:lang="en">(directive) – An instruction expressed as a combination of text and symbols — such as
       segno and coda symbols, fermatas over a bar line, etc., typically above, below, or between
       staves, but not on the staff — that is not encoded elsewhere in more specific elements, like
       <gi scheme="MEI">tempo</gi> or <gi scheme="MEI">dynam</gi>.</desc>
@@ -5293,7 +5293,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="distributor" module="MEI.shared">
-    <desc>Person or agency, other than a publisher, from which access (including electronic access)
+    <desc xml:lang="en">Person or agency, other than a publisher, from which access (including electronic access)
       to a bibliographic entity may be obtained.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -5316,7 +5316,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="div" module="MEI.shared">
-    <desc>(division) – Major structural division of text, such as a preface, chapter or
+    <desc xml:lang="en">(division) – Major structural division of text, such as a preface, chapter or
       section.</desc>
     <classes>
       <memberOf key="att.basic"/>
@@ -5351,56 +5351,56 @@
     </content>
     <attList>
       <attDef ident="type" usage="opt">
-        <desc>Characterizes the textual division in some sense, using any convenient classification
+        <desc xml:lang="en">Characterizes the textual division in some sense, using any convenient classification
           scheme or typology that employs single-token labels.</desc>
         <datatype>
           <rng:data type="NMTOKENS"/>
         </datatype>
         <valList type="semi">
           <valItem ident="abstract">
-            <desc>A summary of the content of a text as continuous prose.</desc>
+            <desc xml:lang="en">A summary of the content of a text as continuous prose.</desc>
           </valItem>
           <valItem ident="ack">
-            <desc>A formal declaration of acknowledgment by the author in which persons and
+            <desc xml:lang="en">A formal declaration of acknowledgment by the author in which persons and
               institutions are thanked for their part in the creation of a text.</desc>
           </valItem>
           <valItem ident="appendix">
-            <desc>An ancillary self-contained section of a work, often providing additional but in
+            <desc xml:lang="en">An ancillary self-contained section of a work, often providing additional but in
               some sense extra-canonical text.</desc>
           </valItem>
           <valItem ident="bibliography">
-            <desc>A list of bibliographic citations.</desc>
+            <desc xml:lang="en">A list of bibliographic citations.</desc>
           </valItem>
           <valItem ident="colophon">
-            <desc>A statement appearing at the end of a book describing the conditions of its
+            <desc xml:lang="en">A statement appearing at the end of a book describing the conditions of its
               physical production.</desc>
           </valItem>
           <valItem ident="contents">
-            <desc>A table of contents, specifying the structure of a work and listing its
+            <desc xml:lang="en">A table of contents, specifying the structure of a work and listing its
               constituents. The list element should be used to mark its structure.</desc>
           </valItem>
           <valItem ident="dedication">
-            <desc>A formal offering or dedication of a text to one or more persons or institutions
+            <desc xml:lang="en">A formal offering or dedication of a text to one or more persons or institutions
               by the author.</desc>
           </valItem>
           <valItem ident="frontispiece">
-            <desc>A pictorial frontispiece, possibly including some text.</desc>
+            <desc xml:lang="en">A pictorial frontispiece, possibly including some text.</desc>
           </valItem>
           <valItem ident="glossary">
-            <desc>A list of terms associated with definition texts (‘glosses’).</desc>
+            <desc xml:lang="en">A list of terms associated with definition texts (‘glosses’).</desc>
           </valItem>
           <valItem ident="half-title">
-            <desc>A page containing only the title of a book — as opposed to the title page, which
+            <desc xml:lang="en">A page containing only the title of a book — as opposed to the title page, which
               also lists subtitle, author, imprint and similar data.</desc>
           </valItem>
           <valItem ident="index">
-            <desc>Any form of index to the work.</desc>
+            <desc xml:lang="en">Any form of index to the work.</desc>
           </valItem>
           <valItem ident="annotations">
-            <desc>A section in which annotations on the text are gathered together.</desc>
+            <desc xml:lang="en">A section in which annotations on the text are gathered together.</desc>
           </valItem>
           <valItem ident="preface">
-            <desc>A foreword or preface addressed to the reader in which the author or publisher
+            <desc xml:lang="en">A foreword or preface addressed to the reader in which the author or publisher
               explains the content, purpose, or origin of the text.</desc>
           </valItem>
         </valList>
@@ -5413,7 +5413,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="dot" module="MEI.shared">
-    <desc>Dot of augmentation or division.</desc>
+    <desc xml:lang="en">Dot of augmentation or division.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -5435,7 +5435,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="dynam" module="MEI.shared">
-    <desc>(dynamic) – Indication of the volume of a note, phrase, or section of music.</desc>
+    <desc xml:lang="en">(dynamic) – Indication of the volume of a note, phrase, or section of music.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.dynam.log"/>
@@ -5485,7 +5485,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="edition" module="MEI.shared">
-    <desc>(edition designation) – A word or text phrase that indicates a difference in either
+    <desc xml:lang="en">(edition designation) – A word or text phrase that indicates a difference in either
       content or form between the item being described and a related item previously issued by the
       same publisher/distributor (<abbr>e.g.</abbr>, 2nd edition, version 2.0, etc.), or simultaneously issued by
       either the same publisher/distributor or another publisher/distributor (<abbr>e.g.</abbr>, large print
@@ -5513,7 +5513,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="editor" module="MEI.shared">
-    <desc>The name of the individual(s), institution(s) or organization(s) acting in an editorial
+    <desc xml:lang="en">The name of the individual(s), institution(s) or organization(s) acting in an editorial
       capacity.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -5536,7 +5536,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="ending" module="MEI.shared">
-    <desc>Alternative ending for a repeated passage of music; <abbr>i.e.</abbr>, prima volta, seconda volta,
+    <desc xml:lang="en">Alternative ending for a repeated passage of music; <abbr>i.e.</abbr>, prima volta, seconda volta,
       etc.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -5579,7 +5579,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="event" module="MEI.shared">
-    <desc>Contains a free-text event description.</desc>
+    <desc xml:lang="en">Contains a free-text event description.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -5620,7 +5620,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="eventList" module="MEI.shared">
-    <desc>Contains historical information given as a sequence of significant past events.</desc>
+    <desc xml:lang="en">Contains historical information given as a sequence of significant past events.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -5668,7 +5668,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="expansion" module="MEI.shared">
-    <desc>Indicates how a section may be programmatically expanded into its 'through-composed'
+    <desc xml:lang="en">Indicates how a section may be programmatically expanded into its 'through-composed'
       form.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -5688,7 +5688,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="extent" module="MEI.shared">
-    <desc>Used to express size in terms other than physical dimensions, such as number of pages,
+    <desc xml:lang="en">Used to express size in terms other than physical dimensions, such as number of pages,
       records, bytes, physical components, etc.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -5718,7 +5718,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="funder" module="MEI.shared">
-    <desc>Names of individuals, institutions, or organizations responsible for funding. Funders
+    <desc xml:lang="en">Names of individuals, institutions, or organizations responsible for funding. Funders
       provide financial support for a project; they are distinct from sponsors, who provide
       intellectual support and authority.</desc>
     <classes>
@@ -5742,7 +5742,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="genre" module="MEI.shared">
-    <desc>Term or terms that designate a category characterizing a particular style, form, or
+    <desc xml:lang="en">Term or terms that designate a category characterizing a particular style, form, or
       content.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -5762,7 +5762,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="group" module="MEI.shared">
-    <desc>Contains a composite musical text, grouping together a sequence of distinct musical texts
+    <desc xml:lang="en">Contains a composite musical text, grouping together a sequence of distinct musical texts
       (or groups of such musical texts) which are regarded as a unit for some purpose, for example,
       the collected works of a composer.</desc>
     <classes>
@@ -5791,7 +5791,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="grpSym" module="MEI.shared">
-    <desc>(group symbol) – A brace or bracket used to group two or more staves of a score or
+    <desc xml:lang="en">(group symbol) – A brace or bracket used to group two or more staves of a score or
       part.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -5829,7 +5829,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="head" module="MEI.shared">
-    <desc>(heading) – Contains any heading, for example, the title of a section of text, or the
+    <desc xml:lang="en">(heading) – Contains any heading, for example, the title of a section of text, or the
       heading of a list.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -5858,7 +5858,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="height" module="MEI.shared">
-    <desc>Description of the vertical size of an object.</desc>
+    <desc xml:lang="en">Description of the vertical size of an object.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -5876,7 +5876,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="identifier" module="MEI.shared">
-    <desc>An alpha-numeric string that establishes the identity of the described material.</desc>
+    <desc xml:lang="en">An alpha-numeric string that establishes the identity of the described material.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.authorized"/>
@@ -5902,7 +5902,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="imprint" module="MEI.shared">
-    <desc>Information relating to the publication or distribution of a bibliographic item.</desc>
+    <desc xml:lang="en">Information relating to the publication or distribution of a bibliographic item.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -5927,7 +5927,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="incip" module="MEI.shared">
-    <desc>(incipit) – The opening music and/or words of a musical or textual work.</desc>
+    <desc xml:lang="en">(incipit) – The opening music and/or words of a musical or textual work.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -5986,7 +5986,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="keyAccid" module="MEI.shared">
-    <desc>(key accidental) – Accidental in a key signature.</desc>
+    <desc xml:lang="en">(key accidental) – Accidental in a key signature.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6009,14 +6009,14 @@
     </constraintSpec>
     <attList>
       <attDef ident="form" usage="opt">
-        <desc>Specifies whether enharmonic (written) values or implicit ("perform-able") values are
+        <desc xml:lang="en">Specifies whether enharmonic (written) values or implicit ("perform-able") values are
           allowed.</desc>
         <valList type="closed">
           <valItem ident="implicit">
-            <desc>Only performed values (sharp, flat, natural) allowed.</desc>
+            <desc xml:lang="en">Only performed values (sharp, flat, natural) allowed.</desc>
           </valItem>
           <valItem ident="explicit">
-            <desc>All enharmonic (written) values allowed.</desc>
+            <desc xml:lang="en">All enharmonic (written) values allowed.</desc>
           </valItem>
         </valList>
       </attDef>
@@ -6028,7 +6028,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="keySig" module="MEI.shared">
-    <desc>(key signature) – Written key signature.</desc>
+    <desc xml:lang="en">(key signature) – Written key signature.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6066,7 +6066,7 @@
     </constraintSpec>
   </elementSpec>
   <elementSpec ident="label" module="MEI.shared">
-    <desc>A container for document text that identifies the feature to which it is attached. For a
+    <desc xml:lang="en">A container for document text that identifies the feature to which it is attached. For a
       "tool tip" or other generated label, use the <att>label</att> attribute.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6094,7 +6094,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="labelAbbr" module="MEI.shared">
-    <desc>A label on the pages following the first.</desc>
+    <desc xml:lang="en">A label on the pages following the first.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6114,7 +6114,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="layer" module="MEI.shared">
-    <desc>An independent stream of events on a staff.</desc>
+    <desc xml:lang="en">An independent stream of events on a staff.</desc>
     <classes>
       <memberOf key="att.basic"/>
       <memberOf key="att.facsimile"/>
@@ -6155,7 +6155,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="layerDef" module="MEI.shared">
-    <desc>(layer definition) – Container for layer meta-information.</desc>
+    <desc xml:lang="en">(layer definition) – Container for layer meta-information.</desc>
     <classes>
       <memberOf key="att.basic"/>
       <memberOf key="att.labelled"/>
@@ -6186,7 +6186,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="lb" module="MEI.shared">
-    <desc>(line beginning) – An empty formatting element that forces text to begin on a new
+    <desc xml:lang="en">(line beginning) – An empty formatting element that forces text to begin on a new
       line.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6208,7 +6208,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="lg" module="MEI.shared">
-    <desc>(line group) – May be used for any section of text that is organized as a group of lines;
+    <desc xml:lang="en">(line group) – May be used for any section of text that is organized as a group of lines;
       however, it is most often used for a group of verse lines functioning as a formal unit, <abbr>e.g.</abbr>, a
       stanza, refrain, verse paragraph, etc.</desc>
     <classes>
@@ -6242,7 +6242,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="librettist" module="MEI.shared">
-    <desc>Person or organization who is a writer of the text of an opera, oratorio, etc.</desc>
+    <desc xml:lang="en">Person or organization who is a writer of the text of an opera, oratorio, etc.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -6261,7 +6261,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="lyricist" module="MEI.shared">
-    <desc>Person or organization who is a writer of the text of a song.</desc>
+    <desc xml:lang="en">Person or organization who is a writer of the text of a song.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -6280,7 +6280,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="mdiv" module="MEI.shared">
-    <desc>(musical division) – Contains a subdivision of the body of a musical text.</desc>
+    <desc xml:lang="en">(musical division) – Contains a subdivision of the body of a musical text.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6321,7 +6321,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="mei" module="MEI.shared">
-    <desc>Contains a single MEI-conformant document, consisting of an MEI header and a musical text,
+    <desc xml:lang="en">Contains a single MEI-conformant document, consisting of an MEI header and a musical text,
       either in isolation or as part of an meiCorpus element.</desc>
     <classes>
       <memberOf key="att.id"/>
@@ -6350,7 +6350,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="monogr" module="MEI.shared">
-    <desc>(monograph level) – Contains bibliographic elements describing an item, for example, a
+    <desc xml:lang="en">(monograph level) – Contains bibliographic elements describing an item, for example, a
       published book or journal, score, recording, or an unpublished manuscript.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6428,7 +6428,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="music" module="MEI.shared">
-    <desc>Contains a single musical text of any kind, whether unitary or composite, for example, an
+    <desc xml:lang="en">Contains a single musical text of any kind, whether unitary or composite, for example, an
       etude, opera, song cycle, symphony, or anthology of piano solos.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6443,7 +6443,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="name" module="MEI.shared">
-    <desc>Proper noun or noun phrase.</desc>
+    <desc xml:lang="en">Proper noun or noun phrase.</desc>
     <classes>
       <memberOf key="att.basic"/>
       <memberOf key="att.bibl"/>
@@ -6480,29 +6480,29 @@
     </constraintSpec>
     <attList>
       <attDef ident="type" usage="opt">
-        <desc>Characterizes the name in some sense, using any convenient classification scheme or
+        <desc xml:lang="en">Characterizes the name in some sense, using any convenient classification scheme or
           typology that employs single-token labels.</desc>
         <datatype>
           <rng:data type="NMTOKENS"/>
         </datatype>
         <valList type="semi">
           <valItem ident="person">
-            <desc>A personal name.</desc>
+            <desc xml:lang="en">A personal name.</desc>
           </valItem>
           <valItem ident="corporation">
-            <desc>Name of a corporate body.</desc>
+            <desc xml:lang="en">Name of a corporate body.</desc>
           </valItem>
           <valItem ident="location">
-            <desc>Name of a location.</desc>
+            <desc xml:lang="en">Name of a location.</desc>
           </valItem>
           <valItem ident="process">
-            <desc>Name of a process or software application.</desc>
+            <desc xml:lang="en">Name of a process or software application.</desc>
           </valItem>
           <valItem ident="style">
-            <desc>Name of a musical style; <abbr>i.e.</abbr>, form, genre, technique, etc.</desc>
+            <desc xml:lang="en">Name of a musical style; <abbr>i.e.</abbr>, form, genre, technique, etc.</desc>
           </valItem>
           <valItem ident="time">
-            <desc>Name of a period of time.</desc>
+            <desc xml:lang="en">Name of a period of time.</desc>
           </valItem>
         </valList>
       </attDef>
@@ -6534,7 +6534,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="note" module="MEI.shared">
-    <desc>A single pitched event. <!-- (Read, p. 63) --> </desc>
+    <desc xml:lang="en">A single pitched event. <!-- (Read, p. 63) --> </desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6573,7 +6573,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="num" module="MEI.shared">
-    <desc>(number) – Numeric information in any form.</desc>
+    <desc xml:lang="en">(number) – Numeric information in any form.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6594,7 +6594,7 @@
     </content>
     <attList>
       <attDef ident="value" usage="opt">
-        <desc>Numeric value capturing a measurement or count. Can only be interpreted in combination
+        <desc xml:lang="en">Numeric value capturing a measurement or count. Can only be interpreted in combination
           with the unit attribute.</desc>
         <datatype>
           <rng:data type="decimal"/>
@@ -6607,7 +6607,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="ornam" module="MEI.shared">
-    <desc>An element indicating an ornament that is not a mordent, turn, or trill. </desc>
+    <desc xml:lang="en">An element indicating an ornament that is not a mordent, turn, or trill. </desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6645,7 +6645,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="p" module="MEI.shared">
-    <desc>(paragraph) – One or more text phrases that form a logical prose passage.</desc>
+    <desc xml:lang="en">(paragraph) – One or more text phrases that form a logical prose passage.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6672,7 +6672,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pad" module="MEI.shared">
-    <desc>(padding) – An indication of extra visual space between notational elements.</desc>
+    <desc xml:lang="en">(padding) – An indication of extra visual space between notational elements.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.pad.log"/>
@@ -6686,7 +6686,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="part" module="MEI.shared">
-    <desc>An alternative visual rendition of the score from the point of view of a particular
+    <desc xml:lang="en">An alternative visual rendition of the score from the point of view of a particular
       performer (or group of performers).</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6726,7 +6726,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="parts" module="MEI.shared">
-    <desc>Provides a container for performers' parts.</desc>
+    <desc xml:lang="en">Provides a container for performers' parts.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.metadataPointing"/>
@@ -6743,7 +6743,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="pb" module="MEI.shared">
-    <desc>(page beginning) – An empty formatting element that forces text to begin on a new
+    <desc xml:lang="en">(page beginning) – An empty formatting element that forces text to begin on a new
       page.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6770,7 +6770,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pgDesc" module="MEI.shared">
-    <desc>(page description) – Contains a brief prose description of the appearance or description
+    <desc xml:lang="en">(page description) – Contains a brief prose description of the appearance or description
       of the content of a physical page.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6795,7 +6795,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pgFoot" module="MEI.shared">
-    <desc>(page footer) – A running footer on the first page. Also, used to temporarily override a
+    <desc xml:lang="en">(page footer) – A running footer on the first page. Also, used to temporarily override a
       running footer on individual pages.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6817,7 +6817,7 @@
     </content>
     <attList>
       <attDef ident="halign" usage="opt">
-        <desc>Records horizontal alignment of the page footer.</desc>
+        <desc xml:lang="en">Records horizontal alignment of the page footer.</desc>
         <datatype>
           <rng:ref name="data.HORIZONTALALIGNMENT"/>
         </datatype>
@@ -6834,7 +6834,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pgFoot2" module="MEI.shared">
-    <desc>(page footer 2) – A running footer on the pages following the first.</desc>
+    <desc xml:lang="en">(page footer 2) – A running footer on the pages following the first.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6855,7 +6855,7 @@
     </content>
     <attList>
       <attDef ident="halign" usage="opt">
-        <desc>Records horizontal alignment of the page footer. Use multiple values to capture an
+        <desc xml:lang="en">Records horizontal alignment of the page footer. Use multiple values to capture an
           alternating pattern.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.HORIZONTALALIGNMENT"/>
@@ -6871,7 +6871,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pgHead" module="MEI.shared">
-    <desc>(page header) – A running header on the first page. Also, used to temporarily override a
+    <desc xml:lang="en">(page header) – A running header on the first page. Also, used to temporarily override a
       running header on individual pages.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6893,7 +6893,7 @@
     </content>
     <attList>
       <attDef ident="halign" usage="opt">
-        <desc>Records horizontal alignment of the page header.</desc>
+        <desc xml:lang="en">Records horizontal alignment of the page header.</desc>
         <datatype>
           <rng:ref name="data.HORIZONTALALIGNMENT"/>
         </datatype>
@@ -6910,7 +6910,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pgHead2" module="MEI.shared">
-    <desc>(page header 2) – A running header on the pages following the first.</desc>
+    <desc xml:lang="en">(page header 2) – A running header on the pages following the first.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6931,7 +6931,7 @@
     </content>
     <attList>
       <attDef ident="halign" usage="opt">
-        <desc>Records horizontal alignment of the page header. Use multiple values to capture an
+        <desc xml:lang="en">Records horizontal alignment of the page header. Use multiple values to capture an
           alternating pattern.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.HORIZONTALALIGNMENT"/>
@@ -6947,7 +6947,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="phrase" module="MEI.shared">
-    <desc>Indication of 1) a "unified melodic idea" or 2) performance technique.</desc>
+    <desc xml:lang="en">Indication of 1) a "unified melodic idea" or 2) performance technique.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -7005,7 +7005,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="physLoc" module="MEI.shared">
-    <desc>(physical location) – Groups information about the current physical location of a
+    <desc xml:lang="en">(physical location) – Groups information about the current physical location of a
       bibliographic item, such as the repository in which it is located and its shelf mark(s), and
       its previous locations.</desc>
     <classes>
@@ -7036,7 +7036,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="publisher" module="MEI.shared">
-    <desc>Name of the organization responsible for the publication of a bibliographic item.</desc>
+    <desc xml:lang="en">Name of the organization responsible for the publication of a bibliographic item.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -7058,7 +7058,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pubPlace" module="MEI.shared">
-    <desc>(publication place) – Name of the place where a bibliographic item was published.</desc>
+    <desc xml:lang="en">(publication place) – Name of the place where a bibliographic item was published.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -7080,7 +7080,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="recipient" module="MEI.shared">
-    <desc>The name of the individual(s), institution(s) or organization(s) receiving
+    <desc xml:lang="en">The name of the individual(s), institution(s) or organization(s) receiving
       correspondence.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -7099,7 +7099,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="relatedItem" module="MEI.shared">
-    <desc>(related item) – Contains or references another bibliographic item which is related to the
+    <desc xml:lang="en">(related item) – Contains or references another bibliographic item which is related to the
       present one.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -7120,7 +7120,7 @@
     </content>
     <attList>
       <attDef ident="rel" usage="req">
-        <desc>Describes the relationship between the entity identified by the <gi scheme="MEI"
+        <desc xml:lang="en">Describes the relationship between the entity identified by the <gi scheme="MEI"
           >relatedItem</gi> element and the resource described in the parent element, <abbr>i.e.</abbr>, <gi
           scheme="MEI">bibl</gi>, <gi scheme="MEI">source</gi> or <gi scheme="MEI"
           >relatedItem</gi>.</desc>
@@ -7131,7 +7131,7 @@
     </attList>
   </elementSpec>
   <elementSpec ident="relation" module="MEI.shared">
-    <desc>Describes a relationship or linkage amongst entities.</desc>
+    <desc xml:lang="en">Describes a relationship or linkage amongst entities.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.authorized"/>
@@ -7206,7 +7206,7 @@
     </constraintSpec>
     <attList>
       <attDef ident="rel" usage="req">
-        <desc>Describes the relationship between the entities identified by the plist and target
+        <desc xml:lang="en">Describes the relationship between the entities identified by the plist and target
           attributes.</desc>
         <datatype>
           <rng:ref name="data.RELATIONSHIP"/>
@@ -7225,7 +7225,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="relationList" module="MEI.shared">
-    <desc>Gathers relation elements.</desc>
+    <desc xml:lang="en">Gathers relation elements.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="model.relationLike"/>
@@ -7240,7 +7240,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="rend" module="MEI.shared">
-    <desc>(render) – A formatting element indicating special visual rendering, <abbr>e.g.</abbr>, bold or
+    <desc xml:lang="en">(render) – A formatting element indicating special visual rendering, <abbr>e.g.</abbr>, bold or
       italicized, of a text word or phrase.</desc>
     <classes>
       <memberOf key="att.color"/>
@@ -7265,7 +7265,7 @@
     </content>
     <attList>
       <attDef ident="rotation" usage="opt">
-        <desc>A positive value for rotation rotates the text in a counter-clockwise fashion, while
+        <desc xml:lang="en">A positive value for rotation rotates the text in a counter-clockwise fashion, while
           negative values produce clockwise rotation.</desc>
         <datatype>
           <rng:ref name="data.DEGREES"/>
@@ -7278,7 +7278,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="repository" module="MEI.shared">
-    <desc>Institution, agency, or individual which holds a bibliographic item.</desc>
+    <desc xml:lang="en">Institution, agency, or individual which holds a bibliographic item.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -7306,7 +7306,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="resp" module="MEI.shared">
-    <desc>(responsibility) – A phrase describing the nature of intellectual responsibility.</desc>
+    <desc xml:lang="en">(responsibility) – A phrase describing the nature of intellectual responsibility.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.authorized"/>
@@ -7332,7 +7332,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="respStmt" module="MEI.shared">
-    <desc>(responsibility statement) – Transcription of text that names one or more individuals,
+    <desc xml:lang="en">(responsibility statement) – Transcription of text that names one or more individuals,
       groups, or in rare cases, mechanical processes, responsible for creation, realization,
       production, funding, or distribution of the intellectual or artistic content.</desc>
     <classes>
@@ -7371,7 +7371,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="rest" module="MEI.shared">
-    <desc>A non-sounding event found in the source being transcribed.</desc>
+    <desc xml:lang="en">A non-sounding event found in the source being transcribed.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -7408,7 +7408,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="role" module="MEI.shared">
-    <desc>Name of a dramatic role, as given in a cast list.</desc>
+    <desc xml:lang="en">Name of a dramatic role, as given in a cast list.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -7427,7 +7427,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="roleDesc" module="MEI.shared">
-    <desc>(role description) – Describes a character’s role in a drama.</desc>
+    <desc xml:lang="en">(role description) – Describes a character’s role in a drama.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -7446,7 +7446,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="sb" module="MEI.shared">
-    <desc>(system beginning) – An empty formatting element that forces musical notation to begin on
+    <desc xml:lang="en">(system beginning) – An empty formatting element that forces musical notation to begin on
       a new line.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -7467,7 +7467,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="score" module="MEI.shared">
-    <desc>Full score view of the musical content.</desc>
+    <desc xml:lang="en">Full score view of the musical content.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.metadataPointing"/>
@@ -7502,7 +7502,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="scoreDef" module="MEI.shared">
-    <desc>(score definition) – Container for score meta-information.</desc>
+    <desc xml:lang="en">(score definition) – Container for score meta-information.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.scoreDef.log"/>
@@ -7553,7 +7553,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="section" module="MEI.shared">
-    <desc>Segment of music data.</desc>
+    <desc xml:lang="en">Segment of music data.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -7600,7 +7600,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="series" module="MEI.shared">
-    <desc>Contains information about the serial publication in which a bibliographic item has
+    <desc xml:lang="en">Contains information about the serial publication in which a bibliographic item has
       appeared.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -7630,7 +7630,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="space" module="MEI.shared">
-    <desc>A placeholder used to fill an incomplete measure, layer, etc. most often so that the
+    <desc xml:lang="en">A placeholder used to fill an incomplete measure, layer, etc. most often so that the
       combined duration of the events equals the number of beats in the measure.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -7647,7 +7647,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="speaker" module="MEI.shared">
-    <desc>Contains a specialized form of heading or label, giving the name of one or more speakers
+    <desc xml:lang="en">Contains a specialized form of heading or label, giving the name of one or more speakers
       in a dramatic text or fragment.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -7669,7 +7669,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="sponsor" module="MEI.shared">
-    <desc>Names of sponsoring individuals, organizations or institutions. Sponsors give their
+    <desc xml:lang="en">Names of sponsoring individuals, organizations or institutions. Sponsors give their
       intellectual authority to a project; they are to be distinguished from funders, who provide
       the funding but do not necessarily take intellectual responsibility.</desc>
     <classes>
@@ -7694,7 +7694,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="stack" module="MEI.shared">
-    <desc>(stacked text) – An inline table with a single column.</desc>
+    <desc xml:lang="en">(stacked text) – An inline table with a single column.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -7711,33 +7711,33 @@
     </content>
     <attList>
       <attDef ident="delim" usage="opt">
-        <desc>Indicates the delimiter used to mark the portions of text that are to be
+        <desc xml:lang="en">Indicates the delimiter used to mark the portions of text that are to be
           stacked.</desc>
         <datatype>
           <rng:data type="string"/>
         </datatype>
       </attDef>
       <attDef ident="align" usage="opt">
-        <desc>Specifies how the stacked text components should be aligned.</desc>
+        <desc xml:lang="en">Specifies how the stacked text components should be aligned.</desc>
         <valList type="closed">
           <valItem ident="left">
-            <desc>Left justified.</desc>
+            <desc xml:lang="en">Left justified.</desc>
           </valItem>
           <valItem ident="right">
-            <desc>Right justified.</desc>
+            <desc xml:lang="en">Right justified.</desc>
           </valItem>
           <valItem ident="center">
-            <desc>Centered.</desc>
+            <desc xml:lang="en">Centered.</desc>
           </valItem>
           <valItem ident="rightdigit">
-            <desc>Aligned on right-most digit.</desc>
+            <desc xml:lang="en">Aligned on right-most digit.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </elementSpec>
   <elementSpec ident="staff" module="MEI.shared">
-    <desc>A group of equidistant horizontal lines on which notes are placed in order to represent
+    <desc xml:lang="en">A group of equidistant horizontal lines on which notes are placed in order to represent
       pitch or a grouping element for individual 'strands' of notes, rests, etc. that may or may not
       actually be rendered on staff lines; that is, both diastematic and non-diastematic
       signs.</desc>
@@ -7803,7 +7803,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="staffDef" module="MEI.shared">
-    <desc>(staff definition) – Container for staff meta-information.</desc>
+    <desc xml:lang="en">(staff definition) – Container for staff meta-information.</desc>
     <classes>
       <memberOf key="att.basic"/>
       <memberOf key="att.labelled"/>
@@ -7951,7 +7951,7 @@
     </constraintSpec>
   </elementSpec>
   <elementSpec ident="staffGrp" module="MEI.shared">
-    <desc>(staff group) – A group of bracketed or braced staves.</desc>
+    <desc xml:lang="en">(staff group) – A group of bracketed or braced staves.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -8000,7 +8000,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="syl" module="MEI.shared">
-    <desc>(syllable) – Individual lyric syllable.</desc>
+    <desc xml:lang="en">(syllable) – Individual lyric syllable.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -8028,7 +8028,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="symbol" module="MEI.shared">
-    <desc>A reference to a previously defined symbol.</desc>
+    <desc xml:lang="en">A reference to a previously defined symbol.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -8063,7 +8063,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="tempo" module="MEI.shared">
-    <desc>Text and symbols descriptive of tempo, mood, or style, <abbr>e.g.</abbr>, "allarg.", "a tempo",
+    <desc xml:lang="en">Text and symbols descriptive of tempo, mood, or style, <abbr>e.g.</abbr>, "allarg.", "a tempo",
       "cantabile", "Moderato", "♩=60", "Moderato ♩ =60").</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -8110,7 +8110,7 @@
     </constraintSpec>
   </elementSpec>
   <elementSpec ident="term" module="MEI.shared">
-    <desc>Keyword or phrase which describes a resource.</desc>
+    <desc xml:lang="en">Keyword or phrase which describes a resource.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -8149,7 +8149,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="textLang" module="MEI.shared">
-    <desc>(text language) – Identifies the languages and writing systems within the work described
+    <desc xml:lang="en">(text language) – Identifies the languages and writing systems within the work described
       by a bibliographic description, not the language of the description.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -8168,14 +8168,14 @@
     </content>
     <attList>
       <attDef ident="lang.main" usage="opt">
-        <desc>(main language) supplies a code which identifies the chief language used in the
+        <desc xml:lang="en">(main language) supplies a code which identifies the chief language used in the
           bibliographic work.</desc>
         <datatype>
           <rng:data type="language"/>
         </datatype>
       </attDef>
       <attDef ident="lang.other" usage="opt">
-        <desc>(other languages) one or more codes identifying any other languages used in the
+        <desc xml:lang="en">(other languages) one or more codes identifying any other languages used in the
           bibliographic work.</desc>
         <datatype maxOccurs="unbounded">
           <rng:data type="language"/>
@@ -8184,7 +8184,7 @@
     </attList>
   </elementSpec>
   <elementSpec ident="title" module="MEI.shared">
-    <desc>Title of a bibliographic entity.</desc>
+    <desc xml:lang="en">Title of a bibliographic entity.</desc>
     <classes>
       <memberOf key="att.authorized"/>
       <memberOf key="att.basic"/>
@@ -8212,66 +8212,66 @@
     </content>
     <attList>
       <attDef ident="level" usage="opt">
-        <desc>Indicates the bibliographic level of the title.</desc>
+        <desc xml:lang="en">Indicates the bibliographic level of the title.</desc>
         <valList type="closed">
           <valItem ident="a">
-            <desc>Analyzed component, such as an article or chapter, within a larger bibliographic
+            <desc xml:lang="en">Analyzed component, such as an article or chapter, within a larger bibliographic
               entity.</desc>
           </valItem>
           <valItem ident="c">
-            <desc>Collection. A group of items that were not originally published, distributed, or
+            <desc xml:lang="en">Collection. A group of items that were not originally published, distributed, or
               produced together.</desc>
           </valItem>
           <valItem ident="d">
-            <desc>Subunit of a collection, <abbr>e.g.</abbr>, item, folder, box, archival series, subgroup, or
+            <desc xml:lang="en">Subunit of a collection, <abbr>e.g.</abbr>, item, folder, box, archival series, subgroup, or
               subcollection.</desc>
           </valItem>
           <valItem ident="i">
-            <desc>Integrating resource, such as a continuously updated loose-leaf service or Web
+            <desc xml:lang="en">Integrating resource, such as a continuously updated loose-leaf service or Web
               site.</desc>
           </valItem>
           <valItem ident="m">
-            <desc>Monograph.</desc>
+            <desc xml:lang="en">Monograph.</desc>
           </valItem>
           <valItem ident="j">
-            <desc>Journal.</desc>
+            <desc xml:lang="en">Journal.</desc>
           </valItem>
           <valItem ident="s">
-            <desc>Series.</desc>
+            <desc xml:lang="en">Series.</desc>
           </valItem>
           <valItem ident="u">
-            <desc>Unpublished (including theses and dissertations unless published by a commercial
+            <desc xml:lang="en">Unpublished (including theses and dissertations unless published by a commercial
               press).</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="type" usage="opt">
-        <desc>Characterizes the title in some sense, using any convenient classification scheme or
+        <desc xml:lang="en">Characterizes the title in some sense, using any convenient classification scheme or
           typology that employs single-token labels.</desc>
         <datatype>
           <rng:data type="NMTOKENS"/>
         </datatype>
         <valList type="semi">
           <valItem ident="main">
-            <desc>Main title.</desc>
+            <desc xml:lang="en">Main title.</desc>
           </valItem>
           <valItem ident="subordinate">
-            <desc>Subtitle or title of part.</desc>
+            <desc xml:lang="en">Subtitle or title of part.</desc>
           </valItem>
           <valItem ident="abbreviated">
-            <desc>Abbreviated form of title.</desc>
+            <desc xml:lang="en">Abbreviated form of title.</desc>
           </valItem>
           <valItem ident="alternative">
-            <desc>Alternate title by which the item is also known.</desc>
+            <desc xml:lang="en">Alternate title by which the item is also known.</desc>
           </valItem>
           <valItem ident="translated">
-            <desc>Translated form of title.</desc>
+            <desc xml:lang="en">Translated form of title.</desc>
           </valItem>
           <valItem ident="uniform">
-            <desc>Collective title.</desc>
+            <desc xml:lang="en">Collective title.</desc>
           </valItem>
           <valItem ident="desc">
-            <desc>Descriptive paraphrase of the work.</desc>
+            <desc xml:lang="en">Descriptive paraphrase of the work.</desc>
           </valItem>
         </valList>
       </attDef>
@@ -8296,7 +8296,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="titlePage" module="MEI.shared">
-    <desc>Contains a transcription of the title page of a text.</desc>
+    <desc xml:lang="en">Contains a transcription of the title page of a text.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -8329,7 +8329,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="titlePart" module="MEI.shared">
-    <desc>Contains a subsection or division of the title of a bibliographic entity.</desc>
+    <desc xml:lang="en">Contains a subsection or division of the title of a bibliographic entity.</desc>
     <classes>
       <memberOf key="att.authorized"/>
       <memberOf key="att.basic"/>
@@ -8357,57 +8357,57 @@
     </content>
     <attList>
       <attDef ident="type" usage="opt">
-        <desc>Characterizes this title component in some sense, using any convenient classification
+        <desc xml:lang="en">Characterizes this title component in some sense, using any convenient classification
           scheme or typology that employs single-token labels.</desc>
         <datatype>
           <rng:data type="NMTOKENS"/>
         </datatype>
         <valList type="semi">
           <valItem ident="alternative">
-            <desc>Alternate title by which the item is also known.</desc>
+            <desc xml:lang="en">Alternate title by which the item is also known.</desc>
           </valItem>
           <valItem ident="arrangement">
-            <desc>Arranged statement for music. Analogous to <abbr>MARC</abbr> 240 subfield o.</desc>
+            <desc xml:lang="en">Arranged statement for music. Analogous to <abbr>MARC</abbr> 240 subfield o.</desc>
           </valItem>
           <valItem ident="carrier">
-            <desc>Medium of the carrier. Analogous to <abbr>MARC</abbr> 240 subfield h.</desc>
+            <desc xml:lang="en">Medium of the carrier. Analogous to <abbr>MARC</abbr> 240 subfield h.</desc>
           </valItem>
           <valItem ident="date">
-            <desc>Publication/creation date(s) of work. Analogous to <abbr>MARC</abbr> 240 subfield f.</desc>
+            <desc xml:lang="en">Publication/creation date(s) of work. Analogous to <abbr>MARC</abbr> 240 subfield f.</desc>
           </valItem>
           <valItem ident="desc">
-            <desc>Descriptive paraphrase of the work.</desc>
+            <desc xml:lang="en">Descriptive paraphrase of the work.</desc>
           </valItem>
           <valItem ident="form">
-            <desc>Form subheading. Analogous to <abbr>MARC</abbr> 240 subfield k.</desc>
+            <desc xml:lang="en">Form subheading. Analogous to <abbr>MARC</abbr> 240 subfield k.</desc>
           </valItem>
           <valItem ident="key">
-            <desc>Key for music. Analogous to <abbr>MARC</abbr> 240 subfield r.</desc>
+            <desc xml:lang="en">Key for music. Analogous to <abbr>MARC</abbr> 240 subfield r.</desc>
           </valItem>
           <valItem ident="language">
-            <desc>Language of a work. Analogous to <abbr>MARC</abbr> 240 subfield l (el).</desc>
+            <desc xml:lang="en">Language of a work. Analogous to <abbr>MARC</abbr> 240 subfield l (el).</desc>
           </valItem>
           <valItem ident="main">
-            <desc>Main title.</desc>
+            <desc xml:lang="en">Main title.</desc>
           </valItem>
           <valItem ident="name">
-            <desc>Name of a part or section of a work. Analogous to <abbr>MARC</abbr> 240 subfield p.</desc>
+            <desc xml:lang="en">Name of a part or section of a work. Analogous to <abbr>MARC</abbr> 240 subfield p.</desc>
           </valItem>
           <valItem ident="number">
-            <desc>Standard number designation of a work or of a part or section of a work. Analogous
+            <desc xml:lang="en">Standard number designation of a work or of a part or section of a work. Analogous
               to <abbr>MARC</abbr> 240 subfield n.</desc>
           </valItem>
           <valItem ident="perfmedium">
-            <desc>Performance medium. Analogous to <abbr>MARC</abbr> 240 subfield m.</desc>
+            <desc xml:lang="en">Performance medium. Analogous to <abbr>MARC</abbr> 240 subfield m.</desc>
           </valItem>
           <valItem ident="subordinate">
-            <desc>Subtitle.</desc>
+            <desc xml:lang="en">Subtitle.</desc>
           </valItem>
           <valItem ident="translated">
-            <desc>Translated form of title.</desc>
+            <desc xml:lang="en">Translated form of title.</desc>
           </valItem>
           <valItem ident="version">
-            <desc>Version. Analogous to <abbr>MARC</abbr> 240 subfield s.</desc>
+            <desc xml:lang="en">Version. Analogous to <abbr>MARC</abbr> 240 subfield s.</desc>
           </valItem>
         </valList>
       </attDef>
@@ -8417,7 +8417,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="width" module="MEI.shared">
-    <desc>Description of the horizontal size of an object.</desc>
+    <desc xml:lang="en">Description of the horizontal size of an object.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -4158,7 +4158,8 @@
     <desc xml:lang="en">Groups elements that may appear as part of a title page transcription.</desc>
   </classSpec>
   <elementSpec ident="accid" module="MEI.shared">
-    <desc xml:lang="en">(accidental) – Records a temporary alteration to the pitch of a note.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">accidental</gloss>
+    <desc xml:lang="en">Records a temporary alteration to the pitch of a note.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -4227,7 +4228,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="addrLine" module="MEI.shared">
-    <desc xml:lang="en">(address line) – Single line of a postal address.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">address line</gloss>
+    <desc xml:lang="en">Single line of a postal address.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -4283,7 +4285,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="analytic" module="MEI.shared">
-    <desc xml:lang="en">(analytic level) – Contains bibliographic elements describing an item (<abbr>e.g.</abbr>, an article or
+    <gloss versionDate="2022-05-18" xml:lang="en">analytic level</gloss>
+    <desc xml:lang="en">Contains bibliographic elements describing an item (<abbr>e.g.</abbr>, an article or
       poem) published within a monograph or journal and not as an independent publication.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4311,7 +4314,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="annot" module="MEI.shared">
-    <desc xml:lang="en">(annotation) – Provides a statement explaining the text or indicating the basis for an
+    <gloss versionDate="2022-05-18" xml:lang="en">annotation</gloss>
+    <desc xml:lang="en">Provides a statement explaining the text or indicating the basis for an
       assertion.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4393,7 +4397,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="artic" module="MEI.shared">
-    <desc xml:lang="en">(articulation) – An indication of how to play a note or chord.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">articulation</gloss>
+    <desc xml:lang="en">An indication of how to play a note or chord.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -4465,7 +4470,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="bibl" module="MEI.shared">
-    <desc xml:lang="en">(bibliographic reference) – Provides a loosely-structured bibliographic citation in which
+    <gloss versionDate="2022-05-18" xml:lang="en">bibliographic reference</gloss>
+    <desc xml:lang="en">Provides a loosely-structured bibliographic citation in which
       the sub-components may or may not be explicitly marked.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4550,7 +4556,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="biblScope" module="MEI.shared">
-    <desc xml:lang="en">(scope of citation) – Defines the scope of a bibliographic reference, for example as a
+    <gloss versionDate="2022-05-18" xml:lang="en">scope of citation</gloss>
+    <desc xml:lang="en">Defines the scope of a bibliographic reference, for example as a
       list of page numbers, or a named subdivision of a larger work.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4587,7 +4594,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="biblStruct" module="MEI.shared">
-    <desc xml:lang="en">(structured bibliographic citation) – Contains a bibliographic citation in which
+    <gloss versionDate="2022-05-18" xml:lang="en">structured bibliographic citation</gloss>
+    <desc xml:lang="en">Contains a bibliographic citation in which
       bibliographic sub-elements must appear in a specified order.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4705,7 +4713,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="castGrp" module="MEI.shared">
-    <desc xml:lang="en">(cast group) – Groups one or more individual castItem elements within a cast list.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">cast group</gloss>
+    <desc xml:lang="en">Groups one or more individual castItem elements within a cast list.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -4773,7 +4782,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="cb" module="MEI.shared">
-    <desc xml:lang="en">(column beginning) – An empty formatting element that forces text to begin in a new
+    <gloss versionDate="2022-05-18" xml:lang="en">column beginning</gloss>
+    <desc xml:lang="en">An empty formatting element that forces text to begin in a new
       column.</desc>
     <classes>
       <memberOf key="att.basic"/>
@@ -4887,7 +4897,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="clefGrp" module="MEI.shared">
-    <desc xml:lang="en">(clef group) – A set of simultaneously-occurring clefs.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">clef group</gloss>
+    <desc xml:lang="en">A set of simultaneously-occurring clefs.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.event"/>
@@ -4906,7 +4917,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="colLayout" module="MEI.shared">
-    <desc xml:lang="en">(column layout) – An empty formatting element that signals the start of columnar
+    <gloss versionDate="2022-05-18" xml:lang="en">column layout</gloss>
+    <desc xml:lang="en">An empty formatting element that signals the start of columnar
       layout.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -5114,7 +5126,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="desc" module="MEI.shared">
-    <desc xml:lang="en">(description) – Container for text that briefly describes the feature to which it is
+    <gloss versionDate="2022-05-18" xml:lang="en">description</gloss>
+    <desc xml:lang="en">Container for text that briefly describes the feature to which it is
       attached, including its intended usage, purpose, or application as appropriate.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -5139,7 +5152,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="dim" module="MEI.shared">
-    <desc xml:lang="en">(dimension) – Any single dimensional specification.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">dimension</gloss>
+    <desc xml:lang="en">Any single dimensional specification.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -5249,7 +5263,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="dir" module="MEI.shared">
-    <desc xml:lang="en">(directive) – An instruction expressed as a combination of text and symbols — such as
+    <gloss versionDate="2022-05-18" xml:lang="en">directive</gloss>
+    <desc xml:lang="en">An instruction expressed as a combination of text and symbols — such as
       segno and coda symbols, fermatas over a bar line, etc., typically above, below, or between
       staves, but not on the staff — that is not encoded elsewhere in more specific elements, like
       <gi scheme="MEI">tempo</gi> or <gi scheme="MEI">dynam</gi>.</desc>
@@ -5316,7 +5331,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="div" module="MEI.shared">
-    <desc xml:lang="en">(division) – Major structural division of text, such as a preface, chapter or
+    <gloss versionDate="2022-05-18" xml:lang="en">division</gloss>
+    <desc xml:lang="en">Major structural division of text, such as a preface, chapter or
       section.</desc>
     <classes>
       <memberOf key="att.basic"/>
@@ -5435,7 +5451,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="dynam" module="MEI.shared">
-    <desc xml:lang="en">(dynamic) – Indication of the volume of a note, phrase, or section of music.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">dynamic</gloss>
+    <desc xml:lang="en">Indication of the volume of a note, phrase, or section of music.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.dynam.log"/>
@@ -5485,7 +5502,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="edition" module="MEI.shared">
-    <desc xml:lang="en">(edition designation) – A word or text phrase that indicates a difference in either
+    <gloss versionDate="2022-05-18" xml:lang="en">edition designation</gloss>
+    <desc xml:lang="en">A word or text phrase that indicates a difference in either
       content or form between the item being described and a related item previously issued by the
       same publisher/distributor (<abbr>e.g.</abbr>, 2nd edition, version 2.0, etc.), or simultaneously issued by
       either the same publisher/distributor or another publisher/distributor (<abbr>e.g.</abbr>, large print
@@ -5791,7 +5809,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="grpSym" module="MEI.shared">
-    <desc xml:lang="en">(group symbol) – A brace or bracket used to group two or more staves of a score or
+    <gloss versionDate="2022-05-18" xml:lang="en">group symbol</gloss>
+    <desc xml:lang="en">A brace or bracket used to group two or more staves of a score or
       part.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -5829,7 +5848,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="head" module="MEI.shared">
-    <desc xml:lang="en">(heading) – Contains any heading, for example, the title of a section of text, or the
+    <gloss versionDate="2022-05-18" xml:lang="en">heading</gloss>
+    <desc xml:lang="en">Contains any heading, for example, the title of a section of text, or the
       heading of a list.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -5927,7 +5947,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="incip" module="MEI.shared">
-    <desc xml:lang="en">(incipit) – The opening music and/or words of a musical or textual work.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">incipit</gloss>
+    <desc xml:lang="en">The opening music and/or words of a musical or textual work.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -5986,7 +6007,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="keyAccid" module="MEI.shared">
-    <desc xml:lang="en">(key accidental) – Accidental in a key signature.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">key accidental</gloss>
+    <desc xml:lang="en">Accidental in a key signature.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6028,7 +6050,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="keySig" module="MEI.shared">
-    <desc xml:lang="en">(key signature) – Written key signature.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">key signature</gloss>
+    <desc xml:lang="en">Written key signature.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6155,7 +6178,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="layerDef" module="MEI.shared">
-    <desc xml:lang="en">(layer definition) – Container for layer meta-information.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">layer definition</gloss>
+    <desc xml:lang="en">Container for layer meta-information.</desc>
     <classes>
       <memberOf key="att.basic"/>
       <memberOf key="att.labelled"/>
@@ -6186,7 +6210,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="lb" module="MEI.shared">
-    <desc xml:lang="en">(line beginning) – An empty formatting element that forces text to begin on a new
+    <gloss versionDate="2022-05-18" xml:lang="en">line beginning</gloss>
+    <desc xml:lang="en">An empty formatting element that forces text to begin on a new
       line.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6208,7 +6233,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="lg" module="MEI.shared">
-    <desc xml:lang="en">(line group) – May be used for any section of text that is organized as a group of lines;
+    <gloss versionDate="2022-05-18" xml:lang="en">line group</gloss>
+    <desc xml:lang="en">May be used for any section of text that is organized as a group of lines;
       however, it is most often used for a group of verse lines functioning as a formal unit, <abbr>e.g.</abbr>, a
       stanza, refrain, verse paragraph, etc.</desc>
     <classes>
@@ -6280,7 +6306,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="mdiv" module="MEI.shared">
-    <desc xml:lang="en">(musical division) – Contains a subdivision of the body of a musical text.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">musical division</gloss>
+    <desc xml:lang="en">Contains a subdivision of the body of a musical text.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6350,7 +6377,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="monogr" module="MEI.shared">
-    <desc xml:lang="en">(monograph level) – Contains bibliographic elements describing an item, for example, a
+    <gloss versionDate="2022-05-18" xml:lang="en">monograph level</gloss>
+    <desc xml:lang="en">Contains bibliographic elements describing an item, for example, a
       published book or journal, score, recording, or an unpublished manuscript.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6573,7 +6601,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="num" module="MEI.shared">
-    <desc xml:lang="en">(number) – Numeric information in any form.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">number</gloss>
+    <desc xml:lang="en">Numeric information in any form.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6645,7 +6674,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="p" module="MEI.shared">
-    <desc xml:lang="en">(paragraph) – One or more text phrases that form a logical prose passage.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">paragraph</gloss>
+    <desc xml:lang="en">One or more text phrases that form a logical prose passage.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6672,7 +6702,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pad" module="MEI.shared">
-    <desc xml:lang="en">(padding) – An indication of extra visual space between notational elements.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">padding</gloss>
+    <desc xml:lang="en">An indication of extra visual space between notational elements.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.pad.log"/>
@@ -6743,7 +6774,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="pb" module="MEI.shared">
-    <desc xml:lang="en">(page beginning) – An empty formatting element that forces text to begin on a new
+    <gloss versionDate="2022-05-18" xml:lang="en">page beginning</gloss>
+    <desc xml:lang="en">An empty formatting element that forces text to begin on a new
       page.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6770,7 +6802,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pgDesc" module="MEI.shared">
-    <desc xml:lang="en">(page description) – Contains a brief prose description of the appearance or description
+    <gloss versionDate="2022-05-18" xml:lang="en">page description</gloss>
+    <desc xml:lang="en">Contains a brief prose description of the appearance or description
       of the content of a physical page.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6795,7 +6828,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pgFoot" module="MEI.shared">
-    <desc xml:lang="en">(page footer) – A running footer on the first page. Also, used to temporarily override a
+    <gloss versionDate="2022-05-18" xml:lang="en">page footer</gloss>
+    <desc xml:lang="en">A running footer on the first page. Also, used to temporarily override a
       running footer on individual pages.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6834,7 +6868,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pgFoot2" module="MEI.shared">
-    <desc xml:lang="en">(page footer 2) – A running footer on the pages following the first.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">page footer 2</gloss>
+    <desc xml:lang="en">A running footer on the pages following the first.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6871,7 +6906,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pgHead" module="MEI.shared">
-    <desc xml:lang="en">(page header) – A running header on the first page. Also, used to temporarily override a
+    <gloss versionDate="2022-05-18" xml:lang="en">page header</gloss>
+    <desc xml:lang="en">A running header on the first page. Also, used to temporarily override a
       running header on individual pages.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6910,7 +6946,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pgHead2" module="MEI.shared">
-    <desc xml:lang="en">(page header 2) – A running header on the pages following the first.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">page header 2</gloss>
+    <desc xml:lang="en">A running header on the pages following the first.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -7005,7 +7042,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="physLoc" module="MEI.shared">
-    <desc xml:lang="en">(physical location) – Groups information about the current physical location of a
+    <gloss versionDate="2022-05-18" xml:lang="en">physical location</gloss>
+    <desc xml:lang="en">Groups information about the current physical location of a
       bibliographic item, such as the repository in which it is located and its shelf mark(s), and
       its previous locations.</desc>
     <classes>
@@ -7058,7 +7096,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pubPlace" module="MEI.shared">
-    <desc xml:lang="en">(publication place) – Name of the place where a bibliographic item was published.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">publication place</gloss>
+    <desc xml:lang="en">Name of the place where a bibliographic item was published.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
@@ -7099,7 +7138,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="relatedItem" module="MEI.shared">
-    <desc xml:lang="en">(related item) – Contains or references another bibliographic item which is related to the
+    <gloss versionDate="2022-05-18" xml:lang="en">related item</gloss>
+    <desc xml:lang="en">Contains or references another bibliographic item which is related to the
       present one.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -7240,7 +7280,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="rend" module="MEI.shared">
-    <desc xml:lang="en">(render) – A formatting element indicating special visual rendering, <abbr>e.g.</abbr>, bold or
+    <gloss versionDate="2022-05-18" xml:lang="en">render</gloss>
+    <desc xml:lang="en">A formatting element indicating special visual rendering, <abbr>e.g.</abbr>, bold or
       italicized, of a text word or phrase.</desc>
     <classes>
       <memberOf key="att.color"/>
@@ -7306,7 +7347,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="resp" module="MEI.shared">
-    <desc xml:lang="en">(responsibility) – A phrase describing the nature of intellectual responsibility.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">responsibility</gloss>
+    <desc xml:lang="en">A phrase describing the nature of intellectual responsibility.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.authorized"/>
@@ -7332,7 +7374,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="respStmt" module="MEI.shared">
-    <desc xml:lang="en">(responsibility statement) – Transcription of text that names one or more individuals,
+    <gloss versionDate="2022-05-18" xml:lang="en">responsibility statement</gloss>
+    <desc xml:lang="en">Transcription of text that names one or more individuals,
       groups, or in rare cases, mechanical processes, responsible for creation, realization,
       production, funding, or distribution of the intellectual or artistic content.</desc>
     <classes>
@@ -7427,7 +7470,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="roleDesc" module="MEI.shared">
-    <desc xml:lang="en">(role description) – Describes a character’s role in a drama.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">role description</gloss>
+    <desc xml:lang="en">Describes a character’s role in a drama.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -7446,7 +7490,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="sb" module="MEI.shared">
-    <desc xml:lang="en">(system beginning) – An empty formatting element that forces musical notation to begin on
+    <gloss versionDate="2022-05-18" xml:lang="en">system beginning</gloss>
+    <desc xml:lang="en">An empty formatting element that forces musical notation to begin on
       a new line.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -7502,7 +7547,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="scoreDef" module="MEI.shared">
-    <desc xml:lang="en">(score definition) – Container for score meta-information.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">score definition</gloss>
+    <desc xml:lang="en">Container for score meta-information.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.scoreDef.log"/>
@@ -7694,7 +7740,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="stack" module="MEI.shared">
-    <desc xml:lang="en">(stacked text) – An inline table with a single column.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">stacked text</gloss>
+    <desc xml:lang="en">An inline table with a single column.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -7803,7 +7850,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="staffDef" module="MEI.shared">
-    <desc xml:lang="en">(staff definition) – Container for staff meta-information.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">staff definition</gloss>
+    <desc xml:lang="en">Container for staff meta-information.</desc>
     <classes>
       <memberOf key="att.basic"/>
       <memberOf key="att.labelled"/>
@@ -7951,7 +7999,8 @@
     </constraintSpec>
   </elementSpec>
   <elementSpec ident="staffGrp" module="MEI.shared">
-    <desc xml:lang="en">(staff group) – A group of bracketed or braced staves.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">staff group</gloss>
+    <desc xml:lang="en">A group of bracketed or braced staves.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -8000,7 +8049,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="syl" module="MEI.shared">
-    <desc xml:lang="en">(syllable) – Individual lyric syllable.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">syllable</gloss>
+    <desc xml:lang="en">Individual lyric syllable.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -8149,7 +8199,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="textLang" module="MEI.shared">
-    <desc xml:lang="en">(text language) – Identifies the languages and writing systems within the work described
+    <gloss versionDate="2022-05-18" xml:lang="en">text language</gloss>
+    <desc xml:lang="en">Identifies the languages and writing systems within the work described
       by a bibliographic description, not the language of the description.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -5,13 +5,13 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.stringtab">
   <moduleSpec ident="MEI.stringtab">
-    <desc>Tablature component declarations.</desc>
+    <desc xml:lang="en">Tablature component declarations.</desc>
   </moduleSpec>
   <classSpec ident="att.stringtab" module="MEI.stringtab" type="atts">
-    <desc>String tablature string and fret information.</desc>
+    <desc xml:lang="en">String tablature string and fret information.</desc>
     <attList>
       <attDef ident="tab.fing" usage="opt">
-        <desc>Indicates which finger, if any, should be used to play an individual string. The
+        <desc xml:lang="en">Indicates which finger, if any, should be used to play an individual string. The
           index, middle, ring, and little fingers are represented by the values 1-4, while <val>t</val> is
           for the thumb. The values <val>x</val> and <val>o</val> indicate muffled and open strings,
           respectively.</desc>
@@ -20,13 +20,13 @@
         </datatype>
       </attDef>
       <attDef ident="tab.fret" usage="opt">
-        <desc>Records the location at which a string should be stopped against a fret.</desc>
+        <desc xml:lang="en">Records the location at which a string should be stopped against a fret.</desc>
         <datatype>
           <rng:ref name="data.FRETNUMBER"/>
         </datatype>
       </attDef>
       <attDef ident="tab.string" usage="opt">
-        <desc>Records which string is to be played.</desc>
+        <desc xml:lang="en">Records which string is to be played.</desc>
         <datatype>
           <rng:ref name="data.STRINGNUMBER"/>
         </datatype>
@@ -34,10 +34,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.stringtab.position" module="MEI.stringtab" type="atts">
-    <desc>String tablature position information.</desc>
+    <desc xml:lang="en">String tablature position information.</desc>
     <attList>
       <attDef ident="tab.pos" usage="opt">
-        <desc>Records fret position.</desc>
+        <desc xml:lang="en">Records fret position.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
@@ -45,10 +45,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.stringtab.tuning" module="MEI.stringtab" type="atts">
-    <desc>String tablature tuning information.</desc>
+    <desc xml:lang="en">String tablature tuning information.</desc>
     <attList>
       <attDef ident="tab.strings" usage="opt">
-        <desc>Provides a *written* pitch and octave for each open string or course of
+        <desc xml:lang="en">Provides a *written* pitch and octave for each open string or course of
           strings.</desc>
         <datatype>
           <rng:list>
@@ -64,7 +64,7 @@
     </attList>
   </classSpec>
   <elementSpec ident="barre" module="MEI.stringtab">
-    <desc>A barre in a chord tablature grid.</desc>
+    <desc xml:lang="en">A barre in a chord tablature grid.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.startEndId"/>
@@ -74,7 +74,7 @@
     </content>
     <attList>
       <attDef ident="fret" usage="opt">
-        <desc>Records the location at which the strings should be stopped against a fret in a
+        <desc xml:lang="en">Records the location at which the strings should be stopped against a fret in a
           fretboard diagram. This may or may not be the same as the actual location on the fretboard
           of the instrument in performance.</desc>
         <datatype>

--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -85,7 +85,7 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The <att>startid</att> and <att>endid</att> attributes are used to indicate the <gi
         scheme="MEI">chordMember</gi> elements on which the barre starts and finishes respectively.
         The fret at which the barre should be created is recorded by the <att>fret</att>

--- a/source/modules/MEI.text.xml
+++ b/source/modules/MEI.text.xml
@@ -84,7 +84,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="back" module="MEI.text">
-    <desc xml:lang="en">(back matter) – Contains any appendixes, advertisements, indexes, etc. following the main
+    <gloss versionDate="2022-05-18" xml:lang="en">back matter</gloss>
+    <desc xml:lang="en">Contains any appendixes, advertisements, indexes, etc. following the main
       body of a musical text.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -131,7 +132,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="front" module="MEI.text">
-    <desc xml:lang="en">(front matter) – Bundles prefatory text found before the start of the musical text.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">front matter</gloss>
+    <desc xml:lang="en">Bundles prefatory text found before the start of the musical text.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -185,7 +187,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="l" module="MEI.text">
-    <desc xml:lang="en">(line of text) – Contains a single line of text within a line group.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">line of text</gloss>
+    <desc xml:lang="en">Contains a single line of text within a line group.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -223,7 +226,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="li" module="MEI.text">
-    <desc xml:lang="en">(list item) – Single item in a <gi scheme="MEI">list</gi>.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">list item</gloss>
+    <desc xml:lang="en">Single item in a <gi scheme="MEI">list</gi>.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -338,7 +342,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="q" module="MEI.text">
-    <desc xml:lang="en">(quoted) – Contains material which is distinguished from the surrounding phrase-level text
+    <gloss versionDate="2022-05-18" xml:lang="en">quoted</gloss>
+    <desc xml:lang="en">Contains material which is distinguished from the surrounding phrase-level text
       using quotation marks or a similar method. Use <gi scheme="MEI">quote</gi> for block-level
       quotations.</desc>
     <classes>
@@ -407,7 +412,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="quote" module="MEI.text">
-    <desc xml:lang="en">(quoted material) – Contains a paragraph-like block of text attributed to an external
+    <gloss versionDate="2022-05-18" xml:lang="en">quoted material</gloss>
+    <desc xml:lang="en">Contains a paragraph-like block of text attributed to an external
       source, normally set off from the surrounding text by spacing or other typographic
       distinction.</desc>
     <classes>

--- a/source/modules/MEI.text.xml
+++ b/source/modules/MEI.text.xml
@@ -5,55 +5,55 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.text">
   <moduleSpec ident="MEI.text">
-    <desc>Text component declarations.</desc>
+    <desc xml:lang="en">Text component declarations.</desc>
   </moduleSpec>
   <classSpec ident="model.backLike" module="MEI.text" type="model">
-    <desc>Groups elements that may contain back matter.</desc>
+    <desc xml:lang="en">Groups elements that may contain back matter.</desc>
     <classes>
       <memberOf key="macro.musicPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.divLike" module="MEI.text" type="model">
-    <desc>Groups elements used to represent generic structural divisions of text.</desc>
+    <desc xml:lang="en">Groups elements used to represent generic structural divisions of text.</desc>
   </classSpec>
   <classSpec ident="model.frontLike" module="MEI.text" type="model">
-    <desc>Groups elements that may contain front matter.</desc>
+    <desc xml:lang="en">Groups elements that may contain front matter.</desc>
     <classes>
       <memberOf key="macro.musicPart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.lgLike" module="MEI.text" type="model">
-    <desc>Groups elements that have a line-grouping function.</desc>
+    <desc xml:lang="en">Groups elements that have a line-grouping function.</desc>
     <classes>
       <memberOf key="model.paracontentPart"/>
       <memberOf key="model.textComponentLike"/>
     </classes>
   </classSpec>
   <classSpec ident="model.listLike" module="MEI.text" type="model">
-    <desc>Groups list-like elements.</desc>
+    <desc xml:lang="en">Groups list-like elements.</desc>
     <classes>
       <memberOf key="model.paracontentPart"/>
       <memberOf key="model.textComponentLike"/>
     </classes>
   </classSpec>
   <classSpec ident="model.lLike" module="MEI.text" type="model">
-    <desc>Groups elements representing metrical components such as verse lines.</desc>
+    <desc xml:lang="en">Groups elements representing metrical components such as verse lines.</desc>
   </classSpec>
   <classSpec ident="model.qLike" module="MEI.text" type="model">
-    <desc>Groups elements related to highlighting which can appear at the phrase-level.</desc>
+    <desc xml:lang="en">Groups elements related to highlighting which can appear at the phrase-level.</desc>
     <classes>
       <memberOf key="model.textPhraseLike.limited"/>
     </classes>
   </classSpec>
   <classSpec ident="model.quoteLike" module="MEI.text" type="model">
-    <desc>Groups elements used to directly contain quotations.</desc>
+    <desc xml:lang="en">Groups elements used to directly contain quotations.</desc>
     <classes>
       <memberOf key="model.paracontentPart"/>
       <memberOf key="model.textComponentLike"/>
     </classes>
   </classSpec>
   <elementSpec ident="argument" module="MEI.text">
-    <desc>Contains a formal list or prose description of topics addressed.</desc>
+    <desc xml:lang="en">Contains a formal list or prose description of topics addressed.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -84,7 +84,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="back" module="MEI.text">
-    <desc>(back matter) – Contains any appendixes, advertisements, indexes, etc. following the main
+    <desc xml:lang="en">(back matter) – Contains any appendixes, advertisements, indexes, etc. following the main
       body of a musical text.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -109,7 +109,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="epigraph" module="MEI.text">
-    <desc>Contains a quotation, anonymous or attributed, appearing on a title page.</desc>
+    <desc xml:lang="en">Contains a quotation, anonymous or attributed, appearing on a title page.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -131,7 +131,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="front" module="MEI.text">
-    <desc>(front matter) – Bundles prefatory text found before the start of the musical text.</desc>
+    <desc xml:lang="en">(front matter) – Bundles prefatory text found before the start of the musical text.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -163,7 +163,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="imprimatur" module="MEI.text">
-    <desc>Contains a formal statement authorizing the publication of a work, sometimes required to
+    <desc xml:lang="en">Contains a formal statement authorizing the publication of a work, sometimes required to
       appear on a title page or its verso.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -185,7 +185,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="l" module="MEI.text">
-    <desc>(line of text) – Contains a single line of text within a line group.</desc>
+    <desc xml:lang="en">(line of text) – Contains a single line of text within a line group.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -207,7 +207,7 @@
     </content>
     <attList>
       <attDef ident="rhythm" usage="opt">
-        <desc>Used to specify a rhythm for the lyric syllables that differs from that of the notes
+        <desc xml:lang="en">Used to specify a rhythm for the lyric syllables that differs from that of the notes
           on the staff, <abbr>e.g.</abbr>, '4,4,4,4' when the rhythm of the notes is '4.,8,4.,8'.</desc>
         <datatype>
           <rng:data type="string"/>
@@ -223,7 +223,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="li" module="MEI.text">
-    <desc>(list item) – Single item in a <gi scheme="MEI">list</gi>.</desc>
+    <desc xml:lang="en">(list item) – Single item in a <gi scheme="MEI">list</gi>.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -246,7 +246,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="list" module="MEI.text">
-    <desc>A formatting element that contains a series of items separated from one another and
+    <desc xml:lang="en">A formatting element that contains a series of items separated from one another and
       arranged in a linear, often vertical, sequence.</desc>
     <classes>
       <memberOf key="att.basic"/>
@@ -281,7 +281,7 @@
     </constraintSpec>
     <attList>
       <attDef ident="form" usage="opt">
-        <desc>Used to indicate the format of a list. In a <val>simple</val> list, <gi scheme="MEI">li</gi>
+        <desc xml:lang="en">Used to indicate the format of a list. In a <val>simple</val> list, <gi scheme="MEI">li</gi>
           elements are not numbered or bulleted. In a <val>marked</val> list, the sequence of the list items
           is not critical, and a bullet, box, dash, or other character is displayed at the start of
           each <gi scheme="MEI">item</gi>. In an <val>ordered</val> list, the sequence of the items is
@@ -290,39 +290,39 @@
           scheme="MEI">li</gi>.</desc>
         <valList type="closed">
           <valItem ident="simple">
-            <desc>Items are not numbered or bulleted.</desc>
+            <desc xml:lang="en">Items are not numbered or bulleted.</desc>
           </valItem>
           <valItem ident="marked">
-            <desc>Bullet, box, dash, or other character is displayed before each item.</desc>
+            <desc xml:lang="en">Bullet, box, dash, or other character is displayed before each item.</desc>
           </valItem>
           <valItem ident="ordered">
-            <desc>Each item is numbered or lettered.</desc>
+            <desc xml:lang="en">Each item is numbered or lettered.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="type" usage="opt">
-        <desc>Captures the nature of the content of a list.</desc>
+        <desc xml:lang="en">Captures the nature of the content of a list.</desc>
         <datatype>
           <rng:data type="NMTOKENS"/>
         </datatype>
         <valList type="semi">
           <valItem ident="gloss">
-            <desc>Each list item glosses some term or concept, which is given by a label element
+            <desc xml:lang="en">Each list item glosses some term or concept, which is given by a label element
               preceding the list item.</desc>
           </valItem>
           <valItem ident="index">
-            <desc>Each list item is an entry in an index such as the alphabetical topical index at
+            <desc xml:lang="en">Each list item is an entry in an index such as the alphabetical topical index at
               the back of a print volume.</desc>
           </valItem>
           <valItem ident="instructions">
-            <desc>Each list item is a step in a sequence of instructions, as in a recipe.</desc>
+            <desc xml:lang="en">Each list item is a step in a sequence of instructions, as in a recipe.</desc>
           </valItem>
           <valItem ident="litany">
-            <desc>Each list item is one of a sequence of petitions, supplications or invocations,
+            <desc xml:lang="en">Each list item is one of a sequence of petitions, supplications or invocations,
               typically in a religious ritual.</desc>
           </valItem>
           <valItem ident="syllogism">
-            <desc>Each list item is part of an argument consisting of two or more propositions and a
+            <desc xml:lang="en">Each list item is part of an argument consisting of two or more propositions and a
               final conclusion derived from them.</desc>
           </valItem>
         </valList>
@@ -338,7 +338,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="q" module="MEI.text">
-    <desc>(quoted) – Contains material which is distinguished from the surrounding phrase-level text
+    <desc xml:lang="en">(quoted) – Contains material which is distinguished from the surrounding phrase-level text
       using quotation marks or a similar method. Use <gi scheme="MEI">quote</gi> for block-level
       quotations.</desc>
     <classes>
@@ -366,31 +366,31 @@
         </datatype>
         <valList type="semi">
           <valItem ident="spoken">
-            <desc>Representation of speech.</desc>
+            <desc xml:lang="en">Representation of speech.</desc>
           </valItem>
           <valItem ident="thought">
-            <desc>Representation of thought, <abbr>e.g.</abbr>, internal monologue.</desc>
+            <desc xml:lang="en">Representation of thought, <abbr>e.g.</abbr>, internal monologue.</desc>
           </valItem>
           <valItem ident="written">
-            <desc>Quotation from a written source.</desc>
+            <desc xml:lang="en">Quotation from a written source.</desc>
           </valItem>
           <valItem ident="soCalled">
-            <desc>Authorial distance.</desc>
+            <desc xml:lang="en">Authorial distance.</desc>
           </valItem>
           <valItem ident="foreign">
-            <desc>Linguistically distinct.</desc>
+            <desc xml:lang="en">Linguistically distinct.</desc>
           </valItem>
           <valItem ident="distinct">
-            <desc>Linguistically distinct.</desc>
+            <desc xml:lang="en">Linguistically distinct.</desc>
           </valItem>
           <valItem ident="term">
-            <desc>Technical term.</desc>
+            <desc xml:lang="en">Technical term.</desc>
           </valItem>
           <valItem ident="emph">
-            <desc>Rhetorically emphasized.</desc>
+            <desc xml:lang="en">Rhetorically emphasized.</desc>
           </valItem>
           <valItem ident="mentioned">
-            <desc>Refering to itself, not its normal referent.</desc>
+            <desc xml:lang="en">Refering to itself, not its normal referent.</desc>
           </valItem>
         </valList>
       </attDef>
@@ -407,7 +407,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="quote" module="MEI.text">
-    <desc>(quoted material) – Contains a paragraph-like block of text attributed to an external
+    <desc xml:lang="en">(quoted material) – Contains a paragraph-like block of text attributed to an external
       source, normally set off from the surrounding text by spacing or other typographic
       distinction.</desc>
     <classes>
@@ -437,7 +437,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="seg" module="MEI.text">
-    <desc>(arbitrary segment) represents any segmentation of text below the "text component"
+    <desc xml:lang="en">(arbitrary segment) represents any segmentation of text below the "text component"
       level.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.text.xml
+++ b/source/modules/MEI.text.xml
@@ -79,7 +79,7 @@
         </rng:zeroOrMore>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -103,7 +103,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -126,7 +126,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -149,7 +149,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p> <gi scheme="MEI">titlePage</gi> may be used to transcribe the item’s title page. Other
         front matter structures, such as a preface, dedication, or table of contents, may be encoded
         as textual divisions; that is, as <gi scheme="MEI">div</gi> elements, with an optional <gi
@@ -157,7 +157,7 @@
         scheme="MEI">pb</gi> element is allowed here in order to accommodate page images, <abbr>e.g.</abbr>,
         cover, endpapers, etc. before and after the actual textual matter.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
@@ -180,7 +180,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -214,11 +214,11 @@
         </datatype>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Do not confuse this element with the <gi scheme="MEI">line</gi> element, which is used for
         graphical lines that occur in music notation.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -240,7 +240,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in the Encoded Archival Description (EAD), Text
         Encoding Initiative (TEI), and HTML standards.</p>
     </remarks>
@@ -326,13 +326,13 @@
               final conclusion derived from them.</desc>
           </valItem>
         </valList>
-        <remarks>
+        <remarks xml:lang="en">
           <p>In a list of type <val>gloss</val> it is a semantic error not to precede each list item with a
             label.</p>
         </remarks>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements in Encoded Archival Description (EAD), Text Encoding
         Initiative (TEI), and HTML standards.</p>
     </remarks>
@@ -395,14 +395,14 @@
         </valList>
       </attDef>
     </attList>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element may be used for a variety of reasons including, but not limited to: direct
         speech or thought, technical terms or jargon, authorial distance, quotations from elsewhere,
         and passages that are mentioned but not used.</p>
       <p>Do not confuse this element, used to capture phrase-level quotations, and <gi scheme="MEI"
         >quote</gi>, intended for block quotations.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements found in HTML, TEI, and EAD standards.</p>
     </remarks>
   </elementSpec>
@@ -427,12 +427,12 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The source for the quote may be included in a <gi scheme="MEI">bibl</gi> sub-element.</p>
       <p>Do not confuse this element, used to capture block-level quotations, and <gi scheme="MEI"
         >q</gi>, intended for inline quotations.</p>
     </remarks>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on elements found in HTML, TEI, and EAD standards.</p>
     </remarks>
   </elementSpec>
@@ -456,7 +456,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>

--- a/source/modules/MEI.usersymbols.xml
+++ b/source/modules/MEI.usersymbols.xml
@@ -249,7 +249,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="propName" module="MEI.usersymbols">
-    <desc xml:lang="en">(property name) – Name of a property of the symbol.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">property name</gloss>
+    <desc xml:lang="en">Name of a property of the symbol.</desc>
     <classes>
       <memberOf key="att.basic"/>
       <memberOf key="att.labelled"/>
@@ -275,7 +276,8 @@
     </attList>
   </elementSpec>
   <elementSpec ident="propValue" module="MEI.usersymbols">
-    <desc xml:lang="en">(property value) – A single property value.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">property value</gloss>
+    <desc xml:lang="en">A single property value.</desc>
     <classes>
       <memberOf key="att.common"/>
     </classes>
@@ -284,7 +286,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="symbolDef" module="MEI.usersymbols">
-    <desc xml:lang="en">(symbol definition) – Declaration of an individual symbol in a symbolTable.</desc>
+    <gloss versionDate="2022-05-18" xml:lang="en">symbol definition</gloss>
+    <desc xml:lang="en">Declaration of an individual symbol in a symbolTable.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.coordinated"/>
@@ -322,7 +325,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="symName" module="MEI.usersymbols">
-    <desc xml:lang="en">(symbol name) – Contains the name of a symbol, expressed following Unicode
+    <gloss versionDate="2022-05-18" xml:lang="en">symbol name</gloss>
+    <desc xml:lang="en">Contains the name of a symbol, expressed following Unicode
       conventions.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -332,7 +336,8 @@
     </content>
   </elementSpec>
   <elementSpec ident="symProp" module="MEI.usersymbols">
-    <desc xml:lang="en">(symbol property) – Provides a name and value for some property of the parent
+    <gloss versionDate="2022-05-18" xml:lang="en">symbol property</gloss>
+    <desc xml:lang="en">Provides a name and value for some property of the parent
       symbol.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.usersymbols.xml
+++ b/source/modules/MEI.usersymbols.xml
@@ -5,13 +5,13 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.usersymbols">
   <moduleSpec ident="MEI.usersymbols">
-    <desc>User-defined symbols component declarations.</desc>
+    <desc xml:lang="en">User-defined symbols component declarations.</desc>
   </moduleSpec>
   <classSpec ident="att.altSym" module="MEI.usersymbols" type="atts">
-    <desc>Attributes supplying pointers to user-defined symbols.</desc>
+    <desc xml:lang="en">Attributes supplying pointers to user-defined symbols.</desc>
     <attList>
       <attDef ident="altsym" usage="opt">
-        <desc>Provides a way of pointing to a user-defined symbol. It must contain a reference to an
+        <desc xml:lang="en">Provides a way of pointing to a user-defined symbol. It must contain a reference to an
           ID of a <gi scheme="MEI">symbolDef</gi> element elsewhere in the document.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
@@ -35,45 +35,45 @@
     </attList>
   </classSpec>
   <classSpec ident="att.anchoredText.log" module="MEI.usersymbols" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.startId"/>
     </classes>
     <attList>
       <attDef ident="func" usage="rec">
-        <desc>Indicates the function of the text.</desc>
+        <desc xml:lang="en">Indicates the function of the text.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="unknown">
-            <desc>The function of the text is unknown.</desc>
+            <desc xml:lang="en">The function of the text is unknown.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.curve.log" module="MEI.usersymbols" type="atts">
-    <desc>Logical domain attributes.</desc>
+    <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.startEndId"/>
     </classes>
     <attList>
       <attDef ident="func" usage="rec">
-        <desc>Indicates the function of the curve.</desc>
+        <desc xml:lang="en">Indicates the function of the curve.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="unknown">
-            <desc>The function of the curve is unknown.</desc>
+            <desc xml:lang="en">The function of the curve is unknown.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.line.log" module="MEI.usersymbols" type="atts">
-    <desc>Attributes for describing the logical behavior of a line.</desc>
+    <desc xml:lang="en">Attributes for describing the logical behavior of a line.</desc>
     <classes>
       <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
@@ -82,34 +82,34 @@
     </classes>
     <attList>
       <attDef ident="func" usage="rec">
-        <desc>Indicates the function of the line.</desc>
+        <desc xml:lang="en">Indicates the function of the line.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="coloration">
-            <desc>Indicates coloration in material transcribed from a source originally in mensural
+            <desc xml:lang="en">Indicates coloration in material transcribed from a source originally in mensural
               notation.</desc>
           </valItem>
           <valItem ident="ligature">
-            <desc>Marks a ligature in material transcribed from a source originally in mensural
+            <desc xml:lang="en">Marks a ligature in material transcribed from a source originally in mensural
               notation.</desc>
           </valItem>
           <valItem ident="unknown">
-            <desc>The function of the line is unknown.</desc>
+            <desc xml:lang="en">The function of the line is unknown.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="model.graphicPrimitiveLike" module="MEI.usersymbols" type="model">
-    <desc>Groups elements that function as drawing primitives.</desc>
+    <desc xml:lang="en">Groups elements that function as drawing primitives.</desc>
   </classSpec>
   <classSpec ident="model.symbolTableLike" module="MEI.usersymbols" type="model">
-    <desc>Groups elements that group symbol definitions.</desc>
+    <desc xml:lang="en">Groups elements that group symbol definitions.</desc>
   </classSpec>
   <elementSpec ident="anchoredText" module="MEI.usersymbols">
-    <desc>Container for text that is fixed to a particular page location, regardless of changes made
+    <desc xml:lang="en">Container for text that is fixed to a particular page location, regardless of changes made
       to the layout of the measures around it.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -143,7 +143,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="curve" module="MEI.usersymbols">
-    <desc>A curved line that cannot be represented by a more specific element, such as a
+    <desc xml:lang="en">A curved line that cannot be represented by a more specific element, such as a
       slur.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -184,7 +184,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="line" module="MEI.usersymbols">
-    <desc>A visual line that cannot be represented by a more specific; <abbr>i.e.</abbr>, semantic,
+    <desc xml:lang="en">A visual line that cannot be represented by a more specific; <abbr>i.e.</abbr>, semantic,
       element.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -234,7 +234,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="mapping" module="MEI.usersymbols">
-    <desc>One or more characters which are related to the parent symbol in some respect, as
+    <desc xml:lang="en">One or more characters which are related to the parent symbol in some respect, as
       specified by the type attribute.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -249,7 +249,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="propName" module="MEI.usersymbols">
-    <desc>(property name) – Name of a property of the symbol.</desc>
+    <desc xml:lang="en">(property name) – Name of a property of the symbol.</desc>
     <classes>
       <memberOf key="att.basic"/>
       <memberOf key="att.labelled"/>
@@ -262,20 +262,20 @@
     </content>
     <attList>
       <attDef ident="type" usage="req">
-        <desc>Characterizes the property name.</desc>
+        <desc xml:lang="en">Characterizes the property name.</desc>
         <valList type="closed">
           <valItem ident="unicode">
-            <desc>A registered Unicode normative or informative property name.</desc>
+            <desc xml:lang="en">A registered Unicode normative or informative property name.</desc>
           </valItem>
           <valItem ident="local">
-            <desc>A locally defined name.</desc>
+            <desc xml:lang="en">A locally defined name.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </elementSpec>
   <elementSpec ident="propValue" module="MEI.usersymbols">
-    <desc>(property value) – A single property value.</desc>
+    <desc xml:lang="en">(property value) – A single property value.</desc>
     <classes>
       <memberOf key="att.common"/>
     </classes>
@@ -284,7 +284,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="symbolDef" module="MEI.usersymbols">
-    <desc>(symbol definition) – Declaration of an individual symbol in a symbolTable.</desc>
+    <desc xml:lang="en">(symbol definition) – Declaration of an individual symbol in a symbolTable.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.coordinated"/>
@@ -322,7 +322,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="symName" module="MEI.usersymbols">
-    <desc>(symbol name) – Contains the name of a symbol, expressed following Unicode
+    <desc xml:lang="en">(symbol name) – Contains the name of a symbol, expressed following Unicode
       conventions.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -332,7 +332,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="symProp" module="MEI.usersymbols">
-    <desc>(symbol property) – Provides a name and value for some property of the parent
+    <desc xml:lang="en">(symbol property) – Provides a name and value for some property of the parent
       symbol.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -343,7 +343,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="symbolTable" module="MEI.usersymbols">
-    <desc>Contains a set of user-defined symbols.</desc>
+    <desc xml:lang="en">Contains a set of user-defined symbols.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="model.symbolTableLike"/>

--- a/source/modules/MEI.usersymbols.xml
+++ b/source/modules/MEI.usersymbols.xml
@@ -131,7 +131,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>This element may be used where semantic markup of the text is neither possible nor
         desirable, such as in optical music recognition (OMR) applications. The content model here
         is similar to paragraph without model.textcomponent and <gi scheme="MEI">pb</gi>
@@ -169,7 +169,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The starting point of the curve may be identified in absolute output coordinate terms using
         the <att>x</att> and <att>y</att> attributes or relative to the location of another element
         using the <att>startid</att> attribute. The attributes in the att.visualOffset class may be
@@ -221,7 +221,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The starting point of the line may be identified in absolute output coordinate terms using
         the <att>x</att> and <att>y</att> attributes. The attributes in the att.visualOffset class
         may be used to record horizontal, vertical, or time offsets from these absolute coordinates
@@ -316,7 +316,7 @@
         <rng:ref name="model.annotLike"/>
       </rng:zeroOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Like a chord table, a symbolTable may be shared between MEI instances through the use of an
         external parsed entity containing the symbolTable to be shared.</p>
     </remarks>
@@ -353,7 +353,7 @@
         <rng:ref name="symbolDef"/>
       </rng:oneOrMore>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Like a chord table, a symbolTable may be shared between mei instances through the use of an
         external parsed entity containing the symbolTable to be shared.</p>
     </remarks>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -149,7 +149,7 @@
             <rng:param name="minExclusive">0</rng:param>
           </rng:data>
         </datatype>
-        <remarks>
+        <remarks xml:lang="en">
           <p>This attribute is ignored if the value of the style attribute is <val>mensur</val>.</p>
         </remarks>
       </attDef>
@@ -164,7 +164,7 @@
         <datatype>
           <rng:ref name="data.STAFFLOC"/>
         </datatype>
-        <remarks>
+        <remarks xml:lang="en">
           <p>The location may include staff lines, the spaces between the lines, and the spaces
             directly above and below the staff. The value ranges between 0 (just below the staff) to
             2 * number of staff lines (directly above the staff). For example, on a 5-line staff the
@@ -503,7 +503,7 @@
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>
-    <remarks>
+    <remarks xml:lang="en">
       <p>If <att>tstamp2</att> is not provided, then the extender should be drawn based on the value
         of <att>tstamp2</att> on the harm ancestor.</p>
     </remarks>
@@ -559,7 +559,7 @@
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>
-    <remarks>
+    <remarks xml:lang="en">
       <p>If <att>tstamp2</att> is not provided, then the extender should be drawn based on the value
         of <att>tstamp2</att> on a fingering ancestor.</p>
     </remarks>
@@ -1619,7 +1619,7 @@
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.COLOR"/>
         </datatype>
-        <remarks>
+        <remarks xml:lang="en">
           <p>The value is structured; that is, it should contain a single color value or have 
             the same number of space-separated values as the number of lines indicated by the
             lines attribute. The first value then applies to the lowest line of the staff.</p>
@@ -1657,7 +1657,7 @@
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
-        <remarks>
+        <remarks xml:lang="en">
           <p>This attribute is ignored when the <att>bar.method</att> attribute’s value is <val>mensur</val> 
             or <val>takt</val>.</p>
         </remarks>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -5,10 +5,10 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI.visual">
   <moduleSpec ident="MEI.visual">
-    <desc>Visual component declarations.</desc>
+    <desc xml:lang="en">Visual component declarations.</desc>
   </moduleSpec>
   <classSpec ident="att.accid.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -25,7 +25,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.ambNote.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.enclosingChars"/>
@@ -36,10 +36,10 @@
     </classes>
   </classSpec>
   <classSpec ident="att.annot.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <attList>
       <attDef ident="place" usage="opt">
-        <desc>Location of the annotation.</desc>
+        <desc xml:lang="en">Location of the annotation.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.PLACEMENT"/>
         </datatype>
@@ -47,7 +47,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.arpeg.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -59,43 +59,43 @@
     </classes>
     <attList>
       <attDef ident="arrow" usage="opt">
-        <desc>Indicates if an arrowhead is to be drawn as part of the arpeggiation symbol.</desc>
+        <desc xml:lang="en">Indicates if an arrowhead is to be drawn as part of the arpeggiation symbol.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
       </attDef>
       <attDef ident="arrow.shape" usage="opt">
-        <desc>Symbol rendered at end of the line.</desc>
+        <desc xml:lang="en">Symbol rendered at end of the line.</desc>
         <datatype>
           <rng:ref name="data.LINESTARTENDSYMBOL"/>
         </datatype>
       </attDef>
       <attDef ident="arrow.size" usage="opt">
-        <desc>Holds the relative size of the arrow symbol.</desc>
+        <desc xml:lang="en">Holds the relative size of the arrow symbol.</desc>
         <datatype>
           <rng:ref name="data.FONTSIZESCALE"/>
         </datatype>
       </attDef>
       <attDef ident="arrow.color" usage="opt">
-        <desc>Captures the overall color of the arrow.</desc>
+        <desc xml:lang="en">Captures the overall color of the arrow.</desc>
         <datatype>
           <rng:ref name="data.COLOR"/>
         </datatype>
       </attDef>
       <attDef ident="arrow.fillcolor" usage="opt">
-        <desc>Captures the fill color of the arrow if different from the line color.</desc>
+        <desc xml:lang="en">Captures the fill color of the arrow if different from the line color.</desc>
         <datatype>
           <rng:ref name="data.COLOR"/>
         </datatype>
       </attDef>
       <attDef ident="line.form" usage="opt">
-        <desc>Visual form of the line.</desc>
+        <desc xml:lang="en">Visual form of the line.</desc>
         <datatype>
           <rng:ref name="data.LINEFORM"/>
         </datatype>
       </attDef>
       <attDef ident="line.width" usage="opt">
-        <desc>Width of the line.</desc>
+        <desc xml:lang="en">Width of the line.</desc>
         <datatype>
           <rng:ref name="data.LINEWIDTH"/>
         </datatype>
@@ -103,7 +103,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.artic.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -119,7 +119,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.attacca.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
@@ -131,7 +131,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.barLine.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -141,7 +141,7 @@
     </classes>
     <attList>
       <attDef ident="len" usage="opt">
-        <desc>States the length of barlines in virtual units. The value must be greater than 0 and
+        <desc xml:lang="en">States the length of barlines in virtual units. The value must be greater than 0 and
           is typically equal to 2 times (the number of staff lines - 1); <abbr>e.g.</abbr>, a value of <val>8</val> for a
           5-line staff.</desc>
         <datatype>
@@ -154,13 +154,13 @@
         </remarks>
       </attDef>
       <attDef ident="method" usage="opt">
-        <desc>Records the method of barring.</desc>
+        <desc xml:lang="en">Records the method of barring.</desc>
         <datatype>
           <rng:ref name="data.BARMETHOD"/>
         </datatype>
       </attDef>
       <attDef ident="place" usage="opt">
-        <desc>Denotes the staff location of the bar line if its length is non-standard.</desc>
+        <desc xml:lang="en">Denotes the staff location of the bar line if its length is non-standard.</desc>
         <datatype>
           <rng:ref name="data.STAFFLOC"/>
         </datatype>
@@ -176,7 +176,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.beam.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.cue"/>
@@ -185,31 +185,31 @@
     </classes>
   </classSpec>
   <classSpec ident="att.beaming.vis" module="MEI.visual" type="atts">
-    <desc>Used by layerDef, staffDef, and scoreDef to provide default values for attributes in the
+    <desc xml:lang="en">Used by layerDef, staffDef, and scoreDef to provide default values for attributes in the
       visual domain related to beaming.</desc>
     <attList>
       <attDef ident="beam.color" usage="opt">
-        <desc>Color of beams, including those associated with tuplets.</desc>
+        <desc xml:lang="en">Color of beams, including those associated with tuplets.</desc>
         <datatype>
           <rng:ref name="data.COLOR"/>
         </datatype>
       </attDef>
       <attDef ident="beam.rend" usage="opt">
-        <desc>Encodes whether a beam is "feathered" and in which direction.</desc>
+        <desc xml:lang="en">Encodes whether a beam is "feathered" and in which direction.</desc>
         <valList type="closed">
           <valItem ident="acc">
-            <desc>Beam lines grow farther apart from left to right.</desc>
+            <desc xml:lang="en">Beam lines grow farther apart from left to right.</desc>
           </valItem>
           <valItem ident="rit">
-            <desc>Beam lines grow closer together from left to right.</desc>
+            <desc xml:lang="en">Beam lines grow closer together from left to right.</desc>
           </valItem>
           <valItem ident="norm">
-            <desc>Beam lines are equally-spaced over the entire length of the beam.</desc>
+            <desc xml:lang="en">Beam lines are equally-spaced over the entire length of the beam.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="beam.slope" usage="opt">
-        <desc>Captures beam slope.</desc>
+        <desc xml:lang="en">Captures beam slope.</desc>
         <datatype>
           <rng:data type="decimal"/>
         </datatype>
@@ -217,13 +217,13 @@
     </attList>
   </classSpec>
   <classSpec ident="att.beamSpan.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.beam.vis"/>
     </classes>
   </classSpec>
   <classSpec ident="att.beatRpt.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -233,7 +233,7 @@
     </classes>
     <attList>
       <attDef ident="slash" usage="req">
-        <desc>Indicates the number of slashes required to render the appropriate beat repeat symbol.
+        <desc xml:lang="en">Indicates the number of slashes required to render the appropriate beat repeat symbol.
           When a single beat consisting of a single note or chord is repeated, the repetition symbol
           is a single thick, slanting slash; therefore, the value <val>1</val> should be used. When the beat
           is divided into even notes, the following values should be used: 4ths or 8ths=1, 16ths=2,
@@ -246,7 +246,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.bend.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes. If the bulge or bezier attributes are present, the bend should
+    <desc xml:lang="en">Visual domain attributes. If the bulge or bezier attributes are present, the bend should
       be rendered as a curve. Otherwise, it should be rendered using lines. The ho and vo attributes
       describe the visual offset of the entire rendered bend. The endho, endvo and startho, startvo
       attribute pairs may be used to encode start and end points relative to their programmatic
@@ -263,7 +263,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.bracketSpan.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -277,7 +277,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.breath.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -291,13 +291,13 @@
     </classes>
   </classSpec>
   <classSpec ident="att.bTrem.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.numberPlacement"/>
     </classes>
   </classSpec>
   <classSpec ident="att.caesura.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -311,7 +311,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.chord.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes for chord. The slur, slur.dir, slur.rend, tie, tie.dir, and
+    <desc xml:lang="en">Visual domain attributes for chord. The slur, slur.dir, slur.rend, tie, tie.dir, and
       tie.rend attributes here are syntactic sugar for these attributes on each of the chord's
       individual notes. The values here apply to all the notes in the chord. If some notes are
       slurred or tied while others aren't, then the individual note attributes must be used.</desc>
@@ -330,7 +330,7 @@
     </classes>
     <attList>
       <attDef ident="cluster" usage="opt">
-        <desc>Indicates a single, alternative note head should be displayed instead of individual
+        <desc xml:lang="en">Indicates a single, alternative note head should be displayed instead of individual
           note heads. The highest and lowest notes of the chord usually indicate the upper and lower
           boundaries of the cluster note head.</desc>
         <datatype>
@@ -340,13 +340,13 @@
     </attList>
   </classSpec>
   <classSpec ident="att.chordDef.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.chordMember.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.clef.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -358,17 +358,17 @@
     </classes>
   </classSpec>
   <classSpec ident="att.cleffing.vis" module="MEI.visual" type="atts">
-    <desc>Used by staffDef and scoreDef to provide default values for attributes in the visual
+    <desc xml:lang="en">Used by staffDef and scoreDef to provide default values for attributes in the visual
       domain related to clefs.</desc>
     <attList>
       <attDef ident="clef.color" usage="opt">
-        <desc>Describes the color of the clef.</desc>
+        <desc xml:lang="en">Describes the color of the clef.</desc>
         <datatype>
           <rng:ref name="data.COLOR"/>
         </datatype>
       </attDef>
       <attDef ident="clef.visible" usage="opt">
-        <desc>Determines whether the clef is to be displayed.</desc>
+        <desc xml:lang="en">Determines whether the clef is to be displayed.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
@@ -376,10 +376,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.clefGrp.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.cpMark.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -392,7 +392,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.curve.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.curvature"/>
@@ -404,7 +404,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.custos.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -414,10 +414,10 @@
     </classes>
   </classSpec>
   <classSpec ident="att.mdiv.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.dir.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
@@ -429,7 +429,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.dot.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -443,7 +443,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.dynam.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
@@ -455,13 +455,13 @@
     </classes>
   </classSpec>
   <classSpec ident="att.ending.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.lineRend"/>
     </classes>
   </classSpec>
   <classSpec ident="att.episema.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -478,15 +478,15 @@
       <attDef ident="form" usage="rec">
         <valList type="closed">
           <valItem ident="h">
-            <desc>Horizontal stroke.</desc>
+            <desc xml:lang="en">Horizontal stroke.</desc>
           </valItem>
           <valItem ident="v">
-            <desc>Vertical stroke.</desc>
+            <desc xml:lang="en">Vertical stroke.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="place" usage="rec">
-        <desc>Captures the placement of the episema with respect to the neume or neume component
+        <desc xml:lang="en">Captures the placement of the episema with respect to the neume or neume component
           with which it is associated.</desc>
         <datatype>
           <rng:ref name="data.EVENTREL"/>
@@ -495,7 +495,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.f.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.extender"/>
@@ -509,7 +509,7 @@
     </remarks>
   </classSpec>
   <classSpec ident="att.fermata.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -522,36 +522,36 @@
     </classes>
     <attList>
       <attDef ident="form" usage="opt">
-        <desc>Describes the visual appearance of the fermata; that is, whether it occurs as upright
+        <desc xml:lang="en">Describes the visual appearance of the fermata; that is, whether it occurs as upright
           or inverted.</desc>
         <valList type="closed">
           <valItem ident="inv">
-            <desc>Inverted, <abbr>i.e.</abbr>, curve or bracket below the dot.</desc>
+            <desc xml:lang="en">Inverted, <abbr>i.e.</abbr>, curve or bracket below the dot.</desc>
           </valItem>
           <valItem ident="norm">
-            <desc>Upright; <abbr>i.e.</abbr>, curve or bracket above the dot.</desc>
+            <desc xml:lang="en">Upright; <abbr>i.e.</abbr>, curve or bracket above the dot.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="shape" usage="opt">
-        <desc>Describes the visual appearance of the fermata; that is, whether it has a curved,
+        <desc xml:lang="en">Describes the visual appearance of the fermata; that is, whether it has a curved,
           square, or angular shape.</desc>
         <valList type="closed">
           <valItem ident="curved">
-            <desc>A curve above or below the dot.</desc>
+            <desc xml:lang="en">A curve above or below the dot.</desc>
           </valItem>
           <valItem ident="square">
-            <desc>A bracket above or below the dot.</desc>
+            <desc xml:lang="en">A bracket above or below the dot.</desc>
           </valItem>
           <valItem ident="angular">
-            <desc>A triangle above or below the dot.</desc>
+            <desc xml:lang="en">A triangle above or below the dot.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.fing.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.extender"/>
@@ -565,7 +565,7 @@
     </remarks>
   </classSpec>
   <classSpec ident="att.fingGrp.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.extender"/>
@@ -577,20 +577,20 @@
       <attDef ident="orient" usage="opt">
         <valList type="closed">
           <valItem ident="horiz">
-            <desc>Combination expressed horizontally, as for brass instruments.</desc>
+            <desc xml:lang="en">Combination expressed horizontally, as for brass instruments.</desc>
           </valItem>
           <valItem ident="vert">
-            <desc>Combination expressed vertically, as for woodwind instruments or piano.</desc>
+            <desc xml:lang="en">Combination expressed vertically, as for woodwind instruments or piano.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.fTrem.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <attList>
       <attDef ident="beams" usage="opt">
-        <desc>Indicates the number of beams present.</desc>
+        <desc xml:lang="en">Indicates the number of beams present.</desc>
         <datatype>
           <rng:data type="positiveInteger">
             <rng:param name="minInclusive">1</rng:param>
@@ -599,7 +599,7 @@
         </datatype>
       </attDef>
       <attDef ident="beams.float" usage="opt">
-        <desc>Captures the number of "floating" beams, <abbr>i.e.</abbr>, those not attached to stems.</desc>
+        <desc xml:lang="en">Captures the number of "floating" beams, <abbr>i.e.</abbr>, those not attached to stems.</desc>
         <datatype>
           <rng:data type="nonNegativeInteger"/>
         </datatype>
@@ -613,7 +613,7 @@
         </constraintSpec>
       </attDef>
       <attDef ident="float.gap" usage="opt">
-        <desc>Records the amount of separation between floating beams and stems.</desc>
+        <desc xml:lang="en">Records the amount of separation between floating beams and stems.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTABS"/>
         </datatype>
@@ -621,7 +621,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.gliss.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -635,7 +635,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.grpSym.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -646,7 +646,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.hairpin.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes. The startho and startvo attributes record the horizontal and
+    <desc xml:lang="en">Visual domain attributes. The startho and startvo attributes record the horizontal and
       vertical offsets of the left end, endho and endvo record the horizontal and vertical offsets
       of the right end, and the opening attribute records the width of the opening in staff
       inter-line units. The x and y attributes give the absolute coordinates of the left end point,
@@ -666,7 +666,7 @@
     </classes>
     <attList>
       <attDef ident="opening" usage="opt">
-        <desc>Specifies the distance between the lines at the open end of a hairpin dynamic
+        <desc xml:lang="en">Specifies the distance between the lines at the open end of a hairpin dynamic
           mark.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTABS"/>
@@ -675,7 +675,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.halfmRpt.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -686,7 +686,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.harm.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
@@ -697,23 +697,23 @@
     </classes>
     <attList>
       <attDef ident="rendgrid" usage="opt">
-        <desc>Describes how the harmonic indication should be rendered.</desc>
+        <desc xml:lang="en">Describes how the harmonic indication should be rendered.</desc>
         <valList type="closed">
           <valItem ident="grid">
-            <desc>Chord tablature grid.</desc>
+            <desc xml:lang="en">Chord tablature grid.</desc>
           </valItem>
           <valItem ident="gridtext">
-            <desc>Chord tablature grid and the element’s textual content.</desc>
+            <desc xml:lang="en">Chord tablature grid and the element’s textual content.</desc>
           </valItem>
           <valItem ident="text">
-            <desc>Textual content of the element.</desc>
+            <desc xml:lang="en">Textual content of the element.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.harpPedal.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -725,7 +725,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.hispanTick.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -739,14 +739,14 @@
     </classes>
     <attList>
       <attDef ident="place" usage="rec">
-        <desc>Captures the placement of the tick mark with respect to the neume or neume component
+        <desc xml:lang="en">Captures the placement of the tick mark with respect to the neume or neume component
           with which it is associated.</desc>
         <datatype>
           <rng:ref name="data.EVENTREL"/>
         </datatype>
       </attDef>
       <attDef ident="tilt" usage="rec">
-        <desc>Direction toward which the mark points.</desc>
+        <desc xml:lang="en">Direction toward which the mark points.</desc>
         <datatype>
           <rng:ref name="data.COMPASSDIRECTION"/>
         </datatype>
@@ -754,10 +754,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.instrDef.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.keyAccid.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -769,14 +769,14 @@
     </classes>
   </classSpec>
   <classSpec ident="att.keySig.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.visibility"/>
     </classes>
     <attList>
       <attDef ident="sig.showchange" usage="opt">
-        <desc>Determines whether cautionary accidentals should be displayed at a key change.</desc>
+        <desc xml:lang="en">Determines whether cautionary accidentals should be displayed at a key change.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
@@ -784,17 +784,17 @@
     </attList>
   </classSpec>
   <classSpec ident="att.keySigDefault.vis" module="MEI.visual" type="atts">
-    <desc>Used by staffDef and scoreDef to provide default values for attributes in the visual
+    <desc xml:lang="en">Used by staffDef and scoreDef to provide default values for attributes in the visual
       domain related to key signatures.</desc>
     <attList>
       <attDef ident="keysig.show" usage="opt">
-        <desc>Indicates whether the key signature should be displayed.</desc>
+        <desc xml:lang="en">Indicates whether the key signature should be displayed.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
       </attDef>
       <attDef ident="keysig.showchange" usage="opt">
-        <desc>Determines whether cautionary accidentals should be displayed at a key change.</desc>
+        <desc xml:lang="en">Determines whether cautionary accidentals should be displayed at a key change.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
@@ -802,13 +802,13 @@
     </attList>
   </classSpec>
   <classSpec ident="att.layer.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.visibility"/>
     </classes>
   </classSpec>
   <classSpec ident="att.layerDef.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.beaming.vis"/>
       <memberOf key="att.textStyle"/>
@@ -816,13 +816,13 @@
     </classes>
   </classSpec>
   <classSpec ident="att.ligature.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
     </classes>
     <attList>
       <attDef ident="form" usage="opt">
-        <desc>Provides an indication of the function of the ligature.</desc>
+        <desc xml:lang="en">Provides an indication of the function of the ligature.</desc>
         <datatype>
           <rng:ref name="data.LIGATUREFORM"/>
         </datatype>
@@ -830,7 +830,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.line.vis" module="MEI.visual" type="atts">
-    <desc>Attributes for describing the visual appearance of a line.</desc>
+    <desc xml:lang="en">Attributes for describing the visual appearance of a line.</desc>
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.placementRelStaff"/>
@@ -841,7 +841,7 @@
     </classes>
     <attList>
       <attDef ident="form" usage="opt">
-        <desc>Visual form of the line.</desc>
+        <desc xml:lang="en">Visual form of the line.</desc>
         <datatype>
           <rng:ref name="data.LINEFORM"/>
         </datatype>
@@ -852,27 +852,27 @@
           @length redundant.
         -->
       <attDef ident="width" usage="opt">
-        <desc>Width of the line.</desc>
+        <desc xml:lang="en">Width of the line.</desc>
         <datatype>
           <rng:ref name="data.LINEWIDTH"/>
         </datatype>
       </attDef>
       <!-- additional visual characteristics of the line -->
       <attDef ident="endsym" usage="opt">
-        <desc>Symbol rendered at end of line.</desc>
+        <desc xml:lang="en">Symbol rendered at end of line.</desc>
         <datatype>
           <rng:ref name="data.LINESTARTENDSYMBOL"/>
         </datatype>
       </attDef>
       <attDef ident="endsym.size" usage="opt">
-        <desc>Holds the relative size of the line-end symbol.</desc>
+        <desc xml:lang="en">Holds the relative size of the line-end symbol.</desc>
         <datatype>
           <rng:ref name="data.FONTSIZESCALE"/>
         </datatype>
       </attDef>
       <!-- Possible addition:
           <attDef ident="segments" usage="opt">
-            <desc>Stores the number of segments used to render a dashed, dotted, or wavy
+            <desc xml:lang="en">Stores the number of segments used to render a dashed, dotted, or wavy
               line.</desc>
             <datatype>
               <rng:data type="positiveInteger"/>
@@ -880,20 +880,20 @@
           </attDef>
         -->
       <attDef ident="startsym" usage="opt">
-        <desc>Symbol rendered at start of line.</desc>
+        <desc xml:lang="en">Symbol rendered at start of line.</desc>
         <datatype>
           <rng:ref name="data.LINESTARTENDSYMBOL"/>
         </datatype>
       </attDef>
       <attDef ident="startsym.size" usage="opt">
-        <desc>Holds the relative size of the line-start symbol.</desc>
+        <desc xml:lang="en">Holds the relative size of the line-start symbol.</desc>
         <datatype>
           <rng:ref name="data.FONTSIZESCALE"/>
         </datatype>
       </attDef>
       <!-- Possible addition:
           <attDef ident="waveheight" usage="opt">
-            <desc>Captures the wave height of a wavy line.</desc>
+            <desc xml:lang="en">Captures the wave height of a wavy line.</desc>
             <datatype>
               <rng:ref name="data.MEASUREMENT"/>
             </datatype>
@@ -902,7 +902,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.liquescent.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -916,18 +916,18 @@
     </classes>
     <attList>
       <attDef ident="curve" usage="opt">
-        <desc>Records direction of curvature.</desc>
+        <desc xml:lang="en">Records direction of curvature.</desc>
         <valList type="closed">
           <valItem ident="a">
-            <desc>Anti-clockwise curvature.</desc>
+            <desc xml:lang="en">Anti-clockwise curvature.</desc>
           </valItem>
           <valItem ident="c">
-            <desc>Clockwise curvature.</desc>
+            <desc xml:lang="en">Clockwise curvature.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="looped" usage="opt">
-        <desc>Indicates whether curve is closed.</desc>
+        <desc xml:lang="en">Indicates whether curve is closed.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
@@ -935,7 +935,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.lv.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes. The vo attribute is the vertical offset (from its normal
+    <desc xml:lang="en">Visual domain attributes. The vo attribute is the vertical offset (from its normal
       position) of the entire rendered tie. The startho, startvo, endho, and endvo attributes
       describe the horizontal and vertical offsets of the start and end points of the sign in terms
       of staff interline distance; that is, in units of 1/2 the distance between adjacent staff
@@ -952,21 +952,21 @@
     </classes>
   </classSpec>
   <classSpec ident="att.lyrics.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.typography"/>
     </classes>
   </classSpec>
   <classSpec ident="att.measure.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.barring"/>
       <memberOf key="att.width"/>
     </classes>
   </classSpec>
   <classSpec ident="att.mensur.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes. These attributes describe the physical appearance of the
+    <desc xml:lang="en">Visual domain attributes. These attributes describe the physical appearance of the
       mensuration sign/time signature of mensural notation.</desc>
     <classes>
       <memberOf key="att.altSym"/>
@@ -978,30 +978,30 @@
     </classes>
     <attList>
       <attDef ident="dot" usage="opt">
-        <desc>Specifies whether a dot is to be added to the base symbol.</desc>
+        <desc xml:lang="en">Specifies whether a dot is to be added to the base symbol.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
       </attDef>
       <attDef ident="form" usage="opt">
-        <desc>Indicates whether the base symbol is written vertically or horizontally.</desc>
+        <desc xml:lang="en">Indicates whether the base symbol is written vertically or horizontally.</desc>
         <valList type="closed">
           <valItem ident="horizontal">
-            <desc>Horizontally oriented.</desc>
+            <desc xml:lang="en">Horizontally oriented.</desc>
           </valItem>
           <valItem ident="vertical">
-            <desc>Vertically oriented.</desc>
+            <desc xml:lang="en">Vertically oriented.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="orient" usage="opt">
-        <desc>Describes the rotation or reflection of the base symbol.</desc>
+        <desc xml:lang="en">Describes the rotation or reflection of the base symbol.</desc>
         <datatype>
           <rng:ref name="data.ORIENTATION"/>
         </datatype>
       </attDef>
       <attDef ident="sign" usage="opt">
-        <desc>The base symbol in the mensuration sign/time signature of mensural notation.</desc>
+        <desc xml:lang="en">The base symbol in the mensuration sign/time signature of mensural notation.</desc>
         <datatype>
           <rng:ref name="data.MENSURATIONSIGN"/>
         </datatype>
@@ -1009,59 +1009,59 @@
     </attList>
   </classSpec>
   <classSpec ident="att.mensural.vis" module="MEI.visual" type="atts">
-    <desc>Used by staffDef and scoreDef to provide default values for attributes in the visual
+    <desc xml:lang="en">Used by staffDef and scoreDef to provide default values for attributes in the visual
       domain related to mensuration.</desc>
     <attList>
       <attDef ident="mensur.color" usage="opt">
-        <desc>Records the color of the mensuration sign. Do not confuse this with the musical term
+        <desc xml:lang="en">Records the color of the mensuration sign. Do not confuse this with the musical term
           'color' as used in pre-CMN notation.</desc>
         <datatype>
           <rng:ref name="data.COLOR"/>
         </datatype>
       </attDef>
       <attDef ident="mensur.dot" usage="opt">
-        <desc>Determines if a dot is to be added to the base symbol.</desc>
+        <desc xml:lang="en">Determines if a dot is to be added to the base symbol.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
       </attDef>
       <attDef ident="mensur.form" usage="opt">
-        <desc>Indicates whether the base symbol is written vertically or horizontally.</desc>
+        <desc xml:lang="en">Indicates whether the base symbol is written vertically or horizontally.</desc>
         <valList type="closed">
           <valItem ident="horizontal">
-            <desc>Horizontally oriented.</desc>
+            <desc xml:lang="en">Horizontally oriented.</desc>
           </valItem>
           <valItem ident="vertical">
-            <desc>Vertically oriented.</desc>
+            <desc xml:lang="en">Vertically oriented.</desc>
           </valItem>
         </valList>
       </attDef>
       <attDef ident="mensur.loc" usage="opt">
-        <desc>Holds the staff location of the mensuration sign.</desc>
+        <desc xml:lang="en">Holds the staff location of the mensuration sign.</desc>
         <datatype>
           <rng:ref name="data.STAFFLOC"/>
         </datatype>
       </attDef>
       <attDef ident="mensur.orient" usage="opt">
-        <desc>Describes the rotation or reflection of the base symbol.</desc>
+        <desc xml:lang="en">Describes the rotation or reflection of the base symbol.</desc>
         <datatype>
           <rng:ref name="data.ORIENTATION"/>
         </datatype>
       </attDef>
       <attDef ident="mensur.sign" usage="opt">
-        <desc>The base symbol in the mensuration sign/time signature of mensural notation.</desc>
+        <desc xml:lang="en">The base symbol in the mensuration sign/time signature of mensural notation.</desc>
         <datatype>
           <rng:ref name="data.MENSURATIONSIGN"/>
         </datatype>
       </attDef>
       <attDef ident="mensur.size" usage="opt">
-        <desc>Describes the relative size of the mensuration sign.</desc>
+        <desc xml:lang="en">Describes the relative size of the mensuration sign.</desc>
         <datatype>
           <rng:ref name="data.FONTSIZE"/>
         </datatype>
       </attDef>
       <attDef ident="mensur.slash" usage="opt">
-        <desc>Indicates the number lines added to the mensuration sign. For example, one slash is
+        <desc xml:lang="en">Indicates the number lines added to the mensuration sign. For example, one slash is
           added for what we now call 'alla breve'.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
@@ -1070,7 +1070,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.meterSig.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1080,7 +1080,7 @@
     </classes>
     <attList>
       <attDef ident="form" usage="opt">
-        <desc>Contains an indication of how the meter signature should be rendered.</desc>
+        <desc xml:lang="en">Contains an indication of how the meter signature should be rendered.</desc>
         <datatype>
           <rng:ref name="data.METERFORM"/>
         </datatype>
@@ -1088,17 +1088,17 @@
     </attList>
   </classSpec>
   <classSpec ident="att.meterSigDefault.vis" module="MEI.visual" type="atts">
-    <desc>Used by staffDef and scoreDef to provide default values for attributes in the visual
+    <desc xml:lang="en">Used by staffDef and scoreDef to provide default values for attributes in the visual
       domain related to meter signature.</desc>
     <attList>
       <attDef ident="meter.form" usage="opt">
-        <desc>Contains an indication of how the meter signature should be rendered.</desc>
+        <desc xml:lang="en">Contains an indication of how the meter signature should be rendered.</desc>
         <datatype>
           <rng:ref name="data.METERFORM"/>
         </datatype>
       </attDef>
       <attDef ident="meter.showchange" usage="opt">
-        <desc>Determines whether the old meter signature should be displayed when the meter
+        <desc xml:lang="en">Determines whether the old meter signature should be displayed when the meter
           signature changes.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
@@ -1107,10 +1107,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.meterSigGrp.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.mordent.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1122,7 +1122,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.mRest.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1137,7 +1137,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.mRpt.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1148,7 +1148,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.mRpt2.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1158,7 +1158,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.mSpace.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.cutout"/>
@@ -1166,7 +1166,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.multiRest.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1179,7 +1179,7 @@
     </classes>
     <attList>
       <attDef ident="block" usage="opt">
-        <desc>The block attribute controls whether the multimeasure rest should be rendered as a block rest 
+        <desc xml:lang="en">The block attribute controls whether the multimeasure rest should be rendered as a block rest 
           or as church rests ("Kirchenpausen"), that are combinations of longa, breve and semibreve rests.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
@@ -1188,7 +1188,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.multiRpt.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1198,7 +1198,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.nc.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1212,7 +1212,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.ncGrp.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.staffLoc"/>
@@ -1223,7 +1223,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.neume.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1237,7 +1237,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.note.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1256,7 +1256,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.octave.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.extender"/>
@@ -1267,7 +1267,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.oriscus.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1281,7 +1281,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.ornam.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1294,36 +1294,36 @@
     </classes>
   </classSpec>
   <classSpec ident="att.ossia.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.pad.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.part.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.parts.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.pb.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <attList>
       <attDef ident="folium" usage="opt">
-        <desc>States the side of a leaf (as in a manuscript) on which the content following the <gi
+        <desc xml:lang="en">States the side of a leaf (as in a manuscript) on which the content following the <gi
           scheme="MEI">pb</gi> element occurs.</desc>
         <valList type="closed">
           <valItem ident="verso">
-            <desc>The back of a manuscript page.</desc>
+            <desc xml:lang="en">The back of a manuscript page.</desc>
           </valItem>
           <valItem ident="recto">
-            <desc>The front of a manuscript page.</desc>
+            <desc xml:lang="en">The front of a manuscript page.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.pedal.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes. The place attribute captures the placement of the pedal marking
+    <desc xml:lang="en">Visual domain attributes. The place attribute captures the placement of the pedal marking
       with respect to the staff with which it is associated. Modern publishing standards require the
       place to be <val>below</val>; however, for transcriptions of manuscript works, this attribute class
       allows the full range of values.</desc>
@@ -1340,18 +1340,18 @@
     </classes>
     <attList>
       <attDef ident="form" usage="opt">
-        <desc>Determines whether piano pedal marks should be rendered as lines or as terms.</desc>
+        <desc xml:lang="en">Determines whether piano pedal marks should be rendered as lines or as terms.</desc>
         <valList type="closed">
           <valItem ident="line">
-            <desc>Continuous line with start and end positions rendered by vertical bars and bounces
+            <desc xml:lang="en">Continuous line with start and end positions rendered by vertical bars and bounces
               shown by upward-pointing "blips".</desc>
           </valItem>
           <valItem ident="pedstar">
-            <desc>Pedal down and half pedal rendered with "Ped.", pedal up rendered by "*", pedal
+            <desc xml:lang="en">Pedal down and half pedal rendered with "Ped.", pedal up rendered by "*", pedal
               "bounce" rendered with "* Ped.".</desc>
           </valItem>
           <valItem ident="altpedstar">
-            <desc>Pedal up and down indications same as with "pedstar", but bounce is rendered with
+            <desc xml:lang="en">Pedal up and down indications same as with "pedstar", but bounce is rendered with
               "Ped." only.</desc>
           </valItem>
         </valList>
@@ -1359,7 +1359,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.phrase.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.visualOffset"/>
@@ -1370,7 +1370,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.proport.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1380,7 +1380,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.quilisma.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1394,7 +1394,7 @@
     </classes>
     <attList>
       <attDef ident="waves" usage="opt">
-        <desc>Number of "crests" of a wavy line.</desc>
+        <desc xml:lang="en">Number of "crests" of a wavy line.</desc>
         <datatype>
           <rng:data type="positiveInteger">
             <rng:param name="minInclusive">2</rng:param>
@@ -1405,10 +1405,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.rdg.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.refrain.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.placementRelStaff"/>
@@ -1420,7 +1420,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.reh.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.placementRelStaff"/>
@@ -1430,7 +1430,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.rest.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1446,7 +1446,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.sb.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.extSym"/>
@@ -1454,21 +1454,21 @@
     </classes>
     <attList>
       <attDef ident="form" usage="opt">
-        <desc>Indicates whether hash marks should be rendered between systems. See Read, p. 436, ex.
+        <desc xml:lang="en">Indicates whether hash marks should be rendered between systems. See Read, p. 436, ex.
           26-3.</desc>
         <valList type="closed">
           <valItem ident="hash">
-            <desc>Display hash marks between systems.</desc>
+            <desc xml:lang="en">Display hash marks between systems.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.score.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.scoreDef.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes for scoreDef in the CMN repertoire.</desc>
+    <desc xml:lang="en">Visual domain attributes for scoreDef in the CMN repertoire.</desc>
     <classes>
       <memberOf key="att.barring"/>
       <memberOf key="att.cleffing.vis"/>
@@ -1492,7 +1492,7 @@
     </classes>
     <attList>
       <attDef ident="vu.height" usage="opt">
-        <desc>Defines the height of a "virtual unit" (vu) in terms of real-world units. A single vu
+        <desc xml:lang="en">Defines the height of a "virtual unit" (vu) in terms of real-world units. A single vu
           is half the distance between adjacent staff lines where the interline space is measured 
           from the middle of a staff line.</desc>
         <datatype>
@@ -1505,10 +1505,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.section.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <attList>
       <attDef ident="restart" usage="opt">
-        <desc>Indicates that staves begin again with this section.</desc>
+        <desc xml:lang="en">Indicates that staves begin again with this section.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
@@ -1516,7 +1516,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.signifLet.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1530,7 +1530,7 @@
     </classes>
     <attList>
       <attDef ident="place" usage="rec">
-        <desc>Captures the placement of the sequence of characters with respect to the neume or
+        <desc xml:lang="en">Captures the placement of the sequence of characters with respect to the neume or
           neume component with which it is associated.</desc>
         <datatype>
           <rng:ref name="data.EVENTREL"/>
@@ -1539,7 +1539,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.slur.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes for slur. The vo attribute is the vertical offset (from its
+    <desc xml:lang="en">Visual domain attributes for slur. The vo attribute is the vertical offset (from its
       normal position) of the entire rendered slur/phrase mark.</desc>
     <classes>
       <memberOf key="att.color"/>
@@ -1552,7 +1552,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.sp.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.visualOffset"/>
@@ -1562,13 +1562,13 @@
     </classes>
   </classSpec>
   <classSpec ident="att.space.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.cutout"/>
     </classes>
     <attList>
       <attDef ident="compressable" usage="opt">
-        <desc>Indicates whether a space is 'compressible', <abbr>i.e.</abbr>, if it may be removed at the
+        <desc xml:lang="en">Indicates whether a space is 'compressible', <abbr>i.e.</abbr>, if it may be removed at the
           discretion of processing software.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
@@ -1577,13 +1577,13 @@
     </attList>
   </classSpec>
   <classSpec ident="att.staff.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.visibility"/>
     </classes>
   </classSpec>
   <classSpec ident="att.staffDef.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes for staffDef.</desc>
+    <desc xml:lang="en">Visual domain attributes for staffDef.</desc>
     <classes>
       <memberOf key="att.barring"/>
       <memberOf key="att.cleffing.vis"/>
@@ -1603,19 +1603,19 @@
     </classes>
     <attList>
       <attDef ident="grid.show" usage="opt">
-        <desc>Determines whether to display guitar chord grids.</desc>
+        <desc xml:lang="en">Determines whether to display guitar chord grids.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
       </attDef>
       <attDef ident="layerscheme" usage="opt">
-        <desc>Indicates the number of layers and their stem directions.</desc>
+        <desc xml:lang="en">Indicates the number of layers and their stem directions.</desc>
         <datatype>
           <rng:ref name="data.LAYERSCHEME"/>
         </datatype>
       </attDef>
       <attDef ident="lines.color" usage="opt">
-        <desc>Captures the colors of the staff lines.</desc>
+        <desc xml:lang="en">Captures the colors of the staff lines.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.COLOR"/>
         </datatype>
@@ -1627,13 +1627,13 @@
         </remarks>
       </attDef>
       <attDef ident="lines.visible" usage="opt">
-        <desc>Records whether all staff lines are visible.</desc>
+        <desc xml:lang="en">Records whether all staff lines are visible.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
       </attDef>
       <attDef ident="spacing" usage="opt">
-        <desc>Records the absolute distance (as opposed to the relative distances recorded in <gi
+        <desc xml:lang="en">Records the absolute distance (as opposed to the relative distances recorded in <gi
           scheme="MEI">scoreDef</gi> elements) between this staff and the preceding one in the same
           system. This value is meaningless for the first staff in a system since the spacing.system
           attribute indicates the spacing between systems.</desc>
@@ -1644,7 +1644,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.staffGrp.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.barring"/>
       <memberOf key="att.staffGroupingSym"/>
@@ -1652,7 +1652,7 @@
     </classes>
     <attList>
       <attDef ident="bar.thru" usage="opt">
-        <desc>Indicates whether bar lines go across the space between staves (true) or are only
+        <desc xml:lang="en">Indicates whether bar lines go across the space between staves (true) or are only
           drawn across the lines of each staff (false).</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
@@ -1665,7 +1665,7 @@
     </attList>
   </classSpec>
   <classSpec ident="att.stageDir.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.visualOffset"/>
@@ -1675,7 +1675,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.strophicus.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1689,7 +1689,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.syl.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.typography"/>
@@ -1710,10 +1710,10 @@
       </constraintSpec> -->
   </classSpec>
   <classSpec ident="att.syllable.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
   </classSpec>
   <classSpec ident="att.symbol.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1725,7 +1725,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.tempo.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.verticalGroup"/>
@@ -1736,7 +1736,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.tie.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes. The vo attribute is the vertical offset (from its normal
+    <desc xml:lang="en">Visual domain attributes. The vo attribute is the vertical offset (from its normal
       position) of the entire rendered tie. The startho, startvo, endho, and endvo attributes
       describe the horizontal and vertical offsets of the start and end points of the tie in terms
       of staff interline distance; that is, in units of 1/2 the distance between adjacent staff
@@ -1753,7 +1753,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.trill.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1769,52 +1769,52 @@
     </classes>
   </classSpec>
   <classSpec ident="att.tuplet.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.numberPlacement"/>
     </classes>
     <attList>
       <attDef ident="bracket.place" usage="opt">
-        <desc>Used to state where a tuplet bracket will be placed in relation to the note
+        <desc xml:lang="en">Used to state where a tuplet bracket will be placed in relation to the note
           heads.</desc>
         <datatype>
           <rng:ref name="data.STAFFREL.basic"/>
         </datatype>
       </attDef>
       <attDef ident="bracket.visible" usage="opt">
-        <desc>States whether a bracket should be rendered with a tuplet.</desc>
+        <desc xml:lang="en">States whether a bracket should be rendered with a tuplet.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
       </attDef>
       <attDef ident="dur.visible" usage="opt">
-        <desc>Determines if the tuplet duration is visible.</desc>
+        <desc xml:lang="en">Determines if the tuplet duration is visible.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
       </attDef>
       <attDef ident="num.format" usage="opt">
-        <desc>Controls how the num:numbase ratio is to be displayed.</desc>
+        <desc xml:lang="en">Controls how the num:numbase ratio is to be displayed.</desc>
         <valList type="closed">
           <valItem ident="count">
-            <desc>Only the num attribute is displayed, <abbr>e.g.</abbr>, '7'.</desc>
+            <desc xml:lang="en">Only the num attribute is displayed, <abbr>e.g.</abbr>, '7'.</desc>
           </valItem>
           <valItem ident="ratio">
-            <desc>Both the num and numbase attributes are displayed, <abbr>e.g.</abbr>, '7:4'.</desc>
+            <desc xml:lang="en">Both the num and numbase attributes are displayed, <abbr>e.g.</abbr>, '7:4'.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.tupletSpan.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.tuplet.vis"/>
     </classes>
   </classSpec>
   <classSpec ident="att.turn.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
@@ -1827,7 +1827,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.verse.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.placementRelStaff"/>
@@ -1839,7 +1839,7 @@
     </classes>
   </classSpec>
   <classSpec ident="att.volta.vis" module="MEI.visual" type="atts">
-    <desc>Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.typography"/>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -16,7 +16,7 @@
         <macroRef key="data.ACCIDENTAL.aeu"/>
       </alternate>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>
         <graphic url="../images/ExampleImages/accid-20100510.png" height="50%" width="50%"/>
       </p>
@@ -134,7 +134,7 @@
         </valItem>
       </valList>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>
         <graphic url="../images/ExampleImages/accidAEU-overview.png" height="50%" width="50%"/>
       </p>
@@ -1007,7 +1007,7 @@
         </valItem>
       </valList>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Color names are taken from the list at <ref
         target="https://www.w3.org/TR/css-color-4/"
         >https://www.w3.org/TR/css-color-4/</ref>. </p>
@@ -1602,7 +1602,7 @@
         </rng:data>
       </rng:choice>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>
         <list>
           <head>Interval direction only:</head>
@@ -2618,7 +2618,7 @@
         </valItem>
       </valList>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>Instrument names are based on the official list in the <ref
         target="https://www.midi.org/specifications-old/item/gm-level-1-sound-set"
         >General MIDI Specifications</ref>.</p>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -5,10 +5,10 @@
   xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron" xml:id="module.MEI">
   <moduleSpec ident="MEI">
-    <desc>Data type definitions.</desc>
+    <desc xml:lang="en">Data type definitions.</desc>
   </moduleSpec>
   <macroSpec ident="data.ACCIDENTAL.WRITTEN" module="MEI" type="dt">
-    <desc>Written accidental values.</desc>
+    <desc xml:lang="en">Written accidental values.</desc>
     <content>
       <alternate>
         <macroRef key="data.ACCIDENTAL.WRITTEN.basic"/>
@@ -23,114 +23,114 @@
     </remarks>
   </macroSpec>
   <macroSpec ident="data.ACCIDENTAL.WRITTEN.basic" module="MEI" type="dt">
-    <desc>Written standard accidental values.</desc>
+    <desc xml:lang="en">Written standard accidental values.</desc>
     <content>
       <valList type="closed">
         <valItem ident="s">
-          <desc>Sharp.</desc>
+          <desc xml:lang="en">Sharp.</desc>
         </valItem>
         <valItem ident="f">
-          <desc>Flat.</desc>
+          <desc xml:lang="en">Flat.</desc>
         </valItem>
         <valItem ident="ss">
-          <desc>Double sharp (written as 2 sharps).</desc>
+          <desc xml:lang="en">Double sharp (written as 2 sharps).</desc>
         </valItem>
         <valItem ident="x">
-          <desc>Double sharp (written using croix).</desc>
+          <desc xml:lang="en">Double sharp (written using croix).</desc>
         </valItem>
         <valItem ident="ff">
-          <desc>Double flat.</desc>
+          <desc xml:lang="en">Double flat.</desc>
         </valItem>
         <valItem ident="xs">
-          <desc>Triple sharp (written as a croix followed by a sharp).</desc>
+          <desc xml:lang="en">Triple sharp (written as a croix followed by a sharp).</desc>
         </valItem>
         <valItem ident="sx">
-          <desc>Triple sharp (written as a sharp followed by a croix).</desc>
+          <desc xml:lang="en">Triple sharp (written as a sharp followed by a croix).</desc>
         </valItem>
         <valItem ident="ts">
-          <desc>Triple sharp (written as 3 sharps).</desc>
+          <desc xml:lang="en">Triple sharp (written as 3 sharps).</desc>
         </valItem>
         <valItem ident="tf">
-          <desc>Triple flat.</desc>
+          <desc xml:lang="en">Triple flat.</desc>
         </valItem>
         <valItem ident="n">
-          <desc>Natural.</desc>
+          <desc xml:lang="en">Natural.</desc>
         </valItem>
         <valItem ident="nf">
-          <desc>Natural + flat; used to cancel preceding double flat.</desc>
+          <desc xml:lang="en">Natural + flat; used to cancel preceding double flat.</desc>
         </valItem>
         <valItem ident="ns">
-          <desc>Natural + sharp; used to cancel preceding double sharp.</desc>
+          <desc xml:lang="en">Natural + sharp; used to cancel preceding double sharp.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.ACCIDENTAL.WRITTEN.extended" module="MEI" type="dt">
-    <desc>Written quarter-tone accidental values.</desc>
+    <desc xml:lang="en">Written quarter-tone accidental values.</desc>
     <content>
       <valList type="closed">
         <!-- su, sd, fu, fd are equivalent to usual symbols plus an arrow (Gould, p. 95)-->
         <valItem ident="su">
-          <desc>Sharp note raised by quarter tone (sharp modified by arrow).</desc>
+          <desc xml:lang="en">Sharp note raised by quarter tone (sharp modified by arrow).</desc>
         </valItem>
         <valItem ident="sd">
-          <desc>Sharp note lowered by quarter tone (sharp modified by arrow).</desc>
+          <desc xml:lang="en">Sharp note lowered by quarter tone (sharp modified by arrow).</desc>
         </valItem>
         <valItem ident="fu">
-          <desc>Flat note raised by quarter tone (flat modified by arrow).</desc>
+          <desc xml:lang="en">Flat note raised by quarter tone (flat modified by arrow).</desc>
         </valItem>
         <valItem ident="fd">
-          <desc>Flat note lowered by quarter tone (flat modified by arrow).</desc>
+          <desc xml:lang="en">Flat note lowered by quarter tone (flat modified by arrow).</desc>
         </valItem>
         <valItem ident="nu">
-          <desc>Natural note raised by quarter tone (natural modified by arrow).</desc>
+          <desc xml:lang="en">Natural note raised by quarter tone (natural modified by arrow).</desc>
         </valItem>
         <valItem ident="nd">
-          <desc>Natural note lowered by quarter tone (natural modified by arrow).</desc>
+          <desc xml:lang="en">Natural note lowered by quarter tone (natural modified by arrow).</desc>
         </valItem>
         <!-- 1qf, 3qf, 1qs, 3qs represent fixed symbols (Gould, p. 96) -->
         <valItem ident="1qf">
-          <desc>1/4-tone flat accidental.</desc>
+          <desc xml:lang="en">1/4-tone flat accidental.</desc>
         </valItem>
         <valItem ident="3qf">
-          <desc>3/4-tone flat accidental.</desc>
+          <desc xml:lang="en">3/4-tone flat accidental.</desc>
         </valItem>
         <valItem ident="1qs">
-          <desc>1/4-tone sharp accidental.</desc>
+          <desc xml:lang="en">1/4-tone sharp accidental.</desc>
         </valItem>
         <valItem ident="3qs">
-          <desc>3/4-tone sharp accidental.</desc>
+          <desc xml:lang="en">3/4-tone sharp accidental.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.ACCIDENTAL.aeu" module="MEI" type="dt">
-    <desc>Arel-Ezgi-Uzdilek (AEU) accidental values (written and gestural/performed).</desc>
+    <desc xml:lang="en">Arel-Ezgi-Uzdilek (AEU) accidental values (written and gestural/performed).</desc>
     <content>
       <valList type="closed">
         <valItem ident="bms">
-          <desc>Büyük mücenneb (sharp).</desc>
+          <desc xml:lang="en">Büyük mücenneb (sharp).</desc>
         </valItem>
         <valItem ident="kms">
-          <desc>Küçük mücenneb (sharp).</desc>
+          <desc xml:lang="en">Küçük mücenneb (sharp).</desc>
         </valItem>
         <valItem ident="bs">
-          <desc>Bakiye (sharp).</desc>
+          <desc xml:lang="en">Bakiye (sharp).</desc>
         </valItem>
         <valItem ident="ks">
-          <desc>Koma (sharp).</desc>
+          <desc xml:lang="en">Koma (sharp).</desc>
         </valItem>
         <valItem ident="kf">
-          <desc>Koma (flat).</desc>
+          <desc xml:lang="en">Koma (flat).</desc>
         </valItem>
         <valItem ident="bf">
-          <desc>Bakiye (flat).</desc>
+          <desc xml:lang="en">Bakiye (flat).</desc>
         </valItem>
         <valItem ident="kmf">
-          <desc>Küçük mücenneb (flat).</desc>
+          <desc xml:lang="en">Küçük mücenneb (flat).</desc>
         </valItem>
         <valItem ident="bmf">
-          <desc>Büyük mücenneb (flat).</desc>
+          <desc xml:lang="en">Büyük mücenneb (flat).</desc>
         </valItem>
       </valList>
     </content>
@@ -141,7 +141,7 @@
     </remarks>
   </macroSpec>
   <macroSpec ident="data.ACCIDENTAL.GESTURAL" module="MEI" type="dt">
-    <desc>Gestural/performed standard accidental values.</desc>
+    <desc xml:lang="en">Gestural/performed standard accidental values.</desc>
     <content>
       <alternate>
         <macroRef key="data.ACCIDENTAL.GESTURAL.basic"/>
@@ -151,170 +151,170 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.ACCIDENTAL.GESTURAL.basic" module="MEI" type="dt">
-    <desc>Gestural/performed accidental values.</desc>
+    <desc xml:lang="en">Gestural/performed accidental values.</desc>
     <content>
       <valList type="closed">
         <valItem ident="s">
-          <desc>Sharp.</desc>
+          <desc xml:lang="en">Sharp.</desc>
         </valItem>
         <valItem ident="f">
-          <desc>Flat.</desc>
+          <desc xml:lang="en">Flat.</desc>
         </valItem>
         <valItem ident="ss">
-          <desc>Double sharp.</desc>
+          <desc xml:lang="en">Double sharp.</desc>
         </valItem>
         <valItem ident="ff">
-          <desc>Double flat.</desc>
+          <desc xml:lang="en">Double flat.</desc>
         </valItem>
         <valItem ident="ts">
-          <desc>Triple sharp.</desc>
+          <desc xml:lang="en">Triple sharp.</desc>
         </valItem>
         <valItem ident="tf">
-          <desc>Triple flat.</desc>
+          <desc xml:lang="en">Triple flat.</desc>
         </valItem>
         <valItem ident="n">
-          <desc>Natural.</desc>
+          <desc xml:lang="en">Natural.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.ACCIDENTAL.GESTURAL.extended" module="MEI" type="dt">
-    <desc>Gestural/performed quarter-tone accidental values.</desc>
+    <desc xml:lang="en">Gestural/performed quarter-tone accidental values.</desc>
     <content>
       <valList type="closed">
         <valItem ident="su">
-          <desc>Three quarter-tones sharp.</desc>
+          <desc xml:lang="en">Three quarter-tones sharp.</desc>
         </valItem>
         <valItem ident="sd">
-          <desc>Quarter-tone sharp.</desc>
+          <desc xml:lang="en">Quarter-tone sharp.</desc>
         </valItem>
         <valItem ident="fu">
-          <desc>Quarter-tone flat.</desc>
+          <desc xml:lang="en">Quarter-tone flat.</desc>
         </valItem>
         <valItem ident="fd">
-          <desc>Three quarter-tones flat.</desc>
+          <desc xml:lang="en">Three quarter-tones flat.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.ARTICULATION" module="MEI" type="dt">
-    <desc>The following list of articulations mostly corresponds to symbols from the Western Musical
+    <desc xml:lang="en">The following list of articulations mostly corresponds to symbols from the Western Musical
       Symbols portion of the Unicode Standard. The dot and stroke values may be used in cases where
       interpretation is difficult or undesirable.</desc>
     <content>
       <valList type="closed">
         <valItem ident="acc">
-          <desc>Accent (Unicode 1D17B).</desc>
+          <desc xml:lang="en">Accent (Unicode 1D17B).</desc>
         </valItem>
         <valItem ident="acc-inv">
-          <desc>Inverted accent.</desc>
+          <desc xml:lang="en">Inverted accent.</desc>
         </valItem>
         <valItem ident="acc-long">
-          <desc>Long accent, used to indicate an elongated accent mark. It is the responsibility of the encoder to distinguish between accents and hairpins.</desc>
+          <desc xml:lang="en">Long accent, used to indicate an elongated accent mark. It is the responsibility of the encoder to distinguish between accents and hairpins.</desc>
         </valItem>
         <valItem ident="acc-soft">
-          <desc>Soft accent, see SMuFL Articulation supplement (U+ED40–U+ED4F).</desc>
+          <desc xml:lang="en">Soft accent, see SMuFL Articulation supplement (U+ED40–U+ED4F).</desc>
         </valItem>
         <valItem ident="stacc">
-          <desc>Staccato (Unicode 1D17C).</desc>
+          <desc xml:lang="en">Staccato (Unicode 1D17C).</desc>
         </valItem>
         <valItem ident="ten">
-          <desc>Tenuto (Unicode 1D17D).</desc>
+          <desc xml:lang="en">Tenuto (Unicode 1D17D).</desc>
         </valItem>
         <valItem ident="stacciss">
-          <desc>Staccatissimo (Unicode 1D17E).</desc>
+          <desc xml:lang="en">Staccatissimo (Unicode 1D17E).</desc>
         </valItem>
         <valItem ident="marc">
-          <desc>Marcato (Unicode 1D17F).</desc>
+          <desc xml:lang="en">Marcato (Unicode 1D17F).</desc>
         </valItem>
         <valItem ident="spicc">
-          <desc>Spiccato.</desc>
+          <desc xml:lang="en">Spiccato.</desc>
         </valItem>
         <valItem ident="doit">
-          <desc>Main note followed by short slide to higher, indeterminate pitch (Unicode
+          <desc xml:lang="en">Main note followed by short slide to higher, indeterminate pitch (Unicode
             1D185).</desc>
         </valItem>
         <valItem ident="scoop">
-          <desc>Main note preceded by short slide from lower, indeterminate pitch (Unicode
+          <desc xml:lang="en">Main note preceded by short slide from lower, indeterminate pitch (Unicode
             1D186).</desc>
         </valItem>
         <valItem ident="rip">
-          <desc>Main note preceded by long slide from lower, often indeterminate pitch; also known
+          <desc xml:lang="en">Main note preceded by long slide from lower, often indeterminate pitch; also known
             as "squeeze".</desc>
         </valItem>
         <valItem ident="plop">
-          <desc>Main note preceded by "slide" from higher, indeterminate pitch.</desc>
+          <desc xml:lang="en">Main note preceded by "slide" from higher, indeterminate pitch.</desc>
         </valItem>
         <valItem ident="fall">
-          <desc>Main note followed by short "slide" to lower, indeterminate pitch.</desc>
+          <desc xml:lang="en">Main note followed by short "slide" to lower, indeterminate pitch.</desc>
         </valItem>
         <valItem ident="longfall">
-          <desc>Main note followed by long "slide" to lower, indeterminate pitch.</desc>
+          <desc xml:lang="en">Main note followed by long "slide" to lower, indeterminate pitch.</desc>
         </valItem>
         <valItem ident="bend">
-          <desc>"lip slur" to lower pitch, then return to written pitch.</desc>
+          <desc xml:lang="en">"lip slur" to lower pitch, then return to written pitch.</desc>
         </valItem>
         <valItem ident="flip">
-          <desc>Main note followed by quick upward rise, then descent in pitch (Unicode
+          <desc xml:lang="en">Main note followed by quick upward rise, then descent in pitch (Unicode
             1D187).</desc>
         </valItem>
         <valItem ident="smear">
-          <desc>(Unicode 1D188).</desc>
+          <desc xml:lang="en">(Unicode 1D188).</desc>
         </valItem>
         <valItem ident="shake">
-          <desc>Alternation between written pitch and next highest overtone (brass instruments) or
+          <desc xml:lang="en">Alternation between written pitch and next highest overtone (brass instruments) or
             note minor third higher (woodwinds).</desc>
         </valItem>
         <valItem ident="dnbow">
-          <desc>Down bow (Unicode 1D1AA).</desc>
+          <desc xml:lang="en">Down bow (Unicode 1D1AA).</desc>
         </valItem>
         <valItem ident="upbow">
-          <desc>Up bow (Unicode 1D1AB).</desc>
+          <desc xml:lang="en">Up bow (Unicode 1D1AB).</desc>
         </valItem>
         <valItem ident="harm">
-          <desc>Harmonic (Unicode 1D1AC).</desc>
+          <desc xml:lang="en">Harmonic (Unicode 1D1AC).</desc>
         </valItem>
         <valItem ident="snap">
-          <desc>Snap pizzicato (Unicode 1D1AD).</desc>
+          <desc xml:lang="en">Snap pizzicato (Unicode 1D1AD).</desc>
         </valItem>
         <valItem ident="fingernail">
-          <desc>Fingernail (Unicode 1D1B3).</desc>
+          <desc xml:lang="en">Fingernail (Unicode 1D1B3).</desc>
         </valItem>
         <valItem ident="damp">
-          <desc>Stop harp string from sounding (Unicode 1D1B4).</desc>
+          <desc xml:lang="en">Stop harp string from sounding (Unicode 1D1B4).</desc>
         </valItem>
         <valItem ident="dampall">
-          <desc>Stop all harp strings from sounding (Unicode 1D1B5).</desc>
+          <desc xml:lang="en">Stop all harp strings from sounding (Unicode 1D1B5).</desc>
         </valItem>
         <valItem ident="open">
-          <desc>Full (as opposed to stopped) tone.</desc>
+          <desc xml:lang="en">Full (as opposed to stopped) tone.</desc>
         </valItem>
         <valItem ident="stop">
-          <desc>"muffled" tone.</desc>
+          <desc xml:lang="en">"muffled" tone.</desc>
         </valItem>
         <valItem ident="dbltongue">
-          <desc>Double tongue (Unicode 1D18A).</desc>
+          <desc xml:lang="en">Double tongue (Unicode 1D18A).</desc>
         </valItem>
         <valItem ident="trpltongue">
-          <desc>Triple tongue (Unicode 1D18B).</desc>
+          <desc xml:lang="en">Triple tongue (Unicode 1D18B).</desc>
         </valItem>
         <valItem ident="heel">
-          <desc>Use heel (organ pedal).</desc>
+          <desc xml:lang="en">Use heel (organ pedal).</desc>
         </valItem>
         <valItem ident="toe">
-          <desc>Use toe (organ pedal).</desc>
+          <desc xml:lang="en">Use toe (organ pedal).</desc>
         </valItem>
         <valItem ident="tap">
-          <desc>Percussive effect on guitar string(s).</desc>
+          <desc xml:lang="en">Percussive effect on guitar string(s).</desc>
         </valItem>
         <valItem ident="lhpizz">
-          <desc>Left-hand pizzicato.</desc>
+          <desc xml:lang="en">Left-hand pizzicato.</desc>
         </valItem>
         <valItem ident="dot">
-          <desc>Uninterpreted dot.</desc>
+          <desc xml:lang="en">Uninterpreted dot.</desc>
         </valItem>
         <valItem ident="stroke">
-          <desc>Uninterpreted stroke.</desc>
+          <desc xml:lang="en">Uninterpreted stroke.</desc>
         </valItem>
       </valList>
     </content>
@@ -334,7 +334,7 @@
     </constraintSpec>
   </macroSpec>
   <macroSpec ident="data.AUGMENTDOT" module="MEI" type="dt">
-    <desc>Dots attribute values (number of augmentation dots) (Read, 113-119, ex. 8-21).</desc>
+    <desc xml:lang="en">Dots attribute values (number of augmentation dots) (Read, 113-119, ex. 8-21).</desc>
     <content>
       <rng:data type="nonNegativeInteger">
         <rng:param name="maxInclusive">4</rng:param>
@@ -342,65 +342,65 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.BARMETHOD" module="MEI" type="dt">
-    <desc>Records where bar lines are drawn. The value 'staff' describes the traditional placement
+    <desc xml:lang="en">Records where bar lines are drawn. The value 'staff' describes the traditional placement
       of bar lines.</desc>
     <content>
       <valList type="closed">
         <valItem ident="mensur">
-          <desc>Between staves only.</desc>
+          <desc xml:lang="en">Between staves only.</desc>
         </valItem>
         <valItem ident="staff">
-          <desc>Between and across staves as necessary.</desc>
+          <desc xml:lang="en">Between and across staves as necessary.</desc>
         </valItem>
         <valItem ident="takt">
-          <desc>Short bar line through a subset of staff lines.</desc>
+          <desc xml:lang="en">Short bar line through a subset of staff lines.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.BARRENDITION" module="MEI" type="dt">
-    <desc>Renderings of bar lines. Some values correspond to the Western Musical Symbols portion of
+    <desc xml:lang="en">Renderings of bar lines. Some values correspond to the Western Musical Symbols portion of
       the Unicode Standard.</desc>
     <content>
       <valList type="closed">
         <valItem ident="dashed">
-          <desc>Dashed line (Unicode 1D104).</desc>
+          <desc xml:lang="en">Dashed line (Unicode 1D104).</desc>
         </valItem>
         <valItem ident="dotted">
-          <desc>Dotted line.</desc>
+          <desc xml:lang="en">Dotted line.</desc>
         </valItem>
         <valItem ident="dbl">
-          <desc>(Unicode 1D101).</desc>
+          <desc xml:lang="en">(Unicode 1D101).</desc>
         </valItem>
         <valItem ident="dbldashed">
-          <desc>Double dashed line.</desc>
+          <desc xml:lang="en">Double dashed line.</desc>
         </valItem>
         <valItem ident="dbldotted">
-          <desc>Double dotted line.</desc>
+          <desc xml:lang="en">Double dotted line.</desc>
         </valItem>
         <valItem ident="end">
-          <desc>(Unicode 1D102).</desc>
+          <desc xml:lang="en">(Unicode 1D102).</desc>
         </valItem>
         <valItem ident="invis">
-          <desc>Bar line not rendered.</desc>
+          <desc xml:lang="en">Bar line not rendered.</desc>
         </valItem>
         <valItem ident="rptstart">
-          <desc>Repeat start (Unicode 1D106).</desc>
+          <desc xml:lang="en">Repeat start (Unicode 1D106).</desc>
         </valItem>
         <valItem ident="rptboth">
-          <desc>Repeat start and end.</desc>
+          <desc xml:lang="en">Repeat start and end.</desc>
         </valItem>
         <valItem ident="rptend">
-          <desc>Repeat end (Unicode 1D107).</desc>
+          <desc xml:lang="en">Repeat end (Unicode 1D107).</desc>
         </valItem>
         <valItem ident="single">
-          <desc>(Unicode 1D100).</desc>
+          <desc xml:lang="en">(Unicode 1D100).</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.BEAM" module="MEI" type="dt">
-    <desc>Beam attribute values: initial, medial, terminal. Nested beaming is permitted.</desc>
+    <desc xml:lang="en">Beam attribute values: initial, medial, terminal. Nested beaming is permitted.</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">[i|m|t][1-6]</rng:param>
@@ -408,23 +408,23 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.BEAMPLACE" module="MEI" type="dt">
-    <desc>Location of a beam relative to the events it affects.</desc>
+    <desc xml:lang="en">Location of a beam relative to the events it affects.</desc>
     <content>
       <valList type="closed">
         <valItem ident="above">
-          <desc>The beam is above the events it affects.</desc>
+          <desc xml:lang="en">The beam is above the events it affects.</desc>
         </valItem>
         <valItem ident="below">
-          <desc>The beam is below the events it affects.</desc>
+          <desc xml:lang="en">The beam is below the events it affects.</desc>
         </valItem>
         <valItem ident="mixed">
-          <desc>The beam is above and below the events it affects.</desc>
+          <desc xml:lang="en">The beam is above and below the events it affects.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.BEAT" module="MEI" type="dt">
-    <desc>A beat location, <abbr>i.e.</abbr>, [0-9]+(\.?[0-9]*)? The value must fall between 0 and the numerator
+    <desc xml:lang="en">A beat location, <abbr>i.e.</abbr>, [0-9]+(\.?[0-9]*)? The value must fall between 0 and the numerator
       of the time signature + 1, where 0 represents the left bar line and the upper boundary
       represents the right bar line. For example, in 12/8 the value must be in the range from 0 to
       13.</desc>
@@ -435,7 +435,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.BEATRPT.REND" module="MEI" type="dt">
-    <desc>Visual and performance information for a repeated beat symbol.</desc>
+    <desc xml:lang="en">Visual and performance information for a repeated beat symbol.</desc>
     <content>
       <rng:choice>
         <rng:data type="positiveInteger">
@@ -448,7 +448,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.BEND.AMOUNT" module="MEI" type="dt">
-    <desc>Either an integer value, a decimal value, or a token. Fractional values are limited to
+    <desc xml:lang="en">Either an integer value, a decimal value, or a token. Fractional values are limited to
       .25, .5, .75, while the token value is restricted to 'full'.</desc>
     <content>
       <rng:choice>
@@ -465,90 +465,90 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.BOOLEAN" module="MEI" type="dt">
-    <desc>Boolean attribute values.</desc>
+    <desc xml:lang="en">Boolean attribute values.</desc>
     <content>
       <valList type="closed">
         <valItem ident="true">
-          <desc>True.</desc>
+          <desc xml:lang="en">True.</desc>
         </valItem>
         <valItem ident="false">
-          <desc>False.</desc>
+          <desc xml:lang="en">False.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.CERTAINTY" module="MEI" type="dt">
-    <desc>Values for certainty attribute. Certainty may be expressed by one of the predefined symbolic values <val>high</val>, 
+    <desc xml:lang="en">Values for certainty attribute. Certainty may be expressed by one of the predefined symbolic values <val>high</val>, 
       <val>medium</val>, or <val>low</val>. The value <val>unknown</val> should be used in cases where the encoder 
       does not wish to assert an opinion about the matter.</desc>
     <content>
       <valList type="closed">
         <valItem ident="high">
-          <desc>High certainty.</desc>
+          <desc xml:lang="en">High certainty.</desc>
         </valItem>
         <valItem ident="medium">
-          <desc>Medium certainty.</desc>
+          <desc xml:lang="en">Medium certainty.</desc>
         </valItem>
         <valItem ident="low">
-          <desc>Low certainty.</desc>
+          <desc xml:lang="en">Low certainty.</desc>
         </valItem>
         <valItem ident="unknown">
-          <desc>An unknown level of certainty.</desc>
+          <desc xml:lang="en">An unknown level of certainty.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.CLEFLINE" module="MEI" type="dt">
-    <desc>Clef line attribute values. The value must be in the range between 1 and the number of
+    <desc xml:lang="en">Clef line attribute values. The value must be in the range between 1 and the number of
       lines on the staff. The numbering of lines starts with the lowest line of the staff.</desc>
     <content>
       <rng:data type="positiveInteger"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.CLEFSHAPE" module="MEI" type="dt">
-    <desc>Clef shape attribute values (Read, p.53-56). Some values correspond to the Unicode
+    <desc xml:lang="en">Clef shape attribute values (Read, p.53-56). Some values correspond to the Unicode
       Standard.</desc>
     <content>
       <valList type="closed">
         <valItem ident="G">
-          <desc>G clef (Unicode 1D11E).</desc>
+          <desc xml:lang="en">G clef (Unicode 1D11E).</desc>
         </valItem>
         <valItem ident="GG">
-          <desc>Double G clef.</desc>
+          <desc xml:lang="en">Double G clef.</desc>
         </valItem>
         <valItem ident="F">
-          <desc>F clef (Unicode 1D122).</desc>
+          <desc xml:lang="en">F clef (Unicode 1D122).</desc>
         </valItem>
         <valItem ident="C">
-          <desc>C clef (Unicode 1D121).</desc>
+          <desc xml:lang="en">C clef (Unicode 1D121).</desc>
         </valItem>
         <valItem ident="perc">
-          <desc>Drum clef (Unicode 1D125 or Unicode 1D126).</desc>
+          <desc xml:lang="en">Drum clef (Unicode 1D125 or Unicode 1D126).</desc>
         </valItem>
         <valItem ident="TAB">
-          <desc>Tablature "clef"; <abbr>i.e.</abbr>, usually "TAB" rendered vertically.</desc>
+          <desc xml:lang="en">Tablature "clef"; <abbr>i.e.</abbr>, usually "TAB" rendered vertically.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.CLUSTER" module="MEI" type="dt">
-    <desc>Tone-cluster rendition.</desc>
+    <desc xml:lang="en">Tone-cluster rendition.</desc>
     <content>
       <valList type="closed">
         <valItem ident="white">
-          <desc>White keys.</desc>
+          <desc xml:lang="en">White keys.</desc>
         </valItem>
         <valItem ident="black">
-          <desc>Black keys.</desc>
+          <desc xml:lang="en">Black keys.</desc>
         </valItem>
         <valItem ident="chromatic">
-          <desc>Mixed black and white keys.</desc>
+          <desc xml:lang="en">Mixed black and white keys.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.CONFIDENCE" module="MEI" type="dt">
-    <desc>Confidence is expressed as a real number between 0 and 1; 0 representing certainly false
+    <desc xml:lang="en">Confidence is expressed as a real number between 0 and 1; 0 representing certainly false
       and 1 representing certainly true.</desc>
     <content>
       <rng:data type="decimal">
@@ -558,452 +558,452 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.COLORNAMES" module="MEI" type="dt">
-    <desc>List of named colors from CSS Color Module Level 4.</desc>
+    <desc xml:lang="en">List of named colors from CSS Color Module Level 4.</desc>
     <content>
       <valList type="closed">
         <valItem ident="aliceblue">
-          <desc>Hex: #f0f8ff / RGB: 240,248,255</desc>
+          <desc xml:lang="en">Hex: #f0f8ff / RGB: 240,248,255</desc>
         </valItem>
         <valItem ident="antiquewhite">
-          <desc>Hex: #faebd7 / RGB: 250,235,215</desc>
+          <desc xml:lang="en">Hex: #faebd7 / RGB: 250,235,215</desc>
         </valItem>
         <valItem ident="aqua">
-          <desc>Hex: #00ffff / RGB: 0,255,255</desc>
+          <desc xml:lang="en">Hex: #00ffff / RGB: 0,255,255</desc>
         </valItem>
         <valItem ident="aquamarine">
-          <desc>Hex: #7fffd4 / RGB: 127,255,212</desc>
+          <desc xml:lang="en">Hex: #7fffd4 / RGB: 127,255,212</desc>
         </valItem>
         <valItem ident="azure">
-          <desc>Hex: #f0ffff / RGB: 240,255,255</desc>
+          <desc xml:lang="en">Hex: #f0ffff / RGB: 240,255,255</desc>
         </valItem>
         <valItem ident="beige">
-          <desc>Hex: #f5f5dc / RGB: 245,245,220</desc>
+          <desc xml:lang="en">Hex: #f5f5dc / RGB: 245,245,220</desc>
         </valItem>
         <valItem ident="bisque">
-          <desc>Hex: #ffe4c4 / RGB: 255,228,196</desc>
+          <desc xml:lang="en">Hex: #ffe4c4 / RGB: 255,228,196</desc>
         </valItem>
         <valItem ident="black">
-          <desc>Hex: #000000 / RGB: 0,0,0</desc>
+          <desc xml:lang="en">Hex: #000000 / RGB: 0,0,0</desc>
         </valItem>
         <valItem ident="blanchedalmond">
-          <desc>Hex: #ffebcd / RGB: 255,235,205</desc>
+          <desc xml:lang="en">Hex: #ffebcd / RGB: 255,235,205</desc>
         </valItem>
         <valItem ident="blue">
-          <desc>Hex: #0000ff / RGB: 0,0,255</desc>
+          <desc xml:lang="en">Hex: #0000ff / RGB: 0,0,255</desc>
         </valItem>
         <valItem ident="blueviolet">
-          <desc>Hex: #8a2be2 / RGB: 138,43,226</desc>
+          <desc xml:lang="en">Hex: #8a2be2 / RGB: 138,43,226</desc>
         </valItem>
         <valItem ident="brown">
-          <desc>Hex: #a52a2a / RGB: 165,42,42</desc>
+          <desc xml:lang="en">Hex: #a52a2a / RGB: 165,42,42</desc>
         </valItem>
         <valItem ident="burlywood">
-          <desc>Hex: #deb887 / RGB: 222,184,135</desc>
+          <desc xml:lang="en">Hex: #deb887 / RGB: 222,184,135</desc>
         </valItem>
         <valItem ident="cadetblue">
-          <desc>Hex: #5f9ea0 / RGB: 95,158,160</desc>
+          <desc xml:lang="en">Hex: #5f9ea0 / RGB: 95,158,160</desc>
         </valItem>
         <valItem ident="chartreuse">
-          <desc>Hex: #7fff00 / RGB: 127,255,0</desc>
+          <desc xml:lang="en">Hex: #7fff00 / RGB: 127,255,0</desc>
         </valItem>
         <valItem ident="chocolate">
-          <desc>Hex: #d2691e / RGB: 210,105,30</desc>
+          <desc xml:lang="en">Hex: #d2691e / RGB: 210,105,30</desc>
         </valItem>
         <valItem ident="coral">
-          <desc>Hex: #ff7f50 / RGB: 255,127,80</desc>
+          <desc xml:lang="en">Hex: #ff7f50 / RGB: 255,127,80</desc>
         </valItem>
         <valItem ident="cornflowerblue">
-          <desc>Hex: #6495ed / RGB: 100,149,237</desc>
+          <desc xml:lang="en">Hex: #6495ed / RGB: 100,149,237</desc>
         </valItem>
         <valItem ident="cornsilk">
-          <desc>Hex: #fff8dc / RGB: 255,248,220</desc>
+          <desc xml:lang="en">Hex: #fff8dc / RGB: 255,248,220</desc>
         </valItem>
         <valItem ident="crimson">
-          <desc>Hex: #dc143c / RGB: 220,20,60</desc>
+          <desc xml:lang="en">Hex: #dc143c / RGB: 220,20,60</desc>
         </valItem>
         <valItem ident="cyan">
-          <desc>Hex: #00ffff / RGB: 0,255,255</desc>
+          <desc xml:lang="en">Hex: #00ffff / RGB: 0,255,255</desc>
         </valItem>
         <valItem ident="darkblue">
-          <desc>Hex: #00008b / RGB: 0,0,139</desc>
+          <desc xml:lang="en">Hex: #00008b / RGB: 0,0,139</desc>
         </valItem>
         <valItem ident="darkcyan">
-          <desc>Hex: #008b8b / RGB: 0,139,139</desc>
+          <desc xml:lang="en">Hex: #008b8b / RGB: 0,139,139</desc>
         </valItem>
         <valItem ident="darkgoldenrod">
-          <desc>Hex: #b8860b / RGB: 184,134,11</desc>
+          <desc xml:lang="en">Hex: #b8860b / RGB: 184,134,11</desc>
         </valItem>
         <valItem ident="darkgray">
-          <desc>Hex: #a9a9a9 / RGB: 169,169,169</desc>
+          <desc xml:lang="en">Hex: #a9a9a9 / RGB: 169,169,169</desc>
         </valItem>
         <valItem ident="darkgreen">
-          <desc>Hex: #006400 / RGB: 0,100,0</desc>
+          <desc xml:lang="en">Hex: #006400 / RGB: 0,100,0</desc>
         </valItem>
         <valItem ident="darkgrey">
-          <desc>Hex: #a9a9a9 / RGB: 169,169,169</desc>
+          <desc xml:lang="en">Hex: #a9a9a9 / RGB: 169,169,169</desc>
         </valItem>
         <valItem ident="darkkhaki">
-          <desc>Hex: #bdb76b / RGB: 189,183,107</desc>
+          <desc xml:lang="en">Hex: #bdb76b / RGB: 189,183,107</desc>
         </valItem>
         <valItem ident="darkmagenta">
-          <desc>Hex: #8b008b / RGB: 139,0,139</desc>
+          <desc xml:lang="en">Hex: #8b008b / RGB: 139,0,139</desc>
         </valItem>
         <valItem ident="darkolivegreen">
-          <desc>Hex: #556b2f / RGB: 85,107,47</desc>
+          <desc xml:lang="en">Hex: #556b2f / RGB: 85,107,47</desc>
         </valItem>
         <valItem ident="darkorange">
-          <desc>Hex: #ff8c00 / RGB: 255,140,0</desc>
+          <desc xml:lang="en">Hex: #ff8c00 / RGB: 255,140,0</desc>
         </valItem>
         <valItem ident="darkorchid">
-          <desc>Hex: #9932cc / RGB: 153,50,204</desc>
+          <desc xml:lang="en">Hex: #9932cc / RGB: 153,50,204</desc>
         </valItem>
         <valItem ident="darkred">
-          <desc>Hex: #8b0000 / RGB: 139,0,0</desc>
+          <desc xml:lang="en">Hex: #8b0000 / RGB: 139,0,0</desc>
         </valItem>
         <valItem ident="darksalmon">
-          <desc>Hex: #e9967a / RGB: 233,150,122</desc>
+          <desc xml:lang="en">Hex: #e9967a / RGB: 233,150,122</desc>
         </valItem>
         <valItem ident="darkseagreen">
-          <desc>Hex: #8fbc8f / RGB: 143,188,143</desc>
+          <desc xml:lang="en">Hex: #8fbc8f / RGB: 143,188,143</desc>
         </valItem>
         <valItem ident="darkslateblue">
-          <desc>Hex: #483d8b / RGB: 72,61,139</desc>
+          <desc xml:lang="en">Hex: #483d8b / RGB: 72,61,139</desc>
         </valItem>
         <valItem ident="darkslategray">
-          <desc>Hex: #2f4f4f / RGB: 47,79,79</desc>
+          <desc xml:lang="en">Hex: #2f4f4f / RGB: 47,79,79</desc>
         </valItem>
         <valItem ident="darkslategrey">
-          <desc>Hex: #2f4f4f / RGB: 47,79,79</desc>
+          <desc xml:lang="en">Hex: #2f4f4f / RGB: 47,79,79</desc>
         </valItem>
         <valItem ident="darkturquoise">
-          <desc>Hex: #00ced1 / RGB: 0,206,209</desc>
+          <desc xml:lang="en">Hex: #00ced1 / RGB: 0,206,209</desc>
         </valItem>
         <valItem ident="darkviolet">
-          <desc>Hex: #9400d3 / RGB: 148,0,211</desc>
+          <desc xml:lang="en">Hex: #9400d3 / RGB: 148,0,211</desc>
         </valItem>
         <valItem ident="deeppink">
-          <desc>Hex: #ff1493 / RGB: 255,20,147</desc>
+          <desc xml:lang="en">Hex: #ff1493 / RGB: 255,20,147</desc>
         </valItem>
         <valItem ident="deepskyblue">
-          <desc>Hex: #00bfff / RGB: 0,191,255</desc>
+          <desc xml:lang="en">Hex: #00bfff / RGB: 0,191,255</desc>
         </valItem>
         <valItem ident="dimgray">
-          <desc>Hex: #696969 / RGB: 105,105,105</desc>
+          <desc xml:lang="en">Hex: #696969 / RGB: 105,105,105</desc>
         </valItem>
         <valItem ident="dimgrey">
-          <desc>Hex: #696969 / RGB: 105,105,105</desc>
+          <desc xml:lang="en">Hex: #696969 / RGB: 105,105,105</desc>
         </valItem>
         <valItem ident="dodgerblue">
-          <desc>Hex: #1e90ff / RGB: 30,144,255</desc>
+          <desc xml:lang="en">Hex: #1e90ff / RGB: 30,144,255</desc>
         </valItem>
         <valItem ident="firebrick">
-          <desc>Hex: #b22222 / RGB: 178,34,34</desc>
+          <desc xml:lang="en">Hex: #b22222 / RGB: 178,34,34</desc>
         </valItem>
         <valItem ident="floralwhite">
-          <desc>Hex: #fffaf0 / RGB: 255,250,240</desc>
+          <desc xml:lang="en">Hex: #fffaf0 / RGB: 255,250,240</desc>
         </valItem>
         <valItem ident="forestgreen">
-          <desc>Hex: #228b22 / RGB: 34,139,34</desc>
+          <desc xml:lang="en">Hex: #228b22 / RGB: 34,139,34</desc>
         </valItem>
         <valItem ident="fuchsia">
-          <desc>Hex: #ff00ff / RGB: 255,0,255</desc>
+          <desc xml:lang="en">Hex: #ff00ff / RGB: 255,0,255</desc>
         </valItem>
         <valItem ident="gainsboro">
-          <desc>Hex: #dcdcdc / RGB: 220,220,220</desc>
+          <desc xml:lang="en">Hex: #dcdcdc / RGB: 220,220,220</desc>
         </valItem>
         <valItem ident="ghostwhite">
-          <desc>Hex: #f8f8ff / RGB: 248,248,255</desc>
+          <desc xml:lang="en">Hex: #f8f8ff / RGB: 248,248,255</desc>
         </valItem>
         <valItem ident="gold">
-          <desc>Hex: #ffd700 / RGB: 255,215,0</desc>
+          <desc xml:lang="en">Hex: #ffd700 / RGB: 255,215,0</desc>
         </valItem>
         <valItem ident="goldenrod">
-          <desc>Hex: #daa520 / RGB: 218,165,32</desc>
+          <desc xml:lang="en">Hex: #daa520 / RGB: 218,165,32</desc>
         </valItem>
         <valItem ident="gray">
-          <desc>Hex: #808080 / RGB: 128,128,128</desc>
+          <desc xml:lang="en">Hex: #808080 / RGB: 128,128,128</desc>
         </valItem>
         <valItem ident="green">
-          <desc>Hex: #008000 / RGB: 0,128,0</desc>
+          <desc xml:lang="en">Hex: #008000 / RGB: 0,128,0</desc>
         </valItem>
         <valItem ident="greenyellow">
-          <desc>Hex: #adff2f / RGB: 173,255,47</desc>
+          <desc xml:lang="en">Hex: #adff2f / RGB: 173,255,47</desc>
         </valItem>
         <valItem ident="grey">
-          <desc>Hex: #808080 / RGB: 128,128,128</desc>
+          <desc xml:lang="en">Hex: #808080 / RGB: 128,128,128</desc>
         </valItem>
         <valItem ident="honeydew">
-          <desc>Hex: #f0fff0 / RGB: 240,255,240</desc>
+          <desc xml:lang="en">Hex: #f0fff0 / RGB: 240,255,240</desc>
         </valItem>
         <valItem ident="hotpink">
-          <desc>Hex: #ff69b4 / RGB: 255,105,180</desc>
+          <desc xml:lang="en">Hex: #ff69b4 / RGB: 255,105,180</desc>
         </valItem>
         <valItem ident="indianred">
-          <desc>Hex: #cd5c5c / RGB: 205,92,92</desc>
+          <desc xml:lang="en">Hex: #cd5c5c / RGB: 205,92,92</desc>
         </valItem>
         <valItem ident="indigo">
-          <desc>Hex: #4b0082 / RGB: 75,0,130</desc>
+          <desc xml:lang="en">Hex: #4b0082 / RGB: 75,0,130</desc>
         </valItem>
         <valItem ident="ivory">
-          <desc>Hex: #fffff0 / RGB: 255,255,240</desc>
+          <desc xml:lang="en">Hex: #fffff0 / RGB: 255,255,240</desc>
         </valItem>
         <valItem ident="khaki">
-          <desc>Hex: #f0e68c / RGB: 240,230,140</desc>
+          <desc xml:lang="en">Hex: #f0e68c / RGB: 240,230,140</desc>
         </valItem>
         <valItem ident="lavender">
-          <desc>Hex: #e6e6fa / RGB: 230,230,250</desc>
+          <desc xml:lang="en">Hex: #e6e6fa / RGB: 230,230,250</desc>
         </valItem>
         <valItem ident="lavenderblush">
-          <desc>Hex: #fff0f5 / RGB: 255,240,245</desc>
+          <desc xml:lang="en">Hex: #fff0f5 / RGB: 255,240,245</desc>
         </valItem>
         <valItem ident="lawngreen">
-          <desc>Hex: #7cfc00 / RGB: 124,252,0</desc>
+          <desc xml:lang="en">Hex: #7cfc00 / RGB: 124,252,0</desc>
         </valItem>
         <valItem ident="lemonchiffon">
-          <desc>Hex: #fffacd / RGB: 255,250,205</desc>
+          <desc xml:lang="en">Hex: #fffacd / RGB: 255,250,205</desc>
         </valItem>
         <valItem ident="lightblue">
-          <desc>Hex: #add8e6 / RGB: 173,216,230</desc>
+          <desc xml:lang="en">Hex: #add8e6 / RGB: 173,216,230</desc>
         </valItem>
         <valItem ident="lightcoral">
-          <desc>Hex: #f08080 / RGB: 240,128,128</desc>
+          <desc xml:lang="en">Hex: #f08080 / RGB: 240,128,128</desc>
         </valItem>
         <valItem ident="lightcyan">
-          <desc>Hex: #e0ffff / RGB: 224,255,255</desc>
+          <desc xml:lang="en">Hex: #e0ffff / RGB: 224,255,255</desc>
         </valItem>
         <valItem ident="lightgoldenrodyellow">
-          <desc>Hex: #fafad2 / RGB: 250,250,210</desc>
+          <desc xml:lang="en">Hex: #fafad2 / RGB: 250,250,210</desc>
         </valItem>
         <valItem ident="lightgray">
-          <desc>Hex: #d3d3d3 / RGB: 211,211,211</desc>
+          <desc xml:lang="en">Hex: #d3d3d3 / RGB: 211,211,211</desc>
         </valItem>
         <valItem ident="lightgreen">
-          <desc>Hex: #90ee90 / RGB: 144,238,144</desc>
+          <desc xml:lang="en">Hex: #90ee90 / RGB: 144,238,144</desc>
         </valItem>
         <valItem ident="lightgrey">
-          <desc>Hex: #d3d3d3 / RGB: 211,211,211</desc>
+          <desc xml:lang="en">Hex: #d3d3d3 / RGB: 211,211,211</desc>
         </valItem>
         <valItem ident="lightpink">
-          <desc>Hex: #ffb6c1 / RGB: 255,182,193</desc>
+          <desc xml:lang="en">Hex: #ffb6c1 / RGB: 255,182,193</desc>
         </valItem>
         <valItem ident="lightsalmon">
-          <desc>Hex: #ffa07a / RGB: 255,160,122</desc>
+          <desc xml:lang="en">Hex: #ffa07a / RGB: 255,160,122</desc>
         </valItem>
         <valItem ident="lightseagreen">
-          <desc>Hex: #20b2aa / RGB: 32,178,170</desc>
+          <desc xml:lang="en">Hex: #20b2aa / RGB: 32,178,170</desc>
         </valItem>
         <valItem ident="lightskyblue">
-          <desc>Hex: #87cefa / RGB: 135,206,250</desc>
+          <desc xml:lang="en">Hex: #87cefa / RGB: 135,206,250</desc>
         </valItem>
         <valItem ident="lightslategray">
-          <desc>Hex: #778899 / RGB: 119,136,153</desc>
+          <desc xml:lang="en">Hex: #778899 / RGB: 119,136,153</desc>
         </valItem>
         <valItem ident="lightslategrey">
-          <desc>Hex: #778899 / RGB: 119,136,153</desc>
+          <desc xml:lang="en">Hex: #778899 / RGB: 119,136,153</desc>
         </valItem>
         <valItem ident="lightsteelblue">
-          <desc>Hex: #b0c4de / RGB: 176,196,222</desc>
+          <desc xml:lang="en">Hex: #b0c4de / RGB: 176,196,222</desc>
         </valItem>
         <valItem ident="lightyellow">
-          <desc>Hex: #ffffe0 / RGB: 255,255,224</desc>
+          <desc xml:lang="en">Hex: #ffffe0 / RGB: 255,255,224</desc>
         </valItem>
         <valItem ident="lime">
-          <desc>Hex: #00ff00 / RGB: 0,255,0</desc>
+          <desc xml:lang="en">Hex: #00ff00 / RGB: 0,255,0</desc>
         </valItem>
         <valItem ident="limegreen">
-          <desc>Hex: #32cd32 / RGB: 50,205,50</desc>
+          <desc xml:lang="en">Hex: #32cd32 / RGB: 50,205,50</desc>
         </valItem>
         <valItem ident="linen">
-          <desc>Hex: #faf0e6 / RGB: 250,240,230</desc>
+          <desc xml:lang="en">Hex: #faf0e6 / RGB: 250,240,230</desc>
         </valItem>
         <valItem ident="magenta">
-          <desc>Hex: #ff00ff / RGB: 255,0,255</desc>
+          <desc xml:lang="en">Hex: #ff00ff / RGB: 255,0,255</desc>
         </valItem>
         <valItem ident="maroon">
-          <desc>Hex: #800000 / RGB: 128,0,0</desc>
+          <desc xml:lang="en">Hex: #800000 / RGB: 128,0,0</desc>
         </valItem>
         <valItem ident="mediumaquamarine">
-          <desc>Hex: #66cdaa / RGB: 102,205,170</desc>
+          <desc xml:lang="en">Hex: #66cdaa / RGB: 102,205,170</desc>
         </valItem>
         <valItem ident="mediumblue">
-          <desc>Hex: #0000cd / RGB: 0,0,205</desc>
+          <desc xml:lang="en">Hex: #0000cd / RGB: 0,0,205</desc>
         </valItem>
         <valItem ident="mediumorchid">
-          <desc>Hex: #ba55d3 / RGB: 186,85,211</desc>
+          <desc xml:lang="en">Hex: #ba55d3 / RGB: 186,85,211</desc>
         </valItem>
         <valItem ident="mediumpurple">
-          <desc>Hex: #9370db / RGB: 147,112,219</desc>
+          <desc xml:lang="en">Hex: #9370db / RGB: 147,112,219</desc>
         </valItem>
         <valItem ident="mediumseagreen">
-          <desc>Hex: #3cb371 / RGB: 60,179,113</desc>
+          <desc xml:lang="en">Hex: #3cb371 / RGB: 60,179,113</desc>
         </valItem>
         <valItem ident="mediumslateblue">
-          <desc>Hex: #7b68ee / RGB: 123,104,238</desc>
+          <desc xml:lang="en">Hex: #7b68ee / RGB: 123,104,238</desc>
         </valItem>
         <valItem ident="mediumspringgreen">
-          <desc>Hex: #00fa9a / RGB: 0,250,154</desc>
+          <desc xml:lang="en">Hex: #00fa9a / RGB: 0,250,154</desc>
         </valItem>
         <valItem ident="mediumturquoise">
-          <desc>Hex: #48d1cc / RGB: 72,209,204</desc>
+          <desc xml:lang="en">Hex: #48d1cc / RGB: 72,209,204</desc>
         </valItem>
         <valItem ident="mediumvioletred">
-          <desc>Hex: #c71585 / RGB: 199,21,133</desc>
+          <desc xml:lang="en">Hex: #c71585 / RGB: 199,21,133</desc>
         </valItem>
         <valItem ident="midnightblue">
-          <desc>Hex: #191970 / RGB: 25,25,112</desc>
+          <desc xml:lang="en">Hex: #191970 / RGB: 25,25,112</desc>
         </valItem>
         <valItem ident="mintcream">
-          <desc>Hex: #f5fffa / RGB: 245,255,250</desc>
+          <desc xml:lang="en">Hex: #f5fffa / RGB: 245,255,250</desc>
         </valItem>
         <valItem ident="mistyrose">
-          <desc>Hex: #ffe4e1 / RGB: 255,228,225</desc>
+          <desc xml:lang="en">Hex: #ffe4e1 / RGB: 255,228,225</desc>
         </valItem>
         <valItem ident="moccasin">
-          <desc>Hex: #ffe4b5 / RGB: 255,228,181</desc>
+          <desc xml:lang="en">Hex: #ffe4b5 / RGB: 255,228,181</desc>
         </valItem>
         <valItem ident="navajowhite">
-          <desc>Hex: #ffdead / RGB: 255,222,173</desc>
+          <desc xml:lang="en">Hex: #ffdead / RGB: 255,222,173</desc>
         </valItem>
         <valItem ident="navy">
-          <desc>Hex: #000080 / RGB: 0,0,128</desc>
+          <desc xml:lang="en">Hex: #000080 / RGB: 0,0,128</desc>
         </valItem>
         <valItem ident="oldlace">
-          <desc>Hex: #fdf5e6 / RGB: 253,245,230</desc>
+          <desc xml:lang="en">Hex: #fdf5e6 / RGB: 253,245,230</desc>
         </valItem>
         <valItem ident="olive">
-          <desc>Hex: #808000 / RGB: 128,128,0</desc>
+          <desc xml:lang="en">Hex: #808000 / RGB: 128,128,0</desc>
         </valItem>
         <valItem ident="olivedrab">
-          <desc>Hex: #6b8e23 / RGB: 107,142,35</desc>
+          <desc xml:lang="en">Hex: #6b8e23 / RGB: 107,142,35</desc>
         </valItem>
         <valItem ident="orange">
-          <desc>Hex: #ffa500 / RGB: 255,165,0</desc>
+          <desc xml:lang="en">Hex: #ffa500 / RGB: 255,165,0</desc>
         </valItem>
         <valItem ident="orangered">
-          <desc>Hex: #ff4500 / RGB: 255,69,0</desc>
+          <desc xml:lang="en">Hex: #ff4500 / RGB: 255,69,0</desc>
         </valItem>
         <valItem ident="orchid">
-          <desc>Hex: #da70d6 / RGB: 218,112,214</desc>
+          <desc xml:lang="en">Hex: #da70d6 / RGB: 218,112,214</desc>
         </valItem>
         <valItem ident="palegoldenrod">
-          <desc>Hex: #eee8aa / RGB: 238,232,170</desc>
+          <desc xml:lang="en">Hex: #eee8aa / RGB: 238,232,170</desc>
         </valItem>
         <valItem ident="palegreen">
-          <desc>Hex: #98fb98 / RGB: 152,251,152</desc>
+          <desc xml:lang="en">Hex: #98fb98 / RGB: 152,251,152</desc>
         </valItem>
         <valItem ident="paleturquoise">
-          <desc>Hex: #afeeee / RGB: 175,238,238</desc>
+          <desc xml:lang="en">Hex: #afeeee / RGB: 175,238,238</desc>
         </valItem>
         <valItem ident="palevioletred">
-          <desc>Hex: #db7093 / RGB: 219,112,147</desc>
+          <desc xml:lang="en">Hex: #db7093 / RGB: 219,112,147</desc>
         </valItem>
         <valItem ident="papayawhip">
-          <desc>Hex: #ffefd5 / RGB: 255,239,213</desc>
+          <desc xml:lang="en">Hex: #ffefd5 / RGB: 255,239,213</desc>
         </valItem>
         <valItem ident="peachpuff">
-          <desc>Hex: #ffdab9 / RGB: 255,218,185</desc>
+          <desc xml:lang="en">Hex: #ffdab9 / RGB: 255,218,185</desc>
         </valItem>
         <valItem ident="peru">
-          <desc>Hex: #cd853f / RGB: 205,133,63</desc>
+          <desc xml:lang="en">Hex: #cd853f / RGB: 205,133,63</desc>
         </valItem>
         <valItem ident="pink">
-          <desc>Hex: #ffc0cb / RGB: 255,192,203</desc>
+          <desc xml:lang="en">Hex: #ffc0cb / RGB: 255,192,203</desc>
         </valItem>
         <valItem ident="plum">
-          <desc>Hex: #dda0dd / RGB: 221,160,221</desc>
+          <desc xml:lang="en">Hex: #dda0dd / RGB: 221,160,221</desc>
         </valItem>
         <valItem ident="powderblue">
-          <desc>Hex: #b0e0e6 / RGB: 176,224,230</desc>
+          <desc xml:lang="en">Hex: #b0e0e6 / RGB: 176,224,230</desc>
         </valItem>
         <valItem ident="purple">
-          <desc>Hex: #800080 / RGB: 128,0,128</desc>
+          <desc xml:lang="en">Hex: #800080 / RGB: 128,0,128</desc>
         </valItem>
         <valItem ident="rebeccapurple">
-          <desc>Hex: #663399 / RGB: 102,51,153</desc>
+          <desc xml:lang="en">Hex: #663399 / RGB: 102,51,153</desc>
         </valItem>
         <valItem ident="red">
-          <desc>Hex: #ff0000 / RGB: 255,0,0</desc>
+          <desc xml:lang="en">Hex: #ff0000 / RGB: 255,0,0</desc>
         </valItem>
         <valItem ident="rosybrown">
-          <desc>Hex: #bc8f8f / RGB: 188,143,143</desc>
+          <desc xml:lang="en">Hex: #bc8f8f / RGB: 188,143,143</desc>
         </valItem>
         <valItem ident="royalblue">
-          <desc>Hex: #4169e1 / RGB: 65,105,225</desc>
+          <desc xml:lang="en">Hex: #4169e1 / RGB: 65,105,225</desc>
         </valItem>
         <valItem ident="saddlebrown">
-          <desc>Hex: #8b4513 / RGB: 139,69,19</desc>
+          <desc xml:lang="en">Hex: #8b4513 / RGB: 139,69,19</desc>
         </valItem>
         <valItem ident="salmon">
-          <desc>Hex: #fa8072 / RGB: 250,128,114</desc>
+          <desc xml:lang="en">Hex: #fa8072 / RGB: 250,128,114</desc>
         </valItem>
         <valItem ident="sandybrown">
-          <desc>Hex: #f4a460 / RGB: 244,164,96</desc>
+          <desc xml:lang="en">Hex: #f4a460 / RGB: 244,164,96</desc>
         </valItem>
         <valItem ident="seagreen">
-          <desc>Hex: #2e8b57 / RGB: 46,139,87</desc>
+          <desc xml:lang="en">Hex: #2e8b57 / RGB: 46,139,87</desc>
         </valItem>
         <valItem ident="seashell">
-          <desc>Hex: #fff5ee / RGB: 255,245,238</desc>
+          <desc xml:lang="en">Hex: #fff5ee / RGB: 255,245,238</desc>
         </valItem>
         <valItem ident="sienna">
-          <desc>Hex: #a0522d / RGB: 160,82,45</desc>
+          <desc xml:lang="en">Hex: #a0522d / RGB: 160,82,45</desc>
         </valItem>
         <valItem ident="silver">
-          <desc>Hex: #c0c0c0 / RGB: 192,192,192</desc>
+          <desc xml:lang="en">Hex: #c0c0c0 / RGB: 192,192,192</desc>
         </valItem>
         <valItem ident="skyblue">
-          <desc>Hex: #87ceeb / RGB: 135,206,235</desc>
+          <desc xml:lang="en">Hex: #87ceeb / RGB: 135,206,235</desc>
         </valItem>
         <valItem ident="slateblue">
-          <desc>Hex: #6a5acd / RGB: 106,90,205</desc>
+          <desc xml:lang="en">Hex: #6a5acd / RGB: 106,90,205</desc>
         </valItem>
         <valItem ident="slategray">
-          <desc>Hex: #708090 / RGB: 112,128,144</desc>
+          <desc xml:lang="en">Hex: #708090 / RGB: 112,128,144</desc>
         </valItem>
         <valItem ident="slategrey">
-          <desc>Hex: #708090 / RGB: 112,128,144</desc>
+          <desc xml:lang="en">Hex: #708090 / RGB: 112,128,144</desc>
         </valItem>
         <valItem ident="snow">
-          <desc>Hex: #fffafa / RGB: 255,250,250</desc>
+          <desc xml:lang="en">Hex: #fffafa / RGB: 255,250,250</desc>
         </valItem>
         <valItem ident="springgreen">
-          <desc>Hex: #00ff7f / RGB: 0,255,127</desc>
+          <desc xml:lang="en">Hex: #00ff7f / RGB: 0,255,127</desc>
         </valItem>
         <valItem ident="steelblue">
-          <desc>Hex: #4682b4 / RGB: 70,130,180</desc>
+          <desc xml:lang="en">Hex: #4682b4 / RGB: 70,130,180</desc>
         </valItem>
         <valItem ident="tan">
-          <desc>Hex: #d2b48c / RGB: 210,180,140</desc>
+          <desc xml:lang="en">Hex: #d2b48c / RGB: 210,180,140</desc>
         </valItem>
         <valItem ident="teal">
-          <desc>Hex: #008080 / RGB: 0,128,128</desc>
+          <desc xml:lang="en">Hex: #008080 / RGB: 0,128,128</desc>
         </valItem>
         <valItem ident="thistle">
-          <desc>Hex: #d8bfd8 / RGB: 216,191,216</desc>
+          <desc xml:lang="en">Hex: #d8bfd8 / RGB: 216,191,216</desc>
         </valItem>
         <valItem ident="tomato">
-          <desc>Hex: #ff6347 / RGB: 255,99,71</desc>
+          <desc xml:lang="en">Hex: #ff6347 / RGB: 255,99,71</desc>
         </valItem>
         <valItem ident="turquoise">
-          <desc>Hex: #40e0d0 / RGB: 64,224,208</desc>
+          <desc xml:lang="en">Hex: #40e0d0 / RGB: 64,224,208</desc>
         </valItem>
         <valItem ident="violet">
-          <desc>Hex: #ee82ee / RGB: 238,130,238</desc>
+          <desc xml:lang="en">Hex: #ee82ee / RGB: 238,130,238</desc>
         </valItem>
         <valItem ident="wheat">
-          <desc>Hex: #f5deb3 / RGB: 245,222,179</desc>
+          <desc xml:lang="en">Hex: #f5deb3 / RGB: 245,222,179</desc>
         </valItem>
         <valItem ident="white">
-          <desc>Hex: #ffffff / RGB: 255,255,255</desc>
+          <desc xml:lang="en">Hex: #ffffff / RGB: 255,255,255</desc>
         </valItem>
         <valItem ident="whitesmoke">
-          <desc>Hex: #f5f5f5 / RGB: 245,245,245</desc>
+          <desc xml:lang="en">Hex: #f5f5f5 / RGB: 245,245,245</desc>
         </valItem>
         <valItem ident="yellow">
-          <desc>Hex: #ffff00 / RGB: 255,255,0</desc>
+          <desc xml:lang="en">Hex: #ffff00 / RGB: 255,255,0</desc>
         </valItem>
         <valItem ident="yellowgreen">
-          <desc>Hex: #9acd32 / RGB: 154,205,50</desc>
+          <desc xml:lang="en">Hex: #9acd32 / RGB: 154,205,50</desc>
         </valItem>
       </valList>
     </content>
@@ -1015,7 +1015,7 @@
     </remarks>
   </macroSpec>
   <macroSpec ident="data.COLORVALUES" module="MEI" type="dt">
-    <desc>Parameterized color values</desc>
+    <desc xml:lang="en">Parameterized color values</desc>
     <content>
       <rng:choice>
         <!-- hex values -->
@@ -1050,7 +1050,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.COLOR" module="MEI" type="dt">
-    <desc>A value in one of the following forms is expected: 1) hexadecimal RRGGBB, 2) hexadecimal
+    <desc xml:lang="en">A value in one of the following forms is expected: 1) hexadecimal RRGGBB, 2) hexadecimal
       RRGGBBAA, 3) CSS RGB, 4) CSS RGBA, 5) HSL, 6) HSLA, or 7) CSS color name.</desc>
     <content>
       <rng:choice>
@@ -1060,7 +1060,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.COMPASSDIRECTION" module="MEI" type="dt">
-    <desc>Description of direction with respect to an imaginary compass.</desc>
+    <desc xml:lang="en">Description of direction with respect to an imaginary compass.</desc>
     <content>
       <alternate>
         <macroRef key="data.COMPASSDIRECTION.basic"/>
@@ -1069,45 +1069,45 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.COMPASSDIRECTION.basic" module="MEI" type="dt">
-    <desc>Basic compass directions.</desc>
+    <desc xml:lang="en">Basic compass directions.</desc>
     <content>
       <valList type="closed">
         <valItem ident="n">
-          <desc>In a northern direction.</desc>
+          <desc xml:lang="en">In a northern direction.</desc>
         </valItem>
         <valItem ident="e">
-          <desc>In an eastern direction.</desc>
+          <desc xml:lang="en">In an eastern direction.</desc>
         </valItem>
         <valItem ident="s">
-          <desc>In a southern direction.</desc>
+          <desc xml:lang="en">In a southern direction.</desc>
         </valItem>
         <valItem ident="w">
-          <desc>In a western direction.</desc>
+          <desc xml:lang="en">In a western direction.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.COMPASSDIRECTION.extended" module="MEI" type="dt">
-    <desc>Additional compass directions.</desc>
+    <desc xml:lang="en">Additional compass directions.</desc>
     <content>
       <valList type="closed">
         <valItem ident="ne">
-          <desc>In a north-eastern direction.</desc>
+          <desc xml:lang="en">In a north-eastern direction.</desc>
         </valItem>
         <valItem ident="nw">
-          <desc>In a north-western direction.</desc>
+          <desc xml:lang="en">In a north-western direction.</desc>
         </valItem>
         <valItem ident="se">
-          <desc>In a south-eastern direction.</desc>
+          <desc xml:lang="en">In a south-eastern direction.</desc>
         </valItem>
         <valItem ident="sw">
-          <desc>In a south-western direction.</desc>
+          <desc xml:lang="en">In a south-western direction.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.DEGREES" module="MEI" type="dt">
-    <desc>360th-unit measure of a circle’s circumference; optionally signed decimal number between
+    <desc xml:lang="en">360th-unit measure of a circle’s circumference; optionally signed decimal number between
       -360 and 360.</desc>
     <content>
       <rng:data type="decimal">
@@ -1117,35 +1117,35 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.DIVISIO" module="MEI" type="dt">
-    <desc>Divisio values.</desc>
+    <desc xml:lang="en">Divisio values.</desc>
     <content>
       <valList type="closed">
         <valItem ident="ternaria">
-          <desc>Divisio ternaria. Three semibreves in a breve.</desc>
+          <desc xml:lang="en">Divisio ternaria. Three semibreves in a breve.</desc>
         </valItem>
         <valItem ident="quaternaria">
-          <desc>Divisio quaternaria. Foursemibreves in a breve.</desc>
+          <desc xml:lang="en">Divisio quaternaria. Foursemibreves in a breve.</desc>
         </valItem>
         <valItem ident="senariaimperf">
-          <desc>Divisio senaria imperfecta. Six semibreves in a breve (breve is divided into two, then into three). Aka senaria gallica.</desc>
+          <desc xml:lang="en">Divisio senaria imperfecta. Six semibreves in a breve (breve is divided into two, then into three). Aka senaria gallica.</desc>
         </valItem>
         <valItem ident="senariaperf">
-          <desc>Divisio senaria perfecta. Six semibreves in a breve (breve is divided into three, then into two). Aka senaria italica.</desc>
+          <desc xml:lang="en">Divisio senaria perfecta. Six semibreves in a breve (breve is divided into three, then into two). Aka senaria italica.</desc>
         </valItem>
         <valItem ident="octonaria">
-          <desc>Divisio octonaria. Eight semibreves in a breve.</desc>
+          <desc xml:lang="en">Divisio octonaria. Eight semibreves in a breve.</desc>
         </valItem>
         <valItem ident="novenaria">
-          <desc>Divisio novenaria. Nine semibreves in a breve.</desc>
+          <desc xml:lang="en">Divisio novenaria. Nine semibreves in a breve.</desc>
         </valItem>
         <valItem ident="duodenaria">
-          <desc>Divisio duodenaria. Twelve semibreves in a breve.</desc>
+          <desc xml:lang="en">Divisio duodenaria. Twelve semibreves in a breve.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.DURATION" module="MEI" type="dt">
-    <desc>Logical, that is, written, duration attribute values.</desc>
+    <desc xml:lang="en">Logical, that is, written, duration attribute values.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.DURATION.cmn"/>
@@ -1154,7 +1154,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.DURATIONRESTS" module="MEI" type="dt">
-    <desc>Logical, that is, written, duration attribute values for rests.</desc>
+    <desc xml:lang="en">Logical, that is, written, duration attribute values for rests.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.DURATION.cmn"/>
@@ -1163,7 +1163,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.DURATION.gestural" module="MEI" type="dt">
-    <desc>Performed duration attribute values.</desc>
+    <desc xml:lang="en">Performed duration attribute values.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.DURATION.cmn"/>
@@ -1172,26 +1172,26 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.ENCLOSURE" module="MEI" type="dt">
-    <desc>Enclosures for editorial notes, accidentals, articulations, etc.</desc>
+    <desc xml:lang="en">Enclosures for editorial notes, accidentals, articulations, etc.</desc>
     <content>
       <valList type="closed">
         <valItem ident="paren">
-          <desc>Parentheses: ( and ).</desc>
+          <desc xml:lang="en">Parentheses: ( and ).</desc>
         </valItem>
         <valItem ident="brack">
-          <desc>Square brackets: [ and ].</desc>
+          <desc xml:lang="en">Square brackets: [ and ].</desc>
         </valItem>
         <valItem ident="box">
-          <desc>Box.</desc>
+          <desc xml:lang="en">Box.</desc>
         </valItem>
         <valItem ident="none">
-          <desc>None.</desc>
+          <desc xml:lang="en">None.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.EVENTREL" module="MEI" type="dt">
-    <desc>Location of musical material relative to a symbol on a staff instead of the staff.</desc>
+    <desc xml:lang="en">Location of musical material relative to a symbol on a staff instead of the staff.</desc>
     <content>
       <alternate>
         <macroRef key="data.EVENTREL.basic"/>
@@ -1200,72 +1200,72 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.EVENTREL.basic" module="MEI" type="dt">
-    <desc>Location of musical material relative to a symbol other than a staff.</desc>
+    <desc xml:lang="en">Location of musical material relative to a symbol other than a staff.</desc>
     <content>
       <valList type="closed">
         <valItem ident="above">
-          <desc>Above.</desc>
+          <desc xml:lang="en">Above.</desc>
         </valItem>
         <valItem ident="below">
-          <desc>Below.</desc>
+          <desc xml:lang="en">Below.</desc>
         </valItem>
         <valItem ident="left">
-          <desc>Left.</desc>
+          <desc xml:lang="en">Left.</desc>
         </valItem>
         <valItem ident="right">
-          <desc>Right.</desc>
+          <desc xml:lang="en">Right.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.EVENTREL.extended" module="MEI" type="dt">
-    <desc>Location of musical material relative to a symbol other than a staff.</desc>
+    <desc xml:lang="en">Location of musical material relative to a symbol other than a staff.</desc>
     <content>
       <valList type="closed">
         <valItem ident="above-left">
-          <desc>Above and left; north-west.</desc>
+          <desc xml:lang="en">Above and left; north-west.</desc>
         </valItem>
         <valItem ident="above-right">
-          <desc>Above and right; north-east.</desc>
+          <desc xml:lang="en">Above and right; north-east.</desc>
         </valItem>
         <valItem ident="below-left">
-          <desc>Below and left; south-west.</desc>
+          <desc xml:lang="en">Below and left; south-west.</desc>
         </valItem>
         <valItem ident="below-right">
-          <desc>Below and right; south-east.</desc>
+          <desc xml:lang="en">Below and right; south-east.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.FILL" module="MEI" type="dt">
-    <desc>Describes how a graphical object, such as a note head, should be filled. The relative
+    <desc xml:lang="en">Describes how a graphical object, such as a note head, should be filled. The relative
       values — top, bottom, left, and right — indicate these locations *after* rotation is
       applied.</desc>
     <content>
       <valList type="closed">
         <valItem ident="void">
-          <desc>Unfilled</desc>
+          <desc xml:lang="en">Unfilled</desc>
         </valItem>
         <valItem ident="solid">
-          <desc>Filled</desc>
+          <desc xml:lang="en">Filled</desc>
         </valItem>
         <valItem ident="top">
-          <desc>Top half filled</desc>
+          <desc xml:lang="en">Top half filled</desc>
         </valItem>
         <valItem ident="bottom">
-          <desc>Bottom half filled</desc>
+          <desc xml:lang="en">Bottom half filled</desc>
         </valItem>
         <valItem ident="left">
-          <desc>Left half filled</desc>
+          <desc xml:lang="en">Left half filled</desc>
         </valItem>
         <valItem ident="right">
-          <desc>Right half filled</desc>
+          <desc xml:lang="en">Right half filled</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.FINGER.FRET" module="MEI" type="dt">
-    <desc>In a guitar chord diagram, a label indicating which finger, if any, should be used to play
+    <desc xml:lang="en">In a guitar chord diagram, a label indicating which finger, if any, should be used to play
       an individual string. The index, middle, ring, and little fingers are represented by the
       values 1-4, while 't' is for the thumb. The values 'x' and 'o' indicate stopped and open
       strings, respectively.</desc>
@@ -1282,19 +1282,19 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.FONTFAMILY" module="MEI" type="dt">
-    <desc>Font family (for text) attribute values.</desc>
+    <desc xml:lang="en">Font family (for text) attribute values.</desc>
     <content>
       <rng:data type="token"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.FONTNAME" module="MEI" type="dt">
-    <desc>Font name (for text) attribute values.</desc>
+    <desc xml:lang="en">Font name (for text) attribute values.</desc>
     <content>
       <rng:data type="token"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.FONTSIZE" module="MEI" type="dt">
-    <desc>Font size expressions.</desc>
+    <desc xml:lang="en">Font size expressions.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.FONTSIZENUMERIC"/>
@@ -1304,7 +1304,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.FONTSIZENUMERIC" module="MEI" type="dt">
-    <desc>Font size expressed as numbers; <abbr>i.e.</abbr>, points or virtual units.</desc>
+    <desc xml:lang="en">Font size expressed as numbers; <abbr>i.e.</abbr>, points or virtual units.</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">\d*(\.\d+)?(pt|vu)</rng:param>
@@ -1329,7 +1329,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.FONTSIZESCALE" module="MEI" type="dt">
-    <desc>Relative size of symbol that may begin/end a line.</desc>
+    <desc xml:lang="en">Relative size of symbol that may begin/end a line.</desc>
     <content>
       <rng:data type="integer">
         <rng:param name="minInclusive">1</rng:param>
@@ -1338,77 +1338,77 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.FONTSIZETERM" module="MEI" type="dt">
-    <desc>Font size expressed as relative term.</desc>
+    <desc xml:lang="en">Font size expressed as relative term.</desc>
     <content>
       <valList type="closed">
         <valItem ident="xx-small">
-          <desc>Smaller than x-small.</desc>
+          <desc xml:lang="en">Smaller than x-small.</desc>
         </valItem>
         <valItem ident="x-small">
-          <desc>Smaller than small, larger than xx-small.</desc>
+          <desc xml:lang="en">Smaller than small, larger than xx-small.</desc>
         </valItem>
         <valItem ident="small">
-          <desc>Smaller than normal, larger than x-small.</desc>
+          <desc xml:lang="en">Smaller than normal, larger than x-small.</desc>
         </valItem>
         <valItem ident="normal">
-          <desc>Smaller than large, larger than small.</desc>
+          <desc xml:lang="en">Smaller than large, larger than small.</desc>
         </valItem>
         <valItem ident="large">
-          <desc>Smaller than x-large, larger than normal.</desc>
+          <desc xml:lang="en">Smaller than x-large, larger than normal.</desc>
         </valItem>
         <valItem ident="x-large">
-          <desc>Smaller than xx-large, larger than large.</desc>
+          <desc xml:lang="en">Smaller than xx-large, larger than large.</desc>
         </valItem>
         <valItem ident="xx-large">
-          <desc>Larger than x-large.</desc>
+          <desc xml:lang="en">Larger than x-large.</desc>
         </valItem>
         <valItem ident="smaller">
-          <desc>One size smaller than the current size.</desc>
+          <desc xml:lang="en">One size smaller than the current size.</desc>
         </valItem>
         <valItem ident="larger">
-          <desc>One size larger than the current size.</desc>
+          <desc xml:lang="en">One size larger than the current size.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.FONTSTYLE" module="MEI" type="dt">
-    <desc>Font style (for text) attribute values.</desc>
+    <desc xml:lang="en">Font style (for text) attribute values.</desc>
     <content>
       <valList type="closed">
         <valItem ident="italic">
-          <desc>Text slants to right.</desc>
+          <desc xml:lang="en">Text slants to right.</desc>
         </valItem>
         <valItem ident="normal">
-          <desc>Unadorned.</desc>
+          <desc xml:lang="en">Unadorned.</desc>
         </valItem>
         <valItem ident="oblique">
-          <desc>Text slants to the left.</desc>
+          <desc xml:lang="en">Text slants to the left.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.FONTWEIGHT" module="MEI" type="dt">
-    <desc>Font weight (for text) attribute values.</desc>
+    <desc xml:lang="en">Font weight (for text) attribute values.</desc>
     <content>
       <valList type="closed">
         <valItem ident="bold">
-          <desc>Bold or heavy.</desc>
+          <desc xml:lang="en">Bold or heavy.</desc>
         </valItem>
         <valItem ident="normal">
-          <desc>Not bold.</desc>
+          <desc xml:lang="en">Not bold.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.FRETNUMBER" module="MEI" type="dt">
-    <desc>In string tablature, the fret number. The value <val>0</val> (zero) indicates the open
+    <desc xml:lang="en">In string tablature, the fret number. The value <val>0</val> (zero) indicates the open
       string.</desc>
     <content>
       <rng:data type="nonNegativeInteger"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.FRETNUMBER.limited" module="MEI" type="dt">
-    <desc>In a guitar chord diagram, the fret where the finger should be placed. Since guitar chord
+    <desc xml:lang="en">In a guitar chord diagram, the fret where the finger should be placed. Since guitar chord
       diagrams are limited to the range of frets that fall under the hand, the values here are a
       subset of those available in data.FRETNUMBER. The pos (position) attribute on the chordDef
       element must be used to indicate at which fret this range begins.</desc>
@@ -1420,39 +1420,39 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.GLISSANDO" module="MEI" type="dt">
-    <desc>Analytical glissando attribute values.</desc>
+    <desc xml:lang="en">Analytical glissando attribute values.</desc>
     <content>
       <valList type="closed">
         <valItem ident="i">
-          <desc>First note/chord in glissando.</desc>
+          <desc xml:lang="en">First note/chord in glissando.</desc>
         </valItem>
         <valItem ident="m">
-          <desc>Note/chord that’s neither first nor last in glissando.</desc>
+          <desc xml:lang="en">Note/chord that’s neither first nor last in glissando.</desc>
         </valItem>
         <valItem ident="t">
-          <desc>Last note in glissando.</desc>
+          <desc xml:lang="en">Last note in glissando.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.GRACE" module="MEI" type="dt">
-    <desc>Do grace notes get time from the current (acc) or previous (unacc) one?</desc>
+    <desc xml:lang="en">Do grace notes get time from the current (acc) or previous (unacc) one?</desc>
     <content>
       <valList type="closed">
         <valItem ident="acc">
-          <desc>Time "stolen" from following note.</desc>
+          <desc xml:lang="en">Time "stolen" from following note.</desc>
         </valItem>
         <valItem ident="unacc">
-          <desc>Time "stolen" from previous note.</desc>
+          <desc xml:lang="en">Time "stolen" from previous note.</desc>
         </valItem>
         <valItem ident="unknown">
-          <desc>No interpretation regarding performed value of grace note.</desc>
+          <desc xml:lang="en">No interpretation regarding performed value of grace note.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.HEADSHAPE" module="MEI" type="dt">
-    <desc>Note head shapes.</desc>
+    <desc xml:lang="en">Note head shapes.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.HEADSHAPE.list"/>
@@ -1462,62 +1462,62 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.HEADSHAPE.list" module="MEI" type="dt">
-    <desc>Enumerated note head shapes.</desc>
+    <desc xml:lang="en">Enumerated note head shapes.</desc>
     <content>
       <valList type="closed">
         <valItem ident="quarter">
-          <desc>Filled, rotated oval (Unicode 1D158).</desc>
+          <desc xml:lang="en">Filled, rotated oval (Unicode 1D158).</desc>
         </valItem>
         <valItem ident="half">
-          <desc>Unfilled, rotated oval (Unicode 1D157).</desc>
+          <desc xml:lang="en">Unfilled, rotated oval (Unicode 1D157).</desc>
         </valItem>
         <valItem ident="whole">
-          <desc>Unfilled, rotated oval (Unicode 1D15D).</desc>
+          <desc xml:lang="en">Unfilled, rotated oval (Unicode 1D15D).</desc>
         </valItem>
         <valItem ident="backslash">
-          <desc>Unfilled backslash (~ reflection of Unicode 1D10D).</desc>
+          <desc xml:lang="en">Unfilled backslash (~ reflection of Unicode 1D10D).</desc>
         </valItem>
         <valItem ident="circle">
-          <desc>Unfilled circle (Unicode 25CB).</desc>
+          <desc xml:lang="en">Unfilled circle (Unicode 25CB).</desc>
         </valItem>
         <valItem ident="+">
-          <desc>Plus sign (Unicode 1D144).</desc>
+          <desc xml:lang="en">Plus sign (Unicode 1D144).</desc>
         </valItem>
         <valItem ident="diamond">
-          <desc>Unfilled diamond (Unicode 1D1B9).</desc>
+          <desc xml:lang="en">Unfilled diamond (Unicode 1D1B9).</desc>
         </valItem>
         <valItem ident="isotriangle">
-          <desc>Unfilled isosceles triangle (Unicode 1D148).</desc>
+          <desc xml:lang="en">Unfilled isosceles triangle (Unicode 1D148).</desc>
         </valItem>
         <valItem ident="oval">
-          <desc>Unfilled, unrotated oval (Unicode 2B2D).</desc>
+          <desc xml:lang="en">Unfilled, unrotated oval (Unicode 2B2D).</desc>
         </valItem>
         <valItem ident="piewedge">
-          <desc>Unfilled downward-pointing wedge (Unicode 1D154).</desc>
+          <desc xml:lang="en">Unfilled downward-pointing wedge (Unicode 1D154).</desc>
         </valItem>
         <valItem ident="rectangle">
-          <desc>Unfilled rectangle (Unicode 25AD).</desc>
+          <desc xml:lang="en">Unfilled rectangle (Unicode 25AD).</desc>
         </valItem>
         <valItem ident="rtriangle">
-          <desc>Unfilled right triangle (Unicode 1D14A).</desc>
+          <desc xml:lang="en">Unfilled right triangle (Unicode 1D14A).</desc>
         </valItem>
         <valItem ident="semicircle">
-          <desc>Unfilled semi-circle (Unicode 1D152).</desc>
+          <desc xml:lang="en">Unfilled semi-circle (Unicode 1D152).</desc>
         </valItem>
         <valItem ident="slash">
-          <desc>Unfilled slash (~ Unicode 1D10D).</desc>
+          <desc xml:lang="en">Unfilled slash (~ Unicode 1D10D).</desc>
         </valItem>
         <valItem ident="square">
-          <desc>Unfilled square (Unicode 1D146).</desc>
+          <desc xml:lang="en">Unfilled square (Unicode 1D146).</desc>
         </valItem>
         <valItem ident="x">
-          <desc>X (Unicode 1D143).</desc>
+          <desc xml:lang="en">X (Unicode 1D143).</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.HEXNUM" module="MEI" type="dt">
-    <desc>Hexadecimal number.</desc>
+    <desc xml:lang="en">Hexadecimal number.</desc>
     <content>
       <rng:data type="string">
         <rng:param name="pattern">(#x|U\+)[A-F0-9]+</rng:param>
@@ -1525,32 +1525,32 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.HORIZONTALALIGNMENT" module="MEI" type="dt">
-    <desc>Data values for attributes that capture horizontal alignment.</desc>
+    <desc xml:lang="en">Data values for attributes that capture horizontal alignment.</desc>
     <content>
       <valList type="closed">
         <valItem ident="left">
-          <desc>Left aligned.</desc>
+          <desc xml:lang="en">Left aligned.</desc>
         </valItem>
         <valItem ident="right">
-          <desc>Right aligned.</desc>
+          <desc xml:lang="en">Right aligned.</desc>
         </valItem>
         <valItem ident="center">
-          <desc>Centered.</desc>
+          <desc xml:lang="en">Centered.</desc>
         </valItem>
         <valItem ident="justify">
-          <desc>Left and right aligned.</desc>
+          <desc xml:lang="en">Left and right aligned.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.IDREF" module="MEI" type="dt">
-    <desc>An ID reference.</desc>
+    <desc xml:lang="en">An ID reference.</desc>
     <content>
       <rng:data type="IDREF"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.INEUMEFORM" module="MEI" type="dt">
-    <desc>Interrupted neume forms.</desc>
+    <desc xml:lang="en">Interrupted neume forms.</desc>
     <content>
       <valList type="closed">
         <valItem ident="liquescent1"/>
@@ -1562,7 +1562,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.INEUMENAME" module="MEI" type="dt">
-    <desc>Interrupted neume, <abbr>i.e.</abbr>, neume written as 2 or more sub-neumes.</desc>
+    <desc xml:lang="en">Interrupted neume, <abbr>i.e.</abbr>, neume written as 2 or more sub-neumes.</desc>
     <content>
       <valList type="closed">
         <valItem ident="pessubpunctis"/>
@@ -1576,7 +1576,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.INTERVAL.HARMONIC" module="MEI" type="dt">
-    <desc>A token indicating diatonic interval quality and size.</desc>
+    <desc xml:lang="en">A token indicating diatonic interval quality and size.</desc>
     <content>
       <rng:choice>
         <rng:data type="token">
@@ -1586,7 +1586,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.INTERVAL.MELODIC" module="MEI" type="dt">
-    <desc>A token indicating direction of the interval but not its precise value, a diatonic
+    <desc xml:lang="en">A token indicating direction of the interval but not its precise value, a diatonic
       interval (with optional direction and quality), or a decimal value in half steps. Decimal
       values are permitted to accommodate micro-tuning.</desc>
     <content>
@@ -1642,7 +1642,7 @@
     </remarks>
   </macroSpec>
   <macroSpec ident="data.ISODATE" module="MEI" type="dt">
-    <desc>ISO date formats.</desc>
+    <desc xml:lang="en">ISO date formats.</desc>
     <content>
       <rng:choice>
         <rng:data type="date"/>
@@ -1660,14 +1660,14 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.ISOTIME" module="MEI" type="dt">
-    <desc>ISO 24-hour time format: HH:MM:SS.ss, <abbr>i.e.</abbr>,
+    <desc xml:lang="en">ISO 24-hour time format: HH:MM:SS.ss, <abbr>i.e.</abbr>,
       [0-9][0-9]:[0-9][0-9]:[0-9][0-9](\.?[0-9]*)?.</desc>
     <content>
       <rng:data type="time"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.KEYFIFTHS" module="MEI" type="dt">
-    <desc>Indicates the location of the tonic in the circle of fifths.</desc>
+    <desc xml:lang="en">Indicates the location of the tonic in the circle of fifths.</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">mixed|0|([1-9]|1[0-2])[f|s]</rng:param>
@@ -1675,7 +1675,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.LAYERSCHEME" module="MEI" type="dt">
-    <desc>Indicates how stems should be drawn when more than one layer is present and stem
+    <desc xml:lang="en">Indicates how stems should be drawn when more than one layer is present and stem
       directions are not indicated on the notes/chords themselves. '1' indicates that there is only
       a single layer on a staff. '2o' means there are two layers with opposing stems. '2f' indicates
       two 'free' layers; that is, opposing stems will be drawn unless one of the layers has 'space'.
@@ -1684,128 +1684,128 @@
     <content>
       <valList type="closed">
         <valItem ident="1">
-          <desc>Single layer.</desc>
+          <desc xml:lang="en">Single layer.</desc>
         </valItem>
         <valItem ident="2o">
-          <desc>Two layers with opposing stems.</desc>
+          <desc xml:lang="en">Two layers with opposing stems.</desc>
         </valItem>
         <valItem ident="2f">
-          <desc>Two layers with 'floating' stems.</desc>
+          <desc xml:lang="en">Two layers with 'floating' stems.</desc>
         </valItem>
         <valItem ident="3o">
-          <desc>Three layers with opposing stems.</desc>
+          <desc xml:lang="en">Three layers with opposing stems.</desc>
         </valItem>
         <valItem ident="3f">
-          <desc>Three layers with 'floating' stems.</desc>
+          <desc xml:lang="en">Three layers with 'floating' stems.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.LIGATUREFORM" module="MEI" type="dt">
-    <desc>Ligature forms.</desc>
+    <desc xml:lang="en">Ligature forms.</desc>
     <content>
       <valList type="closed">
         <valItem ident="recta">
-          <desc>Notes are "squeezed" together.</desc>
+          <desc xml:lang="en">Notes are "squeezed" together.</desc>
         </valItem>
         <valItem ident="obliqua">
-          <desc>Individual notes are replaced by an oblique figure.</desc>
+          <desc xml:lang="en">Individual notes are replaced by an oblique figure.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.LINEFORM" module="MEI" type="dt">
-    <desc>Visual form of a line.</desc>
+    <desc xml:lang="en">Visual form of a line.</desc>
     <content>
       <valList type="closed">
         <valItem ident="dashed">
-          <desc>Dashed line.</desc>
+          <desc xml:lang="en">Dashed line.</desc>
         </valItem>
         <valItem ident="dotted">
-          <desc>Dotted line.</desc>
+          <desc xml:lang="en">Dotted line.</desc>
         </valItem>
         <valItem ident="solid">
-          <desc>Straight, uninterrupted line.</desc>
+          <desc xml:lang="en">Straight, uninterrupted line.</desc>
         </valItem>
         <valItem ident="wavy">
-          <desc>Undulating line.</desc>
+          <desc xml:lang="en">Undulating line.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.LINESTARTENDSYMBOL" module="MEI" type="dt">
-    <desc>Symbol that may begin/end a line.</desc>
+    <desc xml:lang="en">Symbol that may begin/end a line.</desc>
     <content>
       <valList type="closed">
         <valItem ident="angledown">
-          <desc>90 degree turn down (similar to Unicode 231D at end of line, 231C at start).</desc>
+          <desc xml:lang="en">90 degree turn down (similar to Unicode 231D at end of line, 231C at start).</desc>
         </valItem>
         <valItem ident="angleup">
-          <desc>90 degree turn up (similar to Unicode 231F at end of line, 231E at start).</desc>
+          <desc xml:lang="en">90 degree turn up (similar to Unicode 231F at end of line, 231E at start).</desc>
         </valItem>
         <valItem ident="angleright">
-          <desc>90 degree turn right (syntactic sugar for "angledown" for vertical or angled
+          <desc xml:lang="en">90 degree turn right (syntactic sugar for "angledown" for vertical or angled
             lines).</desc>
         </valItem>
         <valItem ident="angleleft">
-          <desc>90 degree turn left (syntactic sugar for "angleup" for vertical or angled
+          <desc xml:lang="en">90 degree turn left (syntactic sugar for "angleup" for vertical or angled
             lines).</desc>
         </valItem>
         <valItem ident="arrow">
-          <desc>Filled, triangular arrowhead (similar to Unicode U+25C0 or SMuFL U+EB78).</desc>
+          <desc xml:lang="en">Filled, triangular arrowhead (similar to Unicode U+25C0 or SMuFL U+EB78).</desc>
         </valItem>
         <valItem ident="arrowopen">
-          <desc>Open triangular arrowhead (similar to Unicode U+02C3 or SMuFL U+EB8A).</desc>
+          <desc xml:lang="en">Open triangular arrowhead (similar to Unicode U+02C3 or SMuFL U+EB8A).</desc>
         </valItem>
         <valItem ident="arrowwhite">
-          <desc>Unfilled, triangular arrowhead (similar to Unicode U+25C1 or SMuFL U+EB82).</desc>
+          <desc xml:lang="en">Unfilled, triangular arrowhead (similar to Unicode U+25C1 or SMuFL U+EB82).</desc>
         </valItem>
         <valItem ident="harpoonleft">
-          <desc>Harpoon-shaped arrowhead left of line (similar to arrowhead of Unicode
+          <desc xml:lang="en">Harpoon-shaped arrowhead left of line (similar to arrowhead of Unicode
             U+21BD).</desc>
         </valItem>
         <valItem ident="harpoonright">
-          <desc>Harpoon-shaped arrowhead right of line (similar to arrowhead of Unicode
+          <desc xml:lang="en">Harpoon-shaped arrowhead right of line (similar to arrowhead of Unicode
             U+21BC).</desc>
         </valItem>
         <valItem ident="H">
-          <desc>Hauptstimme (Unicode U+1D1A6 or SMuFL U+E860).</desc>
+          <desc xml:lang="en">Hauptstimme (Unicode U+1D1A6 or SMuFL U+E860).</desc>
         </valItem>
         <valItem ident="N">
-          <desc>Nebenstimme (Unicode U+1D1A7 or SMuFL U+E861).</desc>
+          <desc xml:lang="en">Nebenstimme (Unicode U+1D1A7 or SMuFL U+E861).</desc>
         </valItem>
         <valItem ident="Th">
-          <desc>Theme (SMuFL U+E864).</desc>
+          <desc xml:lang="en">Theme (SMuFL U+E864).</desc>
         </valItem>
         <valItem ident="ThRetro">
-          <desc>Theme, retrograde (SMuFL U+E865).</desc>
+          <desc xml:lang="en">Theme, retrograde (SMuFL U+E865).</desc>
         </valItem>
         <valItem ident="ThRetroInv">
-          <desc>Theme, retrograde inversion (SMuFL U+E866).</desc>
+          <desc xml:lang="en">Theme, retrograde inversion (SMuFL U+E866).</desc>
         </valItem>
         <valItem ident="ThInv">
-          <desc>Theme, inverted (SMuFL U+E867).</desc>
+          <desc xml:lang="en">Theme, inverted (SMuFL U+E867).</desc>
         </valItem>
         <valItem ident="T">
-          <desc>Theme (SMuFL U+E868).</desc>
+          <desc xml:lang="en">Theme (SMuFL U+E868).</desc>
         </valItem>
         <valItem ident="TInv">
-          <desc>Theme, inverted (SMuFL U+E869).</desc>
+          <desc xml:lang="en">Theme, inverted (SMuFL U+E869).</desc>
         </valItem>
         <valItem ident="CH">
-          <desc>Choralemelodie (SMuFL U+E86A).</desc>
+          <desc xml:lang="en">Choralemelodie (SMuFL U+E86A).</desc>
         </valItem>
         <valItem ident="RH">
-          <desc>Hauptrhythmus (SMuFL U+E86B).</desc>
+          <desc xml:lang="en">Hauptrhythmus (SMuFL U+E86B).</desc>
         </valItem>
         <valItem ident="none">
-          <desc>No start/end symbol.</desc>
+          <desc xml:lang="en">No start/end symbol.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.LINEWIDTH" module="MEI" type="dt">
-    <desc>Datatype of line width measurements.</desc>
+    <desc xml:lang="en">Datatype of line width measurements.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.LINEWIDTHTERM"/>
@@ -1814,23 +1814,23 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.LINEWIDTHTERM" module="MEI" type="dt">
-    <desc>Relative width of a line.</desc>
+    <desc xml:lang="en">Relative width of a line.</desc>
     <content>
       <valList type="closed">
         <valItem ident="narrow">
-          <desc>Default line width.</desc>
+          <desc xml:lang="en">Default line width.</desc>
         </valItem>
         <valItem ident="medium">
-          <desc>Twice as wide as narrow.</desc>
+          <desc xml:lang="en">Twice as wide as narrow.</desc>
         </valItem>
         <valItem ident="wide">
-          <desc>Twice as wide as medium.</desc>
+          <desc xml:lang="en">Twice as wide as medium.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.MEASUREBEAT" module="MEI" type="dt">
-    <desc>A count of measures plus a beat location, <abbr>i.e.</abbr>, [0-9]+m *\+ *[0-9]+(\.?[0-9]*)?. The
+    <desc xml:lang="en">A count of measures plus a beat location, <abbr>i.e.</abbr>, [0-9]+m *\+ *[0-9]+(\.?[0-9]*)?. The
       measure count is the number of barlines crossed by the event, while the beat location is a
       timestamp expressed as a beat with an optional fractional part. For example, "1m+3.5"
       indicates a point in the next measure on the second half of beat 3. The measure number must be
@@ -1846,7 +1846,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.MEASUREBEATOFFSET" module="MEI" type="dt">
-    <desc>A count of measures plus a beat location, <abbr>i.e.</abbr>, (\+|-)?[0-9]+m\+[0-9]+(\.?[0-9]*)?. The
+    <desc xml:lang="en">A count of measures plus a beat location, <abbr>i.e.</abbr>, (\+|-)?[0-9]+m\+[0-9]+(\.?[0-9]*)?. The
       measure count is the number of barlines crossed by the event, while the beat location is a
       timestamp expressed as a beat with an optional fractional part. The measure number must be in
       the range of preceding measures to the number of remaining measures. A value with a positive
@@ -1863,7 +1863,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.MEASUREMENTABS" module="MEI" type="dt">
-    <desc>Measurement expressed in real-world (<abbr>e.g.</abbr>, centimeters, millimeters, inches, points,
+    <desc xml:lang="en">Measurement expressed in real-world (<abbr>e.g.</abbr>, centimeters, millimeters, inches, points,
       picas, or pixels) or virtual units (vu). 'vu' is the default value. Unlike
       data.MEASUREMENTREL, which may be used to express relative measures, only positive values are
       allowed.</desc>
@@ -1874,7 +1874,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.MEASUREMENTREL" module="MEI" type="dt">
-    <desc>Measurement expressed in real-world (<abbr>e.g.</abbr>, centimeters, millimeters, inches, points,
+    <desc xml:lang="en">Measurement expressed in real-world (<abbr>e.g.</abbr>, centimeters, millimeters, inches, points,
       picas, or pixels) or virtual units (vu). 'vu' is the default value. Unlike
       data.MEASUREMENTABS, in which only positive values are allowed, both positive and negative
       values are permitted.</desc>
@@ -1885,186 +1885,186 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.MELODICFUNCTION" module="MEI" type="dt">
-    <desc>Indication of melodic function, <abbr>i.e.</abbr>, anticipation, lower neighbor, escape tone,
+    <desc xml:lang="en">Indication of melodic function, <abbr>i.e.</abbr>, anticipation, lower neighbor, escape tone,
       etc.</desc>
     <content>
       <valList type="closed">
         <valItem ident="aln">
-          <desc>Accented lower neighbor.</desc>
+          <desc xml:lang="en">Accented lower neighbor.</desc>
         </valItem>
         <valItem ident="ant">
-          <desc>Anticipation.</desc>
+          <desc xml:lang="en">Anticipation.</desc>
         </valItem>
         <valItem ident="app">
-          <desc>Appogiatura.</desc>
+          <desc xml:lang="en">Appogiatura.</desc>
         </valItem>
         <valItem ident="apt">
-          <desc>Accented passing tone.</desc>
+          <desc xml:lang="en">Accented passing tone.</desc>
         </valItem>
         <valItem ident="arp">
-          <desc>Arpeggio tone (chordal tone).</desc>
+          <desc xml:lang="en">Arpeggio tone (chordal tone).</desc>
         </valItem>
         <valItem ident="arp7">
-          <desc>Arpeggio tone (7th added to the chord).</desc>
+          <desc xml:lang="en">Arpeggio tone (7th added to the chord).</desc>
         </valItem>
         <valItem ident="aun">
-          <desc>Accented upper neighbor.</desc>
+          <desc xml:lang="en">Accented upper neighbor.</desc>
         </valItem>
         <valItem ident="chg">
-          <desc>Changing tone.</desc>
+          <desc xml:lang="en">Changing tone.</desc>
         </valItem>
         <valItem ident="cln">
-          <desc>Chromatic lower neighbor.</desc>
+          <desc xml:lang="en">Chromatic lower neighbor.</desc>
         </valItem>
         <valItem ident="ct">
-          <desc>Chord tone (<abbr>i.e.</abbr>, not an embellishment).</desc>
+          <desc xml:lang="en">Chord tone (<abbr>i.e.</abbr>, not an embellishment).</desc>
         </valItem>
         <valItem ident="ct7">
-          <desc>Chord tone (7th added to the chord).</desc>
+          <desc xml:lang="en">Chord tone (7th added to the chord).</desc>
         </valItem>
         <valItem ident="cun">
-          <desc>Chromatic upper neighbor.</desc>
+          <desc xml:lang="en">Chromatic upper neighbor.</desc>
         </valItem>
         <valItem ident="cup">
-          <desc>Chromatic unaccented passing tone.</desc>
+          <desc xml:lang="en">Chromatic unaccented passing tone.</desc>
         </valItem>
         <valItem ident="et">
-          <desc>Escape tone.</desc>
+          <desc xml:lang="en">Escape tone.</desc>
         </valItem>
         <valItem ident="ln">
-          <desc>Lower neighbor.</desc>
+          <desc xml:lang="en">Lower neighbor.</desc>
         </valItem>
         <valItem ident="ped">
-          <desc>Pedal tone.</desc>
+          <desc xml:lang="en">Pedal tone.</desc>
         </valItem>
         <valItem ident="rep">
-          <desc>Repeated tone.</desc>
+          <desc xml:lang="en">Repeated tone.</desc>
         </valItem>
         <valItem ident="ret">
-          <desc>Retardation.</desc>
+          <desc xml:lang="en">Retardation.</desc>
         </valItem>
         <valItem ident="23ret">
-          <desc>2-3 retardation.</desc>
+          <desc xml:lang="en">2-3 retardation.</desc>
         </valItem>
         <valItem ident="78ret">
-          <desc>7-8 retardation.</desc>
+          <desc xml:lang="en">7-8 retardation.</desc>
         </valItem>
         <valItem ident="sus">
-          <desc>Suspension.</desc>
+          <desc xml:lang="en">Suspension.</desc>
         </valItem>
         <valItem ident="43sus">
-          <desc>4-3 suspension.</desc>
+          <desc xml:lang="en">4-3 suspension.</desc>
         </valItem>
         <valItem ident="98sus">
-          <desc>9-8 suspension.</desc>
+          <desc xml:lang="en">9-8 suspension.</desc>
         </valItem>
         <valItem ident="76sus">
-          <desc>7-6 suspension.</desc>
+          <desc xml:lang="en">7-6 suspension.</desc>
         </valItem>
         <valItem ident="un">
-          <desc>Upper neighbor.</desc>
+          <desc xml:lang="en">Upper neighbor.</desc>
         </valItem>
         <valItem ident="un7">
-          <desc>Upper neighbor (7th added to the chord).</desc>
+          <desc xml:lang="en">Upper neighbor (7th added to the chord).</desc>
         </valItem>
         <valItem ident="upt">
-          <desc>Unaccented passing tone.</desc>
+          <desc xml:lang="en">Unaccented passing tone.</desc>
         </valItem>
         <valItem ident="upt7">
-          <desc>Unaccented passing tone (7th added to the chord).</desc>
+          <desc xml:lang="en">Unaccented passing tone (7th added to the chord).</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.MENSURATIONSIGN" module="MEI" type="dt">
-    <desc>Mensuration signs attribute values.</desc>
+    <desc xml:lang="en">Mensuration signs attribute values.</desc>
     <content>
       <valList type="closed">
         <valItem ident="C">
-          <desc>Sign for tempus imperfectum.</desc>
+          <desc xml:lang="en">Sign for tempus imperfectum.</desc>
         </valItem>
         <valItem ident="O">
-          <desc>Sign for tempus perfectum.</desc>
+          <desc xml:lang="en">Sign for tempus perfectum.</desc>
         </valItem>
         <valItem ident="t">
-          <desc>Sign for divisio ternaria.</desc>
+          <desc xml:lang="en">Sign for divisio ternaria.</desc>
         </valItem>
         <valItem ident="q">
-          <desc>Sign for divisio quaternaria.</desc>
+          <desc xml:lang="en">Sign for divisio quaternaria.</desc>
         </valItem>
         <valItem ident="si">
-          <desc>Sign for divisio senaria imperfecta.</desc>
+          <desc xml:lang="en">Sign for divisio senaria imperfecta.</desc>
         </valItem>
         <valItem ident="i">
-          <desc>Sign for divisio senaria imperfecta.</desc>
+          <desc xml:lang="en">Sign for divisio senaria imperfecta.</desc>
         </valItem>
         <valItem ident="sg">
-          <desc>Sign for divisio senaria gallica.</desc>
+          <desc xml:lang="en">Sign for divisio senaria gallica.</desc>
         </valItem>
         <valItem ident="g">
-          <desc>Sign for divisio senaria gallica.</desc>
+          <desc xml:lang="en">Sign for divisio senaria gallica.</desc>
         </valItem>
         <valItem ident="sp">
-          <desc>Sign for divisio senaria perfecta.</desc>
+          <desc xml:lang="en">Sign for divisio senaria perfecta.</desc>
         </valItem>
         <valItem ident="p">
-          <desc>Sign for divisio senaria perfecta.</desc>
+          <desc xml:lang="en">Sign for divisio senaria perfecta.</desc>
         </valItem>
         <valItem ident="sy">
-          <desc>Sign for divisio senaria ytalica.</desc>
+          <desc xml:lang="en">Sign for divisio senaria ytalica.</desc>
         </valItem>
         <valItem ident="y">
-          <desc>Sign for divisio senaria ytalica.</desc>
+          <desc xml:lang="en">Sign for divisio senaria ytalica.</desc>
         </valItem>
         <valItem ident="n">
-          <desc>Sign for divisio novenaria.</desc>
+          <desc xml:lang="en">Sign for divisio novenaria.</desc>
         </valItem>
         <valItem ident="oc">
-          <desc>Sign for divisio octonaria.</desc>
+          <desc xml:lang="en">Sign for divisio octonaria.</desc>
         </valItem>
         <valItem ident="d">
-          <desc>Sign for divisio duodenaria.</desc>
+          <desc xml:lang="en">Sign for divisio duodenaria.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.METERFORM" module="MEI" type="dt">
-    <desc>Contains an indication of how a meter signature should be rendered.</desc>
+    <desc xml:lang="en">Contains an indication of how a meter signature should be rendered.</desc>
     <content>
       <valList type="closed">
         <valItem ident="num">
-          <desc>Show only the number of beats.</desc>
+          <desc xml:lang="en">Show only the number of beats.</desc>
         </valItem>
         <valItem ident="denomsym">
-          <desc>The lower number in the meter signature is replaced by a note symbol.</desc>
+          <desc xml:lang="en">The lower number in the meter signature is replaced by a note symbol.</desc>
         </valItem>
         <valItem ident="norm">
-          <desc>Meter signature rendered using traditional numeric values.</desc>
+          <desc xml:lang="en">Meter signature rendered using traditional numeric values.</desc>
         </valItem>
         <valItem ident="invis">
-          <desc>Meter signature not rendered.</desc>
+          <desc xml:lang="en">Meter signature not rendered.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.METERSIGN" module="MEI" type="dt">
-    <desc>Meter.sym attribute values for CMN.</desc>
+    <desc xml:lang="en">Meter.sym attribute values for CMN.</desc>
     <content>
       <valList type="closed">
         <valItem ident="common">
-          <desc>Common time; <abbr>i.e.</abbr>, 4/4.</desc>
+          <desc xml:lang="en">Common time; <abbr>i.e.</abbr>, 4/4.</desc>
         </valItem>
         <valItem ident="cut">
-          <desc>Cut time; <abbr>i.e.</abbr>, 2/2.</desc>
+          <desc xml:lang="en">Cut time; <abbr>i.e.</abbr>, 2/2.</desc>
         </valItem>
         <valItem ident="open">
-          <desc>Open time signature, <abbr>i.e.</abbr>, Senza misura. See Gould pp. 611–615.</desc>
+          <desc xml:lang="en">Open time signature, <abbr>i.e.</abbr>, Senza misura. See Gould pp. 611–615.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.MIDICHANNEL" module="MEI" type="dt">
-    <desc>MIDI channel number. One-based values must be followed by a lower-case letter "o".</desc>
+    <desc xml:lang="en">MIDI channel number. One-based values must be followed by a lower-case letter "o".</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">0|([1-9]|1[0-5])o?|16o</rng:param>
@@ -2072,7 +2072,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.MIDIBPM" module="MEI" type="dt">
-    <desc>Tempo expressed as "beats" per minute, where "beat" is always defined as a quarter note,
+    <desc xml:lang="en">Tempo expressed as "beats" per minute, where "beat" is always defined as a quarter note,
       *not the numerator of the time signature or the metronomic indication*.</desc>
     <content>
       <rng:data type="decimal">
@@ -2081,540 +2081,540 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.MIDIMSPB" module="MEI" type="dt">
-    <desc>Tempo expressed as microseconds per "beat", where "beat" is always defined as a quarter
+    <desc xml:lang="en">Tempo expressed as microseconds per "beat", where "beat" is always defined as a quarter
       note, *not the numerator of the time signature or the metronomic indication*.</desc>
     <content>
       <rng:data type="positiveInteger"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.MIDINAMES" module="MEI" type="dt">
-    <desc>General MIDI instrument names.</desc>
+    <desc xml:lang="en">General MIDI instrument names.</desc>
     <content>
       <valList type="closed">
         <valItem ident="Acoustic_Grand_Piano">
-          <desc>Acoustic Grand Piano, Program #0.</desc>
+          <desc xml:lang="en">Acoustic Grand Piano, Program #0.</desc>
         </valItem>
         <valItem ident="Bright_Acoustic_Piano">
-          <desc>Bright Acoustic Piano, Program #1.</desc>
+          <desc xml:lang="en">Bright Acoustic Piano, Program #1.</desc>
         </valItem>
         <valItem ident="Electric_Grand_Piano">
-          <desc>Electric Grand Piano, Program #2.</desc>
+          <desc xml:lang="en">Electric Grand Piano, Program #2.</desc>
         </valItem>
         <valItem ident="Honky-tonk_Piano">
-          <desc>Honky-tonk Piano, Program #3.</desc>
+          <desc xml:lang="en">Honky-tonk Piano, Program #3.</desc>
         </valItem>
         <valItem ident="Electric_Piano_1">
-          <desc>Electric Piano 1, Program #4.</desc>
+          <desc xml:lang="en">Electric Piano 1, Program #4.</desc>
         </valItem>
         <valItem ident="Electric_Piano_2">
-          <desc>Electric Piano 2, Program #5.</desc>
+          <desc xml:lang="en">Electric Piano 2, Program #5.</desc>
         </valItem>
         <valItem ident="Harpsichord">
-          <desc>Harpsichord, Program #6.</desc>
+          <desc xml:lang="en">Harpsichord, Program #6.</desc>
         </valItem>
         <valItem ident="Clavi">
-          <desc>Clavi, Program #7.</desc>
+          <desc xml:lang="en">Clavi, Program #7.</desc>
         </valItem>
         <valItem ident="Celesta">
-          <desc>Celesta, Program #8.</desc>
+          <desc xml:lang="en">Celesta, Program #8.</desc>
         </valItem>
         <valItem ident="Glockenspiel">
-          <desc>Glockenspiel, Program #9.</desc>
+          <desc xml:lang="en">Glockenspiel, Program #9.</desc>
         </valItem>
         <valItem ident="Music_Box">
-          <desc>Music Box, Program #10.</desc>
+          <desc xml:lang="en">Music Box, Program #10.</desc>
         </valItem>
         <valItem ident="Vibraphone">
-          <desc>Vibraphone, Program #11.</desc>
+          <desc xml:lang="en">Vibraphone, Program #11.</desc>
         </valItem>
         <valItem ident="Marimba">
-          <desc>Marimba, Program #12.</desc>
+          <desc xml:lang="en">Marimba, Program #12.</desc>
         </valItem>
         <valItem ident="Xylophone">
-          <desc>Xylophone, Program #13.</desc>
+          <desc xml:lang="en">Xylophone, Program #13.</desc>
         </valItem>
         <valItem ident="Tubular_Bells">
-          <desc>Tubular Bells, Program #14.</desc>
+          <desc xml:lang="en">Tubular Bells, Program #14.</desc>
         </valItem>
         <valItem ident="Dulcimer">
-          <desc>Dulcimer, Program #15.</desc>
+          <desc xml:lang="en">Dulcimer, Program #15.</desc>
         </valItem>
         <valItem ident="Drawbar_Organ">
-          <desc>Drawbar Organ, Program #16.</desc>
+          <desc xml:lang="en">Drawbar Organ, Program #16.</desc>
         </valItem>
         <valItem ident="Percussive_Organ">
-          <desc>Percussive Organ, Program #17.</desc>
+          <desc xml:lang="en">Percussive Organ, Program #17.</desc>
         </valItem>
         <valItem ident="Rock_Organ">
-          <desc>Rock Organ, Program #18.</desc>
+          <desc xml:lang="en">Rock Organ, Program #18.</desc>
         </valItem>
         <valItem ident="Church_Organ">
-          <desc>Church Organ, Program #19.</desc>
+          <desc xml:lang="en">Church Organ, Program #19.</desc>
         </valItem>
         <valItem ident="Reed_Organ">
-          <desc>Reed Organ, Program #20.</desc>
+          <desc xml:lang="en">Reed Organ, Program #20.</desc>
         </valItem>
         <valItem ident="Accordion">
-          <desc>Accordion, Program #21.</desc>
+          <desc xml:lang="en">Accordion, Program #21.</desc>
         </valItem>
         <valItem ident="Harmonica">
-          <desc>Harmonica, Program #22.</desc>
+          <desc xml:lang="en">Harmonica, Program #22.</desc>
         </valItem>
         <valItem ident="Tango_Accordion">
-          <desc>Tango Accordion, Program #23.</desc>
+          <desc xml:lang="en">Tango Accordion, Program #23.</desc>
         </valItem>
         <valItem ident="Acoustic_Guitar_nylon">
-          <desc>Acoustic Guitar (nylon), Program #24.</desc>
+          <desc xml:lang="en">Acoustic Guitar (nylon), Program #24.</desc>
         </valItem>
         <valItem ident="Acoustic_Guitar_steel">
-          <desc>Acoustic Guitar (steel), Program #25.</desc>
+          <desc xml:lang="en">Acoustic Guitar (steel), Program #25.</desc>
         </valItem>
         <valItem ident="Electric_Guitar_jazz">
-          <desc>Electric Guitar (jazz), Program #26.</desc>
+          <desc xml:lang="en">Electric Guitar (jazz), Program #26.</desc>
         </valItem>
         <valItem ident="Electric_Guitar_clean">
-          <desc>Electric Guitar (clean), Program #27.</desc>
+          <desc xml:lang="en">Electric Guitar (clean), Program #27.</desc>
         </valItem>
         <valItem ident="Electric_Guitar_muted">
-          <desc>Electric Guitar (muted), Program #28.</desc>
+          <desc xml:lang="en">Electric Guitar (muted), Program #28.</desc>
         </valItem>
         <valItem ident="Overdriven_Guitar">
-          <desc>Overdriven Guitar, Program #29.</desc>
+          <desc xml:lang="en">Overdriven Guitar, Program #29.</desc>
         </valItem>
         <valItem ident="Distortion_Guitar">
-          <desc>Distortion Guitar, Program #30.</desc>
+          <desc xml:lang="en">Distortion Guitar, Program #30.</desc>
         </valItem>
         <valItem ident="Guitar_harmonics">
-          <desc>Guitar harmonics, Program #31.</desc>
+          <desc xml:lang="en">Guitar harmonics, Program #31.</desc>
         </valItem>
         <valItem ident="Acoustic_Bass">
-          <desc>Acoustic Bass, Program #32.</desc>
+          <desc xml:lang="en">Acoustic Bass, Program #32.</desc>
         </valItem>
         <valItem ident="Electric_Bass_finger">
-          <desc>Electric Bass (finger), Program #33.</desc>
+          <desc xml:lang="en">Electric Bass (finger), Program #33.</desc>
         </valItem>
         <valItem ident="Electric_Bass_pick">
-          <desc>Electric Bass (pick), Program #34.</desc>
+          <desc xml:lang="en">Electric Bass (pick), Program #34.</desc>
         </valItem>
         <valItem ident="Fretless_Bass">
-          <desc>Fretless Bass, Program #35.</desc>
+          <desc xml:lang="en">Fretless Bass, Program #35.</desc>
         </valItem>
         <valItem ident="Slap_Bass_1">
-          <desc>Slap Bass 1, Program #36.</desc>
+          <desc xml:lang="en">Slap Bass 1, Program #36.</desc>
         </valItem>
         <valItem ident="Slap_Bass_2">
-          <desc>Slap Bass 2, Program #37.</desc>
+          <desc xml:lang="en">Slap Bass 2, Program #37.</desc>
         </valItem>
         <valItem ident="Synth_Bass_1">
-          <desc>Synth Bass 1, Program #38.</desc>
+          <desc xml:lang="en">Synth Bass 1, Program #38.</desc>
         </valItem>
         <valItem ident="Synth_Bass_2">
-          <desc>Synth Bass 2, Program #39.</desc>
+          <desc xml:lang="en">Synth Bass 2, Program #39.</desc>
         </valItem>
         <valItem ident="Violin">
-          <desc>Violin, Program #40.</desc>
+          <desc xml:lang="en">Violin, Program #40.</desc>
         </valItem>
         <valItem ident="Viola">
-          <desc>Viola, Program #41.</desc>
+          <desc xml:lang="en">Viola, Program #41.</desc>
         </valItem>
         <valItem ident="Cello">
-          <desc>Cello, Program #42.</desc>
+          <desc xml:lang="en">Cello, Program #42.</desc>
         </valItem>
         <valItem ident="Contrabass">
-          <desc>Contrabass, Program #43.</desc>
+          <desc xml:lang="en">Contrabass, Program #43.</desc>
         </valItem>
         <valItem ident="Tremolo_Strings">
-          <desc>Tremolo Strings, Program #44.</desc>
+          <desc xml:lang="en">Tremolo Strings, Program #44.</desc>
         </valItem>
         <valItem ident="Pizzicato_Strings">
-          <desc>Pizzicato Strings, Program #45.</desc>
+          <desc xml:lang="en">Pizzicato Strings, Program #45.</desc>
         </valItem>
         <valItem ident="Orchestral_Harp">
-          <desc>Orchestral Harp, Program #46.</desc>
+          <desc xml:lang="en">Orchestral Harp, Program #46.</desc>
         </valItem>
         <valItem ident="Timpani">
-          <desc>Timpani, Program #47.</desc>
+          <desc xml:lang="en">Timpani, Program #47.</desc>
         </valItem>
         <valItem ident="String_Ensemble_1">
-          <desc>String Ensemble 1, Program #48.</desc>
+          <desc xml:lang="en">String Ensemble 1, Program #48.</desc>
         </valItem>
         <valItem ident="String_Ensemble_2">
-          <desc>String Ensemble 2, Program #49.</desc>
+          <desc xml:lang="en">String Ensemble 2, Program #49.</desc>
         </valItem>
         <valItem ident="SynthStrings_1">
-          <desc>SynthStrings 1, Program #50.</desc>
+          <desc xml:lang="en">SynthStrings 1, Program #50.</desc>
         </valItem>
         <valItem ident="SynthStrings_2">
-          <desc>SynthStrings 2, Program #51.</desc>
+          <desc xml:lang="en">SynthStrings 2, Program #51.</desc>
         </valItem>
         <valItem ident="Choir_Aahs">
-          <desc>Choir Aahs, Program #52.</desc>
+          <desc xml:lang="en">Choir Aahs, Program #52.</desc>
         </valItem>
         <valItem ident="Voice_Oohs">
-          <desc>Voice Oohs, Program #53.</desc>
+          <desc xml:lang="en">Voice Oohs, Program #53.</desc>
         </valItem>
         <valItem ident="Synth_Voice">
-          <desc>Synth Voice, Program #54.</desc>
+          <desc xml:lang="en">Synth Voice, Program #54.</desc>
         </valItem>
         <valItem ident="Orchestra_Hit">
-          <desc>Orchestra Hit, Program #55.</desc>
+          <desc xml:lang="en">Orchestra Hit, Program #55.</desc>
         </valItem>
         <valItem ident="Trumpet">
-          <desc>Trumpet, Program #56.</desc>
+          <desc xml:lang="en">Trumpet, Program #56.</desc>
         </valItem>
         <valItem ident="Trombone">
-          <desc>Trombone, Program #57.</desc>
+          <desc xml:lang="en">Trombone, Program #57.</desc>
         </valItem>
         <valItem ident="Tuba">
-          <desc>Tuba, Program #58.</desc>
+          <desc xml:lang="en">Tuba, Program #58.</desc>
         </valItem>
         <valItem ident="Muted_Trumpet">
-          <desc>Muted Trumpet, Program #59.</desc>
+          <desc xml:lang="en">Muted Trumpet, Program #59.</desc>
         </valItem>
         <valItem ident="French_Horn">
-          <desc>French Horn, Program #60.</desc>
+          <desc xml:lang="en">French Horn, Program #60.</desc>
         </valItem>
         <valItem ident="Brass_Section">
-          <desc>Brass Section, Program #61.</desc>
+          <desc xml:lang="en">Brass Section, Program #61.</desc>
         </valItem>
         <valItem ident="SynthBrass_1">
-          <desc>SynthBrass 1, Program #62.</desc>
+          <desc xml:lang="en">SynthBrass 1, Program #62.</desc>
         </valItem>
         <valItem ident="SynthBrass_2">
-          <desc>SynthBrass 2, Program #63.</desc>
+          <desc xml:lang="en">SynthBrass 2, Program #63.</desc>
         </valItem>
         <valItem ident="Soprano_Sax">
-          <desc>Soprano Sax, Program #64.</desc>
+          <desc xml:lang="en">Soprano Sax, Program #64.</desc>
         </valItem>
         <valItem ident="Alto_Sax">
-          <desc>Alto Sax, Program #65.</desc>
+          <desc xml:lang="en">Alto Sax, Program #65.</desc>
         </valItem>
         <valItem ident="Tenor_Sax">
-          <desc>Tenor Sax, Program #66.</desc>
+          <desc xml:lang="en">Tenor Sax, Program #66.</desc>
         </valItem>
         <valItem ident="Baritone_Sax">
-          <desc>Baritone Sax, Program #67.</desc>
+          <desc xml:lang="en">Baritone Sax, Program #67.</desc>
         </valItem>
         <valItem ident="Oboe">
-          <desc>Oboe, Program #68.</desc>
+          <desc xml:lang="en">Oboe, Program #68.</desc>
         </valItem>
         <valItem ident="English_Horn">
-          <desc>English Horn, Program #69.</desc>
+          <desc xml:lang="en">English Horn, Program #69.</desc>
         </valItem>
         <valItem ident="Bassoon">
-          <desc>Bassoon, Program #70.</desc>
+          <desc xml:lang="en">Bassoon, Program #70.</desc>
         </valItem>
         <valItem ident="Clarinet">
-          <desc>Clarinet, Program #71.</desc>
+          <desc xml:lang="en">Clarinet, Program #71.</desc>
         </valItem>
         <valItem ident="Piccolo">
-          <desc>Piccolo, Program #72.</desc>
+          <desc xml:lang="en">Piccolo, Program #72.</desc>
         </valItem>
         <valItem ident="Flute">
-          <desc>Flute, Program #73.</desc>
+          <desc xml:lang="en">Flute, Program #73.</desc>
         </valItem>
         <valItem ident="Recorder">
-          <desc>Recorder, Program #74.</desc>
+          <desc xml:lang="en">Recorder, Program #74.</desc>
         </valItem>
         <valItem ident="Pan_Flute">
-          <desc>Pan Flute, Program #75.</desc>
+          <desc xml:lang="en">Pan Flute, Program #75.</desc>
         </valItem>
         <valItem ident="Blown_Bottle">
-          <desc>Blown Bottle, Program #76.</desc>
+          <desc xml:lang="en">Blown Bottle, Program #76.</desc>
         </valItem>
         <valItem ident="Shakuhachi">
-          <desc>Shakuhachi, Program #77.</desc>
+          <desc xml:lang="en">Shakuhachi, Program #77.</desc>
         </valItem>
         <valItem ident="Whistle">
-          <desc>Whistle, Program #78.</desc>
+          <desc xml:lang="en">Whistle, Program #78.</desc>
         </valItem>
         <valItem ident="Ocarina">
-          <desc>Ocarina, Program #79.</desc>
+          <desc xml:lang="en">Ocarina, Program #79.</desc>
         </valItem>
         <valItem ident="Lead_1_square">
-          <desc>Lead 1 (square), Program #80.</desc>
+          <desc xml:lang="en">Lead 1 (square), Program #80.</desc>
         </valItem>
         <valItem ident="Lead_2_sawtooth">
-          <desc>Lead 2 (sawtooth), Program #81.</desc>
+          <desc xml:lang="en">Lead 2 (sawtooth), Program #81.</desc>
         </valItem>
         <valItem ident="Lead_3_calliope">
-          <desc>Lead 3 (calliope), Program #82.</desc>
+          <desc xml:lang="en">Lead 3 (calliope), Program #82.</desc>
         </valItem>
         <valItem ident="Lead_4_chiff">
-          <desc>Lead 4 (chiff), Program #83.</desc>
+          <desc xml:lang="en">Lead 4 (chiff), Program #83.</desc>
         </valItem>
         <valItem ident="Lead_5_charang">
-          <desc>Lead 5 (charang), Program #84.</desc>
+          <desc xml:lang="en">Lead 5 (charang), Program #84.</desc>
         </valItem>
         <valItem ident="Lead_6_voice">
-          <desc>Lead 6 (voice), Program #85.</desc>
+          <desc xml:lang="en">Lead 6 (voice), Program #85.</desc>
         </valItem>
         <valItem ident="Lead_7_fifths">
-          <desc>Lead 7 (fifths), Program #86.</desc>
+          <desc xml:lang="en">Lead 7 (fifths), Program #86.</desc>
         </valItem>
         <valItem ident="Lead_8_bass_and_lead">
-          <desc>Lead 8 (bass + lead), Program #87.</desc>
+          <desc xml:lang="en">Lead 8 (bass + lead), Program #87.</desc>
         </valItem>
         <valItem ident="Pad_1_new_age">
-          <desc>Pad 1 (new age), Program #88.</desc>
+          <desc xml:lang="en">Pad 1 (new age), Program #88.</desc>
         </valItem>
         <valItem ident="Pad_2_warm">
-          <desc>Pad 2 (warm), Program #89.</desc>
+          <desc xml:lang="en">Pad 2 (warm), Program #89.</desc>
         </valItem>
         <valItem ident="Pad_3_polysynth">
-          <desc>Pad 3 (polysynth), Program #90.</desc>
+          <desc xml:lang="en">Pad 3 (polysynth), Program #90.</desc>
         </valItem>
         <valItem ident="Pad_4_choir">
-          <desc>Pad 4 (choir), Program #91.</desc>
+          <desc xml:lang="en">Pad 4 (choir), Program #91.</desc>
         </valItem>
         <valItem ident="Pad_5_bowed">
-          <desc>Pad 5 (bowed), Program #92.</desc>
+          <desc xml:lang="en">Pad 5 (bowed), Program #92.</desc>
         </valItem>
         <valItem ident="Pad_6_metallic">
-          <desc>Pad 6 (metallic), Program #93.</desc>
+          <desc xml:lang="en">Pad 6 (metallic), Program #93.</desc>
         </valItem>
         <valItem ident="Pad_7_halo">
-          <desc>Pad 7 (halo), Program #94.</desc>
+          <desc xml:lang="en">Pad 7 (halo), Program #94.</desc>
         </valItem>
         <valItem ident="Pad_8_sweep">
-          <desc>Pad 8 (sweep), Program #95.</desc>
+          <desc xml:lang="en">Pad 8 (sweep), Program #95.</desc>
         </valItem>
         <valItem ident="FX_1_rain">
-          <desc>FX 1 (rain), Program #96.</desc>
+          <desc xml:lang="en">FX 1 (rain), Program #96.</desc>
         </valItem>
         <valItem ident="FX_2_soundtrack">
-          <desc>FX 2 (soundtrack), Program #97.</desc>
+          <desc xml:lang="en">FX 2 (soundtrack), Program #97.</desc>
         </valItem>
         <valItem ident="FX_3_crystal">
-          <desc>FX 3 (crystal), Program #98.</desc>
+          <desc xml:lang="en">FX 3 (crystal), Program #98.</desc>
         </valItem>
         <valItem ident="FX_4_atmosphere">
-          <desc>FX 4 (atmosphere), Program #99.</desc>
+          <desc xml:lang="en">FX 4 (atmosphere), Program #99.</desc>
         </valItem>
         <valItem ident="FX_5_brightness">
-          <desc>FX 5 (brightness), Program #100.</desc>
+          <desc xml:lang="en">FX 5 (brightness), Program #100.</desc>
         </valItem>
         <valItem ident="FX_6_goblins">
-          <desc>FX 6 (goblins), Program #101.</desc>
+          <desc xml:lang="en">FX 6 (goblins), Program #101.</desc>
         </valItem>
         <valItem ident="FX_7_echoes">
-          <desc>FX 7 (echoes), Program #102.</desc>
+          <desc xml:lang="en">FX 7 (echoes), Program #102.</desc>
         </valItem>
         <valItem ident="FX_8_sci-fi">
-          <desc>FX 8 (sci-fi), Program #103.</desc>
+          <desc xml:lang="en">FX 8 (sci-fi), Program #103.</desc>
         </valItem>
         <valItem ident="Sitar">
-          <desc>Sitar, Program #104.</desc>
+          <desc xml:lang="en">Sitar, Program #104.</desc>
         </valItem>
         <valItem ident="Banjo">
-          <desc>Banjo, Program #105.</desc>
+          <desc xml:lang="en">Banjo, Program #105.</desc>
         </valItem>
         <valItem ident="Shamisen">
-          <desc>Shamisen, Program #106.</desc>
+          <desc xml:lang="en">Shamisen, Program #106.</desc>
         </valItem>
         <valItem ident="Koto">
-          <desc>Koto, Program #107.</desc>
+          <desc xml:lang="en">Koto, Program #107.</desc>
         </valItem>
         <valItem ident="Kalimba">
-          <desc>Kalimba, Program #108.</desc>
+          <desc xml:lang="en">Kalimba, Program #108.</desc>
         </valItem>
         <valItem ident="Bag_pipe">
-          <desc>Bag pipe, Program #109.</desc>
+          <desc xml:lang="en">Bag pipe, Program #109.</desc>
         </valItem>
         <valItem ident="Fiddle">
-          <desc>Fiddle, Program #110.</desc>
+          <desc xml:lang="en">Fiddle, Program #110.</desc>
         </valItem>
         <valItem ident="Shanai">
-          <desc>Shanai, Program #111.</desc>
+          <desc xml:lang="en">Shanai, Program #111.</desc>
         </valItem>
         <valItem ident="Tinkle_Bell">
-          <desc>Tinkle Bell, Program #112.</desc>
+          <desc xml:lang="en">Tinkle Bell, Program #112.</desc>
         </valItem>
         <valItem ident="Agogo">
-          <desc>Agogo, Program #113.</desc>
+          <desc xml:lang="en">Agogo, Program #113.</desc>
         </valItem>
         <valItem ident="Steel_Drums">
-          <desc>Steel Drums, Program #114.</desc>
+          <desc xml:lang="en">Steel Drums, Program #114.</desc>
         </valItem>
         <valItem ident="Woodblock">
-          <desc>Woodblock, Program #115.</desc>
+          <desc xml:lang="en">Woodblock, Program #115.</desc>
         </valItem>
         <valItem ident="Taiko_Drum">
-          <desc>Taiko Drum, Program #116.</desc>
+          <desc xml:lang="en">Taiko Drum, Program #116.</desc>
         </valItem>
         <valItem ident="Melodic_Tom">
-          <desc>Melodic Tom, Program #117.</desc>
+          <desc xml:lang="en">Melodic Tom, Program #117.</desc>
         </valItem>
         <valItem ident="Synth_Drum">
-          <desc>Synth Drum, Program #118.</desc>
+          <desc xml:lang="en">Synth Drum, Program #118.</desc>
         </valItem>
         <valItem ident="Reverse_Cymbal">
-          <desc>Reverse Cymbal, Program #119.</desc>
+          <desc xml:lang="en">Reverse Cymbal, Program #119.</desc>
         </valItem>
         <valItem ident="Guitar_Fret_Noise">
-          <desc>Guitar Fret Noise, Program #120.</desc>
+          <desc xml:lang="en">Guitar Fret Noise, Program #120.</desc>
         </valItem>
         <valItem ident="Breath_Noise">
-          <desc>Breath Noise, Program #121.</desc>
+          <desc xml:lang="en">Breath Noise, Program #121.</desc>
         </valItem>
         <valItem ident="Seashore">
-          <desc>Seashore, Program #122.</desc>
+          <desc xml:lang="en">Seashore, Program #122.</desc>
         </valItem>
         <valItem ident="Bird_Tweet">
-          <desc>Bird Tweet, Program #123.</desc>
+          <desc xml:lang="en">Bird Tweet, Program #123.</desc>
         </valItem>
         <valItem ident="Telephone_Ring">
-          <desc>Telephone Ring, Program #124.</desc>
+          <desc xml:lang="en">Telephone Ring, Program #124.</desc>
         </valItem>
         <valItem ident="Helicopter">
-          <desc>Helicopter, Program #125.</desc>
+          <desc xml:lang="en">Helicopter, Program #125.</desc>
         </valItem>
         <valItem ident="Applause">
-          <desc>Applause, Program #126.</desc>
+          <desc xml:lang="en">Applause, Program #126.</desc>
         </valItem>
         <valItem ident="Gunshot">
-          <desc>Gunshot, Program #127.</desc>
+          <desc xml:lang="en">Gunshot, Program #127.</desc>
         </valItem>
         <valItem ident="Acoustic_Bass_Drum">
-          <desc>Acoustic Bass Drum, Key #35.</desc>
+          <desc xml:lang="en">Acoustic Bass Drum, Key #35.</desc>
         </valItem>
         <valItem ident="Bass_Drum_1">
-          <desc>Bass Drum 1, Key #36.</desc>
+          <desc xml:lang="en">Bass Drum 1, Key #36.</desc>
         </valItem>
         <valItem ident="Side_Stick">
-          <desc>Side Stick, Key #37.</desc>
+          <desc xml:lang="en">Side Stick, Key #37.</desc>
         </valItem>
         <valItem ident="Acoustic_Snare">
-          <desc>Acoustic Snare, Key #38.</desc>
+          <desc xml:lang="en">Acoustic Snare, Key #38.</desc>
         </valItem>
         <valItem ident="Hand_Clap">
-          <desc>Hand Clap, Key #39.</desc>
+          <desc xml:lang="en">Hand Clap, Key #39.</desc>
         </valItem>
         <valItem ident="Electric_Snare">
-          <desc>Electric Snare, Key #40.</desc>
+          <desc xml:lang="en">Electric Snare, Key #40.</desc>
         </valItem>
         <valItem ident="Low_Floor_Tom">
-          <desc>Low Floor Tom, Key #41.</desc>
+          <desc xml:lang="en">Low Floor Tom, Key #41.</desc>
         </valItem>
         <valItem ident="Closed_Hi_Hat">
-          <desc>Closed Hi Hat, Key #42.</desc>
+          <desc xml:lang="en">Closed Hi Hat, Key #42.</desc>
         </valItem>
         <valItem ident="High_Floor_Tom">
-          <desc>High Floor Tom, Key #43.</desc>
+          <desc xml:lang="en">High Floor Tom, Key #43.</desc>
         </valItem>
         <valItem ident="Pedal_Hi-Hat">
-          <desc>Pedal Hi-Hat, Key #44.</desc>
+          <desc xml:lang="en">Pedal Hi-Hat, Key #44.</desc>
         </valItem>
         <valItem ident="Low_Tom">
-          <desc>Low Tom, Key #45.</desc>
+          <desc xml:lang="en">Low Tom, Key #45.</desc>
         </valItem>
         <valItem ident="Open_Hi-Hat">
-          <desc>Open Hi-Hat, Key #46.</desc>
+          <desc xml:lang="en">Open Hi-Hat, Key #46.</desc>
         </valItem>
         <valItem ident="Low-Mid_Tom">
-          <desc>Low-Mid Tom, Key #47.</desc>
+          <desc xml:lang="en">Low-Mid Tom, Key #47.</desc>
         </valItem>
         <valItem ident="Hi-Mid_Tom">
-          <desc>Hi-Mid Tom, Key #48.</desc>
+          <desc xml:lang="en">Hi-Mid Tom, Key #48.</desc>
         </valItem>
         <valItem ident="Crash_Cymbal_1">
-          <desc>Crash Cymbal 1, Key #49.</desc>
+          <desc xml:lang="en">Crash Cymbal 1, Key #49.</desc>
         </valItem>
         <valItem ident="High_Tom">
-          <desc>High Tom, Key #50.</desc>
+          <desc xml:lang="en">High Tom, Key #50.</desc>
         </valItem>
         <valItem ident="Ride_Cymbal_1">
-          <desc>Ride Cymbal 1, Key #51.</desc>
+          <desc xml:lang="en">Ride Cymbal 1, Key #51.</desc>
         </valItem>
         <valItem ident="Chinese_Cymbal">
-          <desc>Chinese Cymbal, Key #52.</desc>
+          <desc xml:lang="en">Chinese Cymbal, Key #52.</desc>
         </valItem>
         <valItem ident="Ride_Bell">
-          <desc>Ride Bell, Key #53.</desc>
+          <desc xml:lang="en">Ride Bell, Key #53.</desc>
         </valItem>
         <valItem ident="Tambourine">
-          <desc>Tambourine, Key #54.</desc>
+          <desc xml:lang="en">Tambourine, Key #54.</desc>
         </valItem>
         <valItem ident="Splash_Cymbal">
-          <desc>Splash Cymbal, Key #55.</desc>
+          <desc xml:lang="en">Splash Cymbal, Key #55.</desc>
         </valItem>
         <valItem ident="Cowbell">
-          <desc>Cowbell, Key #56.</desc>
+          <desc xml:lang="en">Cowbell, Key #56.</desc>
         </valItem>
         <valItem ident="Crash_Cymbal_2">
-          <desc>Crash Cymbal 2, Key #57.</desc>
+          <desc xml:lang="en">Crash Cymbal 2, Key #57.</desc>
         </valItem>
         <valItem ident="Vibraslap">
-          <desc>Vibraslap, Key #58.</desc>
+          <desc xml:lang="en">Vibraslap, Key #58.</desc>
         </valItem>
         <valItem ident="Ride_Cymbal_2">
-          <desc>Ride Cymbal 2, Key #59.</desc>
+          <desc xml:lang="en">Ride Cymbal 2, Key #59.</desc>
         </valItem>
         <valItem ident="Hi_Bongo">
-          <desc>Hi Bongo, Key #60.</desc>
+          <desc xml:lang="en">Hi Bongo, Key #60.</desc>
         </valItem>
         <valItem ident="Low_Bongo">
-          <desc>Low Bongo, Key #61.</desc>
+          <desc xml:lang="en">Low Bongo, Key #61.</desc>
         </valItem>
         <valItem ident="Mute_Hi_Conga">
-          <desc>Mute Hi Conga, Key #62.</desc>
+          <desc xml:lang="en">Mute Hi Conga, Key #62.</desc>
         </valItem>
         <valItem ident="Open_Hi_Conga">
-          <desc>Open Hi Conga, Key #63.</desc>
+          <desc xml:lang="en">Open Hi Conga, Key #63.</desc>
         </valItem>
         <valItem ident="Low_Conga">
-          <desc>Low Conga, Key #64.</desc>
+          <desc xml:lang="en">Low Conga, Key #64.</desc>
         </valItem>
         <valItem ident="High_Timbale">
-          <desc>High Timbale, Key #65.</desc>
+          <desc xml:lang="en">High Timbale, Key #65.</desc>
         </valItem>
         <valItem ident="Low_Timbale">
-          <desc>Low Timbale, Key #66.</desc>
+          <desc xml:lang="en">Low Timbale, Key #66.</desc>
         </valItem>
         <valItem ident="High_Agogo">
-          <desc>High Agogo, Key #67.</desc>
+          <desc xml:lang="en">High Agogo, Key #67.</desc>
         </valItem>
         <valItem ident="Low_Agogo">
-          <desc>Low Agogo, Key #68.</desc>
+          <desc xml:lang="en">Low Agogo, Key #68.</desc>
         </valItem>
         <valItem ident="Cabasa">
-          <desc>Cabasa, Key #69.</desc>
+          <desc xml:lang="en">Cabasa, Key #69.</desc>
         </valItem>
         <valItem ident="Maracas">
-          <desc>Maracas, Key #70.</desc>
+          <desc xml:lang="en">Maracas, Key #70.</desc>
         </valItem>
         <valItem ident="Short_Whistle">
-          <desc>Short Whistle, Key #71.</desc>
+          <desc xml:lang="en">Short Whistle, Key #71.</desc>
         </valItem>
         <valItem ident="Long_Whistle">
-          <desc>Long Whistle, Key #72.</desc>
+          <desc xml:lang="en">Long Whistle, Key #72.</desc>
         </valItem>
         <valItem ident="Short_Guiro">
-          <desc>Short Guiro, Key #73.</desc>
+          <desc xml:lang="en">Short Guiro, Key #73.</desc>
         </valItem>
         <valItem ident="Long_Guiro">
-          <desc>Long Guiro, Key #74.</desc>
+          <desc xml:lang="en">Long Guiro, Key #74.</desc>
         </valItem>
         <valItem ident="Claves">
-          <desc>Claves, Key #75.</desc>
+          <desc xml:lang="en">Claves, Key #75.</desc>
         </valItem>
         <valItem ident="Hi_Wood_Block">
-          <desc>Hi Wood Block, Key #76.</desc>
+          <desc xml:lang="en">Hi Wood Block, Key #76.</desc>
         </valItem>
         <valItem ident="Low_Wood_Block">
-          <desc>Low Wood Block, Key #77.</desc>
+          <desc xml:lang="en">Low Wood Block, Key #77.</desc>
         </valItem>
         <valItem ident="Mute_Cuica">
-          <desc>Mute Cuica, Key #78.</desc>
+          <desc xml:lang="en">Mute Cuica, Key #78.</desc>
         </valItem>
         <valItem ident="Open_Cuica">
-          <desc>Open Cuica, Key #79.</desc>
+          <desc xml:lang="en">Open Cuica, Key #79.</desc>
         </valItem>
         <valItem ident="Mute_Triangle">
-          <desc>Mute Triangle, Key #80.</desc>
+          <desc xml:lang="en">Mute Triangle, Key #80.</desc>
         </valItem>
         <valItem ident="Open_Triangle">
-          <desc>Open Triangle, Key #81.</desc>
+          <desc xml:lang="en">Open Triangle, Key #81.</desc>
         </valItem>
       </valList>
     </content>
@@ -2627,7 +2627,7 @@
     </remarks>
   </macroSpec>
   <macroSpec ident="data.MIDIVALUE" module="MEI" type="dt">
-    <desc>Generic MIDI value. One-based values must be followed by a lower-case letter "o".</desc>
+    <desc xml:lang="en">Generic MIDI value. One-based values must be followed by a lower-case letter "o".</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">0|([1-9]|[1-9][0-9]|1([0-1][0-9]|2[0-7]))o?|128o</rng:param>
@@ -2635,7 +2635,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.MIDIVALUE_NAME" module="MEI" type="dt">
-    <desc>data.MIDIVALUE or data.NCName values.</desc>
+    <desc xml:lang="en">data.MIDIVALUE or data.NCName values.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.MIDIVALUE"/>
@@ -2644,7 +2644,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.MIDIVALUE_PAN" module="MEI" type="dt">
-    <desc>data.MIDIVALUE or data.PERCENT.LIMITED.SIGNED values.</desc>
+    <desc xml:lang="en">data.MIDIVALUE or data.PERCENT.LIMITED.SIGNED values.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.MIDIVALUE"/>
@@ -2653,7 +2653,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.MIDIVALUE_PERCENT" module="MEI" type="dt">
-    <desc>data.MIDIVALUE or data.PERCENT.LIMITED values.</desc>
+    <desc xml:lang="en">data.MIDIVALUE or data.PERCENT.LIMITED values.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.MIDIVALUE"/>
@@ -2662,7 +2662,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.MODE" module="MEI" type="dt">
-    <desc>Modes.</desc>
+    <desc xml:lang="en">Modes.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.MODE.cmn"/>
@@ -2672,115 +2672,115 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.MODE.cmn" module="MEI" type="dt">
-    <desc>Common modes.</desc>
+    <desc xml:lang="en">Common modes.</desc>
     <content>
       <valList type="closed">
         <valItem ident="major">
-          <desc>Major mode.</desc>
+          <desc xml:lang="en">Major mode.</desc>
         </valItem>
         <valItem ident="minor">
-          <desc>Minor mode.</desc>
+          <desc xml:lang="en">Minor mode.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.MODE.gregorian" module="MEI" type="dt">
-    <desc>Gregorian modes.</desc>
+    <desc xml:lang="en">Gregorian modes.</desc>
     <content>
       <valList type="closed">
         <valItem ident="dorian">
-          <desc>Dorian mode (the first mode).</desc>
+          <desc xml:lang="en">Dorian mode (the first mode).</desc>
         </valItem>
         <valItem ident="hypodorian">
-          <desc>Hypodorian mode (the second mode).</desc>
+          <desc xml:lang="en">Hypodorian mode (the second mode).</desc>
         </valItem>
         <valItem ident="phrygian">
-          <desc>Phrygian mode (the third mode).</desc>
+          <desc xml:lang="en">Phrygian mode (the third mode).</desc>
         </valItem>
         <valItem ident="hypophrygian">
-          <desc>Hypophrygian mode (the fourth mode).</desc>
+          <desc xml:lang="en">Hypophrygian mode (the fourth mode).</desc>
         </valItem>
         <valItem ident="lydian">
-          <desc>Hypolydian mode (the fifth mode).</desc>
+          <desc xml:lang="en">Hypolydian mode (the fifth mode).</desc>
         </valItem>
         <valItem ident="hypolydian">
-          <desc>Lydian mode (the sixth mode).</desc>
+          <desc xml:lang="en">Lydian mode (the sixth mode).</desc>
         </valItem>
         <valItem ident="mixolydian">
-          <desc>Mixolydian mode (the seventh mode).</desc>
+          <desc xml:lang="en">Mixolydian mode (the seventh mode).</desc>
         </valItem>
         <valItem ident="hypomixolydian">
-          <desc>Hypomixolydian mode (the eighth mode).</desc>
+          <desc xml:lang="en">Hypomixolydian mode (the eighth mode).</desc>
         </valItem>
         <valItem ident="peregrinus">
-          <desc>Tonus peregrinus (the ninth mode).</desc>
+          <desc xml:lang="en">Tonus peregrinus (the ninth mode).</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.MODE.extended" module="MEI" type="dt">
-    <desc>Modern modes.</desc>
+    <desc xml:lang="en">Modern modes.</desc>
     <content>
       <valList type="semi">
         <valItem ident="ionian">
-          <desc>Ionian mode.</desc>
+          <desc xml:lang="en">Ionian mode.</desc>
         </valItem>
         <valItem ident="hypoionian">
-          <desc>Hypoionian mode.</desc>
+          <desc xml:lang="en">Hypoionian mode.</desc>
         </valItem>
         <valItem ident="aeolian">
-          <desc>Aeolian mode.</desc>
+          <desc xml:lang="en">Aeolian mode.</desc>
         </valItem>
         <valItem ident="hypoaeolian">
-          <desc>Hypoaeolian mode.</desc>
+          <desc xml:lang="en">Hypoaeolian mode.</desc>
         </valItem>
         <valItem ident="locrian">
-          <desc>Locrian mode.</desc>
+          <desc xml:lang="en">Locrian mode.</desc>
         </valItem>
         <valItem ident="hypolocrian">
-          <desc>Hypolocrian mode.</desc>
+          <desc xml:lang="en">Hypolocrian mode.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.MODSRELATIONSHIP" module="MEI" type="dt">
-    <desc>Bibliographic relationship values based on MODS version 3.4.</desc>
+    <desc xml:lang="en">Bibliographic relationship values based on MODS version 3.4.</desc>
     <content>
       <valList type="closed">
         <valItem ident="preceding">
-          <desc>Temporal predecessor of the resource.</desc>
+          <desc xml:lang="en">Temporal predecessor of the resource.</desc>
         </valItem>
         <valItem ident="succeeding">
-          <desc>Temporal successor to the resource.</desc>
+          <desc xml:lang="en">Temporal successor to the resource.</desc>
         </valItem>
         <valItem ident="original">
-          <desc>Original form of the resource.</desc>
+          <desc xml:lang="en">Original form of the resource.</desc>
         </valItem>
         <valItem ident="host">
-          <desc>Parent containing the resource.</desc>
+          <desc xml:lang="en">Parent containing the resource.</desc>
         </valItem>
         <valItem ident="constituent">
-          <desc>Intellectual or physical component of the resource.</desc>
+          <desc xml:lang="en">Intellectual or physical component of the resource.</desc>
         </valItem>
         <valItem ident="otherVersion">
-          <desc>Version of the resource’s intellectual content not changed enough to be a different
+          <desc xml:lang="en">Version of the resource’s intellectual content not changed enough to be a different
             work.</desc>
         </valItem>
         <valItem ident="otherFormat">
-          <desc>Version of the resource in a different physical format.</desc>
+          <desc xml:lang="en">Version of the resource in a different physical format.</desc>
         </valItem>
         <valItem ident="isReferencedBy">
-          <desc>Published bibliographic description, review, abstract, or index of the resource's
+          <desc xml:lang="en">Published bibliographic description, review, abstract, or index of the resource's
             content.</desc>
         </valItem>
         <valItem ident="references">
-          <desc>Cited or referred to in the resource.</desc>
+          <desc xml:lang="en">Cited or referred to in the resource.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.MODUSMAIOR" module="MEI" type="dt">
-    <desc>Maxima-long relationship values.</desc>
+    <desc xml:lang="en">Maxima-long relationship values.</desc>
     <content>
       <rng:data type="positiveInteger">
         <rng:param name="minInclusive">2</rng:param>
@@ -2789,7 +2789,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.MODUSMINOR" module="MEI" type="dt">
-    <desc>Long-breve relationship values.</desc>
+    <desc xml:lang="en">Long-breve relationship values.</desc>
     <content>
       <rng:data type="positiveInteger">
         <rng:param name="minInclusive">2</rng:param>
@@ -2798,109 +2798,109 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.MUSICFONT" module="MEI" type="dt">
-    <desc>Music font family.</desc>
+    <desc xml:lang="en">Music font family.</desc>
     <content>
       <rng:data type="token"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.NCNAME" module="MEI" type="dt">
-    <desc>"Convenience" datatype that permits combining enumerated values with a user-supplied
+    <desc xml:lang="en">"Convenience" datatype that permits combining enumerated values with a user-supplied
       name.</desc>
     <content>
       <rng:data type="NCName"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.NMTOKEN" module="MEI" type="dt">
-    <desc>"Convenience" datatype that permits combining enumerated values with user-supplied
+    <desc xml:lang="en">"Convenience" datatype that permits combining enumerated values with user-supplied
       values.</desc>
     <content>
       <rng:data type="NMTOKEN"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.NONSTAFFPLACE" module="MEI" type="dt">
-    <desc>Non-staff location.</desc>
+    <desc xml:lang="en">Non-staff location.</desc>
     <content>
       <valList type="closed">
         <valItem ident="botmar">
-          <desc>At the foot of the page.</desc>
+          <desc xml:lang="en">At the foot of the page.</desc>
         </valItem>
         <valItem ident="topmar">
-          <desc>At the top of the page.</desc>
+          <desc xml:lang="en">At the top of the page.</desc>
         </valItem>
         <valItem ident="leftmar">
-          <desc>At the left of the page.</desc>
+          <desc xml:lang="en">At the left of the page.</desc>
         </valItem>
         <valItem ident="rightmar">
-          <desc>At the right of the page.</desc>
+          <desc xml:lang="en">At the right of the page.</desc>
         </valItem>
         <valItem ident="facing">
-          <desc>On the opposite, <abbr>i.e.</abbr>, facing, page.</desc>
+          <desc xml:lang="en">On the opposite, <abbr>i.e.</abbr>, facing, page.</desc>
         </valItem>
         <valItem ident="overleaf">
-          <desc>On the other side of the leaf.</desc>
+          <desc xml:lang="en">On the other side of the leaf.</desc>
         </valItem>
         <valItem ident="end">
-          <desc>At the end of this division; <abbr>e.g.</abbr>, chapter, volume, etc.</desc>
+          <desc xml:lang="en">At the end of this division; <abbr>e.g.</abbr>, chapter, volume, etc.</desc>
         </valItem>
         <valItem ident="inter">
-          <desc>Within a line text; <abbr>i.e.</abbr>, an insertion.</desc>
+          <desc xml:lang="en">Within a line text; <abbr>i.e.</abbr>, an insertion.</desc>
         </valItem>
         <valItem ident="intra">
-          <desc>Between the lines of text, less exact than "sub" or "super".</desc>
+          <desc xml:lang="en">Between the lines of text, less exact than "sub" or "super".</desc>
         </valItem>
         <valItem ident="super">
-          <desc>Above a line of text, more exact than "intra(linear)". Do not confuse with
+          <desc xml:lang="en">Above a line of text, more exact than "intra(linear)". Do not confuse with
             superscript rendition.</desc>
         </valItem>
         <valItem ident="sub">
-          <desc>Below a line of text, more exact than "intra(linear)". Do not confuse with subscript
+          <desc xml:lang="en">Below a line of text, more exact than "intra(linear)". Do not confuse with subscript
             rendition.</desc>
         </valItem>
         <valItem ident="inspace">
-          <desc>In a predefined space; <abbr>i.e.</abbr>, that left by an earlier scribe.</desc>
+          <desc xml:lang="en">In a predefined space; <abbr>i.e.</abbr>, that left by an earlier scribe.</desc>
         </valItem>
         <valItem ident="superimposed">
-          <desc>Obscures original text; <abbr>e.g.</abbr>, via overstrike, addition of new writing surface
+          <desc xml:lang="en">Obscures original text; <abbr>e.g.</abbr>, via overstrike, addition of new writing surface
             material, etc.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.NOTATIONTYPE" module="MEI" type="dt">
-    <desc>Notation type and subtype</desc>
+    <desc xml:lang="en">Notation type and subtype</desc>
     <content>
       <valList type="closed">
         <valItem ident="cmn">
-          <desc>Common Music Notation.</desc>
+          <desc xml:lang="en">Common Music Notation.</desc>
         </valItem>
         <valItem ident="mensural">
-          <desc>Mensural notation.</desc>
+          <desc xml:lang="en">Mensural notation.</desc>
         </valItem>
         <valItem ident="mensural.black">
-          <desc>Black mensural notation.</desc>
+          <desc xml:lang="en">Black mensural notation.</desc>
         </valItem>
         <valItem ident="mensural.white">
-          <desc>White mensural notation.</desc>
+          <desc xml:lang="en">White mensural notation.</desc>
         </valItem>
         <valItem ident="neume">
-          <desc>Neumatic notation.</desc>
+          <desc xml:lang="en">Neumatic notation.</desc>
         </valItem>
         <!--
             <valItem ident="neume.heighted">
-              <desc>Heighted neumatic notation</desc>
+              <desc xml:lang="en">Heighted neumatic notation</desc>
             </valItem>
             <valItem ident="neume.unheighted">
-              <desc>Unheighted neumatic notation</desc>
+              <desc xml:lang="en">Unheighted neumatic notation</desc>
             </valItem>
           -->
         <valItem ident="tab">
-          <desc>Tablature notation.</desc>
+          <desc xml:lang="en">Tablature notation.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.NOTEHEADMODIFIER" module="MEI" type="dt">
-    <desc>Captures any notehead "modifiers"; that is, symbols added to the notehead, such as
+    <desc xml:lang="en">Captures any notehead "modifiers"; that is, symbols added to the notehead, such as
       slashes, lines, text, and enclosures, etc.</desc>
     <content>
       <rng:choice>
@@ -2910,44 +2910,44 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.NOTEHEADMODIFIER.list" module="MEI" type="dt">
-    <desc>Enumerated note head modifier values.</desc>
+    <desc xml:lang="en">Enumerated note head modifier values.</desc>
     <content>
       <valList type="closed">
         <valItem ident="slash">
-          <desc>Slash (upper right to lower left).</desc>
+          <desc xml:lang="en">Slash (upper right to lower left).</desc>
         </valItem>
         <valItem ident="backslash">
-          <desc>Backslash (upper left to lower right).</desc>
+          <desc xml:lang="en">Backslash (upper left to lower right).</desc>
         </valItem>
         <valItem ident="vline">
-          <desc>Vertical line.</desc>
+          <desc xml:lang="en">Vertical line.</desc>
         </valItem>
         <valItem ident="hline">
-          <desc>Horizontal line.</desc>
+          <desc xml:lang="en">Horizontal line.</desc>
         </valItem>
         <valItem ident="centerdot">
-          <desc>Center dot.</desc>
+          <desc xml:lang="en">Center dot.</desc>
         </valItem>
         <valItem ident="paren">
-          <desc>Enclosing parentheses.</desc>
+          <desc xml:lang="en">Enclosing parentheses.</desc>
         </valItem>
         <valItem ident="brack">
-          <desc>Enclosing square brackets.</desc>
+          <desc xml:lang="en">Enclosing square brackets.</desc>
         </valItem>
         <valItem ident="box">
-          <desc>Enclosing box.</desc>
+          <desc xml:lang="en">Enclosing box.</desc>
         </valItem>
         <valItem ident="circle">
-          <desc>Enclosing circle.</desc>
+          <desc xml:lang="en">Enclosing circle.</desc>
         </valItem>
         <valItem ident="dblwhole">
-          <desc>Enclosing "fences".</desc>
+          <desc xml:lang="en">Enclosing "fences".</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.NOTEHEADMODIFIER.pat" module="MEI" type="dt">
-    <desc>Captures text rendered in the center of the notehead.</desc>
+    <desc xml:lang="en">Captures text rendered in the center of the notehead.</desc>
     <content>
       <rng:choice>
         <rng:data type="string">
@@ -2960,7 +2960,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.OCTAVE" module="MEI" type="dt">
-    <desc>Oct attribute values. The default values conform to Acoustical Society of America
+    <desc xml:lang="en">Oct attribute values. The default values conform to Acoustical Society of America
       representation. Read, p. 44.</desc>
     <content>
       <rng:data type="nonNegativeInteger">
@@ -2969,7 +2969,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.OCTAVE.DIS" module="MEI" type="dt">
-    <desc>The amount of octave displacement; that is, '8' (as in '8va' for 1 octave), '15' (for 2
+    <desc xml:lang="en">The amount of octave displacement; that is, '8' (as in '8va' for 1 octave), '15' (for 2
       octaves), or rarely '22' (for 3 octaves).</desc>
     <content>
       <rng:data type="positiveInteger">
@@ -2978,7 +2978,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.ORIENTATION" module="MEI" type="dt">
-    <desc>Rotation or reflection of base symbol values.</desc>
+    <desc xml:lang="en">Rotation or reflection of base symbol values.</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">reversed|90CW|90CCW</rng:param>
@@ -2986,21 +2986,21 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.OTHERSTAFF" module="MEI" type="dt">
-    <desc>For musical material designated to appear on another staff, the location of the staff
+    <desc xml:lang="en">For musical material designated to appear on another staff, the location of the staff
       relative to the current one; <abbr>i.e.</abbr>, the staff above or the staff below.</desc>
     <content>
       <valList type="closed">
         <valItem ident="above">
-          <desc>The staff immediately above.</desc>
+          <desc xml:lang="en">The staff immediately above.</desc>
         </valItem>
         <valItem ident="below">
-          <desc>The staff immediately below.</desc>
+          <desc xml:lang="en">The staff immediately below.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.PAGE.PANELS" module="MEI" type="dt">
-    <desc>The number of panels per page.</desc>
+    <desc xml:lang="en">The number of panels per page.</desc>
     <content>
       <rng:data type="positiveInteger">
         <rng:param name="minInclusive">1</rng:param>
@@ -3009,7 +3009,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.PERCENT" module="MEI" type="dt">
-    <desc>Positive decimal number plus '%', <abbr>i.e.</abbr>, [0-9]+(\.?[0-9]*)?\%.</desc>
+    <desc xml:lang="en">Positive decimal number plus '%', <abbr>i.e.</abbr>, [0-9]+(\.?[0-9]*)?\%.</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">[0-9]+(\.?[0-9]*)?%</rng:param>
@@ -3017,7 +3017,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.PERCENT.LIMITED" module="MEI" type="dt">
-    <desc>Positive decimal number between 0 and 100, followed by a percent sign "%".</desc>
+    <desc xml:lang="en">Positive decimal number between 0 and 100, followed by a percent sign "%".</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">(([0-9]|[1-9][0-9])(\.[0-9]+)?|100(\.0+)?)%</rng:param>
@@ -3025,7 +3025,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.PERCENT.LIMITED.SIGNED" module="MEI" type="dt">
-    <desc>Positive decimal number between -100 and 100, followed by a percent sign "%".</desc>
+    <desc xml:lang="en">Positive decimal number between -100 and 100, followed by a percent sign "%".</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">(\+|-)?(([0-9]|[1-9][0-9])(\.[0-9]+)?|100(\.0+)?)%</rng:param>
@@ -3033,7 +3033,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.PGSCALE" module="MEI" type="dt">
-    <desc>Page scale factor; a percentage of the values in page.height and page.width.</desc>
+    <desc xml:lang="en">Page scale factor; a percentage of the values in page.height and page.width.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.PERCENT"/>
@@ -3041,7 +3041,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.PITCHCLASS" module="MEI" type="dt">
-    <desc>Pclass (pitch class) attribute values.</desc>
+    <desc xml:lang="en">Pclass (pitch class) attribute values.</desc>
     <content>
       <rng:data type="nonNegativeInteger">
         <rng:param name="maxInclusive">11</rng:param>
@@ -3049,7 +3049,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.PITCHNAME" module="MEI" type="dt">
-    <desc>The pitch names (gamut) used within a single octave. The default values conform to
+    <desc xml:lang="en">The pitch names (gamut) used within a single octave. The default values conform to
       Acoustical Society of America representation.</desc>
     <content>
       <rng:data type="token">
@@ -3058,7 +3058,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.PITCHNAME.GES" module="MEI" type="dt">
-    <desc>Gestural pitch names need an additional value for when the notated pitch is not to be
+    <desc xml:lang="en">Gestural pitch names need an additional value for when the notated pitch is not to be
       sounded.</desc>
     <content>
       <rng:data type="token">
@@ -3067,13 +3067,13 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.PITCHNUMBER" module="MEI" type="dt">
-    <desc>Pnum (pitch number, <abbr>e.g.</abbr>, MIDI) attribute values.</desc>
+    <desc xml:lang="en">Pnum (pitch number, <abbr>e.g.</abbr>, MIDI) attribute values.</desc>
     <content>
       <rng:data type="nonNegativeInteger"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.PLACEMENT" module="MEI" type="dt">
-    <desc>Location information.</desc>
+    <desc xml:lang="en">Location information.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.STAFFREL"/>
@@ -3094,7 +3094,7 @@
     </constraintSpec>
   </macroSpec>
   <macroSpec ident="data.PROLATIO" module="MEI" type="dt">
-    <desc>Semibreve-minim relationship values.</desc>
+    <desc xml:lang="en">Semibreve-minim relationship values.</desc>
     <content>
       <rng:data type="positiveInteger">
         <rng:param name="minInclusive">2</rng:param>
@@ -3103,7 +3103,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.RATIO" module="MEI" type="dt">
-    <desc>A ratio, <abbr>i.e.</abbr>, [0-9]+(\.?[0-9]*)?:[0-9]+(\.?[0-9]*)? For example, "40:7.2319".</desc>
+    <desc xml:lang="en">A ratio, <abbr>i.e.</abbr>, [0-9]+(\.?[0-9]*)?:[0-9]+(\.?[0-9]*)? For example, "40:7.2319".</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">[0-9]+(\.?[0-9]*)?:[0-9]+(\.?[0-9]*)?</rng:param>
@@ -3111,7 +3111,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.RELATIONSHIP" module="MEI" type="dt">
-    <desc>General-purpose relationships</desc>
+    <desc xml:lang="en">General-purpose relationships</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.FRBRRELATIONSHIP"/>
@@ -3121,7 +3121,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.ROTATION" module="MEI" type="dt">
-    <desc>Rotation.</desc>
+    <desc xml:lang="en">Rotation.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.DEGREES"/>
@@ -3130,35 +3130,35 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.ROTATIONDIRECTION" module="MEI" type="dt">
-    <desc>Rotation term.</desc>
+    <desc xml:lang="en">Rotation term.</desc>
     <content>
       <valList type="closed">
         <valItem ident="none">
-          <desc>No rotation.</desc>
+          <desc xml:lang="en">No rotation.</desc>
         </valItem>
         <valItem ident="down">
-          <desc>Rotated 180 degrees.</desc>
+          <desc xml:lang="en">Rotated 180 degrees.</desc>
         </valItem>
         <valItem ident="left">
-          <desc>Rotated 270 degrees clockwise.</desc>
+          <desc xml:lang="en">Rotated 270 degrees clockwise.</desc>
         </valItem>
         <valItem ident="ne">
-          <desc>Rotated 45 degrees clockwise.</desc>
+          <desc xml:lang="en">Rotated 45 degrees clockwise.</desc>
         </valItem>
         <valItem ident="nw">
-          <desc>Rotated 315 degrees clockwise.</desc>
+          <desc xml:lang="en">Rotated 315 degrees clockwise.</desc>
         </valItem>
         <valItem ident="se">
-          <desc>Rotated 135 degrees clockwise.</desc>
+          <desc xml:lang="en">Rotated 135 degrees clockwise.</desc>
         </valItem>
         <valItem ident="sw">
-          <desc>Rotated 225 degrees clockwise.</desc>
+          <desc xml:lang="en">Rotated 225 degrees clockwise.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.SCALEDEGREE" module="MEI" type="dt">
-    <desc>Scale degree values.</desc>
+    <desc xml:lang="en">Scale degree values.</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">(\^|v)?[1-7](\+|\-)?</rng:param>
@@ -3166,7 +3166,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.SLASH" module="MEI" type="dt">
-    <desc>The number of slashes to be rendered for tremolandi.</desc>
+    <desc xml:lang="en">The number of slashes to be rendered for tremolandi.</desc>
     <content>
       <rng:data type="positiveInteger">
         <rng:param name="minInclusive">1</rng:param>
@@ -3175,7 +3175,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.SLUR" module="MEI" type="dt">
-    <desc>i=initial, m=medial, t=terminal. Number is used to match endpoints of the slur when slurs
+    <desc xml:lang="en">i=initial, m=medial, t=terminal. Number is used to match endpoints of the slur when slurs
       are nested or overlap.</desc>
     <content>
       <rng:data type="token">
@@ -3191,7 +3191,7 @@
     </exemplum>
   </macroSpec>
   <macroSpec ident="data.STAFFITEM" module="MEI" type="dt">
-    <desc>Items that may be printed above, below, or between staves.</desc>
+    <desc xml:lang="en">Items that may be printed above, below, or between staves.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.STAFFITEM.basic"/>
@@ -3202,46 +3202,46 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.STAFFITEM.basic" module="MEI" type="dt">
-    <desc>Items in all repertoires that may be printed near a staff.</desc>
+    <desc xml:lang="en">Items in all repertoires that may be printed near a staff.</desc>
     <content>
       <valList type="closed">
         <valItem ident="accid">
-          <desc>Accidentals.</desc>
+          <desc xml:lang="en">Accidentals.</desc>
         </valItem>
         <valItem ident="annot">
-          <desc>Annotations.</desc>
+          <desc xml:lang="en">Annotations.</desc>
         </valItem>
         <valItem ident="artic">
-          <desc>Articulations.</desc>
+          <desc xml:lang="en">Articulations.</desc>
         </valItem>
         <valItem ident="dir">
-          <desc>Directives.</desc>
+          <desc xml:lang="en">Directives.</desc>
         </valItem>
         <valItem ident="dynam">
-          <desc>Dynamics.</desc>
+          <desc xml:lang="en">Dynamics.</desc>
         </valItem>
         <valItem ident="harm">
-          <desc>Harmony indications.</desc>
+          <desc xml:lang="en">Harmony indications.</desc>
         </valItem>
         <valItem ident="ornam">
-          <desc>Ornaments.</desc>
+          <desc xml:lang="en">Ornaments.</desc>
         </valItem>
         <!-- phrase more note-attached than staff-attached? -->
         <!--<valItem ident="phrase"/>-->
         <valItem ident="sp">
-          <desc>Spoken text.</desc>
+          <desc xml:lang="en">Spoken text.</desc>
         </valItem>
         <valItem ident="stageDir">
-          <desc>Stage directions.</desc>
+          <desc xml:lang="en">Stage directions.</desc>
         </valItem>
         <valItem ident="tempo">
-          <desc>Tempo markings.</desc>
+          <desc xml:lang="en">Tempo markings.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.STAFFLOC" module="MEI" type="dt">
-    <desc>Staff location. The value '0' indicates the bottom line of the current staff; positive
+    <desc xml:lang="en">Staff location. The value '0' indicates the bottom line of the current staff; positive
       values are used for positions above the bottom line and negative values for the positions
       below. For example, in treble clef, 1 = F4, 2 = G4, 3 = A4, etc. and -1 = D4, -2 = C4, and so
       on.</desc>
@@ -3250,7 +3250,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.STAFFREL" module="MEI" type="dt">
-    <desc>Location of musical material relative to a staff.</desc>
+    <desc xml:lang="en">Location of musical material relative to a staff.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.STAFFREL.basic"/>
@@ -3274,33 +3274,33 @@
     </constraintSpec>
   </macroSpec>
   <macroSpec ident="data.STAFFREL.basic" module="MEI" type="dt">
-    <desc>Location of symbol relative to a staff.</desc>
+    <desc xml:lang="en">Location of symbol relative to a staff.</desc>
     <content>
       <valList type="closed">
         <valItem ident="above">
-          <desc>Above the staff.</desc>
+          <desc xml:lang="en">Above the staff.</desc>
         </valItem>
         <valItem ident="below">
-          <desc>Below the staff.</desc>
+          <desc xml:lang="en">Below the staff.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.STAFFREL.extended" module="MEI" type="dt">
-    <desc>Location of symbol relative to a staff.</desc>
+    <desc xml:lang="en">Location of symbol relative to a staff.</desc>
     <content>
       <valList type="closed">
         <valItem ident="between">
-          <desc>Between staves.</desc>
+          <desc xml:lang="en">Between staves.</desc>
         </valItem>
         <valItem ident="within">
-          <desc>Within/on the staff.</desc>
+          <desc xml:lang="en">Within/on the staff.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.STEMDIRECTION" module="MEI" type="dt">
-    <desc>Stem direction.</desc>
+    <desc xml:lang="en">Stem direction.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.STEMDIRECTION.basic"/>
@@ -3309,126 +3309,126 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.STEMDIRECTION.basic" module="MEI" type="dt">
-    <desc>Common stem directions.</desc>
+    <desc xml:lang="en">Common stem directions.</desc>
     <content>
       <valList type="closed">
         <valItem ident="up">
-          <desc>Stem points upwards.</desc>
+          <desc xml:lang="en">Stem points upwards.</desc>
         </valItem>
         <valItem ident="down">
-          <desc>Stem points downwards.</desc>
+          <desc xml:lang="en">Stem points downwards.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.STEMDIRECTION.extended" module="MEI" type="dt">
-    <desc>Additional stem directions.</desc>
+    <desc xml:lang="en">Additional stem directions.</desc>
     <content>
       <valList type="closed">
         <valItem ident="left">
-          <desc>Stem points left.</desc>
+          <desc xml:lang="en">Stem points left.</desc>
         </valItem>
         <valItem ident="right">
-          <desc>Stem points right.</desc>
+          <desc xml:lang="en">Stem points right.</desc>
         </valItem>
         <valItem ident="ne">
-          <desc>Stem points up and right.</desc>
+          <desc xml:lang="en">Stem points up and right.</desc>
         </valItem>
         <valItem ident="se">
-          <desc>Stem points down and right.</desc>
+          <desc xml:lang="en">Stem points down and right.</desc>
         </valItem>
         <valItem ident="nw">
-          <desc>Stem points up and left.</desc>
+          <desc xml:lang="en">Stem points up and left.</desc>
         </valItem>
         <valItem ident="sw">
-          <desc>Stem points down and left.</desc>
+          <desc xml:lang="en">Stem points down and left.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.STEMMODIFIER" module="MEI" type="dt">
-    <desc>Stem modification.</desc>
+    <desc xml:lang="en">Stem modification.</desc>
     <content>
       <valList type="closed">
         <valItem ident="none">
-          <desc>No modifications to stem.</desc>
+          <desc xml:lang="en">No modifications to stem.</desc>
         </valItem>
         <valItem ident="1slash">
-          <desc>1 slash through stem.</desc>
+          <desc xml:lang="en">1 slash through stem.</desc>
         </valItem>
         <valItem ident="2slash">
-          <desc>2 slashes through stem.</desc>
+          <desc xml:lang="en">2 slashes through stem.</desc>
         </valItem>
         <valItem ident="3slash">
-          <desc>3 slashes through stem.</desc>
+          <desc xml:lang="en">3 slashes through stem.</desc>
         </valItem>
         <valItem ident="4slash">
-          <desc>4 slashes through stem.</desc>
+          <desc xml:lang="en">4 slashes through stem.</desc>
         </valItem>
         <valItem ident="5slash">
-          <desc>5 slashes through stem.</desc>
+          <desc xml:lang="en">5 slashes through stem.</desc>
         </valItem>
         <valItem ident="6slash">
-          <desc>6 slashes through stem.</desc>
+          <desc xml:lang="en">6 slashes through stem.</desc>
         </valItem>
         <valItem ident="sprech">
-          <desc>X placed on stem.</desc>
+          <desc xml:lang="en">X placed on stem.</desc>
         </valItem>
         <valItem ident="z">
-          <desc>Z placed on stem.</desc>
+          <desc xml:lang="en">Z placed on stem.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.STEMPOSITION" module="MEI" type="dt">
-    <desc>Position of a note’s stem relative to the head of the note.</desc>
+    <desc xml:lang="en">Position of a note’s stem relative to the head of the note.</desc>
     <content>
       <valList type="closed">
         <valItem ident="left">
-          <desc>Stem attached to left side of note head.</desc>
+          <desc xml:lang="en">Stem attached to left side of note head.</desc>
         </valItem>
         <valItem ident="right">
-          <desc>Stem attached to right side of note head.</desc>
+          <desc xml:lang="en">Stem attached to right side of note head.</desc>
         </valItem>
         <valItem ident="center">
-          <desc>Stem is originates from center of note head.</desc>
+          <desc xml:lang="en">Stem is originates from center of note head.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.STRINGNUMBER" module="MEI" type="dt">
-    <desc>In string tablature, the number of the string to be played, <abbr>i.e.</abbr>, [1-9]+.</desc>
+    <desc xml:lang="en">In string tablature, the number of the string to be played, <abbr>i.e.</abbr>, [1-9]+.</desc>
     <content>
       <rng:data type="positiveInteger"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.TEMPERAMENT" module="MEI" type="dt">
-    <desc>Temperament or tuning system.</desc>
+    <desc xml:lang="en">Temperament or tuning system.</desc>
     <content>
       <valList type="closed">
         <valItem ident="equal">
-          <desc>Equal or 12-tone temperament.</desc>
+          <desc xml:lang="en">Equal or 12-tone temperament.</desc>
         </valItem>
         <valItem ident="just">
-          <desc>Just intonation.</desc>
+          <desc xml:lang="en">Just intonation.</desc>
         </valItem>
         <valItem ident="mean">
-          <desc>Meantone intonation.</desc>
+          <desc xml:lang="en">Meantone intonation.</desc>
         </valItem>
         <valItem ident="pythagorean">
-          <desc>Pythagorean tuning.</desc>
+          <desc xml:lang="en">Pythagorean tuning.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.TEMPOVALUE" module="MEI" type="dt">
-    <desc>Beats (meter signature denominator) per minute, <abbr>e.g.</abbr>, 120.</desc>
+    <desc xml:lang="en">Beats (meter signature denominator) per minute, <abbr>e.g.</abbr>, 120.</desc>
     <content>
       <rng:data type="decimal"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.TEMPUS" module="MEI" type="dt">
-    <desc>Breve-semibreve relationship values.</desc>
+    <desc xml:lang="en">Breve-semibreve relationship values.</desc>
     <content>
       <rng:data type="positiveInteger">
         <rng:param name="minInclusive">2</rng:param>
@@ -3437,105 +3437,105 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.TEXTRENDITIONLIST" module="MEI" type="dt">
-    <desc>Closed list of text rendition values.</desc>
+    <desc xml:lang="en">Closed list of text rendition values.</desc>
     <content>
       <valList type="closed">
         <valItem ident="quote">
-          <desc>Surrounded by single quotes.</desc>
+          <desc xml:lang="en">Surrounded by single quotes.</desc>
         </valItem>
         <valItem ident="quotedbl">
-          <desc>Surrounded by double quotes.</desc>
+          <desc xml:lang="en">Surrounded by double quotes.</desc>
         </valItem>
         <valItem ident="italic">
-          <desc>Italicized (slanted to right).</desc>
+          <desc xml:lang="en">Italicized (slanted to right).</desc>
         </valItem>
         <valItem ident="oblique">
-          <desc>Oblique (slanted to left).</desc>
+          <desc xml:lang="en">Oblique (slanted to left).</desc>
         </valItem>
         <valItem ident="smcaps">
-          <desc>Small capitals.</desc>
+          <desc xml:lang="en">Small capitals.</desc>
         </valItem>
         <valItem ident="bold">
-          <desc>Relative font weight.</desc>
+          <desc xml:lang="en">Relative font weight.</desc>
         </valItem>
         <valItem ident="bolder">
-          <desc>Relative font weight.</desc>
+          <desc xml:lang="en">Relative font weight.</desc>
         </valItem>
         <valItem ident="lighter">
-          <desc>Relative font weight.</desc>
+          <desc xml:lang="en">Relative font weight.</desc>
         </valItem>
         <valItem ident="box">
-          <desc>Enclosed in box.</desc>
+          <desc xml:lang="en">Enclosed in box.</desc>
         </valItem>
         <valItem ident="circle">
-          <desc>Enclosed in ellipse/circle.</desc>
+          <desc xml:lang="en">Enclosed in ellipse/circle.</desc>
         </valItem>
         <valItem ident="dbox">
-          <desc>Enclosed in diamond.</desc>
+          <desc xml:lang="en">Enclosed in diamond.</desc>
         </valItem>
         <valItem ident="tbox">
-          <desc>Enclosed in triangle.</desc>
+          <desc xml:lang="en">Enclosed in triangle.</desc>
         </valItem>
         <valItem ident="bslash">
-          <desc>Struck through by '\' (back slash).</desc>
+          <desc xml:lang="en">Struck through by '\' (back slash).</desc>
         </valItem>
         <valItem ident="fslash">
-          <desc>Struck through by '/' (forward slash).</desc>
+          <desc xml:lang="en">Struck through by '/' (forward slash).</desc>
         </valItem>
         <valItem ident="line-through">
-          <desc>Struck through by '-'; may be qualified to indicate multiple parallel lines, <abbr>e.g.</abbr>,
+          <desc xml:lang="en">Struck through by '-'; may be qualified to indicate multiple parallel lines, <abbr>e.g.</abbr>,
             line-through(2).</desc>
         </valItem>
         <valItem ident="none">
-          <desc>Not rendered, invisible.</desc>
+          <desc xml:lang="en">Not rendered, invisible.</desc>
         </valItem>
         <valItem ident="overline">
-          <desc>Line above the text; may be qualified to indicate multiple parallel lines, <abbr>e.g.</abbr>,
+          <desc xml:lang="en">Line above the text; may be qualified to indicate multiple parallel lines, <abbr>e.g.</abbr>,
             overline(3).</desc>
         </valItem>
         <valItem ident="overstrike">
-          <desc>Use for deleted text fully or partially obscured by other text (such as 'XXXXX') or
+          <desc xml:lang="en">Use for deleted text fully or partially obscured by other text (such as 'XXXXX') or
             musical symbols (such as notes, rests, etc.).</desc>
         </valItem>
         <valItem ident="strike">
-          <desc>Struck through by '-'; equivalent to line-through; may be qualified to indicate
+          <desc xml:lang="en">Struck through by '-'; equivalent to line-through; may be qualified to indicate
             multiple parallel lines, <abbr>e.g.</abbr>, strike(3).</desc>
         </valItem>
         <valItem ident="sub">
-          <desc>Subscript.</desc>
+          <desc xml:lang="en">Subscript.</desc>
         </valItem>
         <valItem ident="sup">
-          <desc>Superscript.</desc>
+          <desc xml:lang="en">Superscript.</desc>
         </valItem>
         <valItem ident="superimpose">
-          <desc>Use for added text or musical symbols that fully or partially obscure text from an
+          <desc xml:lang="en">Use for added text or musical symbols that fully or partially obscure text from an
             earlier writing stage.</desc>
         </valItem>
         <valItem ident="underline">
-          <desc>Underlined; may be qualified to indicate multiple parallel lines, <abbr>e.g.</abbr>,
+          <desc xml:lang="en">Underlined; may be qualified to indicate multiple parallel lines, <abbr>e.g.</abbr>,
             underline(2).</desc>
         </valItem>
         <valItem ident="x-through">
-          <desc>Crossed-out; equivalent to 'bslash' (\) plus 'fslash' (/); that is, a hand-written
+          <desc xml:lang="en">Crossed-out; equivalent to 'bslash' (\) plus 'fslash' (/); that is, a hand-written
             'X'; may be qualified to indicate multiple parallel lines, <abbr>e.g.</abbr>, x-through(2).</desc>
         </valItem>
         <valItem ident="ltr">
-          <desc>Left-to-right (BIDI embed).</desc>
+          <desc xml:lang="en">Left-to-right (BIDI embed).</desc>
         </valItem>
         <valItem ident="rtl">
-          <desc>Right-to-left (BIDI embed).</desc>
+          <desc xml:lang="en">Right-to-left (BIDI embed).</desc>
         </valItem>
         <valItem ident="lro">
-          <desc>Left-to-right (BIDI override).</desc>
+          <desc xml:lang="en">Left-to-right (BIDI override).</desc>
         </valItem>
         <valItem ident="rlo">
-          <desc>Right-to-left (BIDI override).</desc>
+          <desc xml:lang="en">Right-to-left (BIDI override).</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.TEXTRENDITIONPAR" module="MEI" type="dt">
-    <desc>Parameterized text rendition values.</desc>
+    <desc xml:lang="en">Parameterized text rendition values.</desc>
     <content>
       <rng:choice>
         <rng:data type="string">
@@ -3549,7 +3549,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.TEXTRENDITION" module="MEI" type="dt">
-    <desc>Text rendition values.</desc>
+    <desc xml:lang="en">Text rendition values.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.TEXTRENDITIONLIST"/>
@@ -3558,7 +3558,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.TIE" module="MEI" type="dt">
-    <desc>Tie attribute values: initial, medial, terminal.</desc>
+    <desc xml:lang="en">Tie attribute values: initial, medial, terminal.</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">[i|m|t]</rng:param>
@@ -3566,14 +3566,14 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.TSTAMPOFFSET" module="MEI" type="dt">
-    <desc>A positive or negative offset from the value given in the tstamp attribute in terms of
+    <desc xml:lang="en">A positive or negative offset from the value given in the tstamp attribute in terms of
       musical time, <abbr>i.e.</abbr>, beats[.fractional beat part].</desc>
     <content>
       <rng:data type="decimal"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.TUPLET" module="MEI" type="dt">
-    <desc>Tuplet attribute values: initial, medial, terminal.</desc>
+    <desc xml:lang="en">Tuplet attribute values: initial, medial, terminal.</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">[i|m|t][1-6]</rng:param>
@@ -3581,7 +3581,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.UNEUMEFORM" module="MEI" type="dt">
-    <desc>Basic, <abbr>i.e.</abbr>, single, uninterrupted, neume forms.</desc>
+    <desc xml:lang="en">Basic, <abbr>i.e.</abbr>, single, uninterrupted, neume forms.</desc>
     <content>
       <valList type="closed">
         <valItem ident="liquescent1"/>
@@ -3595,7 +3595,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.UNEUMENAME" module="MEI" type="dt">
-    <desc>Basic, <abbr>i.e.</abbr>, single, uninterrupted, neume names.</desc>
+    <desc xml:lang="en">Basic, <abbr>i.e.</abbr>, single, uninterrupted, neume names.</desc>
     <content>
       <valList type="closed">
         <valItem ident="punctum"/>
@@ -3615,32 +3615,32 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.URI" module="MEI" type="dt">
-    <desc>A Uniform Resource Identifier, see [RFC2396].</desc>
+    <desc xml:lang="en">A Uniform Resource Identifier, see [RFC2396].</desc>
     <content>
       <rng:data type="anyURI"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.VERTICALALIGNMENT" module="MEI" type="dt">
-    <desc>Data values for attributes that capture vertical alignment.</desc>
+    <desc xml:lang="en">Data values for attributes that capture vertical alignment.</desc>
     <content>
       <valList type="closed">
         <valItem ident="top">
-          <desc>Top aligned.</desc>
+          <desc xml:lang="en">Top aligned.</desc>
         </valItem>
         <valItem ident="middle">
-          <desc>Middle aligned.</desc>
+          <desc xml:lang="en">Middle aligned.</desc>
         </valItem>
         <valItem ident="bottom">
-          <desc>Bottom aligned.</desc>
+          <desc xml:lang="en">Bottom aligned.</desc>
         </valItem>
         <valItem ident="baseline">
-          <desc>Baseline aligned.</desc>
+          <desc xml:lang="en">Baseline aligned.</desc>
         </valItem>
       </valList>
     </content>
   </macroSpec>
   <macroSpec ident="data.WORD" module="MEI" type="dt">
-    <desc>A single "word" that contains only letters, digits, punctuation characters, or symbols. It
+    <desc xml:lang="en">A single "word" that contains only letters, digits, punctuation characters, or symbols. It
       cannot contain whitespace.</desc>
     <content>
       <rng:data type="token">
@@ -3649,17 +3649,17 @@
     </content>
   </macroSpec>
   <classSpec ident="att.notationType" module="MEI" type="atts">
-    <desc>Attributes that provide for classification of notation.</desc>
+    <desc xml:lang="en">Attributes that provide for classification of notation.</desc>
     <attList>
       <attDef ident="notationtype" usage="opt">
-        <desc>Contains classification of the notation contained or described by the element bearing
+        <desc xml:lang="en">Contains classification of the notation contained or described by the element bearing
           this attribute.</desc>
         <datatype>
           <rng:ref name="data.NOTATIONTYPE"/>
         </datatype>
       </attDef>
       <attDef ident="notationsubtype" usage="opt">
-        <desc>Provides any sub-classification of the notation contained or described by the element,
+        <desc xml:lang="en">Provides any sub-classification of the notation contained or described by the element,
           additional to that given by its notationtype attribute.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>

--- a/utils/guidelines_xslt/odd2html/specs/elementSpecs.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/elementSpecs.xsl
@@ -75,6 +75,9 @@
             <h2 id="{$element/@ident}">&lt;<xsl:value-of select="$element/@ident"/>&gt;</h2>
             <div class="specs">
                 <div class="desc">
+                    <xsl:if test="$element/tei:gloss">
+                        <xsl:value-of select="concat('(', $element/tei:gloss/text(), ') – ')"/>
+                    </xsl:if>
                     <xsl:apply-templates select="$element/tei:desc/node()" mode="guidelines"/>
                     <xsl:sequence select="$refs"/>
                 </div>


### PR DESCRIPTION
This PR is an attempt to bring the style of the source files a bit more in line with TEI. 

- extracts resolved abbreviations into `gloss` elements with an additional `versionDate` attribute
- adds `xml:lang` attributes to `desc`, `gloss`, and `remarks`

Further adjustments to the XSLTs are needed.