### PR TITLE
fix(build): move schemata into correct folder and add canonicalized.xml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,10 @@ jobs:
           path: ${{ env.SCHEMA_DIR }}
 
       - name: Copy built schema to SCHEMA_DIR
-        run: cp -r dist/schemata/ $SCHEMA_DIR/dev/
+        run: | 
+          cp -r dist/schemata/ $SCHEMA_DIR/
+          mv $SCHEMA_DIR/schemata $SCHEMA_DIR/dev
+          cp -r build/mei-source_canonicalized.xml $SCHEMA_DIR/dev
 
       - name: Check git status before commit
         working-directory: ${{ env.SCHEMA_DIR }}


### PR DESCRIPTION
This PR fixes the step of the deploy action that copies the built schema into the expected folder in the schema repo. Previously, the schemata folder itself, created during the build, was copied to the dev folder. Now only the content of the schemata folder should be found in dev.

It additionally copies the missing mei-source_canonicalized.xml to the schema folder.

Fixes #1133 
Fixes #1138