### PR TITLE
feat(performance): adding extData

### DIFF
--- a/source/docs/12-facsimilesrecordings.xml
+++ b/source/docs/12-facsimilesrecordings.xml
@@ -299,6 +299,14 @@
                      </figure>
                   </p>
                   <p>indicates that the entities identified in <att>data</att> all occur at the same instant.</p>
+                  <p><att>extData</att> is a container for holding non-MEI data formats, similar to <att>extMeta</att> but available in <att>when</att> rather than in MEI.header. <att>extData</att> allows for data from audio or other sources to be linked to notes or other score events. Data should be enclosed in a CDATA tag.</p>
+                  <p>The following example shows JSON formatted performance data encoded with <att>extMeta</att> for a single note (presumed to be defined elsewhere in the document as with the ID "note_1"). Both single-value summaries (e.g., pitch) and time series values (e.g., contF0) are encoded. </p>
+                  <p>
+                     <figure>
+                        <head/>
+                        <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/performances/performances-sample336.txt" parse="text"/></egXML>
+                     </figure>
+                  </p>  
                </div>
             </div>
          </div>

--- a/source/docs/12-facsimilesrecordings.xml
+++ b/source/docs/12-facsimilesrecordings.xml
@@ -299,8 +299,8 @@
                      </figure>
                   </p>
                   <p>indicates that the entities identified in <att>data</att> all occur at the same instant.</p>
-                  <p><gi>extData</gi> is a container for holding non-MEI data formats, similar to <gi>extMeta</gi> but available in <gi>when</gi> rather than in <gi>meiHeader</gi>. <gi>extData</gi> allows for data from audio or other sources to be linked to notes or other score events. Data should be enclosed in a CDATA tag.</p>
-                  <p>The following example shows JSON formatted performance data encoded with <gi>extMeta</gi> for a single note (presumed to be defined elsewhere in the document as with the ID "note_1"). Both single-value summaries (e.g., pitch) and time series values (e.g., contF0) are encoded.</p>
+                  <p><gi scheme="MEI">extData</gi> is a container for holding non-MEI data formats, similar to <gi scheme="MEI">extMeta</gi> but available in <gi scheme="MEI">when</gi> rather than in <gi scheme="MEI">meiHead</gi>. <gi scheme="MEI">extData</gi> allows for data from audio or other sources to be linked to notes or other score events. Data should be enclosed in a CDATA tag.</p>
+                  <p>The following example shows JSON formatted performance data encoded with <gi scheme="MEI">extMeta</gi> for a single note (presumed to be defined elsewhere in the document as with the ID "note_1"). Both single-value summaries (<abbr>e.g.</abbr>, pitch) and time series values (<abbr>e.g.</abbr>, contF0) are encoded.</p>
                   <p>
                      <figure>
                         <head/>

--- a/source/docs/12-facsimilesrecordings.xml
+++ b/source/docs/12-facsimilesrecordings.xml
@@ -300,7 +300,7 @@
                   </p>
                   <p>indicates that the entities identified in <att>data</att> all occur at the same instant.</p>
                   <p><gi>extData</gi> is a container for holding non-MEI data formats, similar to <gi>extMeta</gi> but available in <gi>when</gi> rather than in <gi>meiHeader</gi>. <gi>extData</gi> allows for data from audio or other sources to be linked to notes or other score events. Data should be enclosed in a CDATA tag.</p>
-                  <p>The following example shows JSON formatted performance data encoded with <att>extMeta</att> for a single note (presumed to be defined elsewhere in the document as with the ID "note_1"). Both single-value summaries (e.g., pitch) and time series values (e.g., contF0) are encoded. </p>
+                  <p>The following example shows JSON formatted performance data encoded with <gi>extMeta</gi> for a single note (presumed to be defined elsewhere in the document as with the ID "note_1"). Both single-value summaries (e.g., pitch) and time series values (e.g., contF0) are encoded.</p>
                   <p>
                      <figure>
                         <head/>

--- a/source/docs/12-facsimilesrecordings.xml
+++ b/source/docs/12-facsimilesrecordings.xml
@@ -299,7 +299,7 @@
                      </figure>
                   </p>
                   <p>indicates that the entities identified in <att>data</att> all occur at the same instant.</p>
