### PR TITLE
Replace rng:empty with tei:empty

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -1255,7 +1255,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The modern arpeggiation symbol is a vertical wavy line preceding the chord. When the notes
@@ -1368,7 +1368,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="beamspan_start-_and_end-type_attributes_required" scheme="isoschematron">
       <constraint>
@@ -1403,7 +1403,7 @@
       <memberOf key="model.eventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p> <gi scheme="MEI">beatRpt</gi> may also be used in guitar or rhythm parts to indicate where
@@ -1425,7 +1425,7 @@
       <memberOf key="model.controlEventLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="bend_start-_and_end-type_attributes_required" scheme="isoschematron">
       <constraint>
@@ -1491,7 +1491,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="breath_start-type_attributes_required" scheme="isoschematron">
       <constraint>
@@ -1547,7 +1547,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="fermata_start-type_attributes_required" scheme="isoschematron">
       <constraint>
@@ -1702,7 +1702,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="hairpin_start-_and_end-type_attributes_required" scheme="isoschematron">
       <constraint>
@@ -1740,7 +1740,7 @@
       <memberOf key="model.eventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="harpPedal" module="MEI.cmn">
@@ -1756,7 +1756,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="harpPedal_start-type_attributes_required" scheme="isoschematron">
       <constraint>
@@ -1869,7 +1869,7 @@
       <memberOf key="model.meterSigLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="meterSigGrp" module="MEI.cmn">
@@ -1939,7 +1939,7 @@
       <memberOf key="model.eventLike.measureFilling"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>Automatically-generated numbering of consecutive measures of rest may be controlled via the
@@ -1960,7 +1960,7 @@
       <memberOf key="model.eventLike.measureFilling"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The automated numbering of consecutive measures of rest may be controlled via the
@@ -1982,7 +1982,7 @@
       <memberOf key="model.eventLike.measureFilling"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="mSpace" module="MEI.cmn">
@@ -1998,7 +1998,7 @@
       <memberOf key="model.eventLike.measureFilling"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The automated numbering of consecutive measures of space may be controlled via the
@@ -2020,7 +2020,7 @@
       <memberOf key="model.eventLike.measureFilling"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <!--<remarks xml:lang="en"><p>The num attribute can used to store a number to be rendered along with
         the note. See Read, p. 102-105.</p></remarks>-->
@@ -2038,7 +2038,7 @@
       <memberOf key="model.eventLike.measureFilling"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>In modern publishing practice, repeats of more than two measures should be written out
@@ -2221,7 +2221,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="pedal_start-type_attributes_required" scheme="isoschematron">
       <constraint>
@@ -2421,7 +2421,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="tupletSpan_start-_and_end-type_attributes_required"
       scheme="isoschematron">

--- a/source/modules/MEI.cmnOrnaments.xml
+++ b/source/modules/MEI.cmnOrnaments.xml
@@ -147,7 +147,7 @@
       <memberOf key="model.ornamentLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="mordent_start-type_attributes_required" scheme="isoschematron">
       <constraint>
@@ -176,7 +176,7 @@
       <memberOf key="model.ornamentLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="trill_start-type_attributes_required" scheme="isoschematron">
       <constraint>
@@ -210,7 +210,7 @@
       <memberOf key="model.ornamentLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="turn_start-type_attributes_required" scheme="isoschematron">
       <constraint>

--- a/source/modules/MEI.edittrans.xml
+++ b/source/modules/MEI.edittrans.xml
@@ -537,7 +537,7 @@
       <memberOf key="model.transcriptionLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>When material is omitted because it is illegible or inaudible, <gi scheme="MEI"
@@ -571,7 +571,7 @@
       <memberOf key="model.transcriptionLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="character" usage="opt">

--- a/source/modules/MEI.harmony.xml
+++ b/source/modules/MEI.harmony.xml
@@ -119,7 +119,7 @@
       <memberOf key="att.chordMember.vis"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The <att>string</att>, <att>fret</att>, and <att>fing</att> attributes are provided in

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -513,7 +513,7 @@
       <memberOf key="model.staffDefPart.mensural"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The <gi scheme="MEI">mensur</gi> element is provided for the encoding of mensural notation.
@@ -553,7 +553,7 @@
       <memberOf key="model.staffDefPart.mensural"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The proport element is provided for the encoding of mensural notation. It allows the
@@ -573,7 +573,7 @@
       <memberOf key="att.stem.anl"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="Check_stem" scheme="isoschematron">
       <constraint>

--- a/source/modules/MEI.midi.xml
+++ b/source/modules/MEI.midi.xml
@@ -238,7 +238,7 @@
       <memberOf key="att.midiValue"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The <att>num</att> attribute specifies a MIDI parameter number, while <att>val</att>
@@ -253,7 +253,7 @@
       <memberOf key="att.midi.event"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="num" usage="req">
