### PR TITLE
Unify spelling

### DIFF
--- a/source/docs/02-shared.xml
+++ b/source/docs/02-shared.xml
@@ -305,7 +305,7 @@
                         <specDesc key="att.nNumberLike" atts="n"/>
                      </specList>
                   </p>
-                  <p>The <gi scheme="MEI">pb</gi> element can be used to mark page beginnings. When transcribing an existing document the <att>n</att> attribute should be used to record the page number displayed in the source. It need not be an integer, <abbr>e.g.</abbr>, 'iv', or 'p17-3'. The logical page number can be calculated by counting previous <gi scheme="MEI">pb</gi> ancestor elements. When used in a score context, a page beginning implies an accompanying system beginning. This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+                  <p>The <gi scheme="MEI">pb</gi> element can be used to mark page beginnings. When transcribing an existing document the <att>n</att> attribute should be used to record the page number displayed in the source. It need not be an integer, <abbr>e.g.</abbr>, 'iv', or 'p17-3'. The logical page number can be calculated by counting previous <gi scheme="MEI">pb</gi> ancestor elements. When used in a score context, a page beginning implies an accompanying system beginning. This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
                   <p>
                      <specList>
                         <specDesc key="pgDesc"/>

--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -246,7 +246,7 @@
                <head>Information about an MEI file</head>
                <div xml:id="headerFileDescription" type="div3">
                   <head>File Description</head>
-                  <p>The structure of the bibliographic description of a machine-readable or digital musical text resembles that of a book, an article, or other kinds of textual objects. The file description element of the MEI header has therefore been closely modelled on existing standards in library cataloging; it should thus provide enough information to allow users to give standard bibliographic references to the electronic text, and to allow catalogers to catalog it. Bibliographic citations occurring elsewhere in the header, and in the text itself, are derived from the same model.</p>
+                  <p>The structure of the bibliographic description of a machine-readable or digital musical text resembles that of a book, an article, or other kinds of textual objects. The file description element of the MEI header has therefore been closely modeled on existing standards in library cataloging; it should thus provide enough information to allow users to give standard bibliographic references to the electronic text, and to allow catalogers to catalog it. Bibliographic citations occurring elsewhere in the header, and in the text itself, are derived from the same model.</p>
                   <p>The bibliographic description of an electronic musical text should be supplied by the mandatory <gi scheme="MEI">fileDesc</gi> element:</p>
                   <p>
                      <specList>
@@ -1390,7 +1390,7 @@
                         <specDesc key="titlePage"/>
                      </specList>
                   </p>
-                  <p>The <gi scheme="MEI">titlePage</gi> element, modelled after a similar element in Encoded Archival Description (EAD), may occur within the textual matter preceding or following the musical content of the encoding. Since a diplomatic transcription of the titlepage is often necessary to accurately identify musical material contained within a source, <gi scheme="MEI">titlePage</gi> may also be used within the metadata header as a child of the <gi scheme="MEI">physDesc</gi> element.</p>
+                  <p>The <gi scheme="MEI">titlePage</gi> element, modeled after a similar element in Encoded Archival Description (EAD), may occur within the textual matter preceding or following the musical content of the encoding. Since a diplomatic transcription of the titlepage is often necessary to accurately identify musical material contained within a source, <gi scheme="MEI">titlePage</gi> may also be used within the metadata header as a child of the <gi scheme="MEI">physDesc</gi> element.</p>
                   <p>Detailed analysis of the title page and other preliminaries of older printed books and manuscripts is of major importance in descriptive bibliography and the cataloging of printed books. The following elements are suggested as a means of encoding the major features of most title pages for faithful rendition:</p>
                   <p>
                      <specList>

--- a/source/docs/09-textencoding.xml
+++ b/source/docs/09-textencoding.xml
@@ -267,7 +267,7 @@
                </div>
                <div xml:id="figTableFigures" type="div3">
                   <head>Figures</head>
