### PR TITLE
Develop basic cleanup

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -223,7 +223,7 @@
                 <classSpec type="atts" ident="att.extender" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.fermataPresent" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.filing" module="MEI.shared" mode="delete"/>
-                <classSpec type="atts" ident="att.labelled" module="MEI.shared" mode="delete"/>
+                <!--<classSpec type="atts" ident="att.labelled" module="MEI.shared" mode="delete"/>-->
                 <classSpec type="atts" ident="att.layer.log" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.linking" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.lyricStyle" module="MEI.shared" mode="delete"/>
@@ -247,7 +247,7 @@
                 <classSpec type="atts" ident="att.textStyle" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.tiePresent" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.tupletPresent" module="MEI.shared" mode="delete"/>
-                <classSpec type="atts" ident="att.typed" module="MEI.shared" mode="delete"/>
+                <!--<classSpec type="atts" ident="att.typed" module="MEI.shared" mode="delete"/>-->
                 <!--<classSpec type="atts" ident="att.typography" module="MEI.shared" mode="delete"/>-->
                 <classSpec type="atts" ident="att.verticalGroup" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.visibility" module="MEI.shared" mode="delete"/>
@@ -337,11 +337,11 @@
                     <desc>Attributes common to many elements.</desc>
                     <classes mode="replace">
                         <memberOf key="att.basic" mode="add"/>
-                        <!--<memberOf key="att.labelled" mode="add"/>-->
+                        <memberOf key="att.labelled" mode="add"/>
                         <!--<memberOf key="att.linking" mode="add"/>-->
                         <!--<memberOf key="att.nNumberLike" mode="add"/>-->
                         <!--<memberOf key="att.responsibility" mode="add"/>-->
-                        <!--<memberOf key="att.typed" mode="add"/>-->
+                        <memberOf key="att.typed" mode="add"/>
                     </classes>
                 </classSpec>
 
@@ -919,21 +919,6 @@
                             <datatype maxOccurs="1" minOccurs="1">
                                 <rng:ref name="data.WORD" />
                             </datatype>
-                        </attDef>
-                        <attDef ident="label" usage="opt">
-                            <desc>Captures text to be used to generate a label for the element to which it's attached, a "tool tip" or prefatory text, for example. Should not be used to record document content.</desc>
-                            <datatype maxOccurs="1" minOccurs="1">
-                                <rng:data type="string"/>
-                            </datatype>
-                            <remarks>
-                                <p part="N">
-                                    <att scheme="TEI">label</att> is used to provide a display label for an element's contents,
-                                    for example in the form of a "tool tip" or as the "name" when the element's contents are 
-                                    treated as the "value" in a "name-value pair". Unlike <att scheme="TEI">n</att>,
-                                    <att scheme="TEI">label</att> may contain space characters.</p>
-                                <p part="N">Don't confuse this attribute with the <gi scheme="MEI">label</gi>
-                                    element, which records document content.</p>
-                            </remarks>
                         </attDef>
                     </attList>
                     <remarks>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -970,18 +970,12 @@
                         <rng:optional>
                             <rng:ref name="model.meterSigLike"/>
                         </rng:optional>
-                        <!--<rng:optional>
+                        <rng:optional>
                             <rng:ref name="pgHead"/>
-                        </rng:optional>-->
-                        <!--<rng:optional>
-                            <rng:ref name="pgHead2"/>
-                        </rng:optional>-->
-                        <!--<rng:optional>
+                        </rng:optional>
+                        <rng:optional>
                             <rng:ref name="pgFoot"/>
-                        </rng:optional>-->
-                        <!--<rng:optional>
-                            <rng:ref name="pgFoot2"/>
-                        </rng:optional>-->
+                        </rng:optional>
                         <rng:optional>
                             <rng:ref name="instrGrp"/>
                         </rng:optional>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -70,6 +70,7 @@
                 
                 <classSpec type="atts" ident="att.accid.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.ambNote.anl" module="MEI.analytical" mode="delete"/>
+                <classSpec type="atts" ident="att.anchoredText.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.annot.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.accid.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.arpeg.anl" module="MEI.analytical" mode="delete"/>
@@ -105,6 +106,7 @@
                 <classSpec type="atts" ident="att.fingGrp.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.fTrem.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.gliss.anl" module="MEI.analytical" mode="delete"/>
+                <classSpec type="atts" ident="att.graceGrp.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.grpSym.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.hairpin.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.halfmRpt.anl" module="MEI.analytical" mode="delete"/>
@@ -128,9 +130,11 @@
                 <classSpec type="atts" ident="att.measure.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.melodicFunction.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.mensur.anl" module="MEI.analytical" mode="delete"/>