@@ -273,7 +273,7 @@
       <memberOf key="att.midiNumber"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The value of the <att>num</att> attribute must be in the range 0-127.</p>
@@ -315,7 +315,7 @@
       <memberOf key="model.instrDefLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>This element provides a starting or default instrument declaration for a staff, a group of
@@ -399,7 +399,7 @@
       <memberOf key="att.midiNumber"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="noteOn" module="MEI.midi">
@@ -410,7 +410,7 @@
       <memberOf key="att.midiNumber"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="port" module="MEI.midi">
@@ -421,7 +421,7 @@
       <memberOf key="att.midiNumber"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="prog" module="MEI.midi">
@@ -433,7 +433,7 @@
       <memberOf key="att.midiNumber"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="seqNum" module="MEI.midi">
@@ -444,7 +444,7 @@
       <memberOf key="att.midi.event"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="num" usage="req">
@@ -478,7 +478,7 @@
       <memberOf key="att.midiNumber"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="form" usage="req">

--- a/source/modules/MEI.neumes.xml
+++ b/source/modules/MEI.neumes.xml
@@ -262,7 +262,7 @@
       <memberOf key="model.neumeModifierLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="liquescent" module="MEI.neumes">

--- a/source/modules/MEI.performance.xml
+++ b/source/modules/MEI.performance.xml
@@ -151,7 +151,7 @@
       <memberOf key="att.dataPointing"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="check_when_interval" scheme="isoschematron">
       <constraint>

--- a/source/modules/MEI.ptrref.xml
+++ b/source/modules/MEI.ptrref.xml
@@ -26,7 +26,7 @@
       <memberOf key="model.locrefLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>Unlike the <gi scheme="MEI">ref</gi> element, <gi scheme="MEI">ptr</gi> cannot contain text

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -4221,7 +4221,7 @@
       <memberOf key="model.syllablePart"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>An accidental may raise a pitch by one or two semitones or it may cancel a previous
@@ -4332,7 +4332,7 @@
       <memberOf key="att.ambNote.anl"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="analytic" module="MEI.shared">
@@ -4461,7 +4461,7 @@
       <memberOf key="model.noteModifierLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>Articulations typically affect duration, such as staccato marks, or the force of attack,
@@ -4510,7 +4510,7 @@
       <memberOf key="model.eventLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>This element is provided for repertoires, such as mensural notation, that lack measures.
@@ -4718,7 +4718,7 @@
       <memberOf key="model.controlEventLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="caesura_start-type_attributes_required" scheme="isoschematron">
       <constraint>
@@ -4848,7 +4848,7 @@
       <memberOf key="model.milestoneLike.text"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="n" usage="req">
@@ -4915,7 +4915,7 @@
       <memberOf key="model.syllablePart"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="Clef_position_lines" scheme="isoschematron">
       <constraint>
@@ -4978,7 +4978,7 @@
       <memberOf key="model.milestoneLike.text"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="cols" usage="req">
@@ -5492,7 +5492,7 @@
       <memberOf key="model.eventLike.mensural"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>This element provides an alternative to the <att>dots</att> attribute on <gi scheme="MEI"
@@ -5746,7 +5746,7 @@
       <memberOf key="att.targetEval"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The <att>plist</att> attribute contains an ordered list of identifiers of descendant <gi
@@ -6068,7 +6068,7 @@
       <memberOf key="model.keyAccidLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="Check_keyAccidPlacement" scheme="isoschematron">
       <constraint>
@@ -6270,7 +6270,7 @@
       <memberOf key="model.lbLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The <att>n</att> attribute should be used to record a number associated with this textual
@@ -6762,7 +6762,7 @@
       <memberOf key="model.eventLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="part" module="MEI.shared">
@@ -7166,7 +7166,7 @@
       <memberOf key="model.relationLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="FRBR_relation" scheme="isoschematron">
       <constraint>
@@ -7485,7 +7485,7 @@
       <memberOf key="model.milestoneLike.music"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>Do not confuse this element with the <gi scheme="MEI">lb</gi> element, which performs a
@@ -7664,7 +7664,7 @@
       <memberOf key="model.eventLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="speaker" module="MEI.shared">
@@ -8064,7 +8064,7 @@
       <memberOf key="model.textPhraseLike.limited"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="symbolDef_symbol_attributes_required" scheme="isoschematron">
       <constraint>

--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -70,7 +70,7 @@
       <memberOf key="att.startEndId"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="fret" usage="opt">

--- a/source/modules/MEI.usersymbols.xml
+++ b/source/modules/MEI.usersymbols.xml
@@ -155,7 +155,7 @@
       <memberOf key="model.graphicPrimitiveLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="symbolDef_curve_attributes_required" scheme="isoschematron">
       <constraint>


### PR DESCRIPTION
This is a small step towards pure odd. 
Not affecting any script we have in the repo and shouldn't affect external things. 