### PR TITLE
Fix model class members display in guidelines

### DIFF
--- a/utils/guidelines_xslt/odd2html/generateWebsite.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsite.xsl
@@ -712,6 +712,19 @@
     </xsl:template>
     
     
+    <xsl:function name="tools:getMemberOrder" as="xs:string">
+        <xsl:param name="ident" as="xs:string"/>
+        <xsl:variable name="prefix" as="xs:string">
+            <xsl:choose>
+                <xsl:when test="$ident = $elements/@ident">1_</xsl:when>
+                <xsl:when test="starts-with($ident,'model.')">2_</xsl:when>
+                <xsl:when test="starts-with($ident,'att.')">3_</xsl:when>
+                <xsl:otherwise>5_</xsl:otherwise>
+            </xsl:choose>
+        </xsl:variable>
+        <xsl:value-of select="$prefix || $ident"/>
+    </xsl:function>
+    
     <xd:doc>
         <xd:desc>
             <xd:p>Generates a tab for compact display, i.e. only labels (attributes) / links (everything else)</xd:p>
@@ -734,7 +747,16 @@
                         <span class="textualContent" title="textual content">textual content, </span>
                     </xsl:if>
                     
-                    <xsl:for-each select="$div//item/link/node()"><xsl:sort select="text()"/><xsl:if test="position() gt 1">, </xsl:if><xsl:copy>
+                    <xsl:variable name="deduplicated" as="node()*">
+                        <xsl:variable name="uniqueIdents" select="distinct-values($div//item/link/node()/text())" as="xs:string*"/>
+                        <xsl:for-each select="$uniqueIdents">
+                            <xsl:sort select="tools:getMemberOrder(.)"/>
+                            <xsl:variable name="currentIdent" select="." as="xs:string"/>
+                            <xsl:sequence select="($div//item/link/node()[text() = $currentIdent])[1]"/>
+                        </xsl:for-each>
+                    </xsl:variable>
+                    
+                    <xsl:for-each select="$deduplicated"><xsl:if test="position() gt 1">, </xsl:if><xsl:copy>
                             <xsl:apply-templates select="@*" mode="get.website"/>
                             <xsl:attribute name="title" select="normalize-space(string-join(ancestor::item[1]/desc//text(),' '))"/>
                             <xsl:apply-templates select="node()" mode="get.website"/>

--- a/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
@@ -185,10 +185,11 @@
                     </xsl:for-each>
                 </xsl:variable>-->
                 <xsl:variable name="members.by.module" as="node()*">
-                    <xsl:for-each select="distinct-values($members/self::tei:elementSpec/@module)">
+                    <xsl:for-each select="distinct-values($members//@module)">
                         <xsl:sort select="." data-type="text"/>
                         <xsl:variable name="current.module" select="." as="xs:string"/>
                         <xsl:variable name="relevant.element.names" select="distinct-values($members/self::tei:elementSpec[@module = $current.module]/@ident)" as="xs:string*"/>
+                        <xsl:variable name="relevant.class.names" select="distinct-values($members/self::tei:classSpec[@type='model'][@module = $current.module]/@ident)" as="xs:string*"/>
                         
                         <xsl:variable name="ident" select="$current.module" as="xs:string"/>
                         <xsl:variable name="desc" select="normalize-space(string-join($mei.source//tei:moduleSpec[@ident = $current.module]/tei:desc/text(),' '))" as="xs:string"/>
@@ -206,12 +207,20 @@
                             </xsl:for-each>
                         </xsl:variable>-->
                         <xsl:variable name="content" as="node()*">
-                            <xsl:for-each select="$relevant.element.names">
+                            <xsl:for-each select="distinct-values($relevant.element.names)">
                                 <xsl:sort select="." data-type="text"/>
                                 <xsl:variable name="current.elem" select="." as="xs:string"/>
                                 <item class="element" ident="{$current.elem}" module="{$elements/self::tei:elementSpec[@ident = $current.elem]/@module}">
                                     <link><a class="{tools:getLinkClasses($current.elem)}" href="#{$current.elem}"><xsl:value-of select="$current.elem"/></a></link>
                                     <desc><xsl:apply-templates select="$elements/self::tei:elementSpec[@ident = $current.elem]/tei:desc" mode="guidelines"/></desc>
+                                </item>
+                            </xsl:for-each>
+                            <xsl:for-each select="$relevant.class.names">
+                                <xsl:sort select="." data-type="text"/>
+                                <xsl:variable name="current.class" select="." as="xs:string"/>
+                                <item class="modelClass" ident="{$current.class}" module="{$current.module}">
+                                    <link><a class="{tools:getLinkClasses($current.class)}" href="#{$current.class}"><xsl:value-of select="$current.class"/></a></link>
+                                    <desc><xsl:apply-templates select="$model.classes/self::tei:classSpec[@ident = $current.class]/tei:desc" mode="guidelines"/></desc>
                                 </item>
                             </xsl:for-each>
                         </xsl:variable>


### PR DESCRIPTION
this fixes #988, plus some other display issues (duplicate elements in _containedBy_ at https://music-encoding.org/guidelines/dev/elements/dot.html for instance)