-                  <p>The <gi scheme="MEI">fig</gi> element groups elements representing or containing graphic information such as an illustration or figure. This element is modelled on the figure element in the Text Encoding Initiative (TEI). The <gi scheme="MEI">fig</gi> element is used to contain images, captions, and textual descriptions of the pictures. The images themselves are specified using the <gi scheme="MEI">graphic</gi> element, whose <att>target</att> attribute provides the location of an image. For example:</p>
+                  <p>The <gi scheme="MEI">fig</gi> element groups elements representing or containing graphic information such as an illustration or figure. This element is modeled on the figure element in the Text Encoding Initiative (TEI). The <gi scheme="MEI">fig</gi> element is used to contain images, captions, and textual descriptions of the pictures. The images themselves are specified using the <gi scheme="MEI">graphic</gi> element, whose <att>target</att> attribute provides the location of an image. For example:</p>
                   <p>
                      <figure>
                         <head/>

--- a/source/modules/MEI.corpus.xml
+++ b/source/modules/MEI.corpus.xml
@@ -26,7 +26,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on the teiCorpus element in the Text Encoding Initiative (TEI)
+      <p>This element is modeled on the teiCorpus element in the Text Encoding Initiative (TEI)
         standard. The MEI instances making up the corpus may be related in a number of ways, for
         example, by composer, by similar instrumentation, by holding institution, etc. This
         element’s name should not be changed in order to assure an absolute minimum level of MEI

--- a/source/modules/MEI.critapp.xml
+++ b/source/modules/MEI.critapp.xml
@@ -69,7 +69,7 @@
         lectio difficilior, usus auctoris, etc.).</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="lem" module="MEI.critapp">
@@ -120,7 +120,7 @@
         should only contain those elements allowed within <gi scheme="MEI">verse</gi>.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="rdg" module="MEI.critapp">
@@ -170,7 +170,7 @@
         should only contain those elements allowed within <gi scheme="MEI">verse</gi>.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
 </specGrp>

--- a/source/modules/MEI.drama.xml
+++ b/source/modules/MEI.drama.xml
@@ -109,7 +109,7 @@
         must NOT have any musical attributes.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="stageDir" module="MEI.drama">
@@ -163,7 +163,7 @@
           >stageDir</gi> must NOT have any musical attributes.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
 </specGrp>

--- a/source/modules/MEI.edittrans.xml
+++ b/source/modules/MEI.edittrans.xml
@@ -169,7 +169,7 @@
         >verse</gi>.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -226,7 +226,7 @@
         should only contain those elements allowed within <gi scheme="MEI">verse</gi>.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="choice" module="MEI.edittrans">
@@ -250,7 +250,7 @@
         may be recursively nested.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="corr" module="MEI.edittrans">
@@ -300,7 +300,7 @@
         >verse</gi>.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="cpMark" module="MEI.edittrans">
@@ -419,7 +419,7 @@
         >verse</gi>.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="del" module="MEI.edittrans">
@@ -470,7 +470,7 @@
         should only contain those elements allowed within <gi scheme="MEI">verse</gi>.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -522,7 +522,7 @@
         >verse</gi>.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -558,7 +558,7 @@
         certainty ascribed to the identification of the extent of the missing material.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="handShift" module="MEI.edittrans">
@@ -632,7 +632,7 @@
         hand.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="metaMark" module="MEI.edittrans">
@@ -763,7 +763,7 @@
         >verse</gi>.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="reg" module="MEI.edittrans">
@@ -813,7 +813,7 @@
         should only contain those elements allowed within <gi scheme="MEI">verse</gi>.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="restore" module="MEI.edittrans">
@@ -866,7 +866,7 @@
         >verse</gi>.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="sic" module="MEI.edittrans">
@@ -910,7 +910,7 @@
         should only contain those elements allowed within <gi scheme="MEI">verse</gi>.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="subst" module="MEI.edittrans">
@@ -930,7 +930,7 @@
       </rng:oneOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="supplied" module="MEI.edittrans">
@@ -985,7 +985,7 @@
         >verse</gi>.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="unclear" module="MEI.edittrans">
@@ -1042,7 +1042,7 @@
         >verse</gi>.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
 </specGrp>

