### PR TITLE
BREAKING(MEI.shared): Move att.extender from tempo to att.tempo.vis

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -8059,7 +8059,6 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
-      <memberOf key="att.extender"/>
       <memberOf key="att.facsimile"/>
       <memberOf key="att.lang"/>
       <memberOf key="att.tempo.log"/>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1831,6 +1831,7 @@
   <classSpec ident="att.tempo.vis" module="MEI.visual" type="atts">
     <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
+      <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>


### PR DESCRIPTION
Instead of having `att.extender` directly in `tempo` this moves it to `att.tempo.vis` being more in line with `dir` and `dynam`. 

NB: The latter are also member of `att.verticalGroup`. Should `tempo` also be a member?
