### PR TITLE
Add ordering information to lines.color

### DIFF
--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1622,9 +1622,7 @@
         <remarks>
           <p>The value is structured; that is, it should contain a single color value or have 
             the same number of space-separated values as the number of lines indicated by the
-            lines attribute. The first value then applies to the lowest line of the staff. 
-            A line can be made invisible by assigning it the same color as the
-            background, usually white.</p>
+            lines attribute. The first value then applies to the lowest line of the staff.</p>
           <p>All value from data.COLOR are allowed.</p>
         </remarks>
       </attDef>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1615,13 +1615,18 @@
         </datatype>
       </attDef>
       <attDef ident="lines.color" usage="opt">
-        <desc>Captures the colors of the staff lines. The value is structured; that is, it should
-          have the same number of space-separated RGB values as the number of lines indicated by the
-          lines attribute. A line can be made invisible by assigning it the same RGB value as the
-          background, usually white.</desc>
+        <desc>Captures the colors of the staff lines.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.COLOR"/>
         </datatype>
+        <remarks>
+          <p>The value is structured; that is, it should contain a single color value or have 
+            the same number of space-separated values as the number of lines indicated by the
+            lines attribute. The first value then applies to the lowest line of the staff. 
+            A line can be made invisible by assigning it the same color as the
+            background, usually white.</p>
+          <p>All value from data.COLOR are allowed.</p>
+        </remarks>
       </attDef>
       <attDef ident="lines.visible" usage="opt">
         <desc>Records whether all staff lines are visible.</desc>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1623,7 +1623,7 @@
           <p>The value is structured; that is, it should contain a single color value or have 
             the same number of space-separated values as the number of lines indicated by the
             lines attribute. The first value then applies to the lowest line of the staff.</p>
-          <p>All value from data.COLOR are allowed.</p>
+          <p>All values from data.COLOR are allowed.</p>
         </remarks>
       </attDef>
       <attDef ident="lines.visible" usage="opt">


### PR DESCRIPTION
This PR tries to be a bit more explicit about the possible values in `@lines.color`.

Closes #946