### PR TITLE
Update sourceDesc in headers of guideline chapters 

### DIFF
--- a/source/docs/01-introduction.xml
+++ b/source/docs/01-introduction.xml
@@ -81,8 +81,8 @@
             </availability>
          </publicationStmt>
          <sourceDesc>
-            <p></p>
-         </sourceDesc>
+            <p>Born digital: No previous source exists.</p>
+        </sourceDesc>
       </fileDesc>
    </teiHeader>
    <text>

--- a/source/docs/02-shared.xml
+++ b/source/docs/02-shared.xml
@@ -82,7 +82,7 @@
             </availability>
          </publicationStmt>
          <sourceDesc>
-            <p></p>
+            <p>Born digital: No previous source exists.</p>
          </sourceDesc>
       </fileDesc>
    </teiHeader>

--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -82,7 +82,7 @@
             </availability>
          </publicationStmt>
          <sourceDesc>
-            <p></p>
+            <p>Born digital: No previous source exists.</p>
          </sourceDesc>
       </fileDesc>
    </teiHeader>

--- a/source/docs/04-cmn.xml
+++ b/source/docs/04-cmn.xml
@@ -82,7 +82,7 @@
             </availability>
          </publicationStmt>
          <sourceDesc>
-            <p></p>
+            <p>Born digital: No previous source exists.</p>
          </sourceDesc>
       </fileDesc>
    </teiHeader>

--- a/source/docs/05-mensural.xml
+++ b/source/docs/05-mensural.xml
@@ -82,7 +82,7 @@
             </availability>
          </publicationStmt>
          <sourceDesc>
-            <p></p>
+            <p>Born digital: No previous source exists.</p>
          </sourceDesc>
       </fileDesc>
    </teiHeader>

--- a/source/docs/06-neumes.xml
+++ b/source/docs/06-neumes.xml
@@ -82,7 +82,7 @@
             </availability>
          </publicationStmt>
          <sourceDesc>
-            <p></p>
+            <p>Born digital: No previous source exists.</p>
          </sourceDesc>
       </fileDesc>
    </teiHeader>

--- a/source/docs/07-tablature.xml
+++ b/source/docs/07-tablature.xml
@@ -82,7 +82,7 @@
             </availability>
          </publicationStmt>
          <sourceDesc>
-            <p></p>
+            <p>Born digital: No previous source exists.</p>
          </sourceDesc>
       </fileDesc>
    </teiHeader>

--- a/source/docs/08-lyricsperfdir.xml
+++ b/source/docs/08-lyricsperfdir.xml
@@ -82,7 +82,7 @@
             </availability>
          </publicationStmt>
          <sourceDesc>
-            <p></p>
+            <p>Born digital: No previous source exists.</p>
          </sourceDesc>
       </fileDesc>
    </teiHeader>

--- a/source/docs/09-textencoding.xml
+++ b/source/docs/09-textencoding.xml
@@ -82,7 +82,7 @@
             </availability>
          </publicationStmt>
          <sourceDesc>
-            <p></p>
+            <p>Born digital: No previous source exists.</p>
          </sourceDesc>
       </fileDesc>
    </teiHeader>

--- a/source/docs/10-analysisharm.xml
+++ b/source/docs/10-analysisharm.xml
@@ -82,7 +82,7 @@
             </availability>
          </publicationStmt>
          <sourceDesc>
-            <p></p>
+            <p>Born digital: No previous source exists.</p>
          </sourceDesc>
       </fileDesc>
    </teiHeader>

--- a/source/docs/11-scholarlyediting.xml
+++ b/source/docs/11-scholarlyediting.xml
@@ -82,7 +82,7 @@
             </availability>
          </publicationStmt>
          <sourceDesc>
-            <p></p>
+            <p>Born digital: No previous source exists.</p>
          </sourceDesc>
       </fileDesc>
    </teiHeader>

--- a/source/docs/12-facsimilesrecordings.xml
+++ b/source/docs/12-facsimilesrecordings.xml
@@ -82,7 +82,7 @@
             </availability>
          </publicationStmt>
          <sourceDesc>
-            <p></p>
+            <p>Born digital: No previous source exists.</p>
          </sourceDesc>
       </fileDesc>
    </teiHeader>

--- a/source/docs/13-linkingdata.xml
+++ b/source/docs/13-linkingdata.xml
@@ -82,7 +82,7 @@
             </availability>
          </publicationStmt>
          <sourceDesc>
-            <p></p>
+            <p>Born digital: No previous source exists.</p>
          </sourceDesc>
       </fileDesc>
    </teiHeader>

--- a/source/docs/14-integration.xml
+++ b/source/docs/14-integration.xml
@@ -81,7 +81,7 @@
             </availability>
          </publicationStmt>
          <sourceDesc>
-            <p></p>
+            <p>Born digital: No previous source exists.</p>
          </sourceDesc>
       </fileDesc>
    </teiHeader>


### PR DESCRIPTION
This PR adds minimal source description and resolves #877.

Another thing that could (and probably) should be updated is the license information kept in these files. It still says "Copyright (c) 2018".