### PR TITLE
schema: allow label and labelAbbr within harm tags

### DIFF
--- a/source/modules/MEI.harmony.xml
+++ b/source/modules/MEI.harmony.xml
@@ -203,6 +203,12 @@
     </classes>
     <content>
       <rng:zeroOrMore>
+        <rng:ref name="label"/>
+      </rng:zeroOrMore>
+      <rng:zeroOrMore>
+        <rng:ref name="labelAbbr"/>
+      </rng:zeroOrMore>
+      <rng:zeroOrMore>
         <rng:choice>
           <rng:text/>
           <rng:ref name="model.textPhraseLike.limited"/>


### PR DESCRIPTION
This is my first contribution to the music-encoding repo. I don't know the MEI schema well yet so any help and feedback is appreciated.

This PR allows `<label>` and `<labelAbbr>` whting `<harm>` tags similar to the the same functionality for `<verse>` . @craigsapp mentioned that this should be easy to implement so I hope that my changes are sufficient.

Closes https://github.com/music-encoding/music-encoding/issues/1062
Refs https://github.com/rism-digital/verovio/discussions/3166#discussioncomment-4452490