### PR TITLE
Update pr-labeler.yml

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'music-encoding'
     steps:
-    - uses: actions/labeler@v3
+    - uses: actions/labeler@v4
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true


### PR DESCRIPTION
update labeler action to v4 that builds on the new actions core; to hopefully fix the Warning that node 12 is being deprecated in GithubActions