### PR TITLE
Moves divLine@form to att.divLine.log

### DIFF
--- a/source/modules/MEI.neumes.xml
+++ b/source/modules/MEI.neumes.xml
@@ -10,6 +10,25 @@
   <macroSpec ident="data.STAFFITEM.neumes" module="MEI.neumes" type="dt">
     <desc xml:lang="en">Items in the Neume repertoire that may be printed near a staff.</desc>
   </macroSpec>
+  <classSpec ident="att.divLine.log" module="MEI.neumes" type="atts">
+    <desc xml:lang="en">Logical domain attributes.</desc>
+    <attList>
+      <attDef ident="form" usage="opt">
+        <desc xml:lang="en">Identifies the different kinds of division.</desc>
+        <datatype maxOccurs="unbounded">
+          <rng:data type="NMTOKEN"/>
+        </datatype>
+        <valList type="semi">
+          <valItem ident="caesura"/>
+          <valItem ident="finalis"/>
+          <valItem ident="maior"/>
+          <valItem ident="maxima"/>
+          <valItem ident="minima"/>
+          <valItem ident="virgula"/>
+        </valList>
+      </attDef>
+    </attList>
+  </classSpec>
   <classSpec ident="att.episema.log" module="MEI.neumes" type="atts">
     <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
@@ -522,6 +541,7 @@
       <memberOf key="att.basic"/>
       <memberOf key="att.classed"/>
       <memberOf key="att.color" />
+      <memberOf key="att.divLine.log"/>
       <memberOf key="att.facsimile"/>
       <memberOf key="att.labelled"/>
       <memberOf key="att.linking"/>
@@ -534,21 +554,5 @@
       <memberOf key="att.visualOffset.ho" />
       <memberOf key="model.eventLike.neumes"/>
     </classes>
-    <attList>
-      <attDef ident="form" usage="opt">
-        <desc xml:lang="en">Identifies the different kinds of division.</desc>
-        <datatype maxOccurs="unbounded">
-          <rng:data type="NMTOKEN"/>
-        </datatype>
-        <valList type="semi">
-          <valItem ident="caesura"/>
-          <valItem ident="finalis"/>
-          <valItem ident="maior"/>
-          <valItem ident="maxima"/>
-          <valItem ident="minima"/>
-          <valItem ident="virgula"/>
-        </valList>
-      </attDef>
-    </attList>
   </elementSpec>
 </specGrp>


### PR DESCRIPTION
* This does not change anything to the resulting schema since it only move the attribute definition from the `<divLine>` element definition to a dedicated attribute class.