### PR TITLE
Develop header footer

### DIFF
--- a/source/docs/02-shared.xml
+++ b/source/docs/02-shared.xml
@@ -315,9 +315,7 @@
                   <p>
                      <specList>
                         <specDesc key="pgHead"/>
-                        <specDesc key="pgHead2"/>
                         <specDesc key="pgFoot"/>
-                        <specDesc key="pgFoot2"/>
                      </specList>
                   </p>
                   <p>Columned layout can be captured with the following elements:</p>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -7547,13 +7547,7 @@
         <rng:ref name="pgHead"/>
       </rng:optional>
       <rng:optional>
-        <rng:ref name="pgHead2"/>
-      </rng:optional>
-      <rng:optional>
         <rng:ref name="pgFoot"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="pgFoot2"/>
       </rng:optional>
       <rng:optional>
         <rng:ref name="instrGrp"/>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -6897,7 +6897,7 @@
       <attDef ident="func" usage="opt">
         <desc xml:lang="en">Records the function (i.e., placement) of the page footer.</desc>
         <datatype>
-          <rng:ref name="data.PGFORMFUNC"/>
+          <rng:ref name="data.PGFUNC"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -6902,51 +6902,13 @@
       </attDef>
     </attList>
     <remarks xml:lang="en">
-      <p>This element is used to capture the textual data that often appears on the first page of
+      <p>This element is used to capture the textual data that often appears in
         printed music. It may also be used for similarly formatted material in manuscripts. When
         used within <gi scheme="MEI">pb</gi>, it records a temporary suspension of the pattern of
         page footers established by the use of <gi scheme="MEI">pgFoot</gi> within a previous <gi
         scheme="MEI">scoreDef</gi>. Auto-generated page numbers may be indicated with a processing
-        instruction. The pgHead, pgHead2, pgFoot, and pgFoot2 elements should <hi rend="bold"
+        instruction. The pgHead and pgFoot elements should <hi rend="bold"
         >*not*</hi> be used to encode textual notes/annotations.</p>
-    </remarks>
-  </elementSpec>
-  <elementSpec ident="pgFoot2" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">page footer 2</gloss>
-    <desc xml:lang="en">A running footer on the pages following the first.</desc>
-    <classes>
-      <memberOf key="att.common"/>
-      <memberOf key="att.facsimile"/>
-      <memberOf key="att.lang"/>
-    </classes>
-    <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:text/>
-          <rng:ref name="model.textComponentLike"/>
-          <rng:ref name="model.textPhraseLike.limited"/>
-          <rng:ref name="model.editLike"/>
-          <rng:ref name="model.transcriptionLike"/>
-          <rng:ref name="model.appLike"/>
-          <rng:ref name="anchoredText"/>
-        </rng:choice>
-      </rng:zeroOrMore>
-    </content>
-    <attList>
-      <attDef ident="halign" usage="opt">
-        <desc xml:lang="en">Records horizontal alignment of the page footer. Use multiple values to capture an
-          alternating pattern.</desc>
-        <datatype maxOccurs="unbounded">
-          <rng:ref name="data.HORIZONTALALIGNMENT"/>
-        </datatype>
-      </attDef>
-    </attList>
-    <remarks xml:lang="en">
-      <p>This element is used to capture the textual data that often appears on the second and
-        succeeding pages of printed music. It may also be used for similarly formatted material in
-        manuscripts. Auto-generated page numbers may be indicated with a processing instruction. The
-        pgHead, pgHead2, pgFoot, and pgFoot2 elements should <hi rend="bold">*not*</hi> be used to
-        encode textual notes/annotations.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="pgHead" module="MEI.shared">
@@ -6985,51 +6947,13 @@
       </attDef>
     </attList>
     <remarks xml:lang="en">
-      <p>This element is used to capture the textual data that often appears on the first page of
+      <p>This element is used to capture the textual data that often appears in
         printed music. It may also be used for similarly formatted material in manuscripts. When
         used within <gi scheme="MEI">pb</gi>, it records a temporary suspension of the pattern of
         page headers established by the use of <gi scheme="MEI">pgHead</gi> within a previous <gi
         scheme="MEI">scoreDef</gi>. Auto-generated page numbers may be indicated with a processing
