### PR TITLE
Add `pedline` value to att.pedal.vis@form

### DIFF
--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1355,6 +1355,10 @@
             <desc xml:lang="en">Pedal up and down indications same as with "pedstar", but bounce is rendered with
               "Ped." only.</desc>
           </valItem>
+          <valItem ident="pedline">
+            <desc xml:lang="en">Pedal down rendered with "Ped.", end positions rendered by vertical bars and bounces
+              shown by upward-pointing "blips".</desc>
+          </valItem>
         </valList>
       </attDef>
     </attList>


### PR DESCRIPTION
The value is for pedal represented with "Ped." and a line as requested in #644. Closes #644.