### PR TITLE
Feat(ci): Add dependabot.yml for gh actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    labels:
+      - 'gh actions dependencies'


### PR DESCRIPTION
This PR adds a dependabot yml file to the repo to get notified automatically about updates of the gh actions versions.