### PR TITLE
Use official rng for svg from w3c

### DIFF
--- a/customizations/mei-CMN.xml
+++ b/customizations/mei-CMN.xml
@@ -92,7 +92,7 @@
         <moduleRef key="MEI.visual"/>
 
         <!-- Include SVG -->
-        <moduleRef url="https://www.tei-c.org/release/xml/tei/custom/schema/relaxng/svg11.rng"
+        <moduleRef url="../source/svg11.rng"
           prefix="svg_">
           <content>
             <rng:define name="mei_model.graphicLike" combine="choice">

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -92,7 +92,7 @@
         <moduleRef key="MEI.visual"/>
 
         <!-- Include SVG -->
-        <moduleRef url="https://www.tei-c.org/release/xml/tei/custom/schema/relaxng/svg11.rng"
+        <moduleRef url="../source/svg11.rng"
           prefix="svg_">
           <content>
             <rng:define name="mei_model.graphicLike" combine="choice">

--- a/customizations/mei-Neumes.xml
+++ b/customizations/mei-Neumes.xml
@@ -92,7 +92,7 @@
         <moduleRef key="MEI.visual"/>
 
         <!-- Include SVG -->
-        <moduleRef url="https://www.tei-c.org/release/xml/tei/custom/schema/relaxng/svg11.rng"
+        <moduleRef url="../source/svg11.rng"
           prefix="svg_">
           <content>
             <rng:define name="mei_model.graphicLike" combine="choice">

--- a/customizations/mei-all.xml
+++ b/customizations/mei-all.xml
@@ -97,7 +97,7 @@
         <moduleRef key="MEI.visual"/>
 
         <!-- Include SVG -->
-        <moduleRef url="https://www.tei-c.org/release/xml/tei/custom/schema/relaxng/svg11.rng"
+        <moduleRef url="../source/svg11.rng"
           prefix="svg_">
           <content>
             <rng:define name="mei_model.graphicLike" combine="choice">

--- a/customizations/mei-all_anyStart.xml
+++ b/customizations/mei-all_anyStart.xml
@@ -142,7 +142,7 @@
         <moduleRef key="MEI.visual"/>
 
         <!-- Include SVG -->
-        <moduleRef url="https://www.tei-c.org/release/xml/tei/custom/schema/relaxng/svg11.rng"
+        <moduleRef url="../source/svg11.rng"
           prefix="svg_">
           <content>
             <rng:define name="mei_model.graphicLike" combine="choice">

