### PR TITLE
Develop barlines

### DIFF
--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -364,13 +364,13 @@
     <content>
       <valList type="closed">
         <valItem ident="dashed">
-          <desc xml:lang="en">Dashed line (Unicode 1D104).</desc>
+          <desc xml:lang="en">Dashed line (SMuFL E036 and Unicode 1D104).</desc>
         </valItem>
         <valItem ident="dotted">
-          <desc xml:lang="en">Dotted line.</desc>
+          <desc xml:lang="en">Dotted line (SMuFL E037).</desc>
         </valItem>
         <valItem ident="dbl">
-          <desc xml:lang="en">(Unicode 1D101).</desc>
+          <desc xml:lang="en">Double barline (SMuFL E031 and Unicode 1D101).</desc>
         </valItem>
         <valItem ident="dbldashed">
           <desc xml:lang="en">Double dashed line.</desc>
@@ -385,7 +385,7 @@
           <desc xml:lang="en">Segno serpent with vertical lines (SMuFL E04B).</desc>
         </valItem> 
         <valItem ident="end">
-          <desc xml:lang="en">(Unicode 1D102).</desc>
+          <desc xml:lang="en">End barline (SMuFL E032 and Unicode 1D102).</desc>
         </valItem>
         <valItem ident="heavy">
           <desc xml:lang="en">Heavy barline (SMuFL E034).</desc>
@@ -394,19 +394,19 @@
           <desc xml:lang="en">Bar line not rendered.</desc>
         </valItem>
         <valItem ident="rptstart">
-          <desc xml:lang="en">Repeat start (Unicode 1D106).</desc>
+          <desc xml:lang="en">Repeat start (SMuFL E040 and Unicode 1D106).</desc>
         </valItem>
         <valItem ident="rptboth">
-          <desc xml:lang="en">Repeat start and end.</desc>
+          <desc xml:lang="en">Repeat start and end (SMuFL E042).</desc>
         </valItem>
         <valItem ident="rptend">
-          <desc xml:lang="en">Repeat end (Unicode 1D107).</desc>
+          <desc xml:lang="en">Repeat end (SMuFL E041 and Unicode 1D107).</desc>
         </valItem>
         <valItem ident="segno">
           <desc xml:lang="en">Segno serpent (SMuFL E04A).</desc>
         </valItem>
         <valItem ident="single">
-          <desc xml:lang="en">(Unicode 1D100).</desc>
+          <desc xml:lang="en">Single barline (SMuFL E030 and Unicode 1D100).</desc>
         </valItem>
       </valList>
     </content>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -378,6 +378,9 @@
         <valItem ident="dbldotted">
           <desc xml:lang="en">Double dotted line.</desc>
         </valItem>
+        <valItem ident="dblsegno">
+          <desc xml:lang="en">Segno serpent with vertical lines (SMuFL E04B).</desc>
+        </valItem> 
         <valItem ident="end">
           <desc xml:lang="en">(Unicode 1D102).</desc>
         </valItem>
@@ -392,6 +395,9 @@
         </valItem>
         <valItem ident="rptend">
           <desc xml:lang="en">Repeat end (Unicode 1D107).</desc>
+        </valItem>
+        <valItem ident="segno">
+          <desc xml:lang="en">Segno serpent (SMuFL E04A).</desc>
         </valItem>
         <valItem ident="single">
           <desc xml:lang="en">(Unicode 1D100).</desc>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -403,7 +403,7 @@
           <desc xml:lang="en">Repeat end (SMuFL E041 and Unicode 1D107).</desc>
         </valItem>
         <valItem ident="segno">
-          <desc xml:lang="en">Segno serpent (SMuFL E04A).</desc>
+          <desc xml:lang="en">Segno serpent.</desc>
         </valItem>
         <valItem ident="single">
           <desc xml:lang="en">Single barline (SMuFL E030 and Unicode 1D100).</desc>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -378,12 +378,18 @@
         <valItem ident="dbldotted">
           <desc xml:lang="en">Double dotted line.</desc>
         </valItem>
+        <valItem ident="dblheavy">
+          <desc xml:lang="en">Heavy double barline (SMuFL E035).</desc>
+        </valItem> 
         <valItem ident="dblsegno">
           <desc xml:lang="en">Segno serpent with vertical lines (SMuFL E04B).</desc>
         </valItem> 
         <valItem ident="end">
           <desc xml:lang="en">(Unicode 1D102).</desc>
         </valItem>
+        <valItem ident="heavy">
+          <desc xml:lang="en">Heavy barline (SMuFL E034).</desc>
+        </valItem> 
         <valItem ident="invis">
           <desc xml:lang="en">Bar line not rendered.</desc>
         </valItem>


### PR DESCRIPTION
This PR add data types to bar lines
* segno and dblsegno (#969)
* heavy and dblheavy (#787)

It also add the corresponding SMuFL codes whenever appropriate