### PR TITLE
Fix description for pedal style

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -991,6 +991,7 @@
       rendition.</desc>
     <attList>
       <attDef ident="pedal.style" usage="opt">
+        <desc xml:lang="en">Determines whether piano pedal marks should be rendered as lines or as terms.</desc>
         <datatype>
           <rng:ref name="data.PEDALSTYLE"/>
         </datatype>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1347,6 +1347,7 @@
     </classes>
     <attList>
       <attDef ident="form" usage="opt">
+        <desc xml:lang="en">Determines whether piano pedal marks should be rendered as lines or as terms.</desc>
         <datatype>
           <rng:ref name="data.PEDALSTYLE"/>
         </datatype>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3062,7 +3062,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.PEDALSTYLE" module="MEI" type="dt">
-    <desc xml:lang="en">Determines whether piano pedal marks should be rendered as lines or as terms.</desc>
+    <desc xml:lang="en">Styling of piano pedal marks.</desc>
     <content>
       <valList type="closed">
         <valItem ident="line">


### PR DESCRIPTION
I accidentally moved the attribute description to the new data type. This PR clears this up.