### PR TITLE
Move lg to text module

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -6247,42 +6247,6 @@
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-lb.html">lb</ref> element of the Text Encoding Initiative (TEI).</p>
     </remarks>
   </elementSpec>
-  <elementSpec ident="lg" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">line group</gloss>
-    <desc xml:lang="en">May be used for any section of text that is organized as a group of lines;
-      however, it is most often used for a group of verse lines functioning as a formal unit, <abbr>e.g.</abbr>, a
-      stanza, refrain, verse paragraph, etc.</desc>
-    <classes>
-      <memberOf key="att.common"/>
-      <memberOf key="att.facsimile"/>
-      <memberOf key="att.lang"/>
-      <memberOf key="att.lyrics.anl"/>
-      <memberOf key="att.lyrics.ges"/>
-      <memberOf key="att.lyrics.log"/>
-      <memberOf key="att.lyrics.vis"/>
-      <memberOf key="att.metadataPointing"/>
-      <memberOf key="att.xy"/>
-      <memberOf key="model.lgLike"/>
-    </classes>
-    <content>
-      <rng:zeroOrMore>
-        <rng:ref name="model.headLike"/>
-      </rng:zeroOrMore>
-      <rng:choice>
-        <rng:ref name="model.lLike"/>
-        <rng:ref name="model.lgLike"/>
-      </rng:choice>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:ref name="model.lLike"/>
-          <rng:ref name="model.lgLike"/>
-        </rng:choice>
-      </rng:zeroOrMore>
-    </content>
-    <remarks xml:lang="en">
-      <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-lg.html">lg</ref> element of the Text Encoding Initiative (TEI).</p>
-    </remarks>
-  </elementSpec>
   <elementSpec ident="librettist" module="MEI.shared">
     <desc xml:lang="en">Person or organization who is a writer of the text of an opera, oratorio, etc.</desc>
     <classes>

--- a/source/modules/MEI.text.xml
+++ b/source/modules/MEI.text.xml
@@ -185,8 +185,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="l" module="MEI.text">
-    <gloss versionDate="2022-05-18" xml:lang="en">line of text</gloss>
-    <desc xml:lang="en">Contains a single line of text within a line group.</desc>
+    <gloss versionDate="2023-01-26" xml:lang="en">verse line</gloss>
+    <desc versionDate="2023-01-26" xml:lang="en">Contains a single, possibly incomplete, line of verse.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
@@ -221,6 +221,41 @@
     </remarks>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-l.html">l</ref> element of the Text Encoding Initiative (TEI).</p>
+    </remarks>
+  </elementSpec>
+  <elementSpec ident="lg" module="MEI.shared">
+    <gloss versionDate="2022-05-18" xml:lang="en">line group</gloss>
+    <desc versionDate="2023-01-26" xml:lang="en">Contains one or more verse lines functioning as a formal unit, e.g. a stanza, refrain,
+      verse paragraph, etc.</desc>
+    <classes>
+      <memberOf key="att.common"/>
+      <memberOf key="att.facsimile"/>
+      <memberOf key="att.lang"/>
+      <memberOf key="att.lyrics.anl"/>
+      <memberOf key="att.lyrics.ges"/>
+      <memberOf key="att.lyrics.log"/>
+      <memberOf key="att.lyrics.vis"/>
+      <memberOf key="att.metadataPointing"/>
+      <memberOf key="att.xy"/>
+      <memberOf key="model.lgLike"/>
+    </classes>
+    <content>
+      <rng:zeroOrMore>
+        <rng:ref name="model.headLike"/>
+      </rng:zeroOrMore>
+      <rng:choice>
+        <rng:ref name="model.lLike"/>
+        <rng:ref name="model.lgLike"/>
+      </rng:choice>
+      <rng:zeroOrMore>
+        <rng:choice>
+          <rng:ref name="model.lLike"/>
+          <rng:ref name="model.lgLike"/>
+        </rng:choice>
+      </rng:zeroOrMore>
+    </content>
+    <remarks xml:lang="en">
+      <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-lg.html">lg</ref> element of the Text Encoding Initiative (TEI).</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="li" module="MEI.text">

--- a/source/modules/MEI.text.xml
+++ b/source/modules/MEI.text.xml
@@ -223,7 +223,7 @@
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-l.html">l</ref> element of the Text Encoding Initiative (TEI).</p>
     </remarks>
   </elementSpec>
-  <elementSpec ident="lg" module="MEI.shared">
+  <elementSpec ident="lg" module="MEI.text">
     <gloss versionDate="2022-05-18" xml:lang="en">line group</gloss>
     <desc versionDate="2023-01-26" xml:lang="en">Contains one or more verse lines functioning as a formal unit, e.g. a stanza, refrain,
       verse paragraph, etc.</desc>


### PR DESCRIPTION
This PR brings the descriptions of `lg` and `l` in line with TEI. Also it moves `lg` into the `MEI.text` module.
Closes #1051