### PR TITLE
Fix(utils): Fix caption css

### DIFF
--- a/utils/guidelines_xslt/generateGuidelines.xsl
+++ b/utils/guidelines_xslt/generateGuidelines.xsl
@@ -584,10 +584,10 @@
                 </xsl:choose>
             </xsl:when>
             <xsl:when test="parent::tei:figure and parent::tei:figure/tei:graphic">
-                <figcaption class="caption">Figure <xsl:value-of select="count(preceding::tei:figure[./tei:graphic]) + 1"/>. <xsl:apply-templates select="node()" mode="#current"/></figcaption>
+                <figcaption class="figure-caption">Figure <xsl:value-of select="count(preceding::tei:figure[./tei:graphic]) + 1"/>. <xsl:apply-templates select="node()" mode="#current"/></figcaption>
             </xsl:when>
             <xsl:when test="parent::tei:figure and parent::tei:figure/egx:egXML">
-                <figcaption class="caption">Listing <xsl:value-of select="count(preceding::tei:figure[./egx:egXML]) + 1"/>. <xsl:apply-templates select="node()" mode="#current"/></figcaption>
+                <figcaption class="figure-caption">Listing <xsl:value-of select="count(preceding::tei:figure[./egx:egXML]) + 1"/>. <xsl:apply-templates select="node()" mode="#current"/></figcaption>
             </xsl:when>
             <xsl:when test="parent::tei:figure">
                 <xsl:message terminate="no" select="'WARNING: Not rendering tei:head in tei:figure, because there is no apparent element to which it belongs. Content: ' || text()"/>

--- a/utils/guidelines_xslt/odd2html/guidelines.xsl
+++ b/utils/guidelines_xslt/odd2html/guidelines.xsl
@@ -302,10 +302,10 @@
     <xsl:template match="tei:head[parent::tei:figure]" mode="guidelines">
         <xsl:choose>
             <xsl:when test="parent::tei:figure and parent::tei:figure/tei:graphic">
-                <figcaption class="caption">Figure <xsl:value-of select="count(preceding::tei:figure[./tei:graphic]) + 1"/>. <xsl:apply-templates select="node()" mode="#current"/></figcaption>
+                <figcaption class="figure-caption">Figure <xsl:value-of select="count(preceding::tei:figure[./tei:graphic]) + 1"/>. <xsl:apply-templates select="node()" mode="#current"/></figcaption>
             </xsl:when>
             <xsl:when test="parent::tei:figure and parent::tei:figure/egx:egXML">
-                <figcaption class="caption">Listing <xsl:value-of select="count(preceding::tei:figure[./egx:egXML]) + 1"/>. <xsl:apply-templates select="node()" mode="#current"/></figcaption>
+                <figcaption class="figure-caption">Listing <xsl:value-of select="count(preceding::tei:figure[./egx:egXML]) + 1"/>. <xsl:apply-templates select="node()" mode="#current"/></figcaption>
             </xsl:when>
         </xsl:choose>
     </xsl:template>


### PR DESCRIPTION
I noticed that the captions are different from previous Guidelines. This aligns the style between the versions.

Compare https://github.com/music-encoding/guidelines/issues/154