### PR TITLE
Add documentation of manifestation singleton

### DIFF
--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -1310,7 +1310,7 @@
                   </specList>
                </p>
                <p>The content of the <gi scheme="MEI">item</gi> is quite similar to <gi scheme="MEI">manifestation</gi> with a few omissions:</p>
-               <p>Please note that in case of handwritten sources the <att>singleton</att> attribute is available for the <gi scheme="MEI">manifestation</gi> element to indicate a unique physical object, precisely, manifestation singleton are sources <quote>produced as unique objects, with no siblings <hi rend="italic">intended</hi> in the course of their production.</quote> (<ref target="https://repository.ifla.org/handle/123456789/659">FRBRoo</ref>, p. 57). These cases result in <gi scheme="MEI">item</gi> and <gi scheme="MEI">manifestation</gi> being essentially the same.</p>
+               <p>Please note that in case of handwritten sources the <att>singleton</att> attribute is available for the <gi scheme="MEI">manifestation</gi> element to indicate a unique physical object, precisely, manifestation singleton are sources <quote>produced as unique objects, with no siblings intended in the course of their production.</quote> (<ref target="https://repository.ifla.org/handle/123456789/659">Definition of FRBRoo</ref>, p. 57). These cases result in <gi scheme="MEI">item</gi> and <gi scheme="MEI">manifestation</gi> being essentially the same.</p>
                <p>
                   <specList>
                      <specDesc key="head"/>

--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -1310,7 +1310,7 @@
                   </specList>
                </p>
                <p>The content of the <gi scheme="MEI">item</gi> is quite similar to <gi scheme="MEI">manifestation</gi> with a few omissions:</p>
-               <p>Please note that in case of handwritten sources the <att>singleton</att> attribute (inspired by <ref target="https://repository.ifla.org/handle/123456789/659">FRBRoo</ref>) is available in <gi scheme="MEI">manifestation</gi> to indicate a unique physical object, because <gi scheme="MEI">item</gi> and <gi scheme="MEI">manifestation</gi> are essentially the same.</p>
+               <p>Please note that in case of handwritten sources the <att>singleton</att> attribute is available for the <gi scheme="MEI">manifestation</gi> element to indicate a unique physical object, precisely, manifestation singleton are sources <quote>produced as unique objects, with no siblings <hi rend="italic">intended</hi> in the course of their production.</quote> (<ref target="https://repository.ifla.org/handle/123456789/659">FRBRoo</ref>, p. 57). These cases result in <gi scheme="MEI">item</gi> and <gi scheme="MEI">manifestation</gi> being essentially the same.</p>
                <p>
                   <specList>
                      <specDesc key="head"/>

--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -1310,6 +1310,7 @@
                   </specList>
                </p>
                <p>The content of the <gi scheme="MEI">item</gi> is quite similar to <gi scheme="MEI">manifestation</gi> with a few omissions:</p>
+               <p>Please note that in case of handwritten sources the <att>singleton</att> attribute (inspired by <ref target="https://repository.ifla.org/handle/123456789/659">FRBRoo</ref>) is available in <gi scheme="MEI">manifestation</gi> to indicate a unique physical object, because <gi scheme="MEI">item</gi> and <gi scheme="MEI">manifestation</gi> are essentially the same.</p>
                <p>
                   <specList>
                      <specDesc key="head"/>

--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -761,7 +761,8 @@
                         <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/FRBR/FRBR-sample082.txt" parse="text"/></egXML>
                      </figure>
                   </p>
-                  <p>The itemList element provides functionality similar to that of expressionList; that is, it can be used to group descriptions of individual items (exemplars) of the parent source. Just like <gi scheme="MEI">expressionList</gi>, which can only hold <gi scheme="MEI">expression</gi> sub-components, <gi scheme="MEI">itemList</gi> may only contain <gi scheme="MEI">item</gi> elements.</p>
+                  <p>The <gi scheme="MEI">manifestationList</gi> and <gi scheme="MEI">manifestation</gi> elements are discussed in section <ptr target="#msdesc"/>.</p>
+                  <p>The <gi scheme="MEI">itemList</gi> element provides functionality similar to that of <gi scheme="MEI">expressionList</gi>; that is, it can be used to group descriptions of individual items (exemplars) of the parent source. Just like <gi scheme="MEI">expressionList</gi>, which can only hold <gi scheme="MEI">expression</gi> sub-components, <gi scheme="MEI">itemList</gi> may only contain <gi scheme="MEI">item</gi> elements.</p>
                   <p>
                      <specList>
                         <specDesc key="itemList"/>

--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -1292,6 +1292,7 @@
                      <specDesc key="titleStmt"/>
                      <specDesc key="editionStmt"/>
                      <specDesc key="pubStmt"/>
+                     <specDesc key="availability"/>
                      <specDesc key="physDesc"/>
                      <specDesc key="physLoc"/>
                      <specDesc key="seriesStmt"/>

--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -703,7 +703,7 @@
             <div xml:id="FRBR" type="div2">
                <head>Functional Requirements for Bibliographic Records (FRBR)</head>
                <p>MEI header information may refer to different levels of description of the encoded work: Some information may apply the work in all its various forms and realizations, <abbr>e.g.</abbr>, the name of its composer. Other information may describe a certain version of the work, or a source such as the printed first edition, or only a single copy of that source. Core MEI limits the header information to two such levels of description: work and source, respectively.</p>
