### PR TITLE
schema: allow physDesc on Source

### DIFF
--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -96,6 +96,7 @@
                <head>Introduction</head>
                <p>Metadata means "data about data", <abbr>i.e.</abbr>, information about various aspects of an encoding at hand. There are many different types of metadata, which MEI tries to order according to their respective scope or perspective, as described in <ptr target="#headerstructure"/>. MEI’s approach to metadata is heavily influenced by other existing standards and models, such as TEI, MARC, and FRBR. It attempts to reflect both current library practice and common scholarly methods, for example in the field of source descriptions (see chapter <ptr target="#msdesc"/>).</p>
                <p>This chapter thus addresses the description of an encoded item so that the musical text, as well as its sources, encoding, and revisions are all thoroughly documented. Such documentation is necessary for scholars using the texts, for software processing them, and for catalogers in libraries and archives. Together these descriptions and declarations provide an electronic analog to the title page attached to a printed work. They also constitute an equivalent for the content of the code books or introductory manuals customarily accompanying electronic data sets.</p>
+               <p>For large encoding projects, the Functional Requirements for Bibliographic Records (<abbr>FRBR</abbr>) capabilities of MEI provides most flexibility and descriptive capabilities. However, MEI also provides simpler, non-FRBR methods for source description for those cases where the FRBR capbilities are not needed. These are further discussed in <ptr target="nonfrbrsourcedescription" />./></p>
             </div>
             <div xml:id="headerstructure" type="div2">
                <head>Structure of the MEI Header</head>
@@ -115,6 +116,18 @@
                   <item>This concept is covered in section <ptr target="#headerusecases"/>.</item>
                   <item>A <hi rend="italic">revision history</hi>, tagged <gi scheme="MEI">revisionDesc</gi>, which allows the encoder to provide a history of changes made during the development of the electronic text. The revision history is important for version control and for resolving questions about the history of a file. The MEI elements used to encode the revision description are described in section <ptr target="#headerRevisionDescription"/>.</item>
                </list>
+               <div xml:id="nonfrbrsourcedescription" type="div3">
+                  <head>Non-FRBR Source Description</head>
+                  <p>MEI allows two methodologies to be used when doing metadata capture and source description. The <abbr>FRBR</abbr> methodology, described later in this chapter, gives encoders a mechanism for building detailed descriptions of bibliographic entities. Most bibliographic-based projects should favor the FRBR method.</p>
+                  <p>However, there are cases where detailed bibliographic analysis at the level required by the FRBR module is not possible or desirable. These may include situations such as retro-conversion of non-FRBR catalogues, or capturing the output of notation encoding software where only minimal source description capabilities are available. In these cases, encoders may capture metadata in the MEI header without using FRBR encoding entities and instead choose a simplified methodology for source description.</p>
+                  <p>The <gi scheme="MEI">sourceDesc</gi> element as a child of the <gi scheme="MEI">fileDesc</gi> element may be used to capture simple bibliographic descriptions. An example is given below.</p>
+                  <p>
+                     <figure>
+                        <head/>
+                        <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/header/header-sample080.txt" parse="text"/></egXML>
+                     </figure>
+                  </p>
+               </div>
             </div>
             <div xml:id="commonconcepts" type="div2">
                <head>Common Metadata Concepts</head>

--- a/source/examples/header/header-sample080.txt
+++ b/source/examples/header/header-sample080.txt
@@ -1,0 +1,28 @@
+<fileDesc>
+    <titleStmt>
+        <title>La clé du caveau</title>
+    </titleStmt>
+    <pubStmt>
+        <publisher>Capelle &amp; Renand</publisher>
+        <pubPlace>Paris</pubPlace>
+    </pubStmt>
+    <sourceDesc>
+        <source>
+            <physDesc>
+                <dimensions>
+                    <width unit="cm">9.5</width>
+                    <height unit="cm">14</height>
+                </dimensions>
+                <extent unit="page">376p</extent>
+            </physDesc>
+            <physLoc>
+                <identifier>XA Li 1811/1</identifier>
+                <repository>
+                    <corpName>Universität Bern, Institut für Musikwissenschaft</corpName>
+                    <geogName>Bern</geogName>
+                    <country>Switzerland</country>
+                </repository>
+            </physLoc>
+        </source>
+    </sourceDesc>
+</fileDesc>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -2500,6 +2500,9 @@
           <rng:ref name="model.biblLike"/>
         </rng:choice>
       </rng:zeroOrMore>
+      <rng:optional>
+        <rng:ref name="physDesc"/>
+      </rng:optional>
     </content>
     <constraintSpec ident="check_source_target" scheme="schematron">
       <constraint>
@@ -2516,9 +2519,7 @@
     </constraintSpec>
     <remarks xml:lang="en">
       <p>This element contains, or references via its <att>target</att> attribute, a description of
-        a source used in the creation of the electronic file. For description of a physical
-        embodiment of an expression of a work use the <gi scheme="MEI">manifestation</gi>
-        element.</p>
+        a source used in the creation of the electronic file.</p>
       <p>The <att>data</att> attribute may be used to reference one or more musical features found
         in the content of this particular source.</p>
     </remarks>


### PR DESCRIPTION
Also removed a reference to a 'manifestation' since this module is independent of the FRBR module.

Built locally and looks like it works OK.

Fixes #1078