-        instruction. The pgHead, pgHead2, pgFoot, and pgFoot2 elements should <hi rend="bold"
+        instruction. The pgHead and pgFoot elements should <hi rend="bold"
         >*not*</hi> be used to encode textual notes/annotations.</p>
-    </remarks>
-  </elementSpec>
-  <elementSpec ident="pgHead2" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">page header 2</gloss>
-    <desc xml:lang="en">A running header on the pages following the first.</desc>
-    <classes>
-      <memberOf key="att.common"/>
-      <memberOf key="att.facsimile"/>
-      <memberOf key="att.lang"/>
-    </classes>
-    <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:text/>
-          <rng:ref name="model.textComponentLike"/>
-          <rng:ref name="model.textPhraseLike.limited"/>
-          <rng:ref name="model.editLike"/>
-          <rng:ref name="model.transcriptionLike"/>
-          <rng:ref name="model.appLike"/>
-          <rng:ref name="anchoredText"/>
-        </rng:choice>
-      </rng:zeroOrMore>
-    </content>
-    <attList>
-      <attDef ident="halign" usage="opt">
-        <desc xml:lang="en">Records horizontal alignment of the page header. Use multiple values to capture an
-          alternating pattern.</desc>
-        <datatype maxOccurs="unbounded">
-          <rng:ref name="data.HORIZONTALALIGNMENT"/>
-        </datatype>
-      </attDef>
-    </attList>
-    <remarks xml:lang="en">
-      <p>This element is used to capture the textual data that often appears at the top of the
-        second and succeeding pages of printed music. It may also be used for similarly formatted
-        material in manuscripts. Auto-generated page numbers may be indicated with a processing
-        instruction. The pgHead, pgHead2, pgFoot, and pgFoot2 elements should <hi rend="bold"
-        >not</hi> be used to encode textual notes/annotations.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="phrase" module="MEI.shared">

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -6942,7 +6942,7 @@
       <attDef ident="func" usage="opt">
         <desc xml:lang="en">Records the function (i.e., placement) of the page header.</desc>
         <datatype>
-          <rng:ref name="data.PGFORMFUNC"/>
+          <rng:ref name="data.PGFUNC"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -6868,8 +6868,7 @@
   </elementSpec>
   <elementSpec ident="pgFoot" module="MEI.shared">
     <gloss versionDate="2022-05-18" xml:lang="en">page footer</gloss>
-    <desc xml:lang="en">A running footer on the first page. Also, used to temporarily override a
-      running footer on individual pages.</desc>
+    <desc xml:lang="en">A running footer.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6893,6 +6892,12 @@
         <desc xml:lang="en">Records horizontal alignment of the page footer.</desc>
         <datatype>
           <rng:ref name="data.HORIZONTALALIGNMENT"/>
+        </datatype>
+      </attDef>
+      <attDef ident="func" usage="opt">
+        <desc xml:lang="en">Records the function (i.e., placement) of the page footer.</desc>
+        <datatype>
+          <rng:ref name="data.PGFORMFUNC"/>
         </datatype>
       </attDef>
     </attList>
@@ -6946,8 +6951,7 @@
   </elementSpec>
   <elementSpec ident="pgHead" module="MEI.shared">
     <gloss versionDate="2022-05-18" xml:lang="en">page header</gloss>
-    <desc xml:lang="en">A running header on the first page. Also, used to temporarily override a
-      running header on individual pages.</desc>
+    <desc xml:lang="en">A running header.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -6971,6 +6975,12 @@
         <desc xml:lang="en">Records horizontal alignment of the page header.</desc>
         <datatype>
           <rng:ref name="data.HORIZONTALALIGNMENT"/>
+        </datatype>
+      </attDef>
+      <attDef ident="func" usage="opt">
+        <desc xml:lang="en">Records the function (i.e., placement) of the page header.</desc>
+        <datatype>
+          <rng:ref name="data.PGFORMFUNC"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3071,7 +3071,7 @@
       </rng:data>
     </content>
   </macroSpec>
