### PR TITLE
Fix(docs): Fix issue 120 (guidelines repo)

### DIFF
--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -306,7 +306,7 @@
                         </figure>
                      </p>
                   </div>
-                  <div xml:id="headerPhysicalDescription" type="div4">
+                  <div xml:id="headerFileExtent" type="div4">
                      <head>Extent of the File</head>
                      <p>The third component of the fileDesc is a description of the physical qualities of the file. The <gi scheme="MEI">extent</gi> element is provided for this purpose.</p>
                      <p>

--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -307,7 +307,7 @@
                      </p>
                   </div>
                   <div xml:id="headerPhysicalDescription" type="div4">
-                     <head>Physical Description of the File</head>
+                     <head>Extent of the File</head>
                      <p>The third component of the fileDesc is a description of the physical qualities of the file. The <gi scheme="MEI">extent</gi> element is provided for this purpose.</p>
                      <p>
                         <specList>

--- a/source/examples/header/header-sample031.txt
+++ b/source/examples/header/header-sample031.txt
@@ -1,7 +1,9 @@
-<physDesc>
-   <extent>between 1 MB and 2 MB</extent>
-   <extent>4.2 MiB</extent>
-   <extent>4532 Mbytes</extent>
-   <extent>3200 sentences</extent>
-   <extent>5 90-mm high density diskettes</extent>
-</physDesc>
+<extent>between 1 MB and 2 MB</extent>
+<!-- or -->
+<extent>4.2 MiB</extent>
+<!-- or -->
+<extent>4532 Mbytes</extent>
+<!-- or -->
+<extent>3200 sentences</extent>
+<!-- or -->
+<extent>5 90-mm high density diskettes</extent>


### PR DESCRIPTION
This PR fixes music-encoding/guidelines#120

- Renaming guidelines section 3.4.1.2 to prevent misunderstanding
- update example (invalid encoding)

The example tried to offer a list of possible encodings, but the wrapping element is not allowed for this case. Trying to keep the intention, I just deleted the wrapper and added comments to clarify that the encoded examples are substitutable.