-                  <p><att>extData</att> is a container for holding non-MEI data formats, similar to <att>extMeta</att> but available in <att>when</att> rather than in MEI.header. <att>extData</att> allows for data from audio or other sources to be linked to notes or other score events. Data should be enclosed in a CDATA tag.</p>
+                  <p><gi>extData</gi> is a container for holding non-MEI data formats, similar to <gi>extMeta</gi> but available in <gi>when</gi> rather than in <gi>meiHeader</gi>. <gi>extData</gi> allows for data from audio or other sources to be linked to notes or other score events. Data should be enclosed in a CDATA tag.</p>
                   <p>The following example shows JSON formatted performance data encoded with <att>extMeta</att> for a single note (presumed to be defined elsewhere in the document as with the ID "note_1"). Both single-value summaries (e.g., pitch) and time series values (e.g., contF0) are encoded. </p>
                   <p>
                      <figure>

--- a/source/examples/performances/performances-sample336.txt
+++ b/source/examples/performances/performances-sample336.txt
@@ -1,0 +1,9 @@
+<when absolute="00:00:00.00" xml:id="when_1" data="#note_1">
+    <extData>
+        &lt;![CDATA[
+            {"offset": "00:00:02.9005", 
+            "pitch": "455.98", 
+            "contF0": [454.3737606, 454.7165531, 455.2337513, 455.4622624, 456.0605954]}
+        ]]&gt;
+    </extData>
+</when>

--- a/source/modules/MEI.performance.xml
+++ b/source/modules/MEI.performance.xml
@@ -151,7 +151,9 @@
       <memberOf key="att.dataPointing"/>
     </classes>
     <content>
-      <rng:empty/>
+      <rng:zeroOrMore>
+         <rng:ref name="extData"/>
+      </rng:zeroOrMore>
     </content>
     <constraintSpec ident="check_when_interval" scheme="isoschematron">
       <constraint>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -5769,6 +5769,32 @@
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-extent.html">extent</ref> element of the Text Encoding Initiative (TEI).</p>
     </remarks>
   </elementSpec>
+  <elementSpec ident="extData" module="MEI.shared">
+    <gloss versionDate="2023-05-23" xml:lang="en">extended data</gloss>
+    <desc xml:lang="en">Provides a container element for non-MEI data formats.</desc>
+    <classes>
+      <memberOf key="att.basic" />
+      <memberOf key="att.labelled" />
+      <memberOf key="att.responsibility" />
+      <memberOf key="att.typed" />
+      <memberOf key="att.whitespace"/>
+      <memberOf key="att.pointing"/>
+      <memberOf key="att.internetMedia"/>
+    </classes>
+    <content>
+      <rng:zeroOrMore>
+        <rng:group>
+          <rng:choice>
+            <rng:text/>
+            <rng:ref name="macro.anyXML"/>
+          </rng:choice>
+        </rng:group>
+      </rng:zeroOrMore>
+    </content>
+    <remarks xml:lang="en">
+      <p>Container for holding non-MEI data formats, similar to @extMeta but available in @when rather than in MEI.header. @extData allows for data from audio or other sources to be linked to notes or other score events. Data should be enclosed in a CDATA tag.</p>
+    </remarks>
+  </elementSpec>
   <elementSpec ident="funder" module="MEI.shared">
     <desc xml:lang="en">Names of individuals, institutions, or organizations responsible for funding. Funders
       provide financial support for a project; they are distinct from sponsors, who provide

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -5792,7 +5792,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>Container for holding non-MEI data formats, similar to @extMeta but available in @when rather than in MEI.header. @extData allows for data from audio or other sources to be linked to notes or other score events. Data should be enclosed in a CDATA tag.</p>
+      <p>Container for holding non-MEI data formats, similar to <gi scheme="MEI">extMeta</gi> but available in <gi scheme="MEI">when</gi> rather than in <gi scheme="MEI">meiHead</gi>. The content of this element, by virtue of being inside a <gi scheme="MEI">when</gi> element, is associated with a particular point in time in a media file and this point in time may be linked to symbolic data, such as notes, chords, rests, etc., recorded elsewhere. When the data in <gi scheme="MEI">extData</gi> contains left angle bracket (less-than) or ampersand characters, or when it contains white space that should be preserved (such as line breaks), then the data should be enclosed in a CDATA section (<abbr>e.g.</abbr>, for JSON formatted data).</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="funder" module="MEI.shared">


### PR DESCRIPTION
Defining `<extData>` (based on `<extMeta>`), extending `<when>` to allow for it to contain `<extData>`, and updating relevant documentation.

Fixes #1131 