### PR TITLE
spread out constraints to affected elements

### DIFF
--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -2915,6 +2915,15 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
+    <constraintSpec ident="check_watermark_inline" scheme="isoschematron">
+      <constraint>
+        <sch:rule
+          context="mei:watermark">
+          <sch:assert test="ancestor::mei:physDesc">The watermark element may only appear as a
+            descendant of the physDesc element.</sch:assert>
+        </sch:rule>
+      </constraint>
+    </constraintSpec>
     <remarks xml:lang="en">
       <p>The <att>facs</att> attribute may be used to record the location of the watermark in a
         facsimile image.</p>

--- a/source/modules/MEI.msDesc.xml
+++ b/source/modules/MEI.msDesc.xml
@@ -160,6 +160,15 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
+    <constraintSpec ident="check_catchwords_inline" scheme="isoschematron">
+      <constraint>
+        <sch:rule
+          context="mei:catchwords">
+          <sch:assert test="ancestor::mei:physDesc">The catchwords element may only appear as a
+            descendant of the physDesc element.</sch:assert>
+        </sch:rule>
+      </constraint>
+    </constraintSpec>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-catchwords.html">catchwords</ref> element of the Text Encoding Initiative (TEI).</p>
     </remarks>
@@ -312,6 +321,15 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
+    <constraintSpec ident="check_heraldry_inline" scheme="isoschematron">
+      <constraint>
+        <sch:rule
+          context="mei:heraldry">
+          <sch:assert test="ancestor::mei:physDesc">The heraldry element may only appear as a
+            descendant of the physDesc element.</sch:assert>
+        </sch:rule>
+      </constraint>
+    </constraintSpec>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-heraldry.html">heraldry</ref> element of the Text Encoding Initiative (TEI).</p>
     </remarks>
@@ -440,6 +458,19 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
+    <constraintSpec ident="check_locus_inline" scheme="isoschematron">
+      <constraint>
+        <sch:rule context="mei:locus">
+          <sch:assert
+            test="ancestor::mei:physDesc or parent::mei:contentItem or 
+            ancestor::mei:source[ancestor::mei:componentList[ancestor::mei:sourceDesc or 
+            ancestor::mei:sourceList or ancestor::mei:workList]]"
+            >The locus element may only appear as a descendant of a physDesc element, a
+            contentItem element, or a source element that is a component of another source or
+            work.</sch:assert>
+        </sch:rule>
+      </constraint>
+    </constraintSpec>
     <attList>
       <attDef ident="scheme" usage="opt">
         <desc xml:lang="en">Identifies the foliation scheme in terms of which the location is being specified by
@@ -481,6 +512,19 @@
         <rng:ref name="locus"/>
       </rng:zeroOrMore>
     </content>
+    <constraintSpec ident="check_locusGrp_inline" module="MEI.msDesc" scheme="isoschematron">
+      <constraint>
+        <sch:rule context="mei:locusGrp">
+          <sch:assert
+            test="ancestor::mei:physDesc or parent::mei:contentItem or 
+            ancestor::mei:source[ancestor::mei:componentList[ancestor::mei:sourceDesc or 
+            ancestor::mei:sourceList or ancestor::mei:workList]]"
+            >The locusGrp element may only appear as a descendant of a physDesc element, a
+            contentItem element, or a source element that is a component of another source or
+            work.</sch:assert>
+        </sch:rule>
+      </constraint>
+    </constraintSpec>
     <attList>
       <attDef ident="scheme" usage="opt">
         <desc xml:lang="en">Identifies the foliation scheme in terms of which the location is being specified by
@@ -674,6 +718,15 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
+    <constraintSpec ident="check_secFolio_inline" scheme="isoschematron">
+      <constraint>
+        <sch:rule
+          context="mei:secFolio">
+          <sch:assert test="ancestor::mei:physDesc">The secFolio element may only appear as a
+            descendant of the physDesc element.</sch:assert>
+        </sch:rule>
+      </constraint>
+    </constraintSpec>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-secFol.html">secFol</ref> element of the Text Encoding Initiative (TEI).</p>
     </remarks>
@@ -690,6 +743,15 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
+    <constraintSpec ident="check_signatures_inline" scheme="isoschematron">
+      <constraint>
+        <sch:rule
+          context="mei:signatures">
+          <sch:assert test="ancestor::mei:physDesc">The signatures element may only appear as a
+            descendant of the physDesc element.</sch:assert>
+        </sch:rule>
+      </constraint>
+    </constraintSpec>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-signatures.html">signatures</ref> element of the Text Encoding Initiative (TEI).</p>
     </remarks>
@@ -856,26 +918,4 @@
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-typeNote.html">typeNote</ref> element in the Text Encoding Initiative (TEI).</p>
     </remarks>
   </elementSpec>
-  <constraintSpec ident="check_msDesc_inline" module="MEI.msDesc" scheme="isoschematron">
-    <constraint>
-      <sch:rule
-        context="mei:catchwords | mei:heraldry | mei:secFolio | mei:signatures | mei:watermark">
-        <sch:assert test="ancestor::mei:physDesc">The <sch:name/> element may only appear as a
-          descendant of the physDesc element.</sch:assert>
-      </sch:rule>
-    </constraint>
-  </constraintSpec>
-  <constraintSpec ident="check_locus_inline" module="MEI.msDesc" scheme="isoschematron">
-    <constraint>
-      <sch:rule context="mei:locus | mei:locusGrp">
-        <sch:assert
-          test="ancestor::mei:physDesc or parent::mei:contentItem or 
-          ancestor::mei:source[ancestor::mei:componentList[ancestor::mei:sourceDesc or 
-          ancestor::mei:sourceList or ancestor::mei:workList]]"
-          >The <sch:name/> element may only appear as a descendant of a physDesc element, a
-          contentItem element, or a source element that is a component of another source or
-          work.</sch:assert>
-      </sch:rule>
-    </constraint>
-  </constraintSpec>
 </specGrp>


### PR DESCRIPTION
fixes #1129

This is not the most elegant solution, but it works. Basically, the Schematron rule added on watermark doesn't do anything when msDesc is turned off, but also doesn't do any harm either. When msDesc is turned on, it works as expected.