### PR TITLE
Fix(customizations): Fix `@dur` missing on /chord in MEI Basic. Fixes #1069

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -552,7 +552,7 @@
                         <memberOf key="att.augmentDots"/>
                         <memberOf key="att.chord.log.cmn"/>
                         <memberOf key="att.cue"/>
-                        <memberOf key="att.duration.logical"/>
+                        <memberOf key="att.duration.log"/>
                         <memberOf key="att.event"/>
                         <!--<memberOf key="att.sylText"/>-->
                     </classes>


### PR DESCRIPTION
It seems that the issue was a reference to `att.duration.logical` instead of `att.duration.log`