### PR TITLE
Add ellipse as text enclosing

### DIFF
--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3576,10 +3576,13 @@
           <desc xml:lang="en">Enclosed in box.</desc>
         </valItem>
         <valItem ident="circle">
-          <desc xml:lang="en">Enclosed in ellipse/circle.</desc>
+          <desc xml:lang="en">Enclosed in circle.</desc>
         </valItem>
         <valItem ident="dbox">
           <desc xml:lang="en">Enclosed in diamond.</desc>
+        </valItem>
+        <valItem ident="ellipse">
+          <desc xml:lang="en">Enclosed in ellipse.</desc>
         </valItem>
         <valItem ident="tbox">
           <desc xml:lang="en">Enclosed in triangle.</desc>


### PR DESCRIPTION
This PR makes the distinction between circle and ellipse as text enclosing explicit. 

Before it was not possible to encode differences in layout like the following: 

![image](https://user-images.githubusercontent.com/7693447/235125083-db5d7147-8071-4e89-a712-db159caae1f1.png)

![image](https://user-images.githubusercontent.com/7693447/235134521-b9358965-3bc3-40bf-8ab6-39fab0d3626a.png)

This becomes evidently if you try to reproduce this with a renderer, and for longer texts you only have the option "circle".

![image](https://user-images.githubusercontent.com/7693447/236509467-86b5a997-ef26-438e-99ca-a59c8d3f078f.png)