--- a/source/modules/MEI.facsimile.xml
+++ b/source/modules/MEI.facsimile.xml
@@ -57,7 +57,7 @@
         particular source described in the header.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="surface" module="MEI.facsimile">
@@ -89,7 +89,7 @@
         occurring on this surface.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="zone" module="MEI.facsimile">
@@ -110,7 +110,7 @@
     <remarks xml:lang="en">
       <p>Scalable Vector Graphics (SVG) markup may be used when allowed by the graphicLike
         model.</p>
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
 </specGrp>

--- a/source/modules/MEI.figtable.xml
+++ b/source/modules/MEI.figtable.xml
@@ -69,7 +69,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on the figure element in the Text Encoding Initiative (TEI)
+      <p>This element is modeled on the figure element in the Text Encoding Initiative (TEI)
         standard.</p>
     </remarks>
   </elementSpec>
@@ -103,7 +103,7 @@
         with an illustration. It may or may not function as a description of the illustration.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="graphic" module="MEI.figtable">
@@ -157,7 +157,7 @@
       </attDef>
     </attList>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="table" module="MEI.figtable">
@@ -181,7 +181,7 @@
       </rng:optional>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Encoded Archival Description (EAD), Text
+      <p>This element is modeled on elements in the Encoded Archival Description (EAD), Text
         Encoding Initiative (TEI), and HTML standards.</p>
     </remarks>
   </elementSpec>
@@ -212,7 +212,7 @@
         information.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the HTML standard.</p>
+      <p>This element is modeled on an element in the HTML standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="th" module="MEI.figtable">
@@ -242,7 +242,7 @@
         information.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the HTML standard.</p>
+      <p>This element is modeled on an element in the HTML standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="tr" module="MEI.figtable">
@@ -267,7 +267,7 @@
       <p>More precise rendition of the table and its cells can be specified in a style sheet.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the HTML standard.</p>
+      <p>This element is modeled on an element in the HTML standard.</p>
     </remarks>
   </elementSpec>
 </specGrp>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -307,7 +307,7 @@
         afforded by copyright.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Encoded Archival Description (EAD)
+      <p>This element is modeled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
   </elementSpec>
@@ -324,7 +324,7 @@
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="altId" module="MEI.header">
@@ -367,7 +367,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="application" module="MEI.header">
@@ -400,7 +400,7 @@
       </attDef>
     </attList>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="attUsage" module="MEI.header">
@@ -469,7 +469,7 @@
         >availability</gi> indicates access to the MEI-encoded document itself.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -666,7 +666,7 @@
         new version that supersedes earlier versions.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Encoded Archival Description (EAD)
+      <p>This element is modeled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
   </elementSpec>
@@ -806,7 +806,7 @@
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Encoded Archival Description (EAD)
+      <p>This element is modeled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
   </elementSpec>
@@ -947,7 +947,7 @@
       </attDef>
     </attList>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="cutout" module="MEI.header">
@@ -1108,7 +1108,7 @@
       </rng:oneOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -1142,7 +1142,7 @@
       </rng:choice>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="encodingDesc" module="MEI.header">
@@ -1182,7 +1182,7 @@
       </rng:optional>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="exhibHist" module="MEI.header">
@@ -1217,7 +1217,7 @@
       </rng:choice>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Encoded Archival Description (EAD)
+      <p>This element is modeled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
   </elementSpec>
@@ -1285,7 +1285,7 @@
       <p>Extent in this context represents file size.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -1373,7 +1373,7 @@
         element.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="handList" module="MEI.header">
@@ -1403,7 +1403,7 @@
       </constraint>
     </constraintSpec>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="history" module="MEI.header">
@@ -1537,7 +1537,7 @@
       </rng:oneOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="key" module="MEI.header">
@@ -1590,7 +1590,7 @@
         <att>auth.uri</att> attribute, respectively.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -1612,7 +1612,7 @@
       </rng:oneOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="meiHead" module="MEI.header">
@@ -1685,7 +1685,7 @@
     </attList>
     <remarks xml:lang="en">
       <p>In order to encourage uniformity in the provision of metadata across document types, this
