### PR TITLE
Add notationType to manifestation and extend value list

### DIFF
--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -1284,7 +1284,7 @@
             </div>
             <div xml:id="msdesc" type="div2">
                <head>Encoding Sources in MEI</head>
-               <p>The <gi scheme="MEI">manifestation</gi> and <gi scheme="MEI">item</gi> elements allow detailed description of various types of sources, for instance, a printed text or manuscript, another computer file, an audio or video recording, or a combination of these. Both <gi scheme="MEI">manifestation</gi> and <gi scheme="MEI">item</gi> are part of the <ptr target="#FRBR"/> implementation in MEI. Please note: in MEI 3.0.0, the <gi scheme="MEI">source</gi> element was used to capture this type of information. The <gi scheme="MEI">manifestation</gi> element may contain the following elements:</p>
+               <p>The <gi scheme="MEI">manifestation</gi> and <gi scheme="MEI">item</gi> elements allow detailed description of various types of sources, for instance, a printed text or manuscript, another computer file, an audio or video recording, or a combination of these. Also the format of the notation can be classified within <gi scheme="MEI">manifestation</gi> using <att>notationType</att> and <att>notationSubtype</att>. Both <gi scheme="MEI">manifestation</gi> and <gi scheme="MEI">item</gi> are part of the <ptr target="#FRBR"/> implementation in MEI. Please note: in MEI 3.0.0, the <gi scheme="MEI">source</gi> element was used to capture this type of information. The <gi scheme="MEI">manifestation</gi> element may contain the following elements:</p>
                <p>
                   <specList>
                      <specDesc key="head"/>

--- a/source/modules/MEI.frbr.xml
+++ b/source/modules/MEI.frbr.xml
@@ -310,6 +310,7 @@
       <memberOf key="att.bibl"/>
       <memberOf key="att.componentType"/>
       <memberOf key="att.dataPointing"/>
+      <memberOf key="att.notationType"/>
       <memberOf key="att.pointing"/>
       <memberOf key="att.recordType"/>
       <memberOf key="att.targetEval"/>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -2932,7 +2932,7 @@
   <macroSpec ident="data.NOTATIONTYPE" module="MEI" type="dt">
     <desc xml:lang="en">Notation type and subtype</desc>
     <content>
-      <valList type="closed">
+      <valList type="semi">
         <valItem ident="cmn">
           <desc xml:lang="en">Common Music Notation.</desc>
         </valItem>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -2962,6 +2962,34 @@
       </valList>
     </content>
   </macroSpec>
+  <macroSpec ident="data.NOTATIONTYPE.extended" module="MEI" type="dt">
+    <desc xml:lang="en">Notation type extention</desc>
+    <content>
+      <valList type="semi">
+        <valItem ident="byzantine">
+          <desc xml:lang="en">Byzantine notation.</desc>
+        </valItem>
+        <valItem ident="choral">
+          <desc xml:lang="en">Choral/Square notation.</desc>
+        </valItem>
+        <valItem ident="graphic">
+          <desc xml:lang="en">Graphical notation.</desc>
+        </valItem>
+        <valItem ident="greek">
+          <desc xml:lang="en">Greek notation.</desc>
+        </valItem>
+        <valItem ident="modal">
+          <desc xml:lang="en">Modal notation.</desc>
+        </valItem>
+        <valItem ident="oldslavic">
+          <desc xml:lang="en">Old Slavic notation.</desc>
+        </valItem>
+        <valItem ident="ottoman">
+          <desc xml:lang="en">Ottoman notation.</desc>
+        </valItem>
+      </valList>
+    </content>
+  </macroSpec>
   <macroSpec ident="data.NOTEHEADMODIFIER" module="MEI" type="dt">
     <desc xml:lang="en">Captures any notehead "modifiers"; that is, symbols added to the notehead, such as
       slashes, lines, text, and enclosures, etc.</desc>
@@ -3761,7 +3789,10 @@
         <desc xml:lang="en">Contains classification of the notation contained or described by the element bearing
           this attribute.</desc>
         <datatype>
-          <rng:ref name="data.NOTATIONTYPE"/>
+          <rng:choice>
+            <rng:ref name="data.NOTATIONTYPE"/>
+            <rng:ref name="data.NOTATIONTYPE.extended"/>
+          </rng:choice>
         </datatype>
       </attDef>
       <attDef ident="notationsubtype" usage="opt">


### PR DESCRIPTION
Co-authored-by: @music-encoding/ig-metadata

At the last meeting of the metadata ig in 2022 we discussed the need of having a possibility to encode the notation type within the header. @KristinaRichts came up with some usecases and arguments for implementing this. During the meeting we figured out that the best place, from our view, is the manifestation element. To keep consistency we decided to propose using the existing `@notationType` with an extension instead of creating something new. The extension of the value list (datatype) at `@notationType` is necessary because the scope of the values isn't wide enough for describing the music and (that's the bigger issue I think) the `valList/@type` is closed!

So, the metadata-ig proposes to set the value list to semi and add values for an extension (list is provided by @irmlindcapelle). Also the proposed extension of the value list certainly does not contain all possible notation types. Nevertheless, this beginning should also be an invitation to complete the list over time.

This PR contains
- adding att.notationType to manifestation
- setting `valList/@type` to semi instead of close
- adding an extention for the datatype/valItems
- adding a notice in documentation (proposals for rewording are welcome!)
