### PR TITLE
Unify usage and naming of attributes for controlling visibility of scoreDef properties

### DIFF
--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1120,6 +1120,7 @@
       <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extSym"/>
       <memberOf key="att.typography"/>
+      <memberOf key="att.visibility"/>
     </classes>
     <attList>
       <attDef ident="form" usage="opt">

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1148,6 +1148,12 @@
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
       </attDef>
+      <attDef ident="meter.visible" usage="opt">
+        <desc xml:lang="en">Determines whether the meter signature is to be displayed.</desc>
+        <datatype>
+          <rng:ref name="data.BOOLEAN"/>
+        </datatype>
+      </attDef>
     </attList>
   </classSpec>
   <classSpec ident="att.meterSigGrp.vis" module="MEI.visual" type="atts">

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -824,14 +824,14 @@
     <desc xml:lang="en">Used by staffDef and scoreDef to provide default values for attributes in the visual
       domain related to key signatures.</desc>
     <attList>
-      <attDef ident="keysig.show" usage="opt">
-        <desc xml:lang="en">Indicates whether the key signature should be displayed.</desc>
+      <attDef ident="keysig.showchange" usage="opt">
+        <desc xml:lang="en">Determines whether cautionary accidentals should be displayed at a key change.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>
       </attDef>
-      <attDef ident="keysig.showchange" usage="opt">
-        <desc xml:lang="en">Determines whether cautionary accidentals should be displayed at a key change.</desc>
+      <attDef ident="keysig.visible" usage="opt">
+        <desc xml:lang="en">Determines whether the clef is to be displayed.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -831,7 +831,7 @@
         </datatype>
       </attDef>
       <attDef ident="keysig.visible" usage="opt">
-        <desc xml:lang="en">Determines whether the clef is to be displayed.</desc>
+        <desc xml:lang="en">Determines whether the key signature is to be displayed.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
         </datatype>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -2104,9 +2104,6 @@
         <valItem ident="sym+norm">
           <desc xml:lang="en">Meter signature rendered using both the symbol and the traditional numeric values.</desc>
         </valItem>
-        <valItem ident="invis">
-          <desc xml:lang="en">Meter signature not rendered.</desc>
-        </valItem>
       </valList>
     </content>
   </macroSpec>


### PR DESCRIPTION
This PR make `meterSig` member of `att.visibility` and removes the `invis` value from `data.METERFORM`, aligning this with `clef`. To keep the ability to hide the meter signature also when encoded as attributes on `scoreDef`/`staffDef` this introduces `meter.visible` attribute.
Moreover, it renames `keysig.show` to `keysig.visible` to have a consistent naming of the attributes controlling the visibility.
closes #1096