### PR TITLE
Add num.log and numbase.log to att.mensur.log

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1872,6 +1872,22 @@
       <memberOf key="att.duration.ratio"/>
       <memberOf key="att.mensural.shared"/>
     </classes>
+    <attList>
+      <attDef ident="num.log" usage="opt">
+        <desc xml:lang="en">Along with numbase.log, describes logical duration as a ratio. num.log is the first value in the
+          ratio, while numbase.log is the second. The logical duration can be provided when it differs from the visual duration as given in num.</desc>
+        <datatype>
+          <rng:data type="positiveInteger"/>
+        </datatype>
+      </attDef>
+      <attDef ident="numbase.log" usage="opt">
+        <desc xml:lang="en">Along with num.log, describes logical duration as a ratio. num.log is the first value in the
+          ratio, while numbase.log is the second. The logical duration can be provided when it differs from the visual duration as given in numbase.</desc>
+        <datatype>
+          <rng:data type="positiveInteger"/>
+        </datatype>
+      </attDef>
+    </attList>
   </classSpec>
   <classSpec ident="att.meterConformance" module="MEI.shared" type="atts">
     <desc xml:lang="en">Attributes that provide information about a structure’s conformance to the prevailing


### PR DESCRIPTION
This PR add two attributes `num.log` and `numbase.log` to `mensur` that can be used to override the visual values given in `num` and `numbase`. This relates to the discussion in #686 and with @pe-ro, @kepper and @fujinaga 