-        element is modelled on an element in the Text Encoding Initiative (TEI) standard. This
+        element is modeled on an element in the Text Encoding Initiative (TEI) standard. This
         information is often essential in a machine-readable environment. Five sub-elements must be
         encoded in the following order: <gi scheme="MEI">altId</gi>(optional), <gi scheme="MEI"
         >fileDesc</gi>(required), <gi scheme="MEI">encodingDesc</gi>(optional), <gi scheme="MEI"
@@ -1765,7 +1765,7 @@
       </attDef>
     </attList>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="normalization" module="MEI.header">
@@ -1788,7 +1788,7 @@
       </rng:oneOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="notesStmt" module="MEI.header">
@@ -1807,7 +1807,7 @@
       </rng:oneOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="otherChar" module="MEI.header">
@@ -2066,7 +2066,7 @@
         meta-data rather than a transcription.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Encoded Archival Description (EAD)
+      <p>This element is modeled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
   </elementSpec>
@@ -2089,7 +2089,7 @@
         multiple elements may be used, one for each medium.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Encoded Archival Description (EAD) standard. It
+      <p>This element is modeled on elements in the Encoded Archival Description (EAD) standard. It
         has the same function as the material element in the Text Encoding Initiative (TEI)
         standard.</p>
     </remarks>
@@ -2190,7 +2190,7 @@
       </rng:oneOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="provenance" module="MEI.header">
@@ -2223,7 +2223,7 @@
       </rng:choice>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Encoded Archival Description (EAD) and Text
+      <p>This element is modeled on elements in the Encoded Archival Description (EAD) and Text
         Encoding Initiative (TEI) standards.</p>
     </remarks>
   </elementSpec>
@@ -2253,7 +2253,7 @@
       <p>When an item is unpublished, use only the <gi scheme="MEI">unpub</gi> sub-element.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="revisionDesc" module="MEI.header">
@@ -2277,7 +2277,7 @@
         recent alteration first.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="samplingDecl" module="MEI.header">
@@ -2300,7 +2300,7 @@
       </rng:oneOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="scoreFormat" module="MEI.header">
@@ -2336,7 +2336,7 @@
       </rng:oneOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="seriesStmt" module="MEI.header">
@@ -2378,7 +2378,7 @@
         provided within seriesStmt for the description of a sub-series.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="soundChan" module="MEI.header">
@@ -2467,7 +2467,7 @@
         in the content of this particular source.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -2526,7 +2526,7 @@
       </rng:oneOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="sysReq" module="MEI.header">
@@ -2562,7 +2562,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="tagUsage" module="MEI.header">
@@ -2615,7 +2615,7 @@
       </attDef>
     </attList>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="taxonomy" module="MEI.header">
@@ -2695,7 +2695,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="trackConfig" module="MEI.header">
@@ -2765,7 +2765,7 @@
         solutions used, techniques applied, etc.), the date the treatment was applied, etc.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Encoded Archival Description (EAD)
+      <p>This element is modeled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
   </elementSpec>
@@ -2801,7 +2801,7 @@
       </rng:choice>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Encoded Archival Description (EAD)
+      <p>This element is modeled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
   </elementSpec>
@@ -2845,7 +2845,7 @@
         affecting the availability of the material.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Encoded Archival Description (EAD)
+      <p>This element is modeled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
   </elementSpec>
@@ -2867,7 +2867,7 @@
         facsimile image.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="work" module="MEI.header">

--- a/source/modules/MEI.msDesc.xml
+++ b/source/modules/MEI.msDesc.xml
@@ -55,7 +55,7 @@
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="addDesc" module="MEI.msDesc">
@@ -72,7 +72,7 @@
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="binding" module="MEI.msDesc">
@@ -106,7 +106,7 @@
       </attDef>
     </attList>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="bindingDesc" module="MEI.msDesc">
@@ -144,7 +144,7 @@
       </rng:choice>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="catchwords" module="MEI.msDesc">
@@ -161,7 +161,7 @@
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="collation" module="MEI.msDesc">
@@ -176,7 +176,7 @@
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="colophon" module="MEI.msDesc">
@@ -193,7 +193,7 @@
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="decoDesc" module="MEI.msDesc">
@@ -228,7 +228,7 @@
       </rng:choice>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="decoNote" module="MEI.msDesc">
