### PR TITLE
Fixed: Add glyph.auth and glyph.uri to rend

### DIFF
--- a/source/docs/09-textencoding.xml
+++ b/source/docs/09-textencoding.xml
@@ -256,6 +256,13 @@
                <div xml:id="sharedTextRendition" type="div3">
                   <head>Text Rendition</head>
                   <p>Sometimes, it is desirable to capture the typographical qualities of a word or phrase without assigning it a special meaning. For this purpose, MEI offers the <gi scheme="MEI">rend</gi> element, similar to TEI’s <hi rend="italic">hi</hi> element. Using CSS-like values, its <att>rend</att> attribute can be used to specify many typographic features, such as font style, font variants, and relative font size and weight. In addition, text decoration, direction, and enclosing ‘boxes’ may be captured. While <att>rend</att> is used to record relative font size and weight, absolute values for these qualities (measured in printer’s points) should be specified using the <att>fontsize</att> and <att>fontweight</att> attributes. In addition to commonly found typographical qualities, MEI provides the <att>altrend</att> attribute for the capture of additional, user-defined rendition information.</p>
+                  <p>The <gi scheme="MEI">rend</gi> element can accept <att>glyph.auth</att> and <att>glyph.uri</att> attributes, which provide encoders with the ability to specify an external authority for Unicode codepoints in the textual content. Only the text content that should be rendered using SMuFL code points should go inside the <gi scheme="MEI">rend</gi> element when using <att>glyph.auth</att> and <att>glyph.uri</att>.</p>
+                  <p>
+                     <figure>
+                        <head />
+                        <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/text/text-sample375.txt" parse="text"/></egXML>
+                     </figure>
+                  </p>
                   <p>
                      <specList>
                         <specDesc key="rend"/>

--- a/source/examples/text/text-sample375.txt
+++ b/source/examples/text/text-sample375.txt
@@ -1,0 +1,3 @@
+<rend>
+    This is what a G clef looks like: <rend glyph.auth="smufl">&amp;#xE050;</rend>
+</rend>

--- a/source/modules/MEI.externalsymbols.xml
+++ b/source/modules/MEI.externalsymbols.xml
@@ -24,7 +24,7 @@
       </attDef>
       <attDef ident="glyph.uri" usage="opt">
         <desc xml:lang="en">The web-accessible location of the controlled vocabulary from which the value of
-          <att>glyph.name</att> or <att>glyph.num</att> is taken, or the textual content of the element</desc>
+          <att>glyph.name</att> or <att>glyph.num</att> is taken, or the textual content of the element.</desc>
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>

--- a/source/modules/MEI.externalsymbols.xml
+++ b/source/modules/MEI.externalsymbols.xml
@@ -7,13 +7,12 @@
   <moduleSpec ident="MEI.externalsymbols">
     <desc xml:lang="en">External symbols component declarations.</desc>
   </moduleSpec>
-  <classSpec ident="att.extSym" module="MEI.externalsymbols" type="atts">
-    <desc xml:lang="en">Attributes used to associate MEI features with corresponding glyphs in an
-      externally-defined standard such as SMuFL.</desc>
+  <classSpec ident="att.extSym.auth" module="MEI.externalsymbols" type="atts">
+    <desc xml:lang="en">Attributes that point to an external symbol authority.</desc>
     <attList>
       <attDef ident="glyph.auth" usage="opt">
         <desc xml:lang="en">A name or label associated with the controlled vocabulary from which the value of
-            <att>glyph.name</att> or <att>glyph.num</att> is taken.</desc>
+          <att>glyph.name</att> or <att>glyph.num</att> is taken, or the textual content of the element.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
@@ -23,6 +22,18 @@
           </valItem>
         </valList>
       </attDef>
+      <attDef ident="glyph.uri" usage="opt">
+        <desc xml:lang="en">The web-accessible location of the controlled vocabulary from which the value of
+          <att>glyph.name</att> or <att>glyph.num</att> is taken, or the textual content of the element</desc>
+        <datatype>
+          <rng:ref name="data.URI"/>
+        </datatype>
+      </attDef>
+    </attList>
+  </classSpec>
+  <classSpec ident="att.extSym.names" module="MEI.externalsymbols" type="atts">
+    <desc xml:lang="en">Attributes that specify names or values taken from an external symbol authority.</desc>
+    <attList>
       <attDef ident="glyph.name" usage="opt">
         <desc xml:lang="en">Glyph name.</desc>
         <datatype>
@@ -54,13 +65,14 @@
           </constraint>
         </constraintSpec>
       </attDef>
-      <attDef ident="glyph.uri" usage="opt">
-        <desc xml:lang="en">The web-accessible location of the controlled vocabulary from which the value of
-            <att>glyph.name</att> or <att>glyph.num</att> is taken.</desc>
-        <datatype>
-          <rng:ref name="data.URI"/>
-        </datatype>
-      </attDef>
     </attList>
+  </classSpec>
+  <classSpec ident="att.extSym" module="MEI.externalsymbols" type="atts">
+    <desc xml:lang="en">Attributes used to associate MEI features with corresponding glyphs in an
+      externally-defined standard such as SMuFL.</desc>
+    <classes>
+      <memberOf key="att.extSym.auth"/>
+      <memberOf key="att.extSym.names"/>
+    </classes>
   </classSpec>
 </specGrp>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -7253,6 +7253,7 @@
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.common"/>
+      <memberOf key="att.extSym.auth"/>
       <memberOf key="att.horizontalAlign"/>
       <memberOf key="att.lang"/>
       <memberOf key="att.textRendition"/>
@@ -7282,7 +7283,9 @@
     </attList>
     <remarks xml:lang="en">
       <p>When an entire element should be rendered in a special way, a style sheet function should
-        be used instead of the <gi scheme="MEI">rend</gi> element.</p>
+        be used instead of the <gi scheme="MEI">rend</gi> element. The <att>glyph.auth</att> and <att>glyph.uri</att>
+        attributes may be used to specify an external authority, <abbr>e.g.,</abbr> SMuFL, to be used for
+        displaying code points in the textual content of the element.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="repository" module="MEI.shared">


### PR DESCRIPTION
Addresses result of conversation in #704.

The att.extSym class was broken into two sub-classes so that we could only add rend to one of them, without also pulling in glyph.name and glyph.num. No other elements should be affected by this change.