### PR TITLE
Update `@meiversion` for MEI basic

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -751,7 +751,7 @@
                         <attDef ident="meiversion" usage="req">
                             <desc>Specifies a generic MEI version label.</desc>
                             <valList type="closed">
-                                <valItem ident="5.0.0-rc1+basic">
+                                <valItem ident="5.0.0-dev+basic">
                                     <desc>This version of MEI.</desc>
                                 </valItem>
                             </valList>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -751,7 +751,7 @@
                         <attDef ident="meiversion" usage="req">
                             <desc>Specifies a generic MEI version label.</desc>
                             <valList type="closed">
-                                <valItem ident="4.0.1-rc1+basic">
+                                <valItem ident="5.0.0-rc1+basic">
                                     <desc>This version of MEI.</desc>
                                 </valItem>
                             </valList>


### PR DESCRIPTION
Because this will now be a version 5.0 release, the version attribute needed to be updated accordingly.