+                <classSpec type="atts" ident="att.metaMark.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.meterSig.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.meterSigGrp.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.midi.anl" module="MEI.analytical" mode="delete"/>
+                <classSpec type="atts" ident="att.mNum.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.mordent.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.mRest.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.mRpt.anl" module="MEI.analytical" mode="delete"/>
@@ -148,12 +152,12 @@
                 <classSpec type="atts" ident="att.ossia.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.pad.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.part.anl" module="MEI.analytical" mode="delete"/>
-                <classSpec type="atts" ident="att.accid.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.parts.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.pb.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.pedal.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.phrase.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.pitchClass.anl" module="MEI.analytical" mode="delete"/>
+                <classSpec type="atts" ident="att.plica.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.proport.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.quilisma.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.rdg.anl" module="MEI.analytical" mode="delete"/>
@@ -173,6 +177,7 @@
                 <classSpec type="atts" ident="att.staffDef.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.staffGrp.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.stageDir.anl" module="MEI.analytical" mode="delete"/>
+                <classSpec type="atts" ident="att.stem.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.strophicus.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.syl.anl" module="MEI.analytical" mode="delete"/>
                 <classSpec type="atts" ident="att.syllable.anl" module="MEI.analytical" mode="delete"/>
@@ -192,26 +197,92 @@
                 <classSpec type="atts" ident="att.beamRend" module="MEI.cmn" mode="delete"/>
                 <classSpec type="atts" ident="att.beamSecondary" module="MEI.cmn" mode="delete"/>
                 <classSpec type="atts" ident="att.beamSpan.log" module="MEI.cmn" mode="delete"/>
+                <classSpec type="atts" ident="att.chord.ges.cmn" module="MEI.cmn" mode="delete"/>
                 <classSpec type="atts" ident="att.measure.vis" module="MEI.cmn" mode="delete"/>
+                <classSpec type="atts" ident="att.mNum.log" module="MEI.cmn" mode="delete"/>
+                <classSpec type="atts" ident="att.ossia.log" module="MEI.cmn" mode="delete"/>
+                <classSpec type="atts" ident="att.rest.log.cmn" module="MEI.cmn" mode="delete"/>
                 <classSpec type="atts" ident="att.slurRend" module="MEI.cmn" mode="delete"/>
+                <classSpec type="atts" ident="att.space.log.cmn" module="MEI.cmn" mode="delete"/>
                 <classSpec type="atts" ident="att.tieRend" module="MEI.cmn" mode="delete"/>
-
+                
+                <classSpec type="atts" ident="att.rdg.log" module="MEI.critapp" mode="delete"/>
+                
+                <classSpec type="atts" ident="att.ambitus.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.ambNote.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.anchoredText.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.arpeg.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.articulation.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.barLine.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.beam.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.beatRpt.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.chordDef.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.clef.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.clefGrp.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.curve.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.custos.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.dir.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.dot.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.duration.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.dynam.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.ending.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.graceGrp.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.grpSym.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.halfmRpt.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.harm.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.hispanTick.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.keyAccid.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.keySig.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.layer.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.ligature.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.liquescent.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.lyrics.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.mensur.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.meterSig.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.meterSigGrp.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.midi.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.mNum.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.mordent.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.mRpt.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.mRpt2.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.multiRpt.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.oriscus.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.ossia.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.pad.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.part.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.parts.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.pb.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.plica.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.proport.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.quilisma.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.rdg.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.refrain.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.reh.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.sb.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.scoreDef.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.signifLet.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.staff.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.stem.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.strophicus.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.syl.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.syllable.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.symbol.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.timestamp.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.timestamp2.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.turn.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.verse.ges" module="MEI.gestural" mode="delete"/>
+                <classSpec type="atts" ident="att.volta.ges" module="MEI.gestural" mode="delete"/>
                 
+                <classSpec type="atts" ident="att.refrain.log" module="MEI.lyrics" mode="delete"/>
+                <classSpec type="atts" ident="att.verse.log" module="MEI.lyrics" mode="delete"/>
+                <classSpec type="atts" ident="att.volta.log" module="MEI.lyrics" mode="delete"/>
+                
+                <classSpec type="atts" ident="att.ambitus.log" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.authorized" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.barring" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.bibl" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.classed" module="MEI.shared" mode="delete"/>
+                <classSpec type="atts" ident="att.clefGrp.log" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.color" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.coloration" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.curveRend" module="MEI.shared" mode="delete"/>
@@ -232,13 +303,17 @@
                 <classSpec type="atts" ident="att.noteHeads" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.octaveDefault" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.pages" module="MEI.shared" mode="delete"/>
