### PR TITLE
guidelines: improve documentation for cue vs. small notes

### DIFF
--- a/source/docs/04-cmn.xml
+++ b/source/docs/04-cmn.xml
@@ -1129,7 +1129,9 @@
                      </figure>
                   </p>
                   <p>If the voice from which the cue notes originate is also encoded, they should refer to their sounding counterpart with the <att>corresp</att> attribute.</p>
-                  <p>Cue notes must not be confused with other small notes such as grace notes or <ref target="https://en.wikipedia.org/wiki/Fioritura">fiorituras</ref>.</p>
+                  <p>Cue notes must not be confused with other small notes such as grace notes or <ref target="https://en.wikipedia.org/wiki/Fioritura">fiorituras</ref>. 
+                     The visual size of a note can be controlled with <att>fontsize</att>, which is independent of the information carried by <att>cue</att> (though cue notes are usually 
+                     written in smaller font size).</p>
                </div>
                <div xml:id="cmnDir" type="div3">
                   <head>Directives and Rehearsal marks</head>


### PR DESCRIPTION
fixes #926. Instead of a separate `@size`, it is encouraged to use the existing `@fontsize`. Added a sentence in the Guidelines. Co-authored-by @riedde