### PR TITLE
remove combining reverse solidus example

### DIFF
--- a/source/docs/10-analysisharm.xml
+++ b/source/docs/10-analysisharm.xml
@@ -468,7 +468,7 @@
                               <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/harmony/harmony-sample270.txt" parse="text"/></egXML>
                            </figure>
                         </p>
-                        <p>A usual convention for slashes; that is, 6\ and 6/ for backslash and slash, respectively, may be followed. A more explicit alternative would be to use the "bslash" (backward slash) and "fslash" (forward slash) on the <gi scheme="MEI">rend></gi> element.</p>
+                        <p>You may use 6\ and 6/ for numerals that should be shown with a backslash and slash, respectively. An alternative would be to use the "bslash" (backward slash) and "fslash" (forward slash) on the <gi scheme="MEI">rend></gi> element.</p>
                         <p>
                            <figure>
                               <head>Figured bass with chromatically altered figure</head>

--- a/source/docs/10-analysisharm.xml
+++ b/source/docs/10-analysisharm.xml
@@ -468,7 +468,7 @@
                               <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/harmony/harmony-sample270.txt" parse="text"/></egXML>
                            </figure>
                         </p>
-                        <p>Characters with combining slashes can be handled using the Unicode characters COMBINING REVERSE SOLIDUS OVERLAY (6⃥) and COMBINING LONG SOLIDUS OVERLAY (6̸). The combining nature of these Unicode characters indicates very clearly that they "overstrike" the preceding character. The usual convention for slashes; that is, 6\ and 6/ for backslash and slash, respectively, may also be followed:</p>
+                        <p>A usual convention for slashes; that is, 6\ and 6/ for backslash and slash, respectively, may be followed. A more explicit alternative would be to use the "bslash" (backward slash) and "fslash" (forward slash) on the <gi scheme="MEI">rend></gi> element.</p>
                         <p>
                            <figure>
                               <head>Figured bass with chromatically altered figure</head>

--- a/source/examples/harmony/harmony-sample271.txt
+++ b/source/examples/harmony/harmony-sample271.txt
@@ -1,7 +1,7 @@
 <harm>
    <fb>
-      <f>6⃥</f>
+      <f><rend rend="bslash">6</rend></f>
       <!-- or -->
-      <f>6\</f>
+      <f><rend rend="fslash">6</rend></f>
    </fb>
 </harm>


### PR DESCRIPTION
this has caused headache in the generation of the Guidelines ever since, and more proper ways to encode exist using the rend element. Thus, dropping this example from the guidelines, replacing it with an alternative.