### PR TITLE
fix(neumes): fix incorrect attribute classes in neumes customization

### DIFF
--- a/customizations/mei-Neumes.xml
+++ b/customizations/mei-Neumes.xml
@@ -102,9 +102,9 @@
         </moduleRef>
 
         <!-- Remove dur attributes -->
-        <classSpec ident="att.duration.musical" module="MEI.shared" type="atts" mode="delete"/>
+        <classSpec ident="att.duration.logical" module="MEI.shared" type="atts" mode="delete"/>
         <classSpec ident="att.duration.additive" module="MEI.shared" type="atts" mode="delete"/>
-        <classSpec ident="att.augmentdots" module="MEI.shared" type="atts" mode="delete"/>
+        <classSpec ident="att.augmentDots" module="MEI.shared" type="atts" mode="delete"/>
 
         <!-- Disable CMN-specific model classes in the shared module -->
         <classSpec ident="model.sectionPart.cmn" module="MEI.shared" type="model" mode="delete"/>


### PR DESCRIPTION
This PR fixes the incorrect/renamed attribute classes in the neumes customization.

Fixes #628