@@ -263,7 +263,7 @@
       </rng:choice>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="explicit" module="MEI.msDesc">
@@ -280,7 +280,7 @@
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="foliation" module="MEI.msDesc">
@@ -295,7 +295,7 @@
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="heraldry" module="MEI.msDesc">
@@ -313,7 +313,7 @@
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="layout" module="MEI.msDesc">
@@ -384,7 +384,7 @@
       </attDef>
     </attList>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="layoutDesc" module="MEI.msDesc">
@@ -418,7 +418,7 @@
       </rng:choice>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="locus" module="MEI.msDesc">
@@ -463,7 +463,7 @@
       </attDef>
     </attList>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="locusGrp" module="MEI.msDesc">
@@ -492,7 +492,7 @@
       </attDef>
     </attList>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="rubric" module="MEI.msDesc">
@@ -523,7 +523,7 @@
       </attDef>
     </attList>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="scriptDesc" module="MEI.msDesc">
@@ -558,7 +558,7 @@
       </rng:choice>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="scriptNote" module="MEI.msDesc">
@@ -574,7 +574,7 @@
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="seal" module="MEI.msDesc">
@@ -615,7 +615,7 @@
       </attDef>
     </attList>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="sealDesc" module="MEI.msDesc">
@@ -656,7 +656,7 @@
       </rng:choice>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="secFolio" module="MEI.msDesc">
@@ -675,7 +675,7 @@
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="signatures" module="MEI.msDesc">
@@ -691,7 +691,7 @@
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="stamp" module="MEI.msDesc">
@@ -710,7 +710,7 @@
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="support" module="MEI.msDesc">
@@ -734,7 +734,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="supportDesc" module="MEI.msDesc">
@@ -802,7 +802,7 @@
       </attDef>
     </attList>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="typeDesc" module="MEI.msDesc">
@@ -837,7 +837,7 @@
       </rng:choice>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="typeNote" module="MEI.msDesc">
@@ -853,7 +853,7 @@
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <constraintSpec ident="check_msDesc_inline" module="MEI.msDesc" scheme="isoschematron">

--- a/source/modules/MEI.namesdates.xml
+++ b/source/modules/MEI.namesdates.xml
@@ -72,7 +72,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="bloc" module="MEI.namesdates">
@@ -98,7 +98,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="corpName" module="MEI.namesdates">
@@ -133,7 +133,7 @@
         using the <att>auth</att> attribute.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Encoded Archival Description (EAD)
+      <p>This element is modeled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
   </elementSpec>
@@ -161,7 +161,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="district" module="MEI.namesdates">
@@ -187,7 +187,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="famName" module="MEI.namesdates">
@@ -237,7 +237,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="genName" module="MEI.namesdates">
@@ -264,7 +264,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="geogFeat" module="MEI.namesdates">
@@ -291,7 +291,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="geogName" module="MEI.namesdates">
@@ -327,7 +327,7 @@
         attribute.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Encoded Archival Description (EAD)
+      <p>This element is modeled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
   </elementSpec>
@@ -355,7 +355,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="periodName" module="MEI.namesdates">
@@ -417,7 +417,7 @@
         persName is taken may be recorded using the <att>auth</att> attribute.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Encoded Archival Description (EAD)
+      <p>This element is modeled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
   </elementSpec>
@@ -440,7 +440,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="postCode" module="MEI.namesdates">
@@ -462,7 +462,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="region" module="MEI.namesdates">
@@ -488,7 +488,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="roleName" module="MEI.namesdates">
@@ -515,7 +515,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="settlement" module="MEI.namesdates">
@@ -541,7 +541,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="street" module="MEI.namesdates">
@@ -564,7 +564,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="styleName" module="MEI.namesdates">

--- a/source/modules/MEI.performance.xml
+++ b/source/modules/MEI.performance.xml
@@ -241,7 +241,7 @@
         this point in time.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
 </specGrp>

