### PR TITLE
Make custos part of att.visualOffset.ho

### DIFF
--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -411,6 +411,7 @@
       <memberOf key="att.extSym"/>
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.typography"/>
+      <memberOf key="att.visualOffset.ho"/>
     </classes>
   </classSpec>
   <classSpec ident="att.mdiv.vis" module="MEI.visual" type="atts">


### PR DESCRIPTION
Follow-up PR to #951. Makes it possible to apply a horizontal offset to `custos` as suggested by @pe-ro. 