### PR TITLE
BREAKING(MEI.shared): Remove text.dist and add specific alternatives

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -921,6 +921,12 @@
   <classSpec ident="att.distances" module="MEI.shared" type="atts">
     <desc xml:lang="en">Attributes that describe distance from the staff.</desc>
     <attList>
+      <attDef ident="dir.dist" usage="opt">
+        <desc xml:lang="en">Records the default distance from the staff for directives.</desc>
+        <datatype>
+          <rng:ref name="data.MEASUREMENTSIGNED"/>
+        </datatype>
+      </attDef>
       <attDef ident="dynam.dist" usage="opt">
         <desc xml:lang="en">Records the default distance from the staff for dynamic marks.</desc>
         <datatype>
@@ -934,8 +940,14 @@
           <rng:ref name="data.MEASUREMENTSIGNED"/>
         </datatype>
       </attDef>
-      <attDef ident="text.dist" usage="opt">
-        <desc xml:lang="en">Determines how far from the staff to render text elements.</desc>
+      <attDef ident="reh.dist" usage="opt">
+        <desc xml:lang="en">Records the default distance from the staff for rehearsal marks.</desc>
+        <datatype>
+          <rng:ref name="data.MEASUREMENTSIGNED"/>
+        </datatype>
+      </attDef>
+      <attDef ident="tempo.dist" usage="opt">
+        <desc xml:lang="en">Records the default distance from the staff for tempo marks.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTSIGNED"/>
         </datatype>


### PR DESCRIPTION
This PR removes `@text.dist` from `att.distances` and add the more specific attributes `@dir.dist`, `@tempo.dist`, and `@reh.dist`.
Closes #439