### PR TITLE
fix(styles): fix css for PDF guidelines title

### DIFF
--- a/source/assets/css/print/mei.css
+++ b/source/assets/css/print/mei.css
@@ -219,12 +219,14 @@ body > section.page1 {
     display: block;
     font-size: 1.6rem;
     font-weight: 300;
+    margin-bottom: 1.5rem;
 }
 
 .page1 h1 small.out {
     display: block;
     font-size: 2.4rem;
     font-weight: 500;
+    margin-top: 2rem;
 }
 
 .page1 img#meiLogo {


### PR DESCRIPTION
This PR fixes the CSS for the title placement on the title page of the PDF guidelines. Thus, the text lines do not overlap anymore.

![Screenshot 2023-05-05 212343](https://user-images.githubusercontent.com/21059419/236551405-7fd3e62d-a3b2-4377-87d1-26391be90551.jpg)


Fixes 1st part of the styling issues mentioned in https://github.com/music-encoding/music-encoding/issues/959#issuecomment-1260751411

PR goes to pdf-guidelines-test branch