-  <macroSpec ident="data.PGFORMFUNC" module="MEI" type="dt">
+  <macroSpec ident="data.PGFUNC" module="MEI" type="dt">
     <desc xml:lang="en">Page header and footer function; a value that defines the function (i.e., the placement) of the header or the footer.</desc>
     <content>
       <valList type="closed">

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3093,7 +3093,7 @@
       </valList>
     </content>
     <remarks xml:lang="en">
-      <p>An alternating pattern with "alt1" and "alt2" starts from the first page. However, if header of footer with a func="first" is also defined, it will shift the pattern by one page. A header or footer with func="last" will interupt the pattern accordingly.</p>
+      <p>An alternating pattern with "alt1" and "alt2" starts from the first page. However, if header or footer with a func="first" is also defined, it will shift the pattern by one page. A header or footer with func="last" will interupt the pattern accordingly.</p>
     </remarks>
   </macroSpec>
   <macroSpec ident="data.PGSCALE" module="MEI" type="dt">

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3093,7 +3093,7 @@
       </valList>
     </content>
     <remarks xml:lang="en">
-      <p>An alternating pattern with "alt1" and "alt2" starts from the first page. However, if header or footer with a func="first" is also defined, it will shift the pattern by one page. A header or footer with func="last" will interupt the pattern accordingly.</p>
+      <p>An alternating pattern with "alt1" and "alt2" starts from the first page. However, if header or footer with a func="first" is also defined, it will shift the pattern by one page. A header or footer with func="last" will interupt the pattern.</p>
     </remarks>
   </macroSpec>
   <macroSpec ident="data.PGSCALE" module="MEI" type="dt">

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3071,6 +3071,31 @@
       </rng:data>
     </content>
   </macroSpec>
+  <macroSpec ident="data.PGFORMFUNC" module="MEI" type="dt">
+    <desc xml:lang="en">Page header and footer function; a value that defines the function (i.e., the placement) of the header or the footer.</desc>
+    <content>
+      <valList type="closed">
+        <valItem ident="all">
+          <desc xml:lang="en">Header or footer for all the pages, including first and last unless provided.</desc>
+        </valItem>
+        <valItem ident="first">
+          <desc xml:lang="en">Header or footer for the first page only.</desc>
+        </valItem>
+        <valItem ident="last">
+          <desc xml:lang="en">Header or footer for the last page only.</desc>
+        </valItem>
+        <valItem ident="alt1">
+          <desc xml:lang="en">The first of an alternating pattern of headers or footers.</desc>
+        </valItem>
+        <valItem ident="alt2">
+          <desc xml:lang="en">The second of an alternating pattern of headers or footers.</desc>
+        </valItem>
+      </valList>
+    </content>
+    <remarks xml:lang="en">
+      <p>An alternating pattern with "alt1" and "alt2" starts from the first page. However, if header of footer with a func="first" is also defined, it will shift the pattern by one page. A header or footer with func="last" will interupt the pattern accordingly.</p>
+    </remarks>
+  </macroSpec>
   <macroSpec ident="data.PGSCALE" module="MEI" type="dt">
     <desc xml:lang="en">Page scale factor; a percentage of the values in page.height and page.width.</desc>
     <content>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3076,7 +3076,7 @@
     <content>
       <valList type="closed">
         <valItem ident="all">
-          <desc xml:lang="en">Header or footer for all the pages, including first and last unless provided.</desc>
+          <desc xml:lang="en">Header or footer for all pages, including the first and the last page, unless a page header or footer for the first or the last page is provided.</desc>
         </valItem>
         <valItem ident="first">
           <desc xml:lang="en">Header or footer for the first page only.</desc>


### PR DESCRIPTION
Following the discussion in #572, the PR removes `pgHead2` and `pgFoot2`. They are replaced with a `@func` attribute on `pgHead` and `pgFoot`. The possible values are:
* all
* first
* last
* alt1
* alt2