--- a/source/svg11.rng
+++ b/source/svg11.rng
@@ -1,0 +1,7115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ....................................................................... -->
+<!-- SVG 1.1 DTD ........................................................... -->
+<!-- file: svg11.dtd -->
+<!--
+  SVG 1.1 DTD
+  
+  This is SVG, a language for describing two-dimensional graphics in XML.
+  
+  The Scalable Vector Graphics (SVG)
+  Copyright 2001, 2002 World Wide Web Consortium
+     (Massachusetts Institute of Technology, Institut National de
+      Recherche en Informatique et en Automatique, Keio University).
+      All Rights Reserved.
+  
+  Permission to use, copy, modify and distribute the SVG DTD and its
+  accompanying documentation for any purpose and without fee is hereby
+  granted in perpetuity, provided that the above copyright notice and
+  this paragraph appear in all copies.  The copyright holders make no
+  representation about the suitability of the DTD for any purpose.
+  
+  It is provided "as is" without expressed or implied warranty.
+  
+     Author:   Jun Fujisawa <fujisawa.jun@canon.co.jp>
+     Revision: $Id: svg11.dtd,v 1.2 2002/04/20 18:07:43 fujisawa Exp $
+  
+-->
+<!--
+  This is the driver file for version 1.1 of the SVG DTD.
+  
+  This DTD is identified by the PUBLIC and SYSTEM identifiers:
+  
+     PUBLIC "-//W3C//DTD SVG 1.1//EN"
+     SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"
+-->
+<!--
+  Use this URI to identify the default namespace:
+  
+     "http://www.w3.org/2000/svg"
+  
+  See the Qualified Names module for information
+  on the use of namespace prefixes in the DTD.
+-->
+<!-- reserved for future use with document profiles -->
+<!-- ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: -->
+<!-- Pre-Framework Redeclaration Placeholder ..................... -->
+<!-- Document Model Module ....................................... -->
+<!-- Attribute Collection Module ................................. -->
+<!-- Modular Framework Module .................................... -->
+<!-- ....................................................................... -->
+<!-- SVG 1.1 Modular Framework Module ...................................... -->
+<!--
+  file: svg-framework.mod
+  
+  This is SVG, a language for describing two-dimensional graphics in XML.
+  Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+  Revision: $Id: svg-framework.mod,v 1.2 2002/04/20 18:07:43 fujisawa Exp $
+  
+  This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+  
+     PUBLIC "-//W3C//ENTITIES SVG 1.1 Modular Framework//EN"
+     SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-framework.mod"
+  
+  .......................................................................
+-->
+<!--
+  Modular Framework
+  
+  This module instantiates the modules needed o support the SVG
+  modularization model, including:
+  
+     + Datatypes
+     + Qualified Name
+     + Document Model
+     + Attribute Collection
+-->
+<!-- ....................................................................... -->
+<!-- SVG 1.1 Datatypes Module .............................................. -->
+<!--
+  file: svg-datatypes.mod
+  
+  This is SVG, a language for describing two-dimensional graphics in XML.
+  Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+  Revision: $Id: svg-datatypes.mod,v 1.2 2002/04/20 18:07:42 fujisawa Exp $
+  
+  This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+  
+     PUBLIC "-//W3C//ENTITIES SVG 1.1 Datatypes//EN"
+     SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-datatypes.mod"
+  
+  .......................................................................
+-->
+<!--
+  Datatypes
+  
+  This module declares common data types for properties and attributes.
+-->
+<!-- feature specification -->
+<grammar xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" ns="http://www.w3.org/2000/svg" xmlns="http://relaxng.org/ns/structure/1.0" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
+  <define name="Boolean.datatype">
+    <choice>
+      <value>false</value>
+      <value>true</value>
+    </choice>
+  </define>
+  <!-- 'clip-rule' or 'fill-rule' property/attribute value -->
+  <define name="ClipFillRule.datatype">
+    <choice>
+      <value>nonzero</value>
+      <value>evenodd</value>
+      <value>inherit</value>
+    </choice>
+  </define>
+  <!-- media type, as per [RFC2045] -->
+  <define name="ContentType.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- a <coordinate> -->
+  <define name="Coordinate.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- a list of <coordinate>s -->
+  <define name="Coordinates.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- a <color> value -->
+  <define name="Color.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- a <integer> -->
+  <define name="Integer.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- a language code, as per [RFC3066] -->
+  <define name="LanguageCode.datatype">
+    <data type="NMTOKEN"/>
+  </define>
+  <!-- comma-separated list of language codes, as per [RFC3066] -->
+  <define name="LanguageCodes.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- a <length> -->
+  <define name="Length.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- a list of <length>s -->
+  <define name="Lengths.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- a <number> -->
+  <define name="Number.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- a list of <number>s -->
+  <define name="Numbers.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- opacity value (e.g., <number>) -->
+  <define name="OpacityValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- a path data specification -->
+  <define name="PathData.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- 'preserveAspectRatio' attribute specification -->
+  <define name="PreserveAspectRatioSpec.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- script expression -->
+  <define name="Script.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- An SVG color value (RGB plus optional ICC) -->
+  <define name="SVGColor.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- arbitrary text string -->
+  <define name="Text.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- list of transforms -->
+  <define name="TransformList.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- a Uniform Resource Identifier, see [URI] -->
+  <define name="URI.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- 'viewBox' attribute specification -->
+  <define name="ViewBoxSpec.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- end of svg-datatypes.mod -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Qualified Name Module ......................................... -->
+  <!--
+    file: svg-qname.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-qname.mod,v 1.3 2002/11/03 15:54:14 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ENTITIES SVG 1.1 Qualified Name//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-qname.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Qualified Name
+    
+    This module is contained in two parts, labeled Section 'A' and 'B':
+    
+       Section A declares parameter entities to support namespace-
+       qualified names, namespace declarations, and name prefixing
+       for SVG and extensions.
+    
+       Section B declares parameter entities used to provide
+       namespace-qualified names for all SVG element types:
+  -->
+  <!-- Section A: SVG XML Namespace Framework :::::::::::::::::::::: -->
+  <!--
+    1. Declare a %SVG.prefixed; conditional section keyword, used
+    to activate namespace prefixing. The default value should
+    inherit '%NS.prefixed;' from the DTD driver, so that unless
+    overridden, the default behaviour follows the overall DTD
+    prefixing scheme.
+  -->
+  <!--
+    2. Declare a parameter entity (eg., %SVG.xmlns;) containing
+    the URI reference used to identify the SVG namespace:
+  -->
+  <!--
+    3. Declare parameter entities (eg., %SVG.prefix;) containing
+    the default namespace prefix string(s) to use when prefixing
+    is enabled. This may be overridden in the DTD driver or the
+    internal subset of an document instance. If no default prefix
+    is desired, this may be declared as an empty string.
+  -->
+  <!--
+    4. Declare parameter entities (eg., %SVG.pfx;) containing the
+    colonized prefix(es) (eg., '%SVG.prefix;:') used when
+    prefixing is active, an empty string when it is not.
+  -->
+  <!--
+    5. The parameter entity %SVG.xmlns.extra.attrib; may be
+    redeclared to contain any non-SVG namespace declaration
+    attributes for namespaces embedded in SVG. The default
+    is an empty string.
+  -->
+  <!--
+    Declare a parameter entity XLINK.xmlns.attrib containing
+    the XML Namespace declarations for XLink.
+  -->
+  <define name="XLINK.xmlns.attrib">
+    <empty/>
+  </define>
+  <!--
+    Declare a parameter entity %NS.decl.attrib; containing
+    all XML Namespace declarations used in the DTD, plus the
+    xmlns declaration for SVG, its form dependent on whether
+    prefixing is active.
+  -->
+  <!--
+    Declare a parameter entity %SVG.xmlns.attrib; containing
+    all XML namespace declaration attributes used by SVG,
+    including a default xmlns attribute when prefixing is
+    inactive.
+  -->
+  <define name="SVG.xmlns.attrib">
+    <ref name="XLINK.xmlns.attrib"/>
+  </define>
+  <!-- Section B: SVG Qualified Names :::::::::::::::::::::::::::::: -->
+  <!--
+    6. This section declares parameter entities used to provide
+    namespace-qualified names for all SVG element types.
+  -->
+  <!-- module: svg-structure.mod ......................... -->
+  <!-- module: svg-conditional.mod ....................... -->
+  <!-- module: svg-image.mod ............................. -->
+  <!-- module: svg-style.mod ............................. -->
+  <!-- module: svg-shape.mod ............................. -->
+  <!-- module: svg-text.mod .............................. -->
+  <!-- module: svg-marker.mod ............................ -->
+  <!-- module: svg-profile.mod ........................... -->
+  <!-- module: svg-gradient.mod .......................... -->
+  <!-- module: svg-pattern.mod ........................... -->
+  <!-- module: svg-clip.mod .............................. -->
+  <!-- module: svg-mask.mod .............................. -->
+  <!-- module: svg-filter.mod ............................ -->
+  <!-- module: svg-cursor.mod ............................ -->
+  <!-- module: svg-hyperlink.mod ......................... -->
+  <!-- module: svg-view.mod .............................. -->
+  <!-- module: svg-script.mod ............................ -->
+  <!-- module: svg-animation.mod ......................... -->
+  <!-- module: svg-font.mod .............................. -->
+  <!-- module: svg-extensibility.mod ..................... -->
+  <!-- end of svg-qname.mod -->
+  <!-- instantiate the Document Model declared in the DTD driver -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Document Model Module ......................................... -->
+  <!--
+    file: svg11-model.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg11-model.mod,v 1.3 2002/11/14 15:11:03 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ENTITIES SVG 1.1 Document Model//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-model.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    SVG 1.1 Document Model
+    
+    This module describes the groupings of elements that make up
+    common content models for SVG elements.
+  -->
+  <!-- module: svg-structure.mod ......................... -->
+  <define name="SVG.Description.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Description.class">
+    <choice>
+      <ref name="desc"/>
+      <ref name="title"/>
+      <ref name="metadata"/>
+      <ref name="SVG.Description.extra.class"/>
+    </choice>
+  </define>
+  <define name="SVG.Use.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Use.class">
+    <choice>
+      <ref name="use"/>
+      <ref name="SVG.Use.extra.class"/>
+    </choice>
+  </define>
+  <define name="SVG.Structure.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Structure.class">
+    <choice>
+      <ref name="svg"/>
+      <ref name="g"/>
+      <ref name="defs"/>
+      <ref name="symbol"/>
+      <ref name="SVG.Use.class"/>
+      <ref name="SVG.Structure.extra.class"/>
+    </choice>
+  </define>
+  <!-- module: svg-conditional.mod ....................... -->
+  <define name="SVG.Conditional.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Conditional.class">
+    <choice>
+      <ref name="switch"/>
+      <ref name="SVG.Conditional.extra.class"/>
+    </choice>
+  </define>
+  <!-- module: svg-image.mod ............................. -->
+  <define name="SVG.Image.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Image.class">
+    <choice>
+      <ref name="image"/>
+      <ref name="SVG.Image.extra.class"/>
+    </choice>
+  </define>
+  <!-- module: svg-style.mod ............................. -->
+  <define name="SVG.Style.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Style.class">
+    <choice>
+      <ref name="style"/>
+      <ref name="SVG.Style.extra.class"/>
+    </choice>
+  </define>
+  <!-- module: svg-shape.mod ............................. -->
+  <define name="SVG.Shape.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Shape.class">
+    <choice>
+      <ref name="path"/>
+      <ref name="rect"/>
+      <ref name="circle"/>
+      <ref name="line"/>
+      <ref name="ellipse"/>
+      <ref name="polyline"/>
+      <ref name="polygon"/>
+      <ref name="SVG.Shape.extra.class"/>
+    </choice>
+  </define>
+  <!-- module: svg-text.mod .............................. -->
+  <define name="SVG.Text.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Text.class">
+    <choice>
+      <ref name="text"/>
+      <ref name="altGlyphDef"/>
+      <ref name="SVG.Text.extra.class"/>
+    </choice>
+  </define>
+  <define name="SVG.TextContent.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.TextContent.class">
+    <choice>
+      <ref name="tspan"/>
+      <ref name="tref"/>
+      <ref name="textPath"/>
+      <ref name="altGlyph"/>
+      <ref name="SVG.TextContent.extra.class"/>
+    </choice>
+  </define>
+  <!-- module: svg-marker.mod ............................ -->
+  <define name="SVG.Marker.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Marker.class">
+    <choice>
+      <ref name="marker"/>
+      <ref name="SVG.Marker.extra.class"/>
+    </choice>
+  </define>
+  <!-- module: svg-profile.mod ........................... -->
+  <define name="SVG.ColorProfile.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.ColorProfile.class">
+    <choice>
+      <ref name="color-profile"/>
+      <ref name="SVG.ColorProfile.extra.class"/>
+    </choice>
+  </define>
+  <!-- module: svg-gradient.mod .......................... -->
+  <define name="SVG.Gradient.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Gradient.class">
+    <choice>
+      <ref name="linearGradient"/>
+      <ref name="radialGradient"/>
+      <ref name="SVG.Gradient.extra.class"/>
+    </choice>
+  </define>
+  <!-- module: svg-pattern.mod ........................... -->
+  <define name="SVG.Pattern.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Pattern.class">
+    <choice>
+      <ref name="svgpattern"/>
+      <ref name="SVG.Pattern.extra.class"/>
+    </choice>
+  </define>
+  <!-- module: svg-clip.mod .............................. -->
+  <define name="SVG.Clip.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Clip.class">
+    <choice>
+      <ref name="clipPath"/>
+      <ref name="SVG.Clip.extra.class"/>
+    </choice>
+  </define>
+  <!-- module: svg-mask.mod .............................. -->
+  <define name="SVG.Mask.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Mask.class">
+    <choice>
+      <ref name="mask"/>
+      <ref name="SVG.Mask.extra.class"/>
+    </choice>
+  </define>
+  <!-- module: svg-filter.mod ............................ -->
+  <define name="SVG.Filter.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Filter.class">
+    <choice>
+      <ref name="filter"/>
+      <ref name="SVG.Filter.extra.class"/>
+    </choice>
+  </define>
+  <define name="SVG.FilterPrimitive.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.FilterPrimitive.class">
+    <choice>
+      <ref name="feBlend"/>
+      <ref name="feColorMatrix"/>
+      <ref name="feComponentTransfer"/>
+      <ref name="feComposite"/>
+      <ref name="feConvolveMatrix"/>
+      <ref name="feDiffuseLighting"/>
+      <ref name="feDisplacementMap"/>
+      <ref name="feFlood"/>
+      <ref name="feGaussianBlur"/>
+      <ref name="feImage"/>
+      <ref name="feMerge"/>
+      <ref name="feMorphology"/>
+      <ref name="feOffset"/>
+      <ref name="feSpecularLighting"/>
+      <ref name="feTile"/>
+      <ref name="feTurbulence"/>
+      <ref name="SVG.FilterPrimitive.extra.class"/>
+    </choice>
+  </define>
+  <!-- module: svg-cursor.mod ............................ -->
+  <define name="SVG.Cursor.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Cursor.class">
+    <choice>
+      <ref name="cursor"/>
+      <ref name="SVG.Cursor.extra.class"/>
+    </choice>
+  </define>
+  <!-- module: svg-hyperlink.mod ......................... -->
+  <define name="SVG.Hyperlink.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Hyperlink.class">
+    <choice>
+      <ref name="a"/>
+      <ref name="SVG.Hyperlink.extra.class"/>
+    </choice>
+  </define>
+  <!-- module: svg-view.mod .............................. -->
+  <define name="SVG.View.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.View.class">
+    <choice>
+      <ref name="view"/>
+      <ref name="SVG.View.extra.class"/>
+    </choice>
+  </define>
+  <!-- module: svg-script.mod ............................ -->
+  <define name="SVG.Script.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Script.class">
+    <choice>
+      <ref name="script"/>
+      <ref name="SVG.Script.extra.class"/>
+    </choice>
+  </define>
+  <!-- module: svg-animation.mod ......................... -->
+  <define name="SVG.Animation.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Animation.class">
+    <choice>
+      <ref name="animate"/>
+      <ref name="set"/>
+      <ref name="animateMotion"/>
+      <ref name="animateColor"/>
+      <ref name="animateTransform"/>
+      <ref name="SVG.Animation.extra.class"/>
+    </choice>
+  </define>
+  <!-- module: svg-font.mod .............................. -->
+  <define name="SVG.Font.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Font.class">
+    <choice>
+      <ref name="font"/>
+      <ref name="font-face"/>
+      <ref name="SVG.Font.extra.class"/>
+    </choice>
+  </define>
+  <!-- module: svg-extensibility.mod ..................... -->
+  <define name="SVG.Extensibility.extra.class">
+    <notAllowed/>
+  </define>
+  <define name="SVG.Extensibility.class">
+    <choice>
+      <ref name="foreignObject"/>
+      <ref name="SVG.Extensibility.extra.class"/>
+    </choice>
+  </define>
+  <!-- end of svg11-model.mod -->
+  <!-- instantiate the Attribute Collection declared in the DTD driver -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Attribute Collection Module ................................... -->
+  <!--
+    file: svg11-attribs.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg11-attribs.mod,v 1.4 2002/11/14 15:11:03 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ENTITIES SVG 1.1 Attribute Collection//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11-attribs.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    SVG 1.1 Attribute Collection
+    
+    This module defines the set of common attributes that can be present
+    on many SVG elements.
+  -->
+  <!-- module: svg-conditional.mod ....................... -->
+  <define name="ExtensionList.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="FeatureList.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="SVG.Conditional.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.Conditional.attrib">
+    <optional>
+      <attribute name="requiredFeatures">
+        <ref name="FeatureList.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="requiredExtensions">
+        <ref name="ExtensionList.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="systemLanguage">
+        <ref name="LanguageCodes.datatype"/>
+      </attribute>
+    </optional>
+    <ref name="SVG.Conditional.extra.attrib"/>
+  </define>
+  <!-- module: svg-style.mod ............................. -->
+  <define name="ClassList.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="StyleSheet.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="SVG.Style.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.Style.attrib">
+    <optional>
+      <attribute name="style">
+        <ref name="StyleSheet.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="class">
+        <ref name="ClassList.datatype"/>
+      </attribute>
+    </optional>
+    <ref name="SVG.Style.extra.attrib"/>
+  </define>
+  <!-- module: svg-text.mod .............................. -->
+  <define name="BaselineShiftValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="FontFamilyValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="FontSizeValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="FontSizeAdjustValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="GlyphOrientationHorizontalValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="GlyphOrientationVerticalValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="KerningValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="SpacingValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="TextDecorationValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="SVG.Text.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.Text.attrib">
+    <optional>
+      <attribute name="writing-mode">
+        <choice>
+          <value>lr-tb</value>
+          <value>rl-tb</value>
+          <value>tb-rl</value>
+          <value>lr</value>
+          <value>rl</value>
+          <value>tb</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+    <ref name="SVG.Text.extra.attrib"/>
+  </define>
+  <define name="SVG.TextContent.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.TextContent.attrib">
+    <optional>
+      <attribute name="alignment-baseline">
+        <choice>
+          <value>auto</value>
+          <value>baseline</value>
+          <value>before-edge</value>
+          <value>text-before-edge</value>
+          <value>middle</value>
+          <value>central</value>
+          <value>after-edge</value>
+          <value>text-after-edge</value>
+          <value>ideographic</value>
+          <value>alphabetic</value>
+          <value>hanging</value>
+          <value>mathematical</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="baseline-shift">
+        <ref name="BaselineShiftValue.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="direction">
+        <choice>
+          <value>ltr</value>
+          <value>rtl</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="dominant-baseline">
+        <choice>
+          <value>auto</value>
+          <value>use-script</value>
+          <value>no-change</value>
+          <value>reset-size</value>
+          <value>ideographic</value>
+          <value>alphabetic</value>
+          <value>hanging</value>
+          <value>mathematical</value>
+          <value>central</value>
+          <value>middle</value>
+          <value>text-after-edge</value>
+          <value>text-before-edge</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="glyph-orientation-horizontal">
+        <ref name="GlyphOrientationHorizontalValue.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="glyph-orientation-vertical">
+        <ref name="GlyphOrientationVerticalValue.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="kerning">
+        <ref name="KerningValue.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="letter-spacing">
+        <ref name="SpacingValue.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="text-anchor">
+        <choice>
+          <value>start</value>
+          <value>middle</value>
+          <value>end</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="text-decoration">
+        <ref name="TextDecorationValue.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="unicode-bidi">
+        <choice>
+          <value>normal</value>
+          <value>embed</value>
+          <value>bidi-override</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="word-spacing">
+        <ref name="SpacingValue.datatype"/>
+      </attribute>
+    </optional>
+    <ref name="SVG.TextContent.extra.attrib"/>
+  </define>
+  <define name="SVG.Font.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.Font.attrib">
+    <optional>
+      <attribute name="font-family">
+        <ref name="FontFamilyValue.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="font-size">
+        <ref name="FontSizeValue.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="font-size-adjust">
+        <ref name="FontSizeAdjustValue.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="font-stretch">
+        <choice>
+          <value>normal</value>
+          <value>wider</value>
+          <value>narrower</value>
+          <value>ultra-condensed</value>
+          <value>extra-condensed</value>
+          <value>condensed</value>
+          <value>semi-condensed</value>
+          <value>semi-expanded</value>
+          <value>expanded</value>
+          <value>extra-expanded</value>
+          <value>ultra-expanded</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="font-style">
+        <choice>
+          <value>normal</value>
+          <value>italic</value>
+          <value>oblique</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="font-variant">
+        <choice>
+          <value>normal</value>
+          <value>small-caps</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="font-weight">
+        <choice>
+          <value>normal</value>
+          <value>bold</value>
+          <value>bolder</value>
+          <value>lighter</value>
+          <value>100</value>
+          <value>200</value>
+          <value>300</value>
+          <value>400</value>
+          <value>500</value>
+          <value>600</value>
+          <value>700</value>
+          <value>800</value>
+          <value>900</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+    <ref name="SVG.Font.extra.attrib"/>
+  </define>
+  <!-- module: svg-marker.mod ............................ -->
+  <define name="MarkerValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="SVG.Marker.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.Marker.attrib">
+    <optional>
+      <attribute name="marker-start">
+        <ref name="MarkerValue.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="marker-mid">
+        <ref name="MarkerValue.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="marker-end">
+        <ref name="MarkerValue.datatype"/>
+      </attribute>
+    </optional>
+    <ref name="SVG.Marker.extra.attrib"/>
+  </define>
+  <!-- module: svg-profile.mod ........................... -->
+  <define name="SVG.ColorProfile.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.ColorProfile.attrib">
+    <optional>
+      <attribute name="color-profile"/>
+    </optional>
+    <ref name="SVG.ColorProfile.extra.attrib"/>
+  </define>
+  <!-- module: svg-gradient.mod .......................... -->
+  <define name="NumberOrPercentage.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="SVG.Gradient.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.Gradient.attrib">
+    <optional>
+      <attribute name="stop-color">
+        <ref name="SVGColor.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="stop-opacity">
+        <ref name="OpacityValue.datatype"/>
+      </attribute>
+    </optional>
+    <ref name="SVG.Gradient.extra.attrib"/>
+  </define>
+  <!-- module: svg-clip.mod .............................. -->
+  <define name="ClipPathValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="SVG.Clip.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.Clip.attrib">
+    <optional>
+      <attribute name="clip-path">
+        <ref name="ClipPathValue.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="clip-rule">
+        <ref name="ClipFillRule.datatype"/>
+      </attribute>
+    </optional>
+    <ref name="SVG.Clip.extra.attrib"/>
+  </define>
+  <!-- module: svg-mask.mod .............................. -->
+  <define name="MaskValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="SVG.Mask.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.Mask.attrib">
+    <optional>
+      <attribute name="mask">
+        <ref name="MaskValue.datatype"/>
+      </attribute>
+    </optional>
+    <ref name="SVG.Mask.extra.attrib"/>
+  </define>
+  <!-- module: svg-filter.mod ............................ -->
+  <define name="FilterValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="NumberOptionalNumber.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="SVG.Filter.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.Filter.attrib">
+    <optional>
+      <attribute name="filter">
+        <ref name="FilterValue.datatype"/>
+      </attribute>
+    </optional>
+    <ref name="SVG.Filter.extra.attrib"/>
+  </define>
+  <define name="SVG.FilterColor.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.FilterColor.attrib">
+    <optional>
+      <attribute name="color-interpolation-filters">
+        <choice>
+          <value>auto</value>
+          <value>sRGB</value>
+          <value>linearRGB</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+    <ref name="SVG.FilterColor.extra.attrib"/>
+  </define>
+  <!-- module: svg-cursor.mod ............................ -->
+  <define name="CursorValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="SVG.Cursor.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.Cursor.attrib">
+    <optional>
+      <attribute name="cursor">
+        <ref name="CursorValue.datatype"/>
+      </attribute>
+    </optional>
+    <ref name="SVG.Cursor.extra.attrib"/>
+  </define>
+  <!-- end of svg11-attribs.mod -->
+  <!-- end of svg-framework.mod -->
+  <!-- Post-Framework Redeclaration Placeholder .................... -->
+  <!-- ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: -->
+  <!-- Core Attribute Module ....................................... -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Core Attribute Module ......................................... -->
+  <!--
+    file: svg-core-attrib.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-core-attrib.mod,v 1.3 2002/04/28 13:50:23 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ENTITIES SVG 1.1 Core Attribute//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-core-attrib.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Core Attribute
+    
+       id, xml:base, xml:lang, xml:space
+    
+    This module defines the core set of attributes that can be present on
+    any element.
+  -->
+  <define name="SVG.id.attrib">
+    <optional>
+      <attribute name="id">
+        <data type="ID"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.base.attrib">
+    <optional>
+      <attribute name="xml:base">
+        <ref name="URI.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.lang.attrib">
+    <optional>
+      <attribute name="xml:lang">
+        <ref name="LanguageCode.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.space.attrib">
+    <optional>
+      <attribute name="xml:space">
+        <choice>
+          <value>default</value>
+          <value>preserve</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.Core.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.Core.attrib">
+    <ref name="SVG.id.attrib"/>
+    <ref name="SVG.base.attrib"/>
+    <ref name="SVG.lang.attrib"/>
+    <ref name="SVG.space.attrib"/>
+    <ref name="SVG.Core.extra.attrib"/>
+  </define>
+  <!-- end of svg-core-attrib.mod -->
+  <!-- Container Attribute Module .................................. -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Container Attribute Module .................................... -->
+  <!--
+    file: svg-container-attrib.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-container-attrib.mod,v 1.2 2002/04/20 18:07:42 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ENTITIES SVG 1.1 Container Attribute//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-container-attrib.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Container Attribute
+    
+       enable-background
+    
+    This module defines the Container attribute set.
+  -->
+  <!-- 'enable-background' property/attribute value (e.g., 'new', 'accumulate') -->
+  <define name="EnableBackgroundValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="SVG.enable-background.attrib">
+    <optional>
+      <attribute name="enable-background">
+        <ref name="EnableBackgroundValue.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.Container.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.Container.attrib">
+    <ref name="SVG.enable-background.attrib"/>
+    <ref name="SVG.Container.extra.attrib"/>
+  </define>
+  <!-- end of svg-container-attrib.mod -->
+  <!-- Viewport Attribute Module ................................... -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Viewport Attribute Module ..................................... -->
+  <!--
+    file: svg-viewport-attrib.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-viewport-attrib.mod,v 1.2 2002/04/20 18:07:43 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ENTITIES SVG 1.1 Viewport Attribute//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-viewport-attrib.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Viewport Attribute
+    
+       clip, overflow
+    
+    This module defines the Viewport attribute set.
+  -->
+  <!-- 'clip' property/attribute value (e.g., 'auto', rect(...)) -->
+  <define name="ClipValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="SVG.clip.attrib">
+    <optional>
+      <attribute name="clip">
+        <ref name="ClipValue.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.overflow.attrib">
+    <optional>
+      <attribute name="overflow">
+        <choice>
+          <value>visible</value>
+          <value>hidden</value>
+          <value>scroll</value>
+          <value>auto</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.Viewport.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.Viewport.attrib">
+    <ref name="SVG.clip.attrib"/>
+    <ref name="SVG.overflow.attrib"/>
+    <ref name="SVG.Viewport.extra.attrib"/>
+  </define>
+  <!-- end of svg-viewport-attrib.mod -->
+  <!-- Paint Attribute Module ...................................... -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Paint Attribute Module ........................................ -->
+  <!--
+    file: svg-paint-attrib.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-paint-attrib.mod,v 1.2 2002/04/20 18:07:43 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ENTITIES SVG 1.1 Paint Attribute//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-paint-attrib.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Paint Attribute
+    
+       fill, fill-rule, stroke, stroke-dasharray, stroke-dashoffset,
+       stroke-linecap, stroke-linejoin, stroke-miterlimit, stroke-width, color,
+       color-interpolation, color-rendering
+    
+    This module defines the Paint and Color attribute sets.
+  -->
+  <!-- a 'fill' or 'stroke' property/attribute value: <paint> -->
+  <define name="Paint.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- 'stroke-dasharray' property/attribute value (e.g., 'none', list of <number>s) -->
+  <define name="StrokeDashArrayValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- 'stroke-dashoffset' property/attribute value (e.g., 'none', <legnth>) -->
+  <define name="StrokeDashOffsetValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- 'stroke-miterlimit' property/attribute value (e.g., <number>) -->
+  <define name="StrokeMiterLimitValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- 'stroke-width' property/attribute value (e.g., <length>) -->
+  <define name="StrokeWidthValue.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <define name="SVG.fill.attrib">
+    <optional>
+      <attribute name="fill">
+        <ref name="Paint.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.fill-rule.attrib">
+    <optional>
+      <attribute name="fill-rule">
+        <ref name="ClipFillRule.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.stroke.attrib">
+    <optional>
+      <attribute name="stroke">
+        <ref name="Paint.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.stroke-dasharray.attrib">
+    <optional>
+      <attribute name="stroke-dasharray">
+        <ref name="StrokeDashArrayValue.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.stroke-dashoffset.attrib">
+    <optional>
+      <attribute name="stroke-dashoffset">
+        <ref name="StrokeDashOffsetValue.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.stroke-linecap.attrib">
+    <optional>
+      <attribute name="stroke-linecap">
+        <choice>
+          <value>butt</value>
+          <value>round</value>
+          <value>square</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.stroke-linejoin.attrib">
+    <optional>
+      <attribute name="stroke-linejoin">
+        <choice>
+          <value>miter</value>
+          <value>round</value>
+          <value>bevel</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.stroke-miterlimit.attrib">
+    <optional>
+      <attribute name="stroke-miterlimit">
+        <ref name="StrokeMiterLimitValue.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.stroke-width.attrib">
+    <optional>
+      <attribute name="stroke-width">
+        <ref name="StrokeWidthValue.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.Paint.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.Paint.attrib">
+    <ref name="SVG.fill.attrib"/>
+    <ref name="SVG.fill-rule.attrib"/>
+    <ref name="SVG.stroke.attrib"/>
+    <ref name="SVG.stroke-dasharray.attrib"/>
+    <ref name="SVG.stroke-dashoffset.attrib"/>
+    <ref name="SVG.stroke-linecap.attrib"/>
+    <ref name="SVG.stroke-linejoin.attrib"/>
+    <ref name="SVG.stroke-miterlimit.attrib"/>
+    <ref name="SVG.stroke-width.attrib"/>
+    <ref name="SVG.Paint.extra.attrib"/>
+  </define>
+  <define name="SVG.color.attrib">
+    <optional>
+      <attribute name="color">
+        <ref name="Color.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.color-interpolation.attrib">
+    <optional>
+      <attribute name="color-interpolation">
+        <choice>
+          <value>auto</value>
+          <value>sRGB</value>
+          <value>linearRGB</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.color-rendering.attrib">
+    <optional>
+      <attribute name="color-rendering">
+        <choice>
+          <value>auto</value>
+          <value>optimizeSpeed</value>
+          <value>optimizeQuality</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.Color.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.Color.attrib">
+    <ref name="SVG.color.attrib"/>
+    <ref name="SVG.color-interpolation.attrib"/>
+    <ref name="SVG.color-rendering.attrib"/>
+    <ref name="SVG.Color.extra.attrib"/>
+  </define>
+  <!-- end of svg-paint-attrib.mod -->
+  <!-- Paint Opacity Attribute Module .............................. -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Paint Opacity Attribute Module ................................ -->
+  <!--
+    file: svg-opacity-attrib.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-opacity-attrib.mod,v 1.2 2002/04/20 18:07:43 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ENTITIES SVG 1.1 Paint Opacity Attribute//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-opacity-attrib.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Paint Opacity Attribute
+    
+       opacity, fill-opacity, stroke-opacity
+    
+    This module defines the Opacity attribute set.
+  -->
+  <define name="SVG.opacity.attrib">
+    <optional>
+      <attribute name="opacity">
+        <ref name="OpacityValue.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.fill-opacity.attrib">
+    <optional>
+      <attribute name="fill-opacity">
+        <ref name="OpacityValue.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.stroke-opacity.attrib">
+    <optional>
+      <attribute name="stroke-opacity">
+        <ref name="OpacityValue.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.Opacity.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.Opacity.attrib">
+    <ref name="SVG.opacity.attrib"/>
+    <ref name="SVG.fill-opacity.attrib"/>
+    <ref name="SVG.stroke-opacity.attrib"/>
+    <ref name="SVG.Opacity.extra.attrib"/>
+  </define>
+  <!-- end of svg-opacity-attrib.mod -->
+  <!-- Graphics Attribute Module ................................... -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Graphics Attribute Module ..................................... -->
+  <!--
+    file: svg-graphics-attrib.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-graphics-attrib.mod,v 1.2 2002/04/20 18:07:43 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ENTITIES SVG 1.1 Graphics Attribute//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-graphics-attrib.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Graphics Attribute
+    
+       display, image-rendering, pointer-events, shape-rendering,
+       text-rendering, visibility
+    
+    This module defines the Graphics attribute set.
+  -->
+  <define name="SVG.display.attrib">
+    <optional>
+      <attribute name="display">
+        <choice>
+          <value>inline</value>
+          <value>block</value>
+          <value>list-item</value>
+          <value>run-in</value>
+          <value>compact</value>
+          <value>marker</value>
+          <value>table</value>
+          <value>inline-table</value>
+          <value>table-row-group</value>
+          <value>table-header-group</value>
+          <value>table-footer-group</value>
+          <value>table-row</value>
+          <value>table-column-group</value>
+          <value>table-column</value>
+          <value>table-cell</value>
+          <value>table-caption</value>
+          <value>none</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.image-rendering.attrib">
+    <optional>
+      <attribute name="image-rendering">
+        <choice>
+          <value>auto</value>
+          <value>optimizeSpeed</value>
+          <value>optimizeQuality</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.pointer-events.attrib">
+    <optional>
+      <attribute name="pointer-events">
+        <choice>
+          <value>visiblePainted</value>
+          <value>visibleFill</value>
+          <value>visibleStroke</value>
+          <value>visible</value>
+          <value>painted</value>
+          <value>fill</value>
+          <value>stroke</value>
+          <value>all</value>
+          <value>none</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.shape-rendering.attrib">
+    <optional>
+      <attribute name="shape-rendering">
+        <choice>
+          <value>auto</value>
+          <value>optimizeSpeed</value>
+          <value>crispEdges</value>
+          <value>geometricPrecision</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.text-rendering.attrib">
+    <optional>
+      <attribute name="text-rendering">
+        <choice>
+          <value>auto</value>
+          <value>optimizeSpeed</value>
+          <value>optimizeLegibility</value>
+          <value>geometricPrecision</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.visibility.attrib">
+    <optional>
+      <attribute name="visibility">
+        <choice>
+          <value>visible</value>
+          <value>hidden</value>
+          <value>inherit</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.Graphics.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.Graphics.attrib">
+    <ref name="SVG.display.attrib"/>
+    <ref name="SVG.image-rendering.attrib"/>
+    <ref name="SVG.pointer-events.attrib"/>
+    <ref name="SVG.shape-rendering.attrib"/>
+    <ref name="SVG.text-rendering.attrib"/>
+    <ref name="SVG.visibility.attrib"/>
+    <ref name="SVG.Graphics.extra.attrib"/>
+  </define>
+  <!-- end of svg-graphics-attrib.mod -->
+  <!-- Document Events Attribute Module ............................ -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Document Events Attribute Module .............................. -->
+  <!--
+    file: svg-docevents-attrib.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-docevents-attrib.mod,v 1.2 2002/04/20 18:07:42 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ENTITIES SVG 1.1 Document Events Attribute//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-docevents-attrib.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Document Events Attribute
+    
+       onunload, onabort, onerror, onresize, onscroll, onzoom
+    
+    This module defines the DocumentEvents attribute set.
+  -->
+  <define name="SVG.onunload.attrib">
+    <optional>
+      <attribute name="onunload">
+        <ref name="Script.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.onabort.attrib">
+    <optional>
+      <attribute name="onabort">
+        <ref name="Script.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.onerror.attrib">
+    <optional>
+      <attribute name="onerror">
+        <ref name="Script.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.onresize.attrib">
+    <optional>
+      <attribute name="onresize">
+        <ref name="Script.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.onscroll.attrib">
+    <optional>
+      <attribute name="onscroll">
+        <ref name="Script.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.onzoom.attrib">
+    <optional>
+      <attribute name="onzoom">
+        <ref name="Script.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.DocumentEvents.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.DocumentEvents.attrib">
+    <ref name="SVG.onunload.attrib"/>
+    <ref name="SVG.onabort.attrib"/>
+    <ref name="SVG.onerror.attrib"/>
+    <ref name="SVG.onresize.attrib"/>
+    <ref name="SVG.onscroll.attrib"/>
+    <ref name="SVG.onzoom.attrib"/>
+    <ref name="SVG.DocumentEvents.extra.attrib"/>
+  </define>
+  <!-- end of svg-docevents-attrib.mod -->
+  <!-- Graphical Element Events Attribute Module ................... -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Graphical Element Events Attribute Module ..................... -->
+  <!--
+    file: svg-graphevents-attrib.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-graphevents-attrib.mod,v 1.2 2002/04/20 18:07:43 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ENTITIES SVG 1.1 Graphical Element Events Attribute//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-graphevents-attrib.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Graphical Element Events Attribute
+    
+       onfocusin, onfocusout, onactivate, onclick, onmousedown, onmouseup,
+       onmouseover, onmousemove, onmouseout, onload
+    
+    This module defines the GraphicalEvents attribute set.
+  -->
+  <define name="SVG.onfocusin.attrib">
+    <optional>
+      <attribute name="onfocusin">
+        <ref name="Script.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.onfocusout.attrib">
+    <optional>
+      <attribute name="onfocusout">
+        <ref name="Script.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.onactivate.attrib">
+    <optional>
+      <attribute name="onactivate">
+        <ref name="Script.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.onclick.attrib">
+    <optional>
+      <attribute name="onclick">
+        <ref name="Script.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.onmousedown.attrib">
+    <optional>
+      <attribute name="onmousedown">
+        <ref name="Script.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.onmouseup.attrib">
+    <optional>
+      <attribute name="onmouseup">
+        <ref name="Script.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.onmouseover.attrib">
+    <optional>
+      <attribute name="onmouseover">
+        <ref name="Script.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.onmousemove.attrib">
+    <optional>
+      <attribute name="onmousemove">
+        <ref name="Script.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.onmouseout.attrib">
+    <optional>
+      <attribute name="onmouseout">
+        <ref name="Script.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.onload.attrib">
+    <optional>
+      <attribute name="onload">
+        <ref name="Script.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.GraphicalEvents.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.GraphicalEvents.attrib">
+    <ref name="SVG.onfocusin.attrib"/>
+    <ref name="SVG.onfocusout.attrib"/>
+    <ref name="SVG.onactivate.attrib"/>
+    <ref name="SVG.onclick.attrib"/>
+    <ref name="SVG.onmousedown.attrib"/>
+    <ref name="SVG.onmouseup.attrib"/>
+    <ref name="SVG.onmouseover.attrib"/>
+    <ref name="SVG.onmousemove.attrib"/>
+    <ref name="SVG.onmouseout.attrib"/>
+    <ref name="SVG.onload.attrib"/>
+    <ref name="SVG.GraphicalEvents.extra.attrib"/>
+  </define>
+  <!-- end of svg-graphevents-attrib.mod -->
+  <!-- Animation Events Attribute Module ........................... -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Animation Events Attribute Module ............................. -->
+  <!--
+    file: svg-animevents-attrib.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-animevents-attrib.mod,v 1.3 2002/04/28 13:50:23 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ENTITIES SVG 1.1 Animation Events Attribute//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-animevents-attrib.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Animation Events Attribute
+    
+       onbegin, onend, onrepeat, onload
+    
+    This module defines the AnimationEvents attribute set.
+  -->
+  <define name="SVG.onbegin.attrib">
+    <optional>
+      <attribute name="onbegin">
+        <ref name="Script.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.onend.attrib">
+    <optional>
+      <attribute name="onend">
+        <ref name="Script.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.onrepeat.attrib">
+    <optional>
+      <attribute name="onrepeat">
+        <ref name="Script.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.AnimationEvents.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.AnimationEvents.attrib">
+    <ref name="SVG.onbegin.attrib"/>
+    <ref name="SVG.onend.attrib"/>
+    <ref name="SVG.onrepeat.attrib"/>
+    <ref name="SVG.onload.attrib"/>
+    <ref name="SVG.AnimationEvents.extra.attrib"/>
+  </define>
+  <!-- end of svg-animevents-attrib.mod -->
+  <!-- XLink Attribute Module ...................................... -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 XLink Attribute Module ........................................ -->
+  <!--
+    file: svg-xlink-attrib.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-xlink-attrib.mod,v 1.2 2002/04/20 18:07:43 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ENTITIES SVG 1.1 XLink Attribute//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-xlink-attrib.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    XLink Attribute
+    
+      type, href, role, arcrole, title, show, actuate
+    
+    This module defines the XLink, XLinkRequired, XLinkEmbed, and
+    XLinkReplace attribute set.
+  -->
+  <define name="SVG.XLink.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.XLink.attrib">
+    <ref name="XLINK.xmlns.attrib"/>
+    <optional>
+      <attribute name="xlink:type" a:defaultValue="simple">
+        <value>simple</value>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xlink:href">
+        <ref name="URI.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xlink:role">
+        <ref name="URI.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xlink:arcrole">
+        <ref name="URI.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xlink:title"/>
+    </optional>
+    <optional>
+      <attribute name="xlink:show" a:defaultValue="other">
+        <choice>
+          <value>other</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xlink:actuate" a:defaultValue="onLoad">
+        <value>onLoad</value>
+      </attribute>
+    </optional>
+    <ref name="SVG.XLink.extra.attrib"/>
+  </define>
+  <define name="SVG.XLinkRequired.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.XLinkRequired.attrib">
+    <ref name="XLINK.xmlns.attrib"/>
+    <optional>
+      <attribute name="xlink:type" a:defaultValue="simple">
+        <value>simple</value>
+      </attribute>
+    </optional>
+    <attribute name="xlink:href">
+      <ref name="URI.datatype"/>
+    </attribute>
+    <optional>
+      <attribute name="xlink:role">
+        <ref name="URI.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xlink:arcrole">
+        <ref name="URI.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xlink:title"/>
+    </optional>
+    <optional>
+      <attribute name="xlink:show" a:defaultValue="other">
+        <choice>
+          <value>other</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xlink:actuate" a:defaultValue="onLoad">
+        <value>onLoad</value>
+      </attribute>
+    </optional>
+    <ref name="SVG.XLinkRequired.extra.attrib"/>
+  </define>
+  <define name="SVG.XLinkEmbed.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.XLinkEmbed.attrib">
+    <ref name="XLINK.xmlns.attrib"/>
+    <optional>
+      <attribute name="xlink:type" a:defaultValue="simple">
+        <value>simple</value>
+      </attribute>
+    </optional>
+    <attribute name="xlink:href">
+      <ref name="URI.datatype"/>
+    </attribute>
+    <optional>
+      <attribute name="xlink:role">
+        <ref name="URI.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xlink:arcrole">
+        <ref name="URI.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xlink:title"/>
+    </optional>
+    <optional>
+      <attribute name="xlink:show" a:defaultValue="embed">
+        <choice>
+          <value>embed</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xlink:actuate" a:defaultValue="onLoad">
+        <value>onLoad</value>
+      </attribute>
+    </optional>
+    <ref name="SVG.XLinkEmbed.extra.attrib"/>
+  </define>
+  <define name="SVG.XLinkReplace.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.XLinkReplace.attrib">
+    <ref name="XLINK.xmlns.attrib"/>
+    <optional>
+      <attribute name="xlink:type" a:defaultValue="simple">
+        <value>simple</value>
+      </attribute>
+    </optional>
+    <attribute name="xlink:href">
+      <ref name="URI.datatype"/>
+    </attribute>
+    <optional>
+      <attribute name="xlink:role">
+        <ref name="URI.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xlink:arcrole">
+        <ref name="URI.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xlink:title"/>
+    </optional>
+    <optional>
+      <attribute name="xlink:show" a:defaultValue="replace">
+        <choice>
+          <value>new</value>
+          <value>replace</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xlink:actuate" a:defaultValue="onRequest">
+        <value>onRequest</value>
+      </attribute>
+    </optional>
+    <ref name="SVG.XLinkReplace.extra.attrib"/>
+  </define>
+  <!-- end of svg-xlink-attrib.mod -->
+  <!-- External Resources Attribute Module ......................... -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 External Resources Attribute Module ........................... -->
+  <!--
+    file: svg-extresources-attrib.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-extresources-attrib.mod,v 1.2 2002/04/20 18:07:42 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ENTITIES SVG 1.1 External Resources Attribute//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-extresources-attrib.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    External Resources Attribute
+    
+       externalResourcesRequired
+    
+    This module defines the External attribute set.
+  -->
+  <define name="SVG.externalResourcesRequired.attrib">
+    <optional>
+      <attribute name="externalResourcesRequired">
+        <ref name="Boolean.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <define name="SVG.External.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.External.attrib">
+    <ref name="SVG.externalResourcesRequired.attrib"/>
+    <ref name="SVG.External.extra.attrib"/>
+  </define>
+  <!-- end of svg-extresources-attrib.mod -->
+  <!-- ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: -->
+  <!-- Structure Module ............................................ -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Structure Module .............................................. -->
+  <!--
+    file: svg-structure.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-structure.mod,v 1.5 2002/11/14 15:11:03 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 Structure//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-structure.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Structure
+    
+       svg, g, defs, desc, title, metadata, symbol, use
+    
+    This module declares the major structural elements and their attributes.
+  -->
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.Description.class ............................. -->
+  <!-- SVG.Use.class ..................................... -->
+  <!-- SVG.Structure.class ............................... -->
+  <!-- SVG.Presentation.attrib ........................... -->
+  <define name="SVG.Presentation.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.Presentation.attrib">
+    <ref name="SVG.Container.attrib"/>
+    <ref name="SVG.Viewport.attrib"/>
+    <ref name="SVG.Text.attrib"/>
+    <ref name="SVG.TextContent.attrib"/>
+    <ref name="SVG.Font.attrib"/>
+    <ref name="SVG.Paint.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.Opacity.attrib"/>
+    <ref name="SVG.Graphics.attrib"/>
+    <ref name="SVG.Marker.attrib"/>
+    <ref name="SVG.ColorProfile.attrib"/>
+    <ref name="SVG.Gradient.attrib"/>
+    <ref name="SVG.Clip.attrib"/>
+    <ref name="SVG.Mask.attrib"/>
+    <ref name="SVG.Filter.attrib"/>
+    <ref name="SVG.FilterColor.attrib"/>
+    <ref name="SVG.Cursor.attrib"/>
+    <optional>
+      <attribute name="flood-color">
+        <ref name="SVGColor.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="flood-opacity">
+        <ref name="OpacityValue.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="lighting-color">
+        <ref name="SVGColor.datatype"/>
+      </attribute>
+    </optional>
+    <ref name="SVG.Presentation.extra.attrib"/>
+  </define>
+  <!-- svg: SVG Document Element ......................... -->
+  <define name="SVG.svg.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.svg.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.Structure.class"/>
+        <ref name="SVG.Conditional.class"/>
+        <ref name="SVG.Image.class"/>
+        <ref name="SVG.Style.class"/>
+        <ref name="SVG.Shape.class"/>
+        <ref name="SVG.Text.class"/>
+        <ref name="SVG.Marker.class"/>
+        <ref name="SVG.ColorProfile.class"/>
+        <ref name="SVG.Gradient.class"/>
+        <ref name="SVG.Pattern.class"/>
+        <ref name="SVG.Clip.class"/>
+        <ref name="SVG.Mask.class"/>
+        <ref name="SVG.Filter.class"/>
+        <ref name="SVG.Cursor.class"/>
+        <ref name="SVG.Hyperlink.class"/>
+        <ref name="SVG.View.class"/>
+        <ref name="SVG.Script.class"/>
+        <ref name="SVG.Font.class"/>
+        <ref name="SVG.svg.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="svg">
+    <element name="svg">
+      <ref name="attlist.svg"/>
+      <ref name="SVG.svg.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.svg.element -->
+  <define name="attlist.svg" combine="interleave">
+    <ref name="SVG.xmlns.attrib"/>
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Presentation.attrib"/>
+    <ref name="SVG.DocumentEvents.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="x">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="width">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="height">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="viewBox">
+        <ref name="ViewBoxSpec.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="preserveAspectRatio" a:defaultValue="xMidYMid meet">
+        <ref name="PreserveAspectRatioSpec.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="zoomAndPan" a:defaultValue="magnify">
+        <choice>
+          <value>disable</value>
+          <value>magnify</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="version" a:defaultValue="1.1">
+        <value type="string" datatypeLibrary="">1.1</value>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="baseProfile">
+        <ref name="Text.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="contentScriptType" a:defaultValue="text/ecmascript">
+        <ref name="ContentType.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="contentStyleType" a:defaultValue="text/css">
+        <ref name="ContentType.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.svg.attlist -->
+  <!-- g: Group Element .................................. -->
+  <define name="SVG.g.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.g.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.Structure.class"/>
+        <ref name="SVG.Conditional.class"/>
+        <ref name="SVG.Image.class"/>
+        <ref name="SVG.Style.class"/>
+        <ref name="SVG.Shape.class"/>
+        <ref name="SVG.Text.class"/>
+        <ref name="SVG.Marker.class"/>
+        <ref name="SVG.ColorProfile.class"/>
+        <ref name="SVG.Gradient.class"/>
+        <ref name="SVG.Pattern.class"/>
+        <ref name="SVG.Clip.class"/>
+        <ref name="SVG.Mask.class"/>
+        <ref name="SVG.Filter.class"/>
+        <ref name="SVG.Cursor.class"/>
+        <ref name="SVG.Hyperlink.class"/>
+        <ref name="SVG.View.class"/>
+        <ref name="SVG.Script.class"/>
+        <ref name="SVG.Font.class"/>
+        <ref name="SVG.g.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="g">
+    <element name="g">
+      <ref name="attlist.g"/>
+      <ref name="SVG.g.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.g.element -->
+  <define name="attlist.g" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Presentation.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="transform">
+        <ref name="TransformList.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.g.attlist -->
+  <!-- defs: Definisions Element ......................... -->
+  <define name="SVG.defs.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.defs.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.Structure.class"/>
+        <ref name="SVG.Conditional.class"/>
+        <ref name="SVG.Image.class"/>
+        <ref name="SVG.Style.class"/>
+        <ref name="SVG.Shape.class"/>
+        <ref name="SVG.Text.class"/>
+        <ref name="SVG.Marker.class"/>
+        <ref name="SVG.ColorProfile.class"/>
+        <ref name="SVG.Gradient.class"/>
+        <ref name="SVG.Pattern.class"/>
+        <ref name="SVG.Clip.class"/>
+        <ref name="SVG.Mask.class"/>
+        <ref name="SVG.Filter.class"/>
+        <ref name="SVG.Cursor.class"/>
+        <ref name="SVG.Hyperlink.class"/>
+        <ref name="SVG.View.class"/>
+        <ref name="SVG.Script.class"/>
+        <ref name="SVG.Font.class"/>
+        <ref name="SVG.defs.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="defs">
+    <element name="defs">
+      <ref name="attlist.defs"/>
+      <ref name="SVG.defs.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.defs.element -->
+  <define name="attlist.defs" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Presentation.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="transform">
+        <ref name="TransformList.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.defs.attlist -->
+  <!-- desc: Description Element ......................... -->
+  <define name="SVG.desc.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.desc.content">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="SVG.desc.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="desc">
+    <element name="desc">
+      <ref name="attlist.desc"/>
+      <ref name="SVG.desc.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.desc.element -->
+  <define name="attlist.desc" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+  </define>
+  <!-- end of SVG.desc.attlist -->
+  <!-- title: Title Element .............................. -->
+  <define name="SVG.title.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.title.content">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="SVG.title.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="title">
+    <element name="title">
+      <ref name="attlist.title"/>
+      <ref name="SVG.title.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.title.element -->
+  <define name="attlist.title" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+  </define>
+  <!-- end of SVG.title.attlist -->
+  <!-- metadata: Metadata Element ........................ -->
+  <define name="SVG.metadata.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.metadata.content">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="SVG.metadata.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="metadata">
+    <element name="metadata">
+      <ref name="attlist.metadata"/>
+      <ref name="SVG.metadata.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.metadata.element -->
+  <define name="attlist.metadata" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+  </define>
+  <!-- end of SVG.metadata.attlist -->
+  <!-- symbol: Symbol Element ............................ -->
+  <define name="SVG.symbol.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.symbol.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.Structure.class"/>
+        <ref name="SVG.Conditional.class"/>
+        <ref name="SVG.Image.class"/>
+        <ref name="SVG.Style.class"/>
+        <ref name="SVG.Shape.class"/>
+        <ref name="SVG.Text.class"/>
+        <ref name="SVG.Marker.class"/>
+        <ref name="SVG.ColorProfile.class"/>
+        <ref name="SVG.Gradient.class"/>
+        <ref name="SVG.Pattern.class"/>
+        <ref name="SVG.Clip.class"/>
+        <ref name="SVG.Mask.class"/>
+        <ref name="SVG.Filter.class"/>
+        <ref name="SVG.Cursor.class"/>
+        <ref name="SVG.Hyperlink.class"/>
+        <ref name="SVG.View.class"/>
+        <ref name="SVG.Script.class"/>
+        <ref name="SVG.Font.class"/>
+        <ref name="SVG.symbol.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="symbol">
+    <element name="symbol">
+      <ref name="attlist.symbol"/>
+      <ref name="SVG.symbol.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.symbol.element -->
+  <define name="attlist.symbol" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Presentation.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="viewBox">
+        <ref name="ViewBoxSpec.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="preserveAspectRatio" a:defaultValue="xMidYMid meet">
+        <ref name="PreserveAspectRatioSpec.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.symbol.attlist -->
+  <!-- use: Use Element .................................. -->
+  <define name="SVG.use.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.use.content">
+    <zeroOrMore>
+      <ref name="SVG.Description.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.use.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="use">
+    <element name="use">
+      <ref name="attlist.use"/>
+      <ref name="SVG.use.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.use.element -->
+  <define name="attlist.use" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Presentation.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.XLinkEmbed.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="x">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="width">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="height">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="transform">
+        <ref name="TransformList.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.use.attlist -->
+  <!-- end of svg-structure.mod -->
+  <!-- Conditional Processing Module ............................... -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Conditional Processing Module ................................. -->
+  <!--
+    file: svg-conditional.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-conditional.mod,v 1.4 2002/11/14 15:11:02 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 Conditional Processing//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-conditional.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Conditional Processing
+    
+       switch
+    
+    This module declares markup to provide support for conditional processing.
+  -->
+  <!-- extension list specification -->
+  <!-- feature list specification -->
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.Conditional.class ............................. -->
+  <!-- SVG.Conditional.attrib ............................ -->
+  <!-- SVG.Presentation.attrib ........................... -->
+  <!-- switch: Switch Element ............................ -->
+  <define name="SVG.switch.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.switch.content">
+    <zeroOrMore>
+      <ref name="SVG.Description.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="svg"/>
+        <ref name="g"/>
+        <ref name="use"/>
+        <ref name="text"/>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.Conditional.class"/>
+        <ref name="SVG.Image.class"/>
+        <ref name="SVG.Shape.class"/>
+        <ref name="SVG.Hyperlink.class"/>
+        <ref name="SVG.Extensibility.class"/>
+        <ref name="SVG.switch.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="switch">
+    <element name="switch">
+      <ref name="attlist.switch"/>
+      <ref name="SVG.switch.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.switch.element -->
+  <define name="attlist.switch" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Presentation.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="transform">
+        <ref name="TransformList.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.switch.attlist -->
+  <!-- end of svg-conditional.mod -->
+  <!-- Image Module ................................................ -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Image Module .................................................. -->
+  <!--
+    file: svg-image.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-image.mod,v 1.4 2002/11/14 15:11:03 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 Image//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-image.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Image
+    
+       image
+    
+    This module declares markup to provide support for image.
+  -->
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.Image.class ................................... -->
+  <!-- image: Image Element .............................. -->
+  <define name="SVG.image.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.image.content">
+    <zeroOrMore>
+      <ref name="SVG.Description.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.image.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="image">
+    <element name="image">
+      <ref name="attlist.image"/>
+      <ref name="SVG.image.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.image.element -->
+  <define name="attlist.image" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Viewport.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.Opacity.attrib"/>
+    <ref name="SVG.Graphics.attrib"/>
+    <ref name="SVG.ColorProfile.attrib"/>
+    <ref name="SVG.Clip.attrib"/>
+    <ref name="SVG.Mask.attrib"/>
+    <ref name="SVG.Filter.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.Cursor.attrib"/>
+    <ref name="SVG.XLinkEmbed.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="x">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <attribute name="width">
+      <ref name="Length.datatype"/>
+    </attribute>
+    <attribute name="height">
+      <ref name="Length.datatype"/>
+    </attribute>
+    <optional>
+      <attribute name="preserveAspectRatio" a:defaultValue="xMidYMid meet">
+        <ref name="PreserveAspectRatioSpec.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="transform">
+        <ref name="TransformList.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.image.attlist -->
+  <!-- end of svg-image.mod -->
+  <!-- Style Module ................................................ -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Style Module .................................................. -->
+  <!--
+    file: svg-style.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-style.mod,v 1.3 2002/10/24 17:40:16 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 Style//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-style.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Style
+    
+       style
+    
+    This module declares markup to provide support for stylesheet.
+  -->
+  <!-- list of classes -->
+  <!-- comma-separated list of media descriptors. -->
+  <define name="MediaDesc.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- style sheet data -->
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.Style.class ................................... -->
+  <!-- SVG.Style.attrib .................................. -->
+  <!-- style: Style Element .............................. -->
+  <define name="SVG.style.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.style.content">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="SVG.style.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="style">
+    <element name="style">
+      <ref name="attlist.style"/>
+      <ref name="SVG.style.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.style.element -->
+  <define name="attlist.style" combine="interleave">
+    <optional>
+      <attribute name="xml:space" a:defaultValue="preserve">
+        <value>preserve</value>
+      </attribute>
+    </optional>
+    <ref name="SVG.id.attrib"/>
+    <ref name="SVG.base.attrib"/>
+    <ref name="SVG.lang.attrib"/>
+    <ref name="SVG.Core.extra.attrib"/>
+    <attribute name="type">
+      <ref name="ContentType.datatype"/>
+    </attribute>
+    <optional>
+      <attribute name="media">
+        <ref name="MediaDesc.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="title">
+        <ref name="Text.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.style.attlist -->
+  <!-- end of svg-style.mod -->
+  <!-- Shape Module ................................................ -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Shape Module .................................................. -->
+  <!--
+    file: svg-shape.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-shape.mod,v 1.3 2002/10/24 17:40:16 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 Shape//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-shape.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Shape
+    
+       path, rect, circle, line, ellipse, polyline, polygon
+    
+    This module declares markup to provide support for graphical shapes.
+  -->
+  <!-- a list of points -->
+  <define name="Points.datatype">
+    <data type="string" datatypeLibrary=""/>
+  </define>
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.Shape.class ................................... -->
+  <!-- path: Path Element ................................ -->
+  <define name="SVG.path.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.path.content">
+    <zeroOrMore>
+      <ref name="SVG.Description.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.path.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="path">
+    <element name="path">
+      <ref name="attlist.path"/>
+      <ref name="SVG.path.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.path.element -->
+  <define name="attlist.path" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Paint.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.Opacity.attrib"/>
+    <ref name="SVG.Graphics.attrib"/>
+    <ref name="SVG.Marker.attrib"/>
+    <ref name="SVG.Clip.attrib"/>
+    <ref name="SVG.Mask.attrib"/>
+    <ref name="SVG.Filter.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.Cursor.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <attribute name="d">
+      <ref name="PathData.datatype"/>
+    </attribute>
+    <optional>
+      <attribute name="pathLength">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="transform">
+        <ref name="TransformList.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.path.attlist -->
+  <!-- rect: Rectangle Element ........................... -->
+  <define name="SVG.rect.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.rect.content">
+    <zeroOrMore>
+      <ref name="SVG.Description.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.rect.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="rect">
+    <element name="rect">
+      <ref name="attlist.rect"/>
+      <ref name="SVG.rect.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.rect.element -->
+  <define name="attlist.rect" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Paint.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.Opacity.attrib"/>
+    <ref name="SVG.Graphics.attrib"/>
+    <ref name="SVG.Clip.attrib"/>
+    <ref name="SVG.Mask.attrib"/>
+    <ref name="SVG.Filter.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.Cursor.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="x">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <attribute name="width">
+      <ref name="Length.datatype"/>
+    </attribute>
+    <attribute name="height">
+      <ref name="Length.datatype"/>
+    </attribute>
+    <optional>
+      <attribute name="rx">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="ry">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="transform">
+        <ref name="TransformList.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.rect.attlist -->
+  <!-- circle: Circle Element ............................ -->
+  <define name="SVG.circle.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.circle.content">
+    <zeroOrMore>
+      <ref name="SVG.Description.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.circle.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="circle">
+    <element name="circle">
+      <ref name="attlist.circle"/>
+      <ref name="SVG.circle.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.circle.element -->
+  <define name="attlist.circle" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Paint.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.Opacity.attrib"/>
+    <ref name="SVG.Graphics.attrib"/>
+    <ref name="SVG.Clip.attrib"/>
+    <ref name="SVG.Mask.attrib"/>
+    <ref name="SVG.Filter.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.Cursor.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="cx">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="cy">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <attribute name="r">
+      <ref name="Length.datatype"/>
+    </attribute>
+    <optional>
+      <attribute name="transform">
+        <ref name="TransformList.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.circle.attlist -->
+  <!-- line: Line Element ................................ -->
+  <define name="SVG.line.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.line.content">
+    <zeroOrMore>
+      <ref name="SVG.Description.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.line.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="line">
+    <element name="line">
+      <ref name="attlist.line"/>
+      <ref name="SVG.line.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.line.element -->
+  <define name="attlist.line" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Paint.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.Opacity.attrib"/>
+    <ref name="SVG.Graphics.attrib"/>
+    <ref name="SVG.Marker.attrib"/>
+    <ref name="SVG.Clip.attrib"/>
+    <ref name="SVG.Mask.attrib"/>
+    <ref name="SVG.Filter.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.Cursor.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="x1">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y1">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="x2">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y2">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="transform">
+        <ref name="TransformList.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.line.attlist -->
+  <!-- ellipse: Ellipse Element .......................... -->
+  <define name="SVG.ellipse.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.ellipse.content">
+    <zeroOrMore>
+      <ref name="SVG.Description.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.ellipse.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="ellipse">
+    <element name="ellipse">
+      <ref name="attlist.ellipse"/>
+      <ref name="SVG.ellipse.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.ellipse.element -->
+  <define name="attlist.ellipse" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Paint.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.Opacity.attrib"/>
+    <ref name="SVG.Graphics.attrib"/>
+    <ref name="SVG.Clip.attrib"/>
+    <ref name="SVG.Mask.attrib"/>
+    <ref name="SVG.Filter.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.Cursor.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="cx">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="cy">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <attribute name="rx">
+      <ref name="Length.datatype"/>
+    </attribute>
+    <attribute name="ry">
+      <ref name="Length.datatype"/>
+    </attribute>
+    <optional>
+      <attribute name="transform">
+        <ref name="TransformList.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.ellipse.attlist -->
+  <!-- polyline: Polyline Element ........................ -->
+  <define name="SVG.polyline.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.polyline.content">
+    <zeroOrMore>
+      <ref name="SVG.Description.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.polyline.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="polyline">
+    <element name="polyline">
+      <ref name="attlist.polyline"/>
+      <ref name="SVG.polyline.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.polyline.element -->
+  <define name="attlist.polyline" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Paint.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.Opacity.attrib"/>
+    <ref name="SVG.Graphics.attrib"/>
+    <ref name="SVG.Marker.attrib"/>
+    <ref name="SVG.Clip.attrib"/>
+    <ref name="SVG.Mask.attrib"/>
+    <ref name="SVG.Filter.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.Cursor.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <attribute name="points">
+      <ref name="Points.datatype"/>
+    </attribute>
+    <optional>
+      <attribute name="transform">
+        <ref name="TransformList.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.polyline.attlist -->
+  <!-- polygon: Polygon Element .......................... -->
+  <define name="SVG.polygon.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.polygon.content">
+    <zeroOrMore>
+      <ref name="SVG.Description.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.polygon.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="polygon">
+    <element name="polygon">
+      <ref name="attlist.polygon"/>
+      <ref name="SVG.polygon.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.polygon.element -->
+  <define name="attlist.polygon" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Paint.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.Opacity.attrib"/>
+    <ref name="SVG.Graphics.attrib"/>
+    <ref name="SVG.Marker.attrib"/>
+    <ref name="SVG.Clip.attrib"/>
+    <ref name="SVG.Mask.attrib"/>
+    <ref name="SVG.Filter.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.Cursor.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <attribute name="points">
+      <ref name="Points.datatype"/>
+    </attribute>
+    <optional>
+      <attribute name="transform">
+        <ref name="TransformList.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.polygon.attlist -->
+  <!-- end of svg-shape.mod -->
+  <!-- Text Module ................................................. -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Text Module ................................................... -->
+  <!--
+    file: svg-text.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-text.mod,v 1.4 2002/10/24 17:40:16 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 Text//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-text.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Text
+    
+       text, tspan, tref, textPath, altGlyph, altGlyphDef, altGlyphItem,
+       glyphRef
+    
+    This module declares markup to provide support for alternate glyph.
+  -->
+  <!-- 'baseline-shift' property/attribute value (e.g., 'baseline', 'sub', etc.) -->
+  <!-- 'font-family' property/attribute value (i.e., list of fonts) -->
+  <!-- 'font-size' property/attribute value -->
+  <!-- 'font-size-adjust' property/attribute value -->
+  <!-- 'glyph-orientation-horizontal' property/attribute value (e.g., <angle>) -->
+  <!-- 'glyph-orientation-vertical' property/attribute value (e.g., 'auto', <angle>) -->
+  <!-- 'kerning' property/attribute value (e.g., 'auto', <length>) -->
+  <!-- 'letter-spacing' or 'word-spacing' property/attribute value (e.g., 'normal', <length>) -->
+  <!-- 'text-decoration' property/attribute value (e.g., 'none', 'underline') -->
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.Text.class .................................... -->
+  <!-- SVG.TextContent.class ............................. -->
+  <!-- SVG.Text.attrib ................................... -->
+  <!-- SVG.TextContent.attrib ............................ -->
+  <!-- SVG.Font.attrib ................................... -->
+  <!-- text: Text Element ................................ -->
+  <define name="SVG.text.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.text.content">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.TextContent.class"/>
+        <ref name="SVG.Hyperlink.class"/>
+        <ref name="SVG.text.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="text">
+    <element name="text">
+      <ref name="attlist.text"/>
+      <ref name="SVG.text.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.text.element -->
+  <define name="attlist.text" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Text.attrib"/>
+    <ref name="SVG.TextContent.attrib"/>
+    <ref name="SVG.Font.attrib"/>
+    <ref name="SVG.Paint.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.Opacity.attrib"/>
+    <ref name="SVG.Graphics.attrib"/>
+    <ref name="SVG.Clip.attrib"/>
+    <ref name="SVG.Mask.attrib"/>
+    <ref name="SVG.Filter.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.Cursor.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="x">
+        <ref name="Coordinates.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y">
+        <ref name="Coordinates.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="dx">
+        <ref name="Lengths.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="dy">
+        <ref name="Lengths.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rotate">
+        <ref name="Numbers.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="textLength">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="lengthAdjust">
+        <choice>
+          <value>spacing</value>
+          <value>spacingAndGlyphs</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="transform">
+        <ref name="TransformList.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.text.attlist -->
+  <!-- tspan: Text Span Element .......................... -->
+  <define name="SVG.tspan.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.tspan.content">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="tspan"/>
+        <ref name="tref"/>
+        <ref name="altGlyph"/>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="animateColor"/>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.Hyperlink.class"/>
+        <ref name="SVG.tspan.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="tspan">
+    <element name="tspan">
+      <ref name="attlist.tspan"/>
+      <ref name="SVG.tspan.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.tspan.element -->
+  <define name="attlist.tspan" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.TextContent.attrib"/>
+    <ref name="SVG.Font.attrib"/>
+    <ref name="SVG.Paint.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.Opacity.attrib"/>
+    <ref name="SVG.Graphics.attrib"/>
+    <ref name="SVG.Clip.attrib"/>
+    <ref name="SVG.Mask.attrib"/>
+    <ref name="SVG.Filter.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.Cursor.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="x">
+        <ref name="Coordinates.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y">
+        <ref name="Coordinates.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="dx">
+        <ref name="Lengths.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="dy">
+        <ref name="Lengths.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rotate">
+        <ref name="Numbers.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="textLength">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="lengthAdjust">
+        <choice>
+          <value>spacing</value>
+          <value>spacingAndGlyphs</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.tspan.attlist -->
+  <!-- tref: Text Reference Element ...................... -->
+  <define name="SVG.tref.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.tref.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="animateColor"/>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.tref.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="tref">
+    <element name="tref">
+      <ref name="attlist.tref"/>
+      <ref name="SVG.tref.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.tref.element -->
+  <define name="attlist.tref" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.TextContent.attrib"/>
+    <ref name="SVG.Font.attrib"/>
+    <ref name="SVG.Paint.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.Opacity.attrib"/>
+    <ref name="SVG.Graphics.attrib"/>
+    <ref name="SVG.Clip.attrib"/>
+    <ref name="SVG.Mask.attrib"/>
+    <ref name="SVG.Filter.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.Cursor.attrib"/>
+    <ref name="SVG.XLinkRequired.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="x">
+        <ref name="Coordinates.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y">
+        <ref name="Coordinates.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="dx">
+        <ref name="Lengths.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="dy">
+        <ref name="Lengths.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="rotate">
+        <ref name="Numbers.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="textLength">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="lengthAdjust">
+        <choice>
+          <value>spacing</value>
+          <value>spacingAndGlyphs</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.tref.attlist -->
+  <!-- textPath: Text Path Element ....................... -->
+  <define name="SVG.textPath.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.textPath.content">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="tspan"/>
+        <ref name="tref"/>
+        <ref name="altGlyph"/>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="animateColor"/>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.Hyperlink.class"/>
+        <ref name="SVG.textPath.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="textPath">
+    <element name="textPath">
+      <ref name="attlist.textPath"/>
+      <ref name="SVG.textPath.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.textPath.element -->
+  <define name="attlist.textPath" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.TextContent.attrib"/>
+    <ref name="SVG.Font.attrib"/>
+    <ref name="SVG.Paint.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.Opacity.attrib"/>
+    <ref name="SVG.Graphics.attrib"/>
+    <ref name="SVG.Clip.attrib"/>
+    <ref name="SVG.Mask.attrib"/>
+    <ref name="SVG.Filter.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.Cursor.attrib"/>
+    <ref name="SVG.XLinkRequired.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="startOffset">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="textLength">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="lengthAdjust">
+        <choice>
+          <value>spacing</value>
+          <value>spacingAndGlyphs</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="method">
+        <choice>
+          <value>align</value>
+          <value>stretch</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="spacing">
+        <choice>
+          <value>auto</value>
+          <value>exact</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.textPath.attlist -->
+  <!-- altGlyph: Alternate Glyph Element ................. -->
+  <define name="SVG.altGlyph.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.altGlyph.content">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="SVG.altGlyph.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="altGlyph">
+    <element name="altGlyph">
+      <ref name="attlist.altGlyph"/>
+      <ref name="SVG.altGlyph.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.altGlyph.element -->
+  <define name="attlist.altGlyph" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.TextContent.attrib"/>
+    <ref name="SVG.Font.attrib"/>
+    <ref name="SVG.Paint.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.Opacity.attrib"/>
+    <ref name="SVG.Graphics.attrib"/>
+    <ref name="SVG.Clip.attrib"/>
+    <ref name="SVG.Mask.attrib"/>
+    <ref name="SVG.Filter.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.Cursor.attrib"/>
+    <ref name="SVG.XLink.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="x">
+        <ref name="Coordinates.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y">
+        <ref name="Coordinates.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="dx">
+        <ref name="Lengths.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="dy">
+        <ref name="Lengths.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="glyphRef"/>
+    </optional>
+    <optional>
+      <attribute name="format"/>
+    </optional>
+    <optional>
+      <attribute name="rotate">
+        <ref name="Numbers.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.altGlyph.attlist -->
+  <!-- altGlyphDef: Alternate Glyph Definition Element ... -->
+  <define name="SVG.altGlyphDef.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.altGlyphDef.content">
+    <choice>
+      <choice>
+        <oneOrMore>
+          <ref name="glyphRef"/>
+        </oneOrMore>
+        <oneOrMore>
+          <ref name="altGlyphItem"/>
+        </oneOrMore>
+      </choice>
+      <ref name="SVG.altGlyphDef.extra.content"/>
+    </choice>
+  </define>
+  <define name="altGlyphDef">
+    <element name="altGlyphDef">
+      <ref name="attlist.altGlyphDef"/>
+      <ref name="SVG.altGlyphDef.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.altGlyphDef.element -->
+  <define name="attlist.altGlyphDef" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+  </define>
+  <!-- end of SVG.altGlyphDef.attlist -->
+  <!-- altGlyphItem: Alternate Glyph Item Element ........ -->
+  <define name="SVG.altGlyphItem.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.altGlyphItem.content">
+    <choice>
+      <oneOrMore>
+        <ref name="glyphRef"/>
+      </oneOrMore>
+      <ref name="SVG.altGlyphItem.extra.content"/>
+    </choice>
+  </define>
+  <define name="altGlyphItem">
+    <element name="altGlyphItem">
+      <ref name="attlist.altGlyphItem"/>
+      <ref name="SVG.altGlyphItem.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.altGlyphItem.element -->
+  <define name="attlist.altGlyphItem" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+  </define>
+  <!-- end of SVG.altGlyphItem.attlist -->
+  <!-- glyphRef: Glyph Reference Element ................. -->
+  <define name="SVG.glyphRef.content">
+    <empty/>
+  </define>
+  <define name="glyphRef">
+    <element name="glyphRef">
+      <ref name="attlist.glyphRef"/>
+      <ref name="SVG.glyphRef.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.glyphRef.element -->
+  <define name="attlist.glyphRef" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Font.attrib"/>
+    <ref name="SVG.XLink.attrib"/>
+    <optional>
+      <attribute name="x">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="dx">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="dy">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="glyphRef"/>
+    </optional>
+    <optional>
+      <attribute name="format"/>
+    </optional>
+  </define>
+  <!-- end of SVG.glyphRef.attlist -->
+  <!-- end of svg-text.mod -->
+  <!-- Marker Module ............................................... -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Marker Module ................................................. -->
+  <!--
+    file: svg-marker.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-marker.mod,v 1.4 2002/11/14 15:11:03 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 Marker//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-marker.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Marker
+    
+       marker
+    
+    This module declares markup to provide support for marker.
+  -->
+  <!-- 'marker' property/attribute value (e.g., 'none', <uri>) -->
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.Marker.class .................................. -->
+  <!-- SVG.Marker.attrib ................................. -->
+  <!-- SVG.Presentation.attrib ........................... -->
+  <!-- marker: Marker Element ............................ -->
+  <define name="SVG.marker.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.marker.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.Structure.class"/>
+        <ref name="SVG.Conditional.class"/>
+        <ref name="SVG.Image.class"/>
+        <ref name="SVG.Style.class"/>
+        <ref name="SVG.Shape.class"/>
+        <ref name="SVG.Text.class"/>
+        <ref name="SVG.Marker.class"/>
+        <ref name="SVG.ColorProfile.class"/>
+        <ref name="SVG.Gradient.class"/>
+        <ref name="SVG.Pattern.class"/>
+        <ref name="SVG.Clip.class"/>
+        <ref name="SVG.Mask.class"/>
+        <ref name="SVG.Filter.class"/>
+        <ref name="SVG.Cursor.class"/>
+        <ref name="SVG.Hyperlink.class"/>
+        <ref name="SVG.View.class"/>
+        <ref name="SVG.Script.class"/>
+        <ref name="SVG.Font.class"/>
+        <ref name="SVG.marker.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="marker">
+    <element name="marker">
+      <ref name="attlist.marker"/>
+      <ref name="SVG.marker.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.marker.element -->
+  <define name="attlist.marker" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Presentation.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="refX">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="refY">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="markerUnits">
+        <choice>
+          <value>strokeWidth</value>
+          <value>userSpaceOnUse</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="markerWidth">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="markerHeight">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="orient"/>
+    </optional>
+    <optional>
+      <attribute name="viewBox">
+        <ref name="ViewBoxSpec.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="preserveAspectRatio" a:defaultValue="xMidYMid meet">
+        <ref name="PreserveAspectRatioSpec.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.marker.attlist -->
+  <!-- end of svg-marker.mod -->
+  <!-- Color Profile Module ........................................ -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Color Profile Module .......................................... -->
+  <!--
+    file: svg-profile.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-profile.mod,v 1.3 2002/11/14 15:11:03 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 Color Profile//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-profile.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Color Profile
+    
+       color-profile
+    
+    This module declares markup to provide support for color profile.
+  -->
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.ColorProfile.class ............................ -->
+  <!-- SVG.ColorProfile.attrib ........................... -->
+  <!-- color-profile: Color Profile Element .............. -->
+  <define name="SVG.color-profile.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.color-profile.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.color-profile.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="color-profile">
+    <element name="color-profile">
+      <ref name="attlist.color-profile"/>
+      <ref name="SVG.color-profile.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.color-profile.element -->
+  <define name="attlist.color-profile" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.XLink.attrib"/>
+    <optional>
+      <attribute name="local"/>
+    </optional>
+    <attribute name="name"/>
+    <optional>
+      <attribute name="rendering-intent" a:defaultValue="auto">
+        <choice>
+          <value>auto</value>
+          <value>perceptual</value>
+          <value>relative-colorimetric</value>
+          <value>saturation</value>
+          <value>absolute-colorimetric</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.color-profile.attlist -->
+  <!-- end of svg-profile.mod -->
+  <!-- Gradient Module ............................................. -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Gradient Module ............................................... -->
+  <!--
+    file: svg-gradient.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-gradient.mod,v 1.3 2002/10/24 17:40:15 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 Gradient//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-gradient.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Gradient
+    
+       linearGradient, radialGradient, stop
+    
+    This module declares markup to provide support for gradient fill.
+  -->
+  <!-- a <number> or a <percentage> -->
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.Gradient.class ................................ -->
+  <!-- SVG.Gradient.attrib ............................... -->
+  <!-- linearGradient: Linear Gradient Element ........... -->
+  <define name="SVG.linearGradient.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.linearGradient.content">
+    <zeroOrMore>
+      <ref name="SVG.Description.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="stop"/>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="animateTransform"/>
+        <ref name="SVG.linearGradient.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="linearGradient">
+    <element name="linearGradient">
+      <ref name="attlist.linearGradient"/>
+      <ref name="SVG.linearGradient.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.linearGradient.element -->
+  <define name="attlist.linearGradient" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.Gradient.attrib"/>
+    <ref name="SVG.XLink.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="x1">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y1">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="x2">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y2">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="gradientUnits">
+        <choice>
+          <value>userSpaceOnUse</value>
+          <value>objectBoundingBox</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="gradientTransform">
+        <ref name="TransformList.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="spreadMethod">
+        <choice>
+          <value>pad</value>
+          <value>reflect</value>
+          <value>repeat</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.linearGradient.attlist -->
+  <!-- radialGradient: Radial Gradient Element ........... -->
+  <define name="SVG.radialGradient.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.radialGradient.content">
+    <zeroOrMore>
+      <ref name="SVG.Description.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="stop"/>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="animateTransform"/>
+        <ref name="SVG.radialGradient.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="radialGradient">
+    <element name="radialGradient">
+      <ref name="attlist.radialGradient"/>
+      <ref name="SVG.radialGradient.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.radialGradient.element -->
+  <define name="attlist.radialGradient" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.Gradient.attrib"/>
+    <ref name="SVG.XLink.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="cx">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="cy">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="r">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="fx">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="fy">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="gradientUnits">
+        <choice>
+          <value>userSpaceOnUse</value>
+          <value>objectBoundingBox</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="gradientTransform">
+        <ref name="TransformList.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="spreadMethod">
+        <choice>
+          <value>pad</value>
+          <value>reflect</value>
+          <value>repeat</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.radialGradient.attlist -->
+  <!-- stop: Stop Element ................................ -->
+  <define name="SVG.stop.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.stop.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="animateColor"/>
+        <ref name="SVG.stop.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="stop">
+    <element name="stop">
+      <ref name="attlist.stop"/>
+      <ref name="SVG.stop.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.stop.element -->
+  <define name="attlist.stop" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.Gradient.attrib"/>
+    <attribute name="offset">
+      <ref name="NumberOrPercentage.datatype"/>
+    </attribute>
+  </define>
+  <!-- end of SVG.stop.attlist -->
+  <!-- end of svg-gradient.mod -->
+  <!-- Pattern Module .............................................. -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Pattern Module ................................................ -->
+  <!--
+    file: svg-pattern.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-pattern.mod,v 1.4 2002/11/14 15:11:03 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 Pattern//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-pattern.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Pattern
+    
+       pattern
+    
+    This module declares markup to provide support for pattern fill.
+  -->
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.Pattern.class ................................. -->
+  <!-- SVG.Presentation.attrib ........................... -->
+  <!-- pattern: Pattern Element .......................... -->
+  <define name="SVG.pattern.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.pattern.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.Structure.class"/>
+        <ref name="SVG.Conditional.class"/>
+        <ref name="SVG.Image.class"/>
+        <ref name="SVG.Style.class"/>
+        <ref name="SVG.Shape.class"/>
+        <ref name="SVG.Text.class"/>
+        <ref name="SVG.Marker.class"/>
+        <ref name="SVG.ColorProfile.class"/>
+        <ref name="SVG.Gradient.class"/>
+        <ref name="SVG.Pattern.class"/>
+        <ref name="SVG.Clip.class"/>
+        <ref name="SVG.Mask.class"/>
+        <ref name="SVG.Filter.class"/>
+        <ref name="SVG.Cursor.class"/>
+        <ref name="SVG.Hyperlink.class"/>
+        <ref name="SVG.View.class"/>
+        <ref name="SVG.Script.class"/>
+        <ref name="SVG.Font.class"/>
+        <ref name="SVG.pattern.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="svgpattern">
+    <element name="pattern">
+      <ref name="attlist.pattern"/>
+      <ref name="SVG.pattern.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.pattern.element -->
+  <define name="attlist.pattern" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Presentation.attrib"/>
+    <ref name="SVG.XLink.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="x">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="width">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="height">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="patternUnits">
+        <choice>
+          <value>userSpaceOnUse</value>
+          <value>objectBoundingBox</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="patternContentUnits">
+        <choice>
+          <value>userSpaceOnUse</value>
+          <value>objectBoundingBox</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="patternTransform">
+        <ref name="TransformList.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="viewBox">
+        <ref name="ViewBoxSpec.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="preserveAspectRatio" a:defaultValue="xMidYMid meet">
+        <ref name="PreserveAspectRatioSpec.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.pattern.attlist -->
+  <!-- end of svg-pattern.mod -->
+  <!-- Clip Module ................................................. -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Clip Module ................................................... -->
+  <!--
+    file: svg-clip.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-clip.mod,v 1.3 2002/10/24 17:40:15 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 Clip//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-clip.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Clip
+    
+       clipPath
+    
+    This module declares markup to provide support for clipping.
+  -->
+  <!-- 'clip-path' property/attribute value (e.g., 'none', <uri>) -->
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.Clip.class .................................... -->
+  <!-- SVG.Clip.attrib ................................... -->
+  <!-- clipPath: Clip Path Element ....................... -->
+  <define name="SVG.clipPath.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.clipPath.content">
+    <zeroOrMore>
+      <ref name="SVG.Description.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.Use.class"/>
+        <ref name="SVG.Shape.class"/>
+        <ref name="SVG.Text.class"/>
+        <ref name="SVG.clipPath.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="clipPath">
+    <element name="clipPath">
+      <ref name="attlist.clipPath"/>
+      <ref name="SVG.clipPath.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.clipPath.element -->
+  <define name="attlist.clipPath" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Text.attrib"/>
+    <ref name="SVG.TextContent.attrib"/>
+    <ref name="SVG.Font.attrib"/>
+    <ref name="SVG.Paint.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.Opacity.attrib"/>
+    <ref name="SVG.Graphics.attrib"/>
+    <ref name="SVG.Clip.attrib"/>
+    <ref name="SVG.Mask.attrib"/>
+    <ref name="SVG.Filter.attrib"/>
+    <ref name="SVG.Cursor.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="transform">
+        <ref name="TransformList.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="clipPathUnits">
+        <choice>
+          <value>userSpaceOnUse</value>
+          <value>objectBoundingBox</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.clipPath.attlist -->
+  <!-- end of svg-clip.mod -->
+  <!-- Mask Module ................................................. -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Mask Module ................................................... -->
+  <!--
+    file: svg-mask.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-mask.mod,v 1.4 2002/11/14 15:11:03 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 Mask//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-mask.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Mask
+    
+       mask
+    
+    This module declares markup to provide support for masking.
+  -->
+  <!-- 'mask' property/attribute value (e.g., 'none', <uri>) -->
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.Mask.class .................................... -->
+  <!-- SVG.Mask.attrib ................................... -->
+  <!-- SVG.Presentation.attrib ........................... -->
+  <!-- mask: Mask Element ................................ -->
+  <define name="SVG.mask.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.mask.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.Structure.class"/>
+        <ref name="SVG.Conditional.class"/>
+        <ref name="SVG.Image.class"/>
+        <ref name="SVG.Style.class"/>
+        <ref name="SVG.Shape.class"/>
+        <ref name="SVG.Text.class"/>
+        <ref name="SVG.Marker.class"/>
+        <ref name="SVG.ColorProfile.class"/>
+        <ref name="SVG.Gradient.class"/>
+        <ref name="SVG.Pattern.class"/>
+        <ref name="SVG.Clip.class"/>
+        <ref name="SVG.Mask.class"/>
+        <ref name="SVG.Filter.class"/>
+        <ref name="SVG.Cursor.class"/>
+        <ref name="SVG.Hyperlink.class"/>
+        <ref name="SVG.View.class"/>
+        <ref name="SVG.Script.class"/>
+        <ref name="SVG.Font.class"/>
+        <ref name="SVG.mask.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="mask">
+    <element name="mask">
+      <ref name="attlist.mask"/>
+      <ref name="SVG.mask.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.mask.element -->
+  <define name="attlist.mask" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Presentation.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="x">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="width">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="height">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="maskUnits">
+        <choice>
+          <value>userSpaceOnUse</value>
+          <value>objectBoundingBox</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="maskContentUnits">
+        <choice>
+          <value>userSpaceOnUse</value>
+          <value>objectBoundingBox</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.mask.attlist -->
+  <!-- end of svg-mask.mod -->
+  <!-- Filter Module ............................................... -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Filter Module ................................................. -->
+  <!--
+    file: svg-filter.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-filter.mod,v 1.4 2002/11/14 15:11:02 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 Filter//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-filter.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Filter
+    
+       filter, feBlend, feColorMatrix, feComponentTransfer, feComposite,
+       feConvolveMatrix, feDiffuseLighting, feDisplacementMap, feFlood,
+       feGaussianBlur, feImage, feMerge, feMergeNode, feMorphology, feOffset,
+       feSpecularLighting, feTile, feTurbulence, feDistantLight, fePointLight,
+       feSpotLight, feFuncR, feFuncG, feFuncB, feFuncA
+    
+    This module declares markup to provide support for filter effect.
+  -->
+  <!-- 'filter' property/attribute value (e.g., 'none', <uri>) -->
+  <!-- list of <number>s, but at least one and at most two -->
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.Filter.class .................................. -->
+  <!-- SVG.FilterPrimitive.class ......................... -->
+  <!-- SVG.Filter.attrib ................................. -->
+  <!-- SVG.FilterColor.attrib ............................ -->
+  <!-- SVG.FilterPrimitive.attrib ........................ -->
+  <define name="SVG.FilterPrimitive.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.FilterPrimitive.attrib">
+    <optional>
+      <attribute name="x">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="width">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="height">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="result"/>
+    </optional>
+    <ref name="SVG.FilterPrimitive.extra.attrib"/>
+  </define>
+  <!-- SVG.FilterPrimitiveWithIn.attrib .................. -->
+  <define name="SVG.FilterPrimitiveWithIn.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.FilterPrimitiveWithIn.attrib">
+    <ref name="SVG.FilterPrimitive.attrib"/>
+    <optional>
+      <attribute name="in"/>
+    </optional>
+    <ref name="SVG.FilterPrimitiveWithIn.extra.attrib"/>
+  </define>
+  <!-- SVG.Presentation.attrib ........................... -->
+  <!-- filter: Filter Element ............................ -->
+  <define name="SVG.filter.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.filter.content">
+    <zeroOrMore>
+      <ref name="SVG.Description.class"/>
+    </zeroOrMore>
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="SVG.FilterPrimitive.class"/>
+        <ref name="SVG.filter.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="filter">
+    <element name="filter">
+      <ref name="attlist.filter"/>
+      <ref name="SVG.filter.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.filter.element -->
+  <define name="attlist.filter" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Presentation.attrib"/>
+    <ref name="SVG.XLink.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="x">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="width">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="height">
+        <ref name="Length.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="filterRes">
+        <ref name="NumberOptionalNumber.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="filterUnits">
+        <choice>
+          <value>userSpaceOnUse</value>
+          <value>objectBoundingBox</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="primitiveUnits">
+        <choice>
+          <value>userSpaceOnUse</value>
+          <value>objectBoundingBox</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.filter.attlist -->
+  <!-- feBlend: Filter Effect Blend Element .............. -->
+  <define name="SVG.feBlend.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feBlend.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="SVG.feBlend.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feBlend">
+    <element name="feBlend">
+      <ref name="attlist.feBlend"/>
+      <ref name="SVG.feBlend.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feBlend.element -->
+  <define name="attlist.feBlend" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.FilterColor.attrib"/>
+    <ref name="SVG.FilterPrimitiveWithIn.attrib"/>
+    <attribute name="in2"/>
+    <optional>
+      <attribute name="mode" a:defaultValue="normal">
+        <choice>
+          <value>normal</value>
+          <value>multiply</value>
+          <value>screen</value>
+          <value>darken</value>
+          <value>lighten</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.feBlend.attlist -->
+  <!-- feColorMatrix: Filter Effect Color Matrix Element . -->
+  <define name="SVG.feColorMatrix.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feColorMatrix.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="SVG.feColorMatrix.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feColorMatrix">
+    <element name="feColorMatrix">
+      <ref name="attlist.feColorMatrix"/>
+      <ref name="SVG.feColorMatrix.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feColorMatrix.element -->
+  <define name="attlist.feColorMatrix" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.FilterColor.attrib"/>
+    <ref name="SVG.FilterPrimitiveWithIn.attrib"/>
+    <optional>
+      <attribute name="type" a:defaultValue="matrix">
+        <choice>
+          <value>matrix</value>
+          <value>saturate</value>
+          <value>hueRotate</value>
+          <value>luminanceToAlpha</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="values"/>
+    </optional>
+  </define>
+  <!-- end of SVG.feColorMatrix.attlist -->
+  <!-- feComponentTransfer: Filter Effect Component Transfer Element -->
+  <define name="SVG.feComponentTransfer.extra.content">
+    <empty/>
+  </define>
+  <define name="SVG.feComponentTransfer.content">
+    <optional>
+      <ref name="feFuncR"/>
+    </optional>
+    <optional>
+      <ref name="feFuncG"/>
+    </optional>
+    <optional>
+      <ref name="feFuncB"/>
+    </optional>
+    <optional>
+      <ref name="feFuncA"/>
+    </optional>
+    <ref name="SVG.feComponentTransfer.extra.content"/>
+  </define>
+  <define name="feComponentTransfer">
+    <element name="feComponentTransfer">
+      <ref name="attlist.feComponentTransfer"/>
+      <ref name="SVG.feComponentTransfer.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feComponentTransfer.element -->
+  <define name="attlist.feComponentTransfer" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.FilterColor.attrib"/>
+    <ref name="SVG.FilterPrimitiveWithIn.attrib"/>
+  </define>
+  <!-- end of SVG.feComponentTransfer.attlist -->
+  <!-- feComposite: Filter Effect Composite Element ...... -->
+  <define name="SVG.feComposite.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feComposite.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="SVG.feComposite.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feComposite">
+    <element name="feComposite">
+      <ref name="attlist.feComposite"/>
+      <ref name="SVG.feComposite.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feComposite.element -->
+  <define name="attlist.feComposite" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.FilterColor.attrib"/>
+    <ref name="SVG.FilterPrimitiveWithIn.attrib"/>
+    <attribute name="in2"/>
+    <optional>
+      <attribute name="operator" a:defaultValue="over">
+        <choice>
+          <value>over</value>
+          <value>in</value>
+          <value>out</value>
+          <value>atop</value>
+          <value>xor</value>
+          <value>arithmetic</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="k1">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="k2">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="k3">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="k4">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.feComposite.attlist -->
+  <!-- feConvolveMatrix: Filter Effect Convolve Matrix Element -->
+  <define name="SVG.feConvolveMatrix.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feConvolveMatrix.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="SVG.feConvolveMatrix.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feConvolveMatrix">
+    <element name="feConvolveMatrix">
+      <ref name="attlist.feConvolveMatrix"/>
+      <ref name="SVG.feConvolveMatrix.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feConvolveMatrix.element -->
+  <define name="attlist.feConvolveMatrix" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.FilterColor.attrib"/>
+    <ref name="SVG.FilterPrimitiveWithIn.attrib"/>
+    <attribute name="order">
+      <ref name="NumberOptionalNumber.datatype"/>
+    </attribute>
+    <attribute name="kernelMatrix"/>
+    <optional>
+      <attribute name="divisor">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="bias">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="targetX">
+        <ref name="Integer.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="targetY">
+        <ref name="Integer.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="edgeMode" a:defaultValue="duplicate">
+        <choice>
+          <value>duplicate</value>
+          <value>wrap</value>
+          <value>none</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="kernelUnitLength">
+        <ref name="NumberOptionalNumber.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="preserveAlpha">
+        <ref name="Boolean.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.feConvolveMatrix.attlist -->
+  <!-- feDiffuseLighting: Filter Effect Diffuse Lighting Element -->
+  <define name="SVG.feDiffuseLighting.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feDiffuseLighting.content">
+    <choice>
+      <ref name="feDistantLight"/>
+      <ref name="fePointLight"/>
+      <ref name="feSpotLight"/>
+    </choice>
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="animateColor"/>
+        <ref name="SVG.feDiffuseLighting.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feDiffuseLighting">
+    <element name="feDiffuseLighting">
+      <ref name="attlist.feDiffuseLighting"/>
+      <ref name="SVG.feDiffuseLighting.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feDiffuseLighting.element -->
+  <define name="attlist.feDiffuseLighting" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.FilterColor.attrib"/>
+    <ref name="SVG.FilterPrimitiveWithIn.attrib"/>
+    <optional>
+      <attribute name="lighting-color">
+        <ref name="SVGColor.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="surfaceScale">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="diffuseConstant">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="kernelUnitLength">
+        <ref name="NumberOptionalNumber.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.feDiffuseLighting.attlist -->
+  <!-- feDisplacementMap: Filter Effect Displacement Map Element -->
+  <define name="SVG.feDisplacementMap.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feDisplacementMap.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="SVG.feDisplacementMap.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feDisplacementMap">
+    <element name="feDisplacementMap">
+      <ref name="attlist.feDisplacementMap"/>
+      <ref name="SVG.feDisplacementMap.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feDisplacementMap.element -->
+  <define name="attlist.feDisplacementMap" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.FilterColor.attrib"/>
+    <ref name="SVG.FilterPrimitiveWithIn.attrib"/>
+    <attribute name="in2"/>
+    <optional>
+      <attribute name="scale">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="xChannelSelector" a:defaultValue="A">
+        <choice>
+          <value>R</value>
+          <value>G</value>
+          <value>B</value>
+          <value>A</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="yChannelSelector" a:defaultValue="A">
+        <choice>
+          <value>R</value>
+          <value>G</value>
+          <value>B</value>
+          <value>A</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.feDisplacementMap.attlist -->
+  <!-- feFlood: Filter Effect Flood Element .............. -->
+  <define name="SVG.feFlood.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feFlood.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="animateColor"/>
+        <ref name="SVG.feFlood.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feFlood">
+    <element name="feFlood">
+      <ref name="attlist.feFlood"/>
+      <ref name="SVG.feFlood.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feFlood.element -->
+  <define name="attlist.feFlood" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.FilterColor.attrib"/>
+    <ref name="SVG.FilterPrimitiveWithIn.attrib"/>
+    <optional>
+      <attribute name="flood-color">
+        <ref name="SVGColor.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="flood-opacity">
+        <ref name="OpacityValue.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.feFlood.attlist -->
+  <!-- feGaussianBlur: Filter Effect Gaussian Blur Element -->
+  <define name="SVG.feGaussianBlur.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feGaussianBlur.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="SVG.feGaussianBlur.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feGaussianBlur">
+    <element name="feGaussianBlur">
+      <ref name="attlist.feGaussianBlur"/>
+      <ref name="SVG.feGaussianBlur.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feGaussianBlur.element -->
+  <define name="attlist.feGaussianBlur" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.FilterColor.attrib"/>
+    <ref name="SVG.FilterPrimitiveWithIn.attrib"/>
+    <optional>
+      <attribute name="stdDeviation">
+        <ref name="NumberOptionalNumber.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.feGaussianBlur.attlist -->
+  <!-- feImage: Filter Effect Image Element .............. -->
+  <define name="SVG.feImage.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feImage.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="animateTransform"/>
+        <ref name="SVG.feImage.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feImage">
+    <element name="feImage">
+      <ref name="attlist.feImage"/>
+      <ref name="SVG.feImage.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feImage.element -->
+  <define name="attlist.feImage" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Presentation.attrib"/>
+    <ref name="SVG.FilterPrimitive.attrib"/>
+    <ref name="SVG.XLinkEmbed.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="preserveAspectRatio" a:defaultValue="xMidYMid meet">
+        <ref name="PreserveAspectRatioSpec.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.feImage.attlist -->
+  <!-- feMerge: Filter Effect Merge Element .............. -->
+  <define name="SVG.feMerge.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feMerge.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="feMergeNode"/>
+        <ref name="SVG.feMerge.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feMerge">
+    <element name="feMerge">
+      <ref name="attlist.feMerge"/>
+      <ref name="SVG.feMerge.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feMerge.element -->
+  <define name="attlist.feMerge" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.FilterColor.attrib"/>
+    <ref name="SVG.FilterPrimitive.attrib"/>
+  </define>
+  <!-- end of SVG.feMerge.attlist -->
+  <!-- feMergeNode: Filter Effect Merge Node Element ..... -->
+  <define name="SVG.feMergeNode.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feMergeNode.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="SVG.feMergeNode.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feMergeNode">
+    <element name="feMergeNode">
+      <ref name="attlist.feMergeNode"/>
+      <ref name="SVG.feMergeNode.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feMergeNode.element -->
+  <define name="attlist.feMergeNode" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <optional>
+      <attribute name="in"/>
+    </optional>
+  </define>
+  <!-- end of SVG.feMergeNode.attlist -->
+  <!-- feMorphology: Filter Effect Morphology Element .... -->
+  <define name="SVG.feMorphology.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feMorphology.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="SVG.feMorphology.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feMorphology">
+    <element name="feMorphology">
+      <ref name="attlist.feMorphology"/>
+      <ref name="SVG.feMorphology.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feMorphology.element -->
+  <define name="attlist.feMorphology" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.FilterColor.attrib"/>
+    <ref name="SVG.FilterPrimitiveWithIn.attrib"/>
+    <optional>
+      <attribute name="operator" a:defaultValue="erode">
+        <choice>
+          <value>erode</value>
+          <value>dilate</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="radius">
+        <ref name="NumberOptionalNumber.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.feMorphology.attlist -->
+  <!-- feOffset: Filter Effect Offset Element ............ -->
+  <define name="SVG.feOffset.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feOffset.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="SVG.feOffset.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feOffset">
+    <element name="feOffset">
+      <ref name="attlist.feOffset"/>
+      <ref name="SVG.feOffset.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feOffset.element -->
+  <define name="attlist.feOffset" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.FilterColor.attrib"/>
+    <ref name="SVG.FilterPrimitiveWithIn.attrib"/>
+    <optional>
+      <attribute name="dx">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="dy">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.feOffset.attlist -->
+  <!-- feSpecularLighting: Filter Effect Specular Lighting Element -->
+  <define name="SVG.feSpecularLighting.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feSpecularLighting.content">
+    <choice>
+      <ref name="feDistantLight"/>
+      <ref name="fePointLight"/>
+      <ref name="feSpotLight"/>
+    </choice>
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="animateColor"/>
+        <ref name="SVG.feSpecularLighting.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feSpecularLighting">
+    <element name="feSpecularLighting">
+      <ref name="attlist.feSpecularLighting"/>
+      <ref name="SVG.feSpecularLighting.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feSpecularLighting.element -->
+  <define name="attlist.feSpecularLighting" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Color.attrib"/>
+    <ref name="SVG.FilterColor.attrib"/>
+    <ref name="SVG.FilterPrimitiveWithIn.attrib"/>
+    <optional>
+      <attribute name="lighting-color">
+        <ref name="SVGColor.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="surfaceScale">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specularConstant">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specularExponent">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="kernelUnitLength">
+        <ref name="NumberOptionalNumber.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.feSpecularLighting.attlist -->
+  <!-- feTile: Filter Effect Tile Element ................ -->
+  <define name="SVG.feTile.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feTile.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="SVG.feTile.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feTile">
+    <element name="feTile">
+      <ref name="attlist.feTile"/>
+      <ref name="SVG.feTile.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feTile.element -->
+  <define name="attlist.feTile" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.FilterColor.attrib"/>
+    <ref name="SVG.FilterPrimitiveWithIn.attrib"/>
+  </define>
+  <!-- end of SVG.feTile.attlist -->
+  <!-- feTurbulence: Filter Effect Turbulence Element .... -->
+  <define name="SVG.feTurbulence.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feTurbulence.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="SVG.feTurbulence.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feTurbulence">
+    <element name="feTurbulence">
+      <ref name="attlist.feTurbulence"/>
+      <ref name="SVG.feTurbulence.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feTurbulence.element -->
+  <define name="attlist.feTurbulence" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.FilterColor.attrib"/>
+    <ref name="SVG.FilterPrimitive.attrib"/>
+    <optional>
+      <attribute name="baseFrequency">
+        <ref name="NumberOptionalNumber.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="numOctaves">
+        <ref name="Integer.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="seed">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="stitchTiles" a:defaultValue="noStitch">
+        <choice>
+          <value>stitch</value>
+          <value>noStitch</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="type" a:defaultValue="turbulence">
+        <choice>
+          <value>fractalNoise</value>
+          <value>turbulence</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.feTurbulence.attlist -->
+  <!-- feDistantLight: Filter Effect Distant Light Element -->
+  <define name="SVG.feDistantLight.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feDistantLight.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="SVG.feDistantLight.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feDistantLight">
+    <element name="feDistantLight">
+      <ref name="attlist.feDistantLight"/>
+      <ref name="SVG.feDistantLight.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feDistantLight.element -->
+  <define name="attlist.feDistantLight" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <optional>
+      <attribute name="azimuth">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="elevation">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.feDistantLight.attlist -->
+  <!-- fePointLight: Filter Effect Point Light Element ... -->
+  <define name="SVG.fePointLight.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.fePointLight.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="SVG.fePointLight.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="fePointLight">
+    <element name="fePointLight">
+      <ref name="attlist.fePointLight"/>
+      <ref name="SVG.fePointLight.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.fePointLight.element -->
+  <define name="attlist.fePointLight" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <optional>
+      <attribute name="x">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="z">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.fePointLight.attlist -->
+  <!-- feSpotLight: Filter Effect Spot Light Element ..... -->
+  <define name="SVG.feSpotLight.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feSpotLight.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="SVG.feSpotLight.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feSpotLight">
+    <element name="feSpotLight">
+      <ref name="attlist.feSpotLight"/>
+      <ref name="SVG.feSpotLight.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feSpotLight.element -->
+  <define name="attlist.feSpotLight" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <optional>
+      <attribute name="x">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="z">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="pointsAtX">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="pointsAtY">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="pointsAtZ">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="specularExponent">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="limitingConeAngle">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.feSpotLight.attlist -->
+  <!-- feFuncR: Filter Effect Function Red Element ....... -->
+  <define name="SVG.feFuncR.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feFuncR.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="SVG.feFuncR.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feFuncR">
+    <element name="feFuncR">
+      <ref name="attlist.feFuncR"/>
+      <ref name="SVG.feFuncR.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feFuncR.element -->
+  <define name="attlist.feFuncR" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <attribute name="type">
+      <choice>
+        <value>identity</value>
+        <value>table</value>
+        <value>discrete</value>
+        <value>linear</value>
+        <value>gamma</value>
+      </choice>
+    </attribute>
+    <optional>
+      <attribute name="tableValues"/>
+    </optional>
+    <optional>
+      <attribute name="slope">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="intercept">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="amplitude">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="exponent">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="offset">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.feFuncR.attlist -->
+  <!-- feFuncG: Filter Effect Function Green Element ..... -->
+  <define name="SVG.feFuncG.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feFuncG.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="SVG.feFuncG.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feFuncG">
+    <element name="feFuncG">
+      <ref name="attlist.feFuncG"/>
+      <ref name="SVG.feFuncG.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feFuncG.element -->
+  <define name="attlist.feFuncG" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <attribute name="type">
+      <choice>
+        <value>identity</value>
+        <value>table</value>
+        <value>discrete</value>
+        <value>linear</value>
+        <value>gamma</value>
+      </choice>
+    </attribute>
+    <optional>
+      <attribute name="tableValues"/>
+    </optional>
+    <optional>
+      <attribute name="slope">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="intercept">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="amplitude">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="exponent">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="offset">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.feFuncG.attlist -->
+  <!-- feFuncB: Filter Effect Function Blue Element ...... -->
+  <define name="SVG.feFuncB.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feFuncB.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="SVG.feFuncB.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feFuncB">
+    <element name="feFuncB">
+      <ref name="attlist.feFuncB"/>
+      <ref name="SVG.feFuncB.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feFuncB.element -->
+  <define name="attlist.feFuncB" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <attribute name="type">
+      <choice>
+        <value>identity</value>
+        <value>table</value>
+        <value>discrete</value>
+        <value>linear</value>
+        <value>gamma</value>
+      </choice>
+    </attribute>
+    <optional>
+      <attribute name="tableValues"/>
+    </optional>
+    <optional>
+      <attribute name="slope">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="intercept">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="amplitude">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="exponent">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="offset">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.feFuncB.attlist -->
+  <!-- feFuncA: Filter Effect Function Alpha Element ..... -->
+  <define name="SVG.feFuncA.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.feFuncA.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="animate"/>
+        <ref name="set"/>
+        <ref name="SVG.feFuncA.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="feFuncA">
+    <element name="feFuncA">
+      <ref name="attlist.feFuncA"/>
+      <ref name="SVG.feFuncA.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.feFuncA.element -->
+  <define name="attlist.feFuncA" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <attribute name="type">
+      <choice>
+        <value>identity</value>
+        <value>table</value>
+        <value>discrete</value>
+        <value>linear</value>
+        <value>gamma</value>
+      </choice>
+    </attribute>
+    <optional>
+      <attribute name="tableValues"/>
+    </optional>
+    <optional>
+      <attribute name="slope">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="intercept">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="amplitude">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="exponent">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="offset">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.feFuncA.attlist -->
+  <!-- end of svg-filter.mod -->
+  <!-- Cursor Module ............................................... -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Cursor Module ................................................. -->
+  <!--
+    file: svg-cursor.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-cursor.mod,v 1.3 2002/10/24 17:40:15 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 Cursor//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-cursor.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Cursor
+    
+       cursor
+    
+    This module declares markup to provide support for cursor.
+  -->
+  <!-- 'cursor' property/attribute value (e.g., 'crosshair', <uri>) -->
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.Cursor.class .................................. -->
+  <!-- SVG.Cursor.attrib ................................. -->
+  <!-- cursor: Cursor Element ............................ -->
+  <define name="SVG.cursor.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.cursor.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.cursor.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="cursor">
+    <element name="cursor">
+      <ref name="attlist.cursor"/>
+      <ref name="SVG.cursor.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.cursor.element -->
+  <define name="attlist.cursor" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.XLinkRequired.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="x">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.cursor.attlist -->
+  <!-- end of svg-cursor.mod -->
+  <!-- Hyperlinking Module ......................................... -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Hyperlinking Module ........................................... -->
+  <!--
+    file: svg-hyperlink.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-hyperlink.mod,v 1.4 2002/11/14 15:11:02 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 Hyperlinking//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-hyperlink.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Hyperlinking
+    
+       a
+    
+    This module declares markup to provide support for hyper linking.
+  -->
+  <!-- link to this target -->
+  <define name="LinkTarget.datatype">
+    <data type="NMTOKEN"/>
+  </define>
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.Hyperlink.class ............................... -->
+  <!-- SVG.Presentation.attrib ........................... -->
+  <!-- a: Anchor Element ................................. -->
+  <define name="SVG.a.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.a.content">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.Structure.class"/>
+        <ref name="SVG.Conditional.class"/>
+        <ref name="SVG.Image.class"/>
+        <ref name="SVG.Style.class"/>
+        <ref name="SVG.Shape.class"/>
+        <ref name="SVG.Text.class"/>
+        <ref name="SVG.Marker.class"/>
+        <ref name="SVG.ColorProfile.class"/>
+        <ref name="SVG.Gradient.class"/>
+        <ref name="SVG.Pattern.class"/>
+        <ref name="SVG.Clip.class"/>
+        <ref name="SVG.Mask.class"/>
+        <ref name="SVG.Filter.class"/>
+        <ref name="SVG.Cursor.class"/>
+        <ref name="SVG.Hyperlink.class"/>
+        <ref name="SVG.View.class"/>
+        <ref name="SVG.Script.class"/>
+        <ref name="SVG.Font.class"/>
+        <ref name="SVG.a.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="a">
+    <element name="a">
+      <ref name="attlist.a"/>
+      <ref name="SVG.a.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.a.element -->
+  <define name="attlist.a" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Presentation.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.XLinkReplace.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="transform">
+        <ref name="TransformList.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="target">
+        <ref name="LinkTarget.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.a.attlist -->
+  <!-- end of svg-hyperlink.mod -->
+  <!-- View Module ................................................. -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 View Module ................................................... -->
+  <!--
+    file: svg-view.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-view.mod,v 1.3 2002/10/24 17:40:16 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 View//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-view.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    View
+    
+       view
+    
+    This module declares markup to provide support for view.
+  -->
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.View.class .................................... -->
+  <!-- view: View Element ................................ -->
+  <define name="SVG.view.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.view.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.view.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="view">
+    <element name="view">
+      <ref name="attlist.view"/>
+      <ref name="SVG.view.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.view.element -->
+  <define name="attlist.view" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="viewBox">
+        <ref name="ViewBoxSpec.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="preserveAspectRatio" a:defaultValue="xMidYMid meet">
+        <ref name="PreserveAspectRatioSpec.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="zoomAndPan" a:defaultValue="magnify">
+        <choice>
+          <value>disable</value>
+          <value>magnify</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="viewTarget"/>
+    </optional>
+  </define>
+  <!-- end of SVG.view.attlist -->
+  <!-- end of svg-view.mod -->
+  <!-- Scripting Module ............................................ -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Scripting Module .............................................. -->
+  <!--
+    file: svg-script.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-script.mod,v 1.3 2002/10/24 17:40:16 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 Scripting//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-script.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Scripting
+    
+       script
+    
+    This module declares markup to provide support for scripting.
+  -->
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.Script.class .................................. -->
+  <!-- script: Script Element ............................ -->
+  <define name="SVG.script.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.script.content">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="SVG.script.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="script">
+    <element name="script">
+      <ref name="attlist.script"/>
+      <ref name="SVG.script.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.script.element -->
+  <define name="attlist.script" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.XLink.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <attribute name="type">
+      <ref name="ContentType.datatype"/>
+    </attribute>
+  </define>
+  <!-- end of SVG.script.attlist -->
+  <!-- end of svg-script.mod -->
+  <!-- Animation Module ............................................ -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Animation Module .............................................. -->
+  <!--
+    file: svg-animation.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-animation.mod,v 1.3 2002/10/24 17:40:14 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 Animation//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-animation.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Animation
+    
+       animate, set, animateMotion, animateColor, animateTransform, mpath
+    
+    This module declares markup to provide support for animation.
+  -->
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.Animation.class ............................... -->
+  <!-- SVG.Animation.attrib .............................. -->
+  <define name="SVG.Animation.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.Animation.attrib">
+    <ref name="SVG.XLink.attrib"/>
+    <ref name="SVG.Animation.extra.attrib"/>
+  </define>
+  <!-- SVG.AnimationAttribute.attrib ..................... -->
+  <define name="SVG.AnimationAttribute.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.AnimationAttribute.attrib">
+    <attribute name="attributeName"/>
+    <optional>
+      <attribute name="attributeType"/>
+    </optional>
+    <ref name="SVG.AnimationAttribute.extra.attrib"/>
+  </define>
+  <!-- SVG.AnimationTiming.attrib ........................ -->
+  <define name="SVG.AnimationTiming.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.AnimationTiming.attrib">
+    <optional>
+      <attribute name="begin"/>
+    </optional>
+    <optional>
+      <attribute name="dur"/>
+    </optional>
+    <optional>
+      <attribute name="end"/>
+    </optional>
+    <optional>
+      <attribute name="min"/>
+    </optional>
+    <optional>
+      <attribute name="max"/>
+    </optional>
+    <optional>
+      <attribute name="restart" a:defaultValue="always">
+        <choice>
+          <value>always</value>
+          <value>never</value>
+          <value>whenNotActive</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="repeatCount"/>
+    </optional>
+    <optional>
+      <attribute name="repeatDur"/>
+    </optional>
+    <optional>
+      <attribute name="fill" a:defaultValue="remove">
+        <choice>
+          <value>remove</value>
+          <value>freeze</value>
+        </choice>
+      </attribute>
+    </optional>
+    <ref name="SVG.AnimationTiming.extra.attrib"/>
+  </define>
+  <!-- SVG.AnimationValue.attrib ......................... -->
+  <define name="SVG.AnimationValue.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.AnimationValue.attrib">
+    <optional>
+      <attribute name="calcMode" a:defaultValue="linear">
+        <choice>
+          <value>discrete</value>
+          <value>linear</value>
+          <value>paced</value>
+          <value>spline</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="values"/>
+    </optional>
+    <optional>
+      <attribute name="keyTimes"/>
+    </optional>
+    <optional>
+      <attribute name="keySplines"/>
+    </optional>
+    <optional>
+      <attribute name="from"/>
+    </optional>
+    <optional>
+      <attribute name="to"/>
+    </optional>
+    <optional>
+      <attribute name="by"/>
+    </optional>
+    <ref name="SVG.AnimationValue.extra.attrib"/>
+  </define>
+  <!-- SVG.AnimationAddtion.attrib ....................... -->
+  <define name="SVG.AnimationAddtion.extra.attrib">
+    <empty/>
+  </define>
+  <define name="SVG.AnimationAddtion.attrib">
+    <optional>
+      <attribute name="additive" a:defaultValue="replace">
+        <choice>
+          <value>replace</value>
+          <value>sum</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="accumulate" a:defaultValue="none">
+        <choice>
+          <value>none</value>
+          <value>sum</value>
+        </choice>
+      </attribute>
+    </optional>
+    <ref name="SVG.AnimationAddtion.extra.attrib"/>
+  </define>
+  <!-- animate: Animate Element .......................... -->
+  <define name="SVG.animate.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.animate.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.animate.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="animate">
+    <element name="animate">
+      <ref name="attlist.animate"/>
+      <ref name="SVG.animate.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.animate.element -->
+  <define name="attlist.animate" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.AnimationEvents.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <ref name="SVG.Animation.attrib"/>
+    <ref name="SVG.AnimationAttribute.attrib"/>
+    <ref name="SVG.AnimationTiming.attrib"/>
+    <ref name="SVG.AnimationValue.attrib"/>
+    <ref name="SVG.AnimationAddtion.attrib"/>
+  </define>
+  <!-- end of SVG.animate.attlist -->
+  <!-- set: Set Element .................................. -->
+  <define name="SVG.set.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.set.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.set.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="set">
+    <element name="set">
+      <ref name="attlist.set"/>
+      <ref name="SVG.set.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.set.element -->
+  <define name="attlist.set" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.AnimationEvents.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <ref name="SVG.Animation.attrib"/>
+    <ref name="SVG.AnimationAttribute.attrib"/>
+    <ref name="SVG.AnimationTiming.attrib"/>
+    <optional>
+      <attribute name="to"/>
+    </optional>
+  </define>
+  <!-- end of SVG.set.attlist -->
+  <!-- animateMotion: Animate Motion Element ............. -->
+  <define name="SVG.animateMotion.extra.content">
+    <empty/>
+  </define>
+  <define name="SVG.animateMotion.content">
+    <zeroOrMore>
+      <ref name="SVG.Description.class"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="mpath"/>
+    </optional>
+    <ref name="SVG.animateMotion.extra.content"/>
+  </define>
+  <define name="animateMotion">
+    <element name="animateMotion">
+      <ref name="attlist.animateMotion"/>
+      <ref name="SVG.animateMotion.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.animateMotion.element -->
+  <define name="attlist.animateMotion" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.AnimationEvents.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <ref name="SVG.Animation.attrib"/>
+    <ref name="SVG.AnimationTiming.attrib"/>
+    <ref name="SVG.AnimationAddtion.attrib"/>
+    <optional>
+      <attribute name="calcMode" a:defaultValue="paced">
+        <choice>
+          <value>discrete</value>
+          <value>linear</value>
+          <value>paced</value>
+          <value>spline</value>
+        </choice>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="values"/>
+    </optional>
+    <optional>
+      <attribute name="keyTimes"/>
+    </optional>
+    <optional>
+      <attribute name="keySplines"/>
+    </optional>
+    <optional>
+      <attribute name="from"/>
+    </optional>
+    <optional>
+      <attribute name="to"/>
+    </optional>
+    <optional>
+      <attribute name="by"/>
+    </optional>
+    <optional>
+      <attribute name="path"/>
+    </optional>
+    <optional>
+      <attribute name="keyPoints"/>
+    </optional>
+    <optional>
+      <attribute name="rotate"/>
+    </optional>
+    <optional>
+      <attribute name="origin"/>
+    </optional>
+  </define>
+  <!-- end of SVG.animateMotion.attlist -->
+  <!-- animateColor: Animate Color Element ............... -->
+  <define name="SVG.animateColor.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.animateColor.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.animateColor.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="animateColor">
+    <element name="animateColor">
+      <ref name="attlist.animateColor"/>
+      <ref name="SVG.animateColor.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.animateColor.element -->
+  <define name="attlist.animateColor" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.AnimationEvents.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <ref name="SVG.Animation.attrib"/>
+    <ref name="SVG.AnimationAttribute.attrib"/>
+    <ref name="SVG.AnimationTiming.attrib"/>
+    <ref name="SVG.AnimationValue.attrib"/>
+    <ref name="SVG.AnimationAddtion.attrib"/>
+  </define>
+  <!-- end of SVG.animateColor.attlist -->
+  <!-- animateTransform: Animate Transform Element ....... -->
+  <define name="SVG.animateTransform.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.animateTransform.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.animateTransform.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="animateTransform">
+    <element name="animateTransform">
+      <ref name="attlist.animateTransform"/>
+      <ref name="SVG.animateTransform.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.animateTransform.element -->
+  <define name="attlist.animateTransform" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.AnimationEvents.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <ref name="SVG.Animation.attrib"/>
+    <ref name="SVG.AnimationAttribute.attrib"/>
+    <ref name="SVG.AnimationTiming.attrib"/>
+    <ref name="SVG.AnimationValue.attrib"/>
+    <ref name="SVG.AnimationAddtion.attrib"/>
+    <optional>
+      <attribute name="type" a:defaultValue="translate">
+        <choice>
+          <value>translate</value>
+          <value>scale</value>
+          <value>rotate</value>
+          <value>skewX</value>
+          <value>skewY</value>
+        </choice>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.animateTransform.attlist -->
+  <!-- mpath: Motion Path Element ........................ -->
+  <define name="SVG.mpath.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.mpath.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.mpath.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="mpath">
+    <element name="mpath">
+      <ref name="attlist.mpath"/>
+      <ref name="SVG.mpath.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.mpath.element -->
+  <define name="attlist.mpath" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.XLinkRequired.attrib"/>
+    <ref name="SVG.External.attrib"/>
+  </define>
+  <!-- end of SVG.mpath.attlist -->
+  <!-- end of svg-animation.mod -->
+  <!-- Font Module ................................................. -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Font Module ................................................... -->
+  <!--
+    file: svg-font.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-font.mod,v 1.4 2002/11/14 15:11:02 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 Font//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-font.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Font
+    
+       font, font-face, glyph, missing-glyph, hkern, vkern, font-face-src,
+       font-face-uri, font-face-format, font-face-name, definition-src
+    
+    This module declares markup to provide support for template.
+  -->
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.Font.class .................................... -->
+  <!-- SVG.Presentation.attrib ........................... -->
+  <!-- font: Font Element ................................ -->
+  <define name="SVG.font.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.font.content">
+    <zeroOrMore>
+      <ref name="SVG.Description.class"/>
+    </zeroOrMore>
+    <ref name="font-face"/>
+    <ref name="missing-glyph"/>
+    <zeroOrMore>
+      <choice>
+        <ref name="glyph"/>
+        <ref name="hkern"/>
+        <ref name="vkern"/>
+        <ref name="SVG.font.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="font">
+    <element name="font">
+      <ref name="attlist.font"/>
+      <ref name="SVG.font.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.font.element -->
+  <define name="attlist.font" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Presentation.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="horiz-origin-x">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="horiz-origin-y">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <attribute name="horiz-adv-x">
+      <ref name="Number.datatype"/>
+    </attribute>
+    <optional>
+      <attribute name="vert-origin-x">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="vert-origin-y">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="vert-adv-y">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.font.attlist -->
+  <!-- font-face: Font Face Element ...................... -->
+  <define name="SVG.font-face.extra.content">
+    <empty/>
+  </define>
+  <define name="SVG.font-face.content">
+    <zeroOrMore>
+      <ref name="SVG.Description.class"/>
+    </zeroOrMore>
+    <optional>
+      <ref name="font-face-src"/>
+    </optional>
+    <optional>
+      <ref name="definition-src"/>
+    </optional>
+    <ref name="SVG.font-face.extra.content"/>
+  </define>
+  <define name="font-face">
+    <element name="font-face">
+      <ref name="attlist.font-face"/>
+      <ref name="SVG.font-face.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.font-face.element -->
+  <define name="attlist.font-face" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <optional>
+      <attribute name="font-family"/>
+    </optional>
+    <optional>
+      <attribute name="font-style"/>
+    </optional>
+    <optional>
+      <attribute name="font-variant"/>
+    </optional>
+    <optional>
+      <attribute name="font-weight"/>
+    </optional>
+    <optional>
+      <attribute name="font-stretch"/>
+    </optional>
+    <optional>
+      <attribute name="font-size"/>
+    </optional>
+    <optional>
+      <attribute name="unicode-range"/>
+    </optional>
+    <optional>
+      <attribute name="units-per-em">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="panose-1"/>
+    </optional>
+    <optional>
+      <attribute name="stemv">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="stemh">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="slope">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="cap-height">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="x-height">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="accent-height">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="ascent">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="descent">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="widths"/>
+    </optional>
+    <optional>
+      <attribute name="bbox"/>
+    </optional>
+    <optional>
+      <attribute name="ideographic">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="alphabetic">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="mathematical">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="hanging">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="v-ideographic">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="v-alphabetic">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="v-mathematical">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="v-hanging">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="underline-position">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="underline-thickness">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="strikethrough-position">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="strikethrough-thickness">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="overline-position">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="overline-thickness">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.font-face.attlist -->
+  <!-- glyph: Glyph Element .............................. -->
+  <define name="SVG.glyph.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.glyph.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.Structure.class"/>
+        <ref name="SVG.Conditional.class"/>
+        <ref name="SVG.Image.class"/>
+        <ref name="SVG.Style.class"/>
+        <ref name="SVG.Shape.class"/>
+        <ref name="SVG.Text.class"/>
+        <ref name="SVG.Marker.class"/>
+        <ref name="SVG.ColorProfile.class"/>
+        <ref name="SVG.Gradient.class"/>
+        <ref name="SVG.Pattern.class"/>
+        <ref name="SVG.Clip.class"/>
+        <ref name="SVG.Mask.class"/>
+        <ref name="SVG.Filter.class"/>
+        <ref name="SVG.Cursor.class"/>
+        <ref name="SVG.Hyperlink.class"/>
+        <ref name="SVG.View.class"/>
+        <ref name="SVG.Script.class"/>
+        <ref name="SVG.Font.class"/>
+        <ref name="SVG.glyph.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="glyph">
+    <element name="glyph">
+      <ref name="attlist.glyph"/>
+      <ref name="SVG.glyph.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.glyph.element -->
+  <define name="attlist.glyph" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Presentation.attrib"/>
+    <optional>
+      <attribute name="unicode"/>
+    </optional>
+    <optional>
+      <attribute name="glyph-name"/>
+    </optional>
+    <optional>
+      <attribute name="d">
+        <ref name="PathData.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="orientation"/>
+    </optional>
+    <optional>
+      <attribute name="arabic-form"/>
+    </optional>
+    <optional>
+      <attribute name="lang">
+        <ref name="LanguageCodes.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="horiz-adv-x">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="vert-origin-x">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="vert-origin-y">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="vert-adv-y">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.glyph.attlist -->
+  <!-- missing-glyph: Missing Glyph Element .............. -->
+  <define name="SVG.missing-glyph.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.missing-glyph.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="SVG.Description.class"/>
+        <ref name="SVG.Animation.class"/>
+        <ref name="SVG.Structure.class"/>
+        <ref name="SVG.Conditional.class"/>
+        <ref name="SVG.Image.class"/>
+        <ref name="SVG.Style.class"/>
+        <ref name="SVG.Shape.class"/>
+        <ref name="SVG.Text.class"/>
+        <ref name="SVG.Marker.class"/>
+        <ref name="SVG.ColorProfile.class"/>
+        <ref name="SVG.Gradient.class"/>
+        <ref name="SVG.Pattern.class"/>
+        <ref name="SVG.Clip.class"/>
+        <ref name="SVG.Mask.class"/>
+        <ref name="SVG.Filter.class"/>
+        <ref name="SVG.Cursor.class"/>
+        <ref name="SVG.Hyperlink.class"/>
+        <ref name="SVG.View.class"/>
+        <ref name="SVG.Script.class"/>
+        <ref name="SVG.Font.class"/>
+        <ref name="SVG.missing-glyph.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="missing-glyph">
+    <element name="missing-glyph">
+      <ref name="attlist.missing-glyph"/>
+      <ref name="SVG.missing-glyph.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.missing-glyph.element -->
+  <define name="attlist.missing-glyph" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Presentation.attrib"/>
+    <optional>
+      <attribute name="d">
+        <ref name="PathData.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="horiz-adv-x">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="vert-origin-x">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="vert-origin-y">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="vert-adv-y">
+        <ref name="Number.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <!-- end of SVG.missing-glyph.attlist -->
+  <!-- hkern: Horizontal Kerning Element ................. -->
+  <define name="SVG.hkern.content">
+    <empty/>
+  </define>
+  <define name="hkern">
+    <element name="hkern">
+      <ref name="attlist.hkern"/>
+      <ref name="SVG.hkern.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.hkern.element -->
+  <define name="attlist.hkern" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <optional>
+      <attribute name="u1"/>
+    </optional>
+    <optional>
+      <attribute name="g1"/>
+    </optional>
+    <optional>
+      <attribute name="u2"/>
+    </optional>
+    <optional>
+      <attribute name="g2"/>
+    </optional>
+    <attribute name="k">
+      <ref name="Number.datatype"/>
+    </attribute>
+  </define>
+  <!-- end of SVG.hkern.attlist -->
+  <!-- vkern: Vertical Kerning Element ................... -->
+  <define name="SVG.vkern.content">
+    <empty/>
+  </define>
+  <define name="vkern">
+    <element name="vkern">
+      <ref name="attlist.vkern"/>
+      <ref name="SVG.vkern.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.vkern.element -->
+  <define name="attlist.vkern" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <optional>
+      <attribute name="u1"/>
+    </optional>
+    <optional>
+      <attribute name="g1"/>
+    </optional>
+    <optional>
+      <attribute name="u2"/>
+    </optional>
+    <optional>
+      <attribute name="g2"/>
+    </optional>
+    <attribute name="k">
+      <ref name="Number.datatype"/>
+    </attribute>
+  </define>
+  <!-- end of SVG.vkern.attlist -->
+  <!-- font-face-src: Font Face Source Element ........... -->
+  <define name="SVG.font-face-src.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.font-face-src.content">
+    <oneOrMore>
+      <choice>
+        <ref name="font-face-uri"/>
+        <ref name="font-face-name"/>
+        <ref name="SVG.font-face-src.extra.content"/>
+      </choice>
+    </oneOrMore>
+  </define>
+  <define name="font-face-src">
+    <element name="font-face-src">
+      <ref name="attlist.font-face-src"/>
+      <ref name="SVG.font-face-src.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.font-face-src.element -->
+  <define name="attlist.font-face-src" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+  </define>
+  <!-- end of SVG.font-face-src.attlist -->
+  <!-- font-face-uri: Font Face URI Element .............. -->
+  <define name="SVG.font-face-uri.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.font-face-uri.content">
+    <zeroOrMore>
+      <choice>
+        <ref name="font-face-format"/>
+        <ref name="SVG.font-face-uri.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="font-face-uri">
+    <element name="font-face-uri">
+      <ref name="attlist.font-face-uri"/>
+      <ref name="SVG.font-face-uri.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.font-face-uri.element -->
+  <define name="attlist.font-face-uri" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.XLinkRequired.attrib"/>
+  </define>
+  <!-- end of SVG.font-face-uri.attlist -->
+  <!-- font-face-format: Font Face Format Element ........ -->
+  <define name="SVG.font-face-format.content">
+    <empty/>
+  </define>
+  <define name="font-face-format">
+    <element name="font-face-format">
+      <ref name="attlist.font-face-format"/>
+      <ref name="SVG.font-face-format.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.font-face-format.element -->
+  <define name="attlist.font-face-format" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <optional>
+      <attribute name="string"/>
+    </optional>
+  </define>
+  <!-- end of SVG.font-face-format.attlist -->
+  <!-- font-face-name: Font Face Name Element ............ -->
+  <define name="SVG.font-face-name.content">
+    <empty/>
+  </define>
+  <define name="font-face-name">
+    <element name="font-face-name">
+      <ref name="attlist.font-face-name"/>
+      <ref name="SVG.font-face-name.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.font-face-name.element -->
+  <define name="attlist.font-face-name" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <optional>
+      <attribute name="name"/>
+    </optional>
+  </define>
+  <!-- end of SVG.font-face-name.attlist -->
+  <!-- definition-src: Definition Source Element ......... -->
+  <define name="SVG.definition-src.content">
+    <empty/>
+  </define>
+  <define name="definition-src">
+    <element name="definition-src">
+      <ref name="attlist.definition-src"/>
+      <ref name="SVG.definition-src.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.definition-src.element -->
+  <define name="attlist.definition-src" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.XLinkRequired.attrib"/>
+  </define>
+  <!-- end of SVG.definition-src.attlist -->
+  <!-- end of svg-font.mod -->
+  <!-- Extensibility Module ........................................ -->
+  <!-- ....................................................................... -->
+  <!-- SVG 1.1 Extensibility Module .......................................... -->
+  <!--
+    file: svg-extensibility.mod
+    
+    This is SVG, a language for describing two-dimensional graphics in XML.
+    Copyright 2001, 2002 W3C (MIT, INRIA, Keio), All Rights Reserved.
+    Revision: $Id: svg-extensibility.mod,v 1.4 2002/11/14 15:11:02 fujisawa Exp $
+    
+    This DTD module is identified by the PUBLIC and SYSTEM identifiers:
+    
+       PUBLIC "-//W3C//ELEMENTS SVG 1.1 Extensibility//EN"
+       SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg-extensibility.mod"
+    
+    .......................................................................
+  -->
+  <!--
+    Extensibility
+    
+       foreignObject
+    
+    This module declares markup to provide support for extensibility.
+  -->
+  <!-- Qualified Names (Default) ......................... -->
+  <!-- Attribute Collections (Default) ................... -->
+  <!-- SVG.Extensibility.class ........................... -->
+  <!-- SVG.Presentation.attrib ........................... -->
+  <!-- foreignObject: Foreign Object Element ............. -->
+  <define name="SVG.foreignObject.extra.content">
+    <notAllowed/>
+  </define>
+  <define name="SVG.foreignObject.content">
+    <zeroOrMore>
+      <choice>
+        <text/>
+        <ref name="SVG.foreignObject.extra.content"/>
+      </choice>
+    </zeroOrMore>
+  </define>
+  <define name="foreignObject">
+    <element name="foreignObject">
+      <ref name="attlist.foreignObject"/>
+      <ref name="SVG.foreignObject.content"/>
+    </element>
+  </define>
+  <!-- end of SVG.foreignObject.element -->
+  <define name="attlist.foreignObject" combine="interleave">
+    <ref name="SVG.Core.attrib"/>
+    <ref name="SVG.Conditional.attrib"/>
+    <ref name="SVG.Style.attrib"/>
+    <ref name="SVG.Presentation.attrib"/>
+    <ref name="SVG.GraphicalEvents.attrib"/>
+    <ref name="SVG.External.attrib"/>
+    <optional>
+      <attribute name="x">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <optional>
+      <attribute name="y">
+        <ref name="Coordinate.datatype"/>
+      </attribute>
+    </optional>
+    <attribute name="width">
+      <ref name="Length.datatype"/>
+    </attribute>
+    <attribute name="height">
+      <ref name="Length.datatype"/>
+    </attribute>
+    <optional>
+      <attribute name="transform">
+        <ref name="TransformList.datatype"/>
+      </attribute>
+    </optional>
+  </define>
+  <start>
+    <choice>
+      <ref name="switch"/>
+      <ref name="altGlyphDef"/>
+      <ref name="feDisplacementMap"/>
+      <ref name="font-face-name"/>
+      <ref name="altGlyph"/>
+      <ref name="feColorMatrix"/>
+      <ref name="svgpattern"/>
+      <ref name="use"/>
+      <ref name="feSpecularLighting"/>
+      <ref name="rect"/>
+      <ref name="cursor"/>
+      <ref name="line"/>
+      <ref name="feFlood"/>
+      <ref name="title"/>
+      <ref name="script"/>
+      <ref name="font-face-format"/>
+      <ref name="desc"/>
+      <ref name="defs"/>
+      <ref name="vkern"/>
+      <ref name="tspan"/>
+      <ref name="filter"/>
+      <ref name="symbol"/>
+      <ref name="polygon"/>
+      <ref name="feMergeNode"/>
+      <ref name="marker"/>
+      <ref name="feImage"/>
+      <ref name="feComposite"/>
+      <ref name="set"/>
+      <ref name="animateMotion"/>
+      <ref name="feBlend"/>
+      <ref name="radialGradient"/>
+      <ref name="color-profile"/>
+      <ref name="feConvolveMatrix"/>
+      <ref name="altGlyphItem"/>
+      <ref name="linearGradient"/>
+      <ref name="g"/>
+      <ref name="circle"/>
+      <ref name="ellipse"/>
+      <ref name="feFuncR"/>
+      <ref name="a"/>
+      <ref name="style"/>
+      <ref name="path"/>
+      <ref name="feMorphology"/>
+      <ref name="animate"/>
+      <ref name="tref"/>
+      <ref name="feFuncG"/>
+      <ref name="missing-glyph"/>
+      <ref name="feFuncB"/>
+      <ref name="feFuncA"/>
+      <ref name="mask"/>
+      <ref name="font-face"/>
+      <ref name="polyline"/>
+      <ref name="textPath"/>
+      <ref name="foreignObject"/>
+      <ref name="feTurbulence"/>
+      <ref name="svg"/>
+      <ref name="feTile"/>
+      <ref name="font"/>
+      <ref name="fePointLight"/>
+      <ref name="font-face-uri"/>
+      <ref name="feComponentTransfer"/>
+      <ref name="feOffset"/>
+      <ref name="stop"/>
+      <ref name="image"/>
+      <ref name="view"/>
+      <ref name="text"/>
+      <ref name="animateTransform"/>
+      <ref name="glyphRef"/>
+      <ref name="definition-src"/>
+      <ref name="animateColor"/>
+      <ref name="font-face-src"/>
+      <ref name="feMerge"/>
+      <ref name="clipPath"/>
+      <ref name="feDiffuseLighting"/>
+      <ref name="glyph"/>
+      <ref name="feSpotLight"/>
+      <ref name="feGaussianBlur"/>
+      <ref name="metadata"/>
+      <ref name="hkern"/>
+      <ref name="mpath"/>
+      <ref name="feDistantLight"/>
+    </choice>
+  </start>
+</grammar>
+<!-- end of SVG.foreignObject.attlist -->
+<!-- end of svg-extensibility.mod -->
+<!-- end of SVG 1.1 DTD .................................................... -->
+<!-- ....................................................................... -->


### PR DESCRIPTION
tei-c.org is down, so building the schema fails because of the hard-coded url for `svg11.rng`. 
In this PR it is replaced with the "official" rng from w3c. 