### PR TITLE
Bring facs description in line with TEI

### DIFF
--- a/source/modules/MEI.facsimile.xml
+++ b/source/modules/MEI.facsimile.xml
@@ -11,9 +11,9 @@
     <desc xml:lang="en">Attributes that associate a feature corresponding with all or part of an image.</desc>
     <attList>
       <attDef ident="facs" usage="opt">
-        <desc xml:lang="en">Permits the current element to reference a facsimile surface or image zone which
-          corresponds to it.</desc>
-        <datatype maxOccurs="unbounded">
+        <gloss versionDate="2022-10-18" xml:lang="en">facsimile</gloss>
+        <desc versionDate="2022-10-18" xml:lang="en">points to one or more images, portions of an image, or surfaces which correspond to the current element.</desc>
+        <datatype minOccurs="1" maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
         </datatype>
         <constraintSpec ident="check_facsTarget" scheme="isoschematron">

--- a/source/modules/MEI.facsimile.xml
+++ b/source/modules/MEI.facsimile.xml
@@ -12,7 +12,7 @@
     <attList>
       <attDef ident="facs" usage="opt">
         <gloss versionDate="2022-10-18" xml:lang="en">facsimile</gloss>
-        <desc versionDate="2022-10-18" xml:lang="en">points to one or more images, portions of an image, or surfaces which correspond to the current element.</desc>
+        <desc versionDate="2022-10-18" xml:lang="en">Points to one or more images, portions of an image, or surfaces which correspond to the current element.</desc>
         <datatype minOccurs="1" maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
         </datatype>

--- a/source/modules/MEI.facsimile.xml
+++ b/source/modules/MEI.facsimile.xml
@@ -93,7 +93,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="zone" module="MEI.facsimile">
-    <desc xml:lang="en">Defines an area of interest within a surface or graphic file.</desc>
+    <desc xml:lang="en">Defines an area of interest within a <gi scheme="MEI">surface</gi> or graphic file.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.coordinated"/>


### PR DESCRIPTION
This PR brings the description of `@facs` in line with the TEI.
Also a link to the `surface` element has been added.