### PR TITLE
make stem.vis part of att.extSym and att.visibility

### DIFF
--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -380,6 +380,7 @@
         <memberOf key="att.xy"/>
         <memberOf key="att.color"/>
         <memberOf key="att.extSym"/>
+        <memberOf key="att.visibility"/>
     </classes>
     <attList>
       <attDef ident="pos" usage="opt">

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -379,6 +379,7 @@
     <classes>
         <memberOf key="att.xy"/>
         <memberOf key="att.color"/>
+        <memberOf key="att.extSym"/>
     </classes>
     <attList>
       <attDef ident="pos" usage="opt">


### PR DESCRIPTION
Mensural stems were missing the possibility to be identified with a specific glyph. This PR makes `stem.vis` part of `att.extSym` to fix this.

Also this makes it part of [att.visibility](https://music-encoding.org/guidelines/dev/attribute-classes/att.visibility.html) to be more in line with [att.stems](https://music-encoding.org/guidelines/v4/attribute-classes/att.stems.html).