### PR TITLE
link moduleFacet to module description

### DIFF
--- a/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
@@ -47,10 +47,11 @@
     </xd:doc>
     <xsl:function name="tools:getModuleFacet" as="node()">
         <xsl:param name="object" as="node()"/>
+        <xsl:variable name="facetId" select="$object/@module" as="xs:string"/>
         <div class="facet module">
             <div class="label">Module</div>
             <div class="statement text">
-                <xsl:value-of select="$object/@module"/>
+                <a href="../modules/{$facetId}.html"><xsl:value-of select="$facetId"/></a>
             </div>
         </div>
     </xsl:function>


### PR DESCRIPTION
This commit adds an HTML link to the module facet in the specs, e.g. in an element's description