### PR TITLE
Change model.syllablePart

### DIFF
--- a/customizations/mei-Neumes.xml
+++ b/customizations/mei-Neumes.xml
@@ -127,27 +127,6 @@
             <memberOf key="model.rdgPart.music"/>
           </classes>
         </classSpec>
-        
-        <!-- Allow custos and clef to appear within layer; compensate side effect of removing membership in model.layerPart from model.eventLike -->
-        <elementSpec ident="custos" module="MEI.shared" mode="change">
-          <classes mode="change">
-            <memberOf key="model.layerPart.neumes" mode="add"/>
-          </classes>
-        </elementSpec>
-        <elementSpec ident="clef" module="MEI.shared" mode="change">
-          <classes mode="change">
-            <memberOf key="model.layerPart.neumes" mode="add"/>
-          </classes>
-        </elementSpec>
-        
-        <!-- remove custos and clef (among others) from within syllable -->
-        <classSpec ident="model.eventLike" module="MEI.shared" type="model" mode="change">
-          <classes mode="change">
-            <memberOf key="model.syllablePart" mode="delete"/>
-          </classes>
-        </classSpec>
-        
-
       </schemaSpec>
     </body>
   </text>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -3883,7 +3883,6 @@
     <desc>Groups event elements that occur in all notational repertoires.</desc>
     <classes>
       <memberOf key="model.layerPart"/>
-      <memberOf key="model.syllablePart"/>
     </classes>
   </classSpec>
   <classSpec ident="model.headLike" module="MEI.shared" type="model">
@@ -4852,6 +4851,7 @@
       <memberOf key="att.clef.vis"/>
       <memberOf key="model.eventLike"/>
       <memberOf key="model.staffDefPart"/>
+      <memberOf key="model.syllablePart"/>
     </classes>
     <content>
       <rng:empty/>


### PR DESCRIPTION
This PR removes `model.eventLike` from `model.syllablePart` and makes `clef` direct member of `model.syllablePart` instead. 
This solves the problem with `<custos>` being allowed in `<syllable>` from #968 saves us having to remove and re-add things in the Neumes customization.