-               <p>However, when the FRBR module is available more detailed descriptions are possible. With certain limitations, mainly due to the musical nature of the works encoded in MEI, the FRBR module adapts the <ref target="http://www.ifla.org/publications/functional-requirements-for-bibliographic-records">Functional Requirements for Bibliographic Records (FRBR)</ref> as recommended by the International Federation of Library Associations and Institutions (IFLA).</p>
+               <p>However, when the FRBR module is available more detailed descriptions are possible. With certain limitations, mainly due to the musical nature of the works encoded in MEI, the FRBR module adapts the <ref target="https://repository.ifla.org/handle/123456789/811">Functional Requirements for Bibliographic Records (FRBR)</ref> as recommended by the International Federation of Library Associations and Institutions (IFLA).</p>
                <p>The IFLA’s FRBR model distinguishes four levels of abstraction, or entities:</p>
                <list type="gloss">
                   <label>Work</label>

--- a/source/modules/MEI.frbr.xml
+++ b/source/modules/MEI.frbr.xml
@@ -376,9 +376,11 @@
     </constraintSpec>
     <attList>
       <attDef ident="singleton">
+        <desc xml:lang="en">Indicates the manifestation is a unique physical object</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
+        <remarks xml:lang="en"><p>Manifestation singleton encompasses: manuscripts, preperatory sketches and final clean drafts.</p></remarks>
       </attDef>
     </attList>
   </elementSpec>

--- a/source/modules/MEI.frbr.xml
+++ b/source/modules/MEI.frbr.xml
@@ -388,7 +388,7 @@
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
         <remarks xml:lang="en"><p>This attribute is inspired by the <ref target="https://repository.ifla.org/handle/123456789/659">FRBRoo</ref> concept of manifestation singleton.</p></remarks>
-        <remarks xml:lang="en"><p>Manifestation singleton encompasses: manuscripts, preperatory sketches and final clean drafts.</p></remarks>
+        <remarks xml:lang="en"><p>Manifestation singleton encompasses: manuscripts, preperatory sketches, and final clean drafts.</p></remarks>
       </attDef>
     </attList>
   </elementSpec>

--- a/source/modules/MEI.frbr.xml
+++ b/source/modules/MEI.frbr.xml
@@ -387,6 +387,7 @@
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
+        <remarks xml:lang="en"><p>This attribute is inspired by the <ref target="https://repository.ifla.org/handle/123456789/659">FRBRoo</ref> concept of manifestation singleton.</p></remarks>
         <remarks xml:lang="en"><p>Manifestation singleton encompasses: manuscripts, preperatory sketches and final clean drafts.</p></remarks>
       </attDef>
     </attList>

--- a/source/modules/MEI.frbr.xml
+++ b/source/modules/MEI.frbr.xml
@@ -383,7 +383,7 @@
     </constraintSpec>
     <attList>
       <attDef ident="singleton">
-        <desc xml:lang="en">Indicates the manifestation is a unique physical object</desc>
+        <desc xml:lang="en">Indicates the manifestation is a unique physical object.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>

--- a/source/modules/MEI.frbr.xml
+++ b/source/modules/MEI.frbr.xml
@@ -377,7 +377,7 @@
     <constraintSpec ident="check_singleton_availability" scheme="schematron">
       <constraint>
         <sch:rule context="mei:manifestation[@singleton eq 'false'] | mei:manifestation[not(@singleton)]">
-          <sch:report test="mei:availability">Availability is only permitted when @singleton equals "true".</sch:report>
+          <sch:assert test="not(mei:availability)">Availability is only permitted when @singleton equals "true".</sch:assert>
         </sch:rule>
       </constraint>
     </constraintSpec>

--- a/source/modules/MEI.frbr.xml
+++ b/source/modules/MEI.frbr.xml
@@ -377,7 +377,7 @@
     <constraintSpec ident="check_singleton_availability" scheme="schematron">
       <constraint>
         <sch:rule context="mei:manifestation[@singleton eq 'false'] | mei:manifestation[not(@singleton)]">
-          <sch:assert test="mei:availability">Availability is only permitted when @singleton equals "true".</sch:assert>
+          <sch:report test="mei:availability">Availability is only permitted when @singleton equals "true".</sch:report>
         </sch:rule>
       </constraint>
     </constraintSpec>

--- a/source/modules/MEI.frbr.xml
+++ b/source/modules/MEI.frbr.xml
@@ -374,6 +374,13 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
+    <constraintSpec ident="check_singleton_availability" scheme="schematron">
+      <constraint>
+        <sch:rule context="mei:manifestation[@singleton eq 'false'] | mei:manifestation[not(@singleton)]">
+          <sch:assert test="mei:availability">Availability is only permitted when @singleton equals "true".</sch:assert>
+        </sch:rule>
+      </constraint>
+    </constraintSpec>
     <attList>
       <attDef ident="singleton">
         <desc xml:lang="en">Indicates the manifestation is a unique physical object</desc>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -43,6 +43,9 @@
       <rng:optional>
         <rng:ref name="pubStmt"/>
       </rng:optional>
+      <rng:optional>
+        <rng:ref name="availability"/>
+      </rng:optional>
       <rng:zeroOrMore>
         <rng:ref name="physDesc"/>
       </rng:zeroOrMore>


### PR DESCRIPTION
- add documentation of `manifestation/@singleton` at Specs and Guidelines
- adding `<availability>` to `<manifestation>` because it is available in `<item>` and it is needed in case of `@singleton="true"`
- restricting `<availability>` to this case

Closes #906 

Co-authored-by: @doerners 
Co-authored-by: @mss2221 