+                <classSpec type="atts" ident="att.part.log" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.partIdent" module="MEI.shared" mode="delete"/>
+                <classSpec type="atts" ident="att.parts.log" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.pointing" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.responsibility" module="MEI.shared" mode="delete"/>
+                <classSpec type="atts" ident="att.score.log" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.scoreDef.log" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.source" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.spacing" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.staff.log" module="MEI.shared" mode="delete"/>
+                <classSpec type="atts" ident="att.staffGrp.log" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.staffItems" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.staffLoc" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.staffLoc.pitched" module="MEI.shared" mode="delete"/>
@@ -263,19 +338,33 @@
                 <classSpec type="atts" ident="att.xy2" module="MEI.shared" mode="delete"/>
 
                 <classSpec type="atts" ident="att.accid.vis" module="MEI.visual" mode="delete"/>
+                <classSpec type="atts" ident="att.ambitus.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.ambNote.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.beaming.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.barLine.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.chord.vis" module="MEI.visual" mode="delete"/>
+                <classSpec type="atts" ident="att.chordDef.vis" module="MEI.visual" mode="delete"/>
+                <classSpec type="atts" ident="att.chordMember.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.cleffing.vis" module="MEI.visual" mode="delete"/>
+                <classSpec type="atts" ident="att.clefGrp.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.fermata.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.fingGrp.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.fTrem.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.harm.vis" module="MEI.visual" mode="delete"/>
+                <classSpec type="atts" ident="att.instrDef.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.keysigDefault.vis" module="MEI.visual" mode="delete"/>
+                <classSpec type="atts" ident="att.mdiv.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.meterSigDefault.vis" module="MEI.visual" mode="delete"/>
+                <classSpec type="atts" ident="att.meterSigGrp.vis" module="MEI.visual" mode="delete"/>
+                <classSpec type="atts" ident="att.ossia.vis" module="MEI.visual" mode="delete"/>
+                <classSpec type="atts" ident="att.pad.vis" module="MEI.visual" mode="delete"/>
+                <classSpec type="atts" ident="att.part.vis" module="MEI.visual" mode="delete"/>
+                <classSpec type="atts" ident="att.parts.vis" module="MEI.visual" mode="delete"/>
+                <classSpec type="atts" ident="att.rdg.vis" module="MEI.visual" mode="delete"/>
+                <classSpec type="atts" ident="att.score.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.scoreDef.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.staffDef.vis" module="MEI.visual" mode="delete"/>
+                <classSpec type="atts" ident="att.syllable.vis" module="MEI.visual" mode="delete"/>
 
                 <!--<classSpec type="atts" ident="att.arpeg.vis" module="MEI.visual" mode="change">
                     <desc>Visual domain attributes.</desc>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -56,7 +56,7 @@
                 <!--<moduleRef key="MEI.frbr"/>-->
                 <moduleRef key="MEI.gestural"/>
                 <moduleRef key="MEI.harmony"/>
-                <moduleRef key="MEI.header" include="meiHead fileDesc titleStmt pubStmt date availability composer lyricist arranger"/>
+                <moduleRef key="MEI.header" include="meiHead fileDesc titleStmt pubStmt availability composer lyricist arranger"/>
                 <moduleRef key="MEI.lyrics"/>
                 <!--<moduleRef key="MEI.msDesc"/>-->
                 <moduleRef key="MEI.midi" include="instDef" />

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -62,7 +62,7 @@
                 <moduleRef key="MEI.shared" except="annot barLine cb colLayout custos div group keySig pad part parts relation relationList"/>
                 <!--<moduleRef key="MEI.msDesc"/>-->
                 <moduleRef key="MEI.stringtab"/>
-                <moduleRef key="MEI.text" except="front back"/>
+                <!--<moduleRef key="MEI.text"/>-->
                 <moduleRef key="MEI.visual"/>
 
                 <classSpec type="atts" ident="att.notationType" module="MEI" mode="delete"/>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -59,6 +59,7 @@
                 <moduleRef key="MEI.header" include="meiHead fileDesc titleStmt pubStmt date availability composer lyricist arranger"/>
                 <moduleRef key="MEI.lyrics"/>
                 <!--<moduleRef key="MEI.msDesc"/>-->
+                <moduleRef key="MEI.midi" include="instDef" />
                 <moduleRef key="MEI.namesdates" include="persName" />
                 <moduleRef key="MEI.shared" include="accid artic body caesura chord clef clefGrp date dir dynam label labelAbbr layer lb mdiv mei music note ornam pb pgFoot pgHead pubPlace rend respStmt rest sb score scoreDef section space staff staffDef staffGrp syl tempo title "/>
                 <moduleRef key="MEI.stringtab"/>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -336,7 +336,7 @@
                 <classSpec type="atts" ident="att.common" module="MEI.shared" mode="change">
                     <desc>Attributes common to many elements.</desc>
                     <classes mode="replace">
-                        <memberOf key="att.basic" mode="add"/>
+                        <memberOf key="att.id" mode="add"/>
                         <memberOf key="att.labelled" mode="add"/>
                         <!--<memberOf key="att.linking" mode="add"/>-->
                         <!--<memberOf key="att.nNumberLike" mode="add"/>-->

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -51,16 +51,16 @@
                 <moduleRef key="MEI.cmn"
                     except="attacca beamSpan bend bracketSpan meterSig meterSigGrp mRpt2 mSpace oLayer ossia oStaff tupletSpan"/>
                 <moduleRef key="MEI.cmnOrnaments"/>
-                <moduleRef key="MEI.figtable"/>
+                <!--<moduleRef key="MEI.figtable"/>-->
                 <moduleRef key="MEI.fingering"/>
-                <moduleRef key="MEI.frbr"/>
+                <!--<moduleRef key="MEI.frbr"/>-->
                 <moduleRef key="MEI.gestural"/>
                 <moduleRef key="MEI.harmony"/>
                 <moduleRef key="MEI.header" include="meiHead fileDesc titleStmt title pubStmt publisher pubPlace date availability composer lyricist arranger"/>
                 <moduleRef key="MEI.lyrics"/>
-                <moduleRef key="MEI.msDesc"/>
                 <moduleRef key="MEI.namesdates"/>
                 <moduleRef key="MEI.shared" except="annot barLine cb colLayout custos div group keySig pad part parts relation relationList"/>
+                <!--<moduleRef key="MEI.msDesc"/>-->
                 <moduleRef key="MEI.stringtab"/>
                 <moduleRef key="MEI.text" except="front back"/>
                 <moduleRef key="MEI.visual"/>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -58,9 +58,9 @@
                 <moduleRef key="MEI.harmony"/>
                 <moduleRef key="MEI.header" include="meiHead fileDesc titleStmt pubStmt date availability composer lyricist arranger"/>
                 <moduleRef key="MEI.lyrics"/>
-                <moduleRef key="MEI.shared" except="annot barLine cb colLayout custos div group keySig pad part parts relation relationList"/>
                 <!--<moduleRef key="MEI.msDesc"/>-->
                 <moduleRef key="MEI.namesdates" include="persName" />
+                <moduleRef key="MEI.shared" include="accid artic body caesura chord clef clefGrp date dir dynam label labelAbbr layer lb mdiv mei music note ornam pb pgFoot pgHead pubPlace rend respStmt rest sb score scoreDef section space staff staffDef staffGrp syl tempo title "/>
                 <moduleRef key="MEI.stringtab"/>
                 <!--<moduleRef key="MEI.text"/>-->
                 <moduleRef key="MEI.visual"/>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -58,9 +58,9 @@
                 <moduleRef key="MEI.harmony"/>
                 <moduleRef key="MEI.header" include="meiHead fileDesc titleStmt title pubStmt publisher pubPlace date availability composer lyricist arranger"/>
                 <moduleRef key="MEI.lyrics"/>
-                <moduleRef key="MEI.namesdates"/>
                 <moduleRef key="MEI.shared" except="annot barLine cb colLayout custos div group keySig pad part parts relation relationList"/>
                 <!--<moduleRef key="MEI.msDesc"/>-->
+                <moduleRef key="MEI.namesdates" include="persName" />
                 <moduleRef key="MEI.stringtab"/>
                 <!--<moduleRef key="MEI.text"/>-->
                 <moduleRef key="MEI.visual"/>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -56,7 +56,7 @@
                 <!--<moduleRef key="MEI.frbr"/>-->
                 <moduleRef key="MEI.gestural"/>
                 <moduleRef key="MEI.harmony"/>
-                <moduleRef key="MEI.header" include="meiHead fileDesc titleStmt title pubStmt publisher pubPlace date availability composer lyricist arranger"/>
+                <moduleRef key="MEI.header" include="meiHead fileDesc titleStmt pubStmt date availability composer lyricist arranger"/>
                 <moduleRef key="MEI.lyrics"/>
                 <moduleRef key="MEI.shared" except="annot barLine cb colLayout custos div group keySig pad part parts relation relationList"/>
                 <!--<moduleRef key="MEI.msDesc"/>-->


### PR DESCRIPTION
This PR essentially removes elements that are not relevant for MEI basic but that were still through the inclusion of some modules.

The modules entirely removed are:
* `figtable`
* `frbr`
* `msDesc`
* `text`

For some modules, the definition of the elements available was changed from an `@except` list to a `@include` one to give a better understanding of what is available in MEI basic. This is the case for:
* `namesdates`
* `meiHead`
* `shared`

The PR also adds `instDef` from `midi`.

It also put back `@label` and `@type` in `att.common` and allows `pgHead` and `pgFoot` in `scoreDef` (see #1128)