### PR TITLE
Add clarification for GG clef in data.CLEFSHAPE

### DIFF
--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -541,7 +541,9 @@
           <desc xml:lang="en">G clef (Unicode 1D11E).</desc>
         </valItem>
         <valItem ident="GG">
-          <desc xml:lang="en">Double G clef.</desc>
+          <desc xml:lang="en">Double G clef. Sounds one octave lower than G clef. 
+            As this clef is usually not written with an "8" below the clef, do not combine with 
+            <att>dis</att>/<att>dis.place</att>/<att>clef.dis</att>/<att>clef.dis.place</att>.</desc>
         </valItem>
         <valItem ident="F">
           <desc xml:lang="en">F clef (Unicode 1D122).</desc>


### PR DESCRIPTION
Sibmei so far output GG clefs as `<clef shape="GG" dis="8" dis.place="below"/>`, but in my understanding, `GG` is already transposing by itself without the `dis*` attributes. Before changing that in Sibmei, I'd like to make sure this is agreed upon and while I'm at it, document it for anybody else who wonders.

I carefully phrased "As this clef is usually not written with an "8" below" because should there be the odd and unlikely case of a `GG` clef with an 8 written below, then the `dis*` attributes would of course be appropriate.  But shall we open the can of worms if those attributes are visual or gestural?  And there are odd uses, like Carl Maria von Weber apparently writes them for flutes, oboes and some other instruments I wouldn't expect [here](https://www.loc.gov/resource/ihas.200154550.0/?sp=10&st=image):

![grafik](https://user-images.githubusercontent.com/1147152/198389015-d85c05e6-fc9b-4a01-af10-8b6ef93ac5d6.png)