--- a/source/modules/MEI.ptrref.xml
+++ b/source/modules/MEI.ptrref.xml
@@ -33,7 +33,7 @@
         or sub-elements to describe the referenced object.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Encoded Archival Description (EAD) and Text
+      <p>This element is modeled on elements in the Encoded Archival Description (EAD) and Text
         Encoding Initiative (TEI) standards.</p>
     </remarks>
   </elementSpec>
@@ -63,7 +63,7 @@
         and sub-elements to describe the destination.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Encoded Archival Description (EAD) and TEI
+      <p>This element is modeled on elements in the Encoded Archival Description (EAD) and TEI
         standards.</p>
     </remarks>
   </elementSpec>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -4237,7 +4237,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="address" module="MEI.shared">
@@ -4262,7 +4262,7 @@
       </rng:choice>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -4289,7 +4289,7 @@
         lines of an address.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -4479,7 +4479,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -4553,7 +4553,7 @@
         >ref</gi>, which does not provide special bibliographic sub-elements.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -4591,7 +4591,7 @@
       </constraint>
     </constraintSpec>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="biblScope" module="MEI.shared">
@@ -4629,7 +4629,7 @@
     <remarks xml:lang="en">
       <p>Use the <att>from</att> and <att>to</att> attributes to regularize the beginning and ending
         values provided in the element content.</p>
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="biblStruct" module="MEI.shared">
@@ -4769,7 +4769,7 @@
       </rng:oneOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="castItem" module="MEI.shared">
@@ -4793,7 +4793,7 @@
       </rng:oneOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="castList" module="MEI.shared">
@@ -4817,7 +4817,7 @@
       </rng:oneOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="cb" module="MEI.shared">
@@ -4859,7 +4859,7 @@
       </attDef>
     </attList>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="chord" module="MEI.shared">
@@ -5068,7 +5068,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI).</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI).</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="custos" module="MEI.shared">
@@ -5116,7 +5116,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -5187,7 +5187,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="dim" module="MEI.shared">
@@ -5297,7 +5297,7 @@
         materials.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -5366,7 +5366,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="div" module="MEI.shared">
@@ -5463,7 +5463,7 @@
     </attList>
     <remarks xml:lang="en">
       <p>Often, the <gi scheme="MEI">head</gi> sub-element identifies the <gi scheme="MEI"
-        >div</gi>’s purpose. This element is modelled on an element in the Text Encoding Initiative
+        >div</gi>’s purpose. This element is modeled on an element in the Text Encoding Initiative
         (TEI) standard.</p>
     </remarks>
   </elementSpec>
@@ -5565,7 +5565,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -5589,7 +5589,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="ending" module="MEI.shared">
@@ -5770,7 +5770,7 @@
         width.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -5795,7 +5795,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="genre" module="MEI.shared">
@@ -5844,7 +5844,7 @@
         have its own front and back matter.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="grpSym" module="MEI.shared">
@@ -5912,7 +5912,7 @@
         its purpose.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in Encoded Archival Description (EAD), Text Encoding
+      <p>This element is modeled on elements in Encoded Archival Description (EAD), Text Encoding
         Initiative (TEI), and HTML standards.</p>
     </remarks>
   </elementSpec>
@@ -5981,7 +5981,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -6148,7 +6148,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
       <p>Don't confuse this element, which is used to capture labelling text appearing in the
         document, with the <att>label</att> attribute, which records text to be used to generate a
         designation for the element to which it’s attached, a "tool tip" or prefatory text, for
@@ -6268,7 +6268,7 @@
         performs a similar function for musical notation.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="lg" module="MEI.shared">
@@ -6303,7 +6303,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="librettist" module="MEI.shared">
@@ -6596,7 +6596,7 @@
         <att>auth.uri</att> attributes.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Encoded Archival Description (EAD)
+      <p>This element is modeled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
   </elementSpec>
@@ -6736,7 +6736,7 @@
         the first letter of the content is often indented, enlarged, or both.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Encoded Archival Description, Text Encoding
+      <p>This element is modeled on elements in the Encoded Archival Description, Text Encoding
         Initiative (TEI), and HTML standards.</p>
     </remarks>
   </elementSpec>
@@ -6837,7 +6837,7 @@
         score context, a page beginning implies an accompanying system beginning.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="pgDesc" module="MEI.shared">
@@ -7108,7 +7108,7 @@
       </rng:optional>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Encoded Archival Description (EAD)
+      <p>This element is modeled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
   </elementSpec>
@@ -7131,7 +7131,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="pubPlace" module="MEI.shared">
@@ -7154,7 +7154,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="recipient" module="MEI.shared">
@@ -7381,7 +7381,7 @@
         using the <att>auth</att> attribute.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Encoded Archival Description (EAD)
+      <p>This element is modeled on an element in the Encoded Archival Description (EAD)
         standard.</p>
     </remarks>
   </elementSpec>
@@ -7409,7 +7409,7 @@
         <att>auth</att> attribute.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="respStmt" module="MEI.shared">
@@ -7449,7 +7449,7 @@
       </constraint>
     </constraintSpec>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="rest" module="MEI.shared">
@@ -7505,7 +7505,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="roleDesc" module="MEI.shared">
@@ -7525,7 +7525,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="sb" module="MEI.shared">
@@ -7711,7 +7711,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="space" module="MEI.shared">
@@ -7750,7 +7750,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="sponsor" module="MEI.shared">
@@ -7774,7 +7774,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -8234,7 +8234,7 @@
         identifier of the element containing the category label.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="textLang" module="MEI.shared">
@@ -8382,7 +8382,7 @@
         or name may be indicated in the <att>nonfiling</att> attribute.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="titlePage" module="MEI.shared">
@@ -8415,7 +8415,7 @@
         transcription is provided.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in Encoded Archival Description (EAD) standard.</p>
+      <p>This element is modeled on an element in Encoded Archival Description (EAD) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="titlePart" module="MEI.shared">
@@ -8503,7 +8503,7 @@
       </attDef>
     </attList>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="width" module="MEI.shared">

--- a/source/modules/MEI.text.xml
+++ b/source/modules/MEI.text.xml
@@ -80,7 +80,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="back" module="MEI.text">
@@ -105,7 +105,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -128,7 +128,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="front" module="MEI.text">
@@ -160,7 +160,7 @@
         cover, endpapers, etc. before and after the actual textual matter.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) and Encoded
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) and Encoded
         Archival Description (EAD) standards.</p>
     </remarks>
   </elementSpec>
@@ -183,7 +183,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="l" module="MEI.text">
@@ -222,7 +222,7 @@
         graphical lines that occur in music notation.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on elements in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="li" module="MEI.text">
@@ -245,7 +245,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in the Encoded Archival Description (EAD), Text
+      <p>This element is modeled on elements in the Encoded Archival Description (EAD), Text
         Encoding Initiative (TEI), and HTML standards.</p>
     </remarks>
   </elementSpec>
@@ -337,7 +337,7 @@
       </attDef>
     </attList>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements in Encoded Archival Description (EAD), Text Encoding
+      <p>This element is modeled on elements in Encoded Archival Description (EAD), Text Encoding
         Initiative (TEI), and HTML standards.</p>
     </remarks>
   </elementSpec>
@@ -408,7 +408,7 @@
         >quote</gi>, intended for block quotations.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements found in HTML, TEI, and EAD standards.</p>
+      <p>This element is modeled on elements found in HTML, TEI, and EAD standards.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="quote" module="MEI.text">
@@ -439,7 +439,7 @@
         >q</gi>, intended for inline quotations.</p>
     </remarks>
     <remarks xml:lang="en">
-      <p>This element is modelled on elements found in HTML, TEI, and EAD standards.</p>
+      <p>This element is modeled on elements found in HTML, TEI, and EAD standards.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="seg" module="MEI.text">
@@ -463,7 +463,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>This element is modelled on an element in the Text Encoding Initiative (TEI) standard.</p>
+      <p>This element is modeled on an element in the Text Encoding Initiative (TEI) standard.</p>
     </remarks>
   </elementSpec>
 </specGrp>


### PR DESCRIPTION
This PR supersedes #899 by just Americanize spelling of `modeled`