### PR TITLE
Fix(customizations): Fix some wrong references to attribute classes in MEI basic

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -195,17 +195,17 @@
                 <classSpec type="atts" ident="att.slurRend" module="MEI.cmn" mode="delete"/>
                 <classSpec type="atts" ident="att.tieRend" module="MEI.cmn" mode="delete"/>
 
-                <classSpec type="atts" ident="att.articulation.gestural" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.articulation.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.dir.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.dot.ges" module="MEI.gestural" mode="delete"/>
-                <classSpec type="atts" ident="att.duration.gestural" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.duration.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.dynam.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.ending.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.halfmRpt.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.harm.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.scoreDef.ges" module="MEI.gestural" mode="delete"/>
-                <classSpec type="atts" ident="att.timestamp.gestural" module="MEI.gestural" mode="delete"/>
-                <classSpec type="atts" ident="att.timestamp2.gestural" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.timestamp.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.timestamp2.ges" module="MEI.gestural" mode="delete"/>
                 
                 <classSpec type="atts" ident="att.authorized" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.barring" module="MEI.shared" mode="delete"/>
@@ -399,8 +399,8 @@
                         <memberOf key="att.alignment" mode="add"/>
                         <memberOf key="att.layerIdent" mode="add"/>
                         <memberOf key="att.staffIdent" mode="add"/>
-                        <!--<memberOf key="att.timestamp.gestural" mode="add"/>-->
-                        <!--<memberOf key="att.timestamp.logical" mode="add"/>-->
+                        <!--<memberOf key="att.timestamp.ges" mode="add"/>-->
+                        <!--<memberOf key="att.timestamp.log" mode="add"/>-->
                     </classes>
                 </classSpec>
 
@@ -490,9 +490,9 @@
                 <classSpec ident="att.note.ges" module="MEI.gestural" type="atts" mode="replace">
                     <desc>Gestural domain attributes.</desc>
                     <classes>
-                        <!--<memberOf key="att.accidental.gestural"/>-->
-                        <!--<memberOf key="att.articulation.gestural"/>-->
-                        <!--<memberOf key="att.duration.gestural"/>-->
+                        <!--<memberOf key="att.accidental.ges"/>-->
+                        <!--<memberOf key="att.articulation.ges"/>-->
+                        <!--<memberOf key="att.duration.ges"/>-->
                         <memberOf key="att.instrumentIdent"/>
                         <memberOf key="att.midiVelocity"/>
                         <memberOf key="att.note.ges.mensural"/>
@@ -534,7 +534,7 @@
                 <classSpec ident="att.rest.ges" module="MEI.gestural" type="atts" mode="change">
                     <desc>Gestural domain attributes.</desc>
                     <classes mode="replace">
-                        <!--<memberOf key="att.duration.gestural"/>-->
+                        <!--<memberOf key="att.duration.ges"/>-->
                         <memberOf key="att.instrumentIdent"/>
                         <!--<memberOf key="att.rest.ges.mensural"/>-->
                     </classes>


### PR DESCRIPTION
This PR fixes some wrong references to attribute classes previously names `.gestural` or `.logical` and that have been changed to `.ges` and `.log`.

Some of the wrong references caused for many attributes to be preserved in MEI basic when the references are for `delete` modifications.

References in comments were also adjusted