### PR TITLE
Cleanup Verovio examples

### DIFF
--- a/source/examples/verovio/accid-03.mei
+++ b/source/examples/verovio/accid-03.mei
@@ -1,5 +1,8 @@
-<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
-   <meiHead meiversion="4.0.0">
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+   <meiHead>
       <fileDesc>
          <titleStmt>
             <title>Alignment of editorial accidentals</title>
@@ -11,53 +14,36 @@
             <annot>Editorial accidentals are aligned on the centre of the notehead.</annot>
          </notesStmt>
       </fileDesc>
-      <encodingDesc>
-         <appInfo>
-            <application version="0.9.13">
-               <name>Verovio</name>
-            </application>
-         </appInfo>
-      </encodingDesc>
-      <workDesc>
-         <work>
-            <titleStmt>
-               <title/>
-            </titleStmt>
-         </work>
-      </workDesc>
+      <encodingDesc />
    </meiHead>
-   <music meiversion="4.0.0">
+   <music>
       <body>
-         <mdiv xml:id="mdiv-0000001056540324">
-            <score xml:id="score-0000000884943276">
-               <scoreDef xml:id="scoredef-000000027977328" n="1" label="feature-example">
-                  <staffGrp xml:id="m-000000028778056">
-                     <staffDef xml:id="staffdef-000000129725177"
-                               n="1"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"/>
+         <mdiv>
+            <score>
+               <scoreDef n="1">
+                  <staffGrp>
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                   </staffGrp>
                </scoreDef>
-               <section xml:id="section-000000076944697">
-                  <measure xml:id="measure-L2" right="end" n="1">
-                     <staff xml:id="staff-L2F1" n="1">
-								<?edit-start?>
-                        <layer xml:id="layer-L2F1" n="1">
-                           <note xml:id="note-L3F1" dur="1" oct="5" pname="f">
-                              <accid xml:id="accid-000000113038940" accid="s" func="edit"/>
+               <section>
+                  <measure right="end" n="1">
+                     <staff n="1">
+                        <?edit-start?>
+                        <layer n="1">
+                           <note dur="1" oct="5" pname="f">
+                              <accid accid="s" func="edit" />
                            </note>
-                           <note xml:id="note-L4F1" dur="1" oct="5" pname="f">
-                              <accid xml:id="accid-000000162539045" accid="f" func="edit"/>
+                           <note dur="1" oct="5" pname="f">
+                              <accid accid="f" func="edit" />
                            </note>
-                           <note xml:id="note-L5F1" dur="1" oct="5" pname="f">
-                              <accid xml:id="accid-000000208946960" accid="n" func="edit"/>
+                           <note dur="1" oct="5" pname="f">
+                              <accid accid="n" func="edit" />
                            </note>
-                           <note xml:id="note-L6F1" dur="1" oct="5" pname="f">
-                              <accid xml:id="accid-000000207644959" accid="x" func="edit"/>
+                           <note dur="1" oct="5" pname="f">
+                              <accid accid="x" func="edit" />
                            </note>
-                           <note xml:id="note-L7F1" dur="1" oct="5" pname="f">
-                              <accid xml:id="accid-000000179518178" accid="ff" func="edit"/>
+                           <note dur="1" oct="5" pname="f">
+                              <accid accid="ff" func="edit" />
                            </note>
                         </layer>
                         <?edit-end?>

--- a/source/examples/verovio/alteration.mei
+++ b/source/examples/verovio/alteration.mei
@@ -1,5 +1,8 @@
-<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">
-   <meiHead meiversion="4.0.1">
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+   <meiHead>
       <fileDesc>
          <titleStmt>
             <title>Example of 'alteration'</title>
@@ -12,58 +15,46 @@
          </notesStmt>
       </fileDesc>
    </meiHead>
-   <music meiversion="4.0.1">
+   <music>
       <body>
          <mdiv>
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1"
-                               label="voice"
-                               notationtype="mensural.white"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"
-                               modusminor="3"/>
-                     <staffDef n="2"
-                               label="reference"
-                               notationtype="mensural.white"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"
-                               modusminor="3"/>
+                     <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" />
+                     <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" />
                   </staffGrp>
                </scoreDef>
                <section>
                   <staff n="1">
-                            <?edit-start?>
-                     <layer>
-                        <note dur="longa" dur.quality="perfecta"/>
-                        <barLine form="dashed"/>
-                        <note dur="brevis"/>
-                        <barLine form="dashed"/>
-                        <note dur="brevis" dur.quality="altera"/>
-                        <barLine form="dashed"/>
-                        <note dur="longa" dur.quality="perfecta"/>
-                        <barLine form="dashed"/>
+                     <?edit-start?>
+                     <layer n="1">
+                        <note dur="longa" dur.quality="perfecta" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" dur.quality="altera" />
+                        <barLine form="dashed" />
+                        <note dur="longa" dur.quality="perfecta" />
+                        <barLine form="dashed" />
                      </layer>
                      <?edit-end?>
                   </staff>
                   <staff n="2">
-                     <layer>
-                        <note dur="brevis" pname="a" oct="4"/>
-                        <note dur="brevis" pname="a" oct="4"/>
-                        <note dur="brevis" pname="a" oct="4"/>
-                        <barLine form="dashed"/>
-                        <note dur="brevis" pname="a" oct="4"/>
-                        <barLine form="dashed"/>
-                        <note dur="brevis" pname="a" oct="4"/>
-                        <note dur="brevis" pname="a" oct="4"/>
-                        <barLine form="dashed"/>
-                        <note dur="brevis" pname="a" oct="4"/>
-                        <note dur="brevis" pname="a" oct="4"/>
-                        <note dur="brevis" pname="a" oct="4"/>
-                        <barLine form="dashed"/>
+                     <layer n="1">
+                        <note dur="brevis" oct="4" pname="a" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <barLine form="dashed" />
                      </layer>
                   </staff>
                </section>

--- a/source/examples/verovio/ars_antiqua.mei
+++ b/source/examples/verovio/ars_antiqua.mei
@@ -1,5 +1,8 @@
-<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">
-   <meiHead meiversion="4.0.1">
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+   <meiHead>
       <fileDesc>
          <titleStmt>
             <title>Example of 'imperfection' and 'dot of division'</title>
@@ -12,71 +15,57 @@
          </notesStmt>
       </fileDesc>
    </meiHead>
-   <music meiversion="4.0.1">
+   <music>
       <body>
          <mdiv>
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1"
-                               label="voice"
-                               notationtype="mensural.black"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"
-                               modusminor="3"
-                               tempus="3"/>
-                     <staffDef n="2"
-                               label="reference"
-                               notationtype="mensural.black"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"
-                               modusminor="3"
-                               tempus="3"/>
+                     <staffDef label="voice" n="1" notationtype="mensural.black" lines="5" clef.shape="G" clef.line="2" modusminor="3" tempus="3" mensur.sign="O" mensur.slash="1" />
+                     <staffDef label="reference" n="2" notationtype="mensural.black" lines="5" clef.shape="G" clef.line="2" modusminor="3" tempus="3" mensur.sign="O" mensur.slash="1" />
                   </staffGrp>
                </scoreDef>
                <section>
                   <staff n="1">
-                            <?edit-start?>
-                     <layer>
-                        <note dur="longa" dur.quality="perfecta"/>
-                        <barLine form="dashed"/>
-                        <note dur="semibrevis" dur.quality="minor"/>
-                        <note dur="semibrevis" dur.quality="minor"/>
-                        <note dur="semibrevis" dur.quality="minor"/>
-                        <dot form="div"/>
-                        <barLine form="dashed"/>
-                        <note dur="semibrevis" dur.quality="minor"/>
-                        <note dur="semibrevis" dur.quality="maior"/>
-                        <barLine form="dashed"/>
-                        <note dur="brevis"/>
-                        <barLine form="dashed"/>
-                        <note dur="longa" dur.quality="duplex"/>
-                        <barLine form="dashed"/>
-                     </layer>
+                     <?edit-start?>
+                     <layer n="1">
+                        <note dur="longa" dur.quality="perfecta" />
+                        <barLine form="dashed" />
+                        <note dur="semibrevis" dur.quality="minor" />
+                        <note dur="semibrevis" dur.quality="minor" />
+                        <note dur="semibrevis" dur.quality="minor" />
+                        <dot form="div" />
+                        <barLine form="dashed" />
+                        <note dur="semibrevis" dur.quality="minor" />
+                        <note dur="semibrevis" dur.quality="maior" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" />
+                        <barLine form="dashed" />
+                        <note dur="longa" dur.quality="duplex" />
+                        <barLine form="dashed" />
+                     </layer>  
                      <?edit-end?>
                   </staff>
                   <staff n="2">
-                     <layer>
-                        <note dur="brevis"/>
-                        <note dur="brevis"/>
-                        <note dur="brevis"/>
-                        <barLine form="dashed"/>
-                        <note dur="brevis"/>
-                        <barLine form="dashed"/>
-                        <note dur="brevis"/>
-                        <barLine form="dashed"/>
-                        <note dur="brevis"/>
-                        <barLine form="dashed"/>
-                        <note dur="brevis"/>
-                        <note dur="brevis"/>
-                        <note dur="brevis"/>
-                        <barLine form="dashed"/>
-                        <note dur="brevis"/>
-                        <note dur="brevis"/>
-                        <note dur="brevis"/>
-                        <barLine form="dashed"/>
+                     <layer n="1">
+                        <note dur="brevis" />
+                        <note dur="brevis" />
+                        <note dur="brevis" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" />
+                        <note dur="brevis" />
+                        <note dur="brevis" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" />
+                        <note dur="brevis" />
+                        <note dur="brevis" />
+                        <barLine form="dashed" />
                      </layer>
                   </staff>
                </section>

--- a/source/examples/verovio/augmentation.mei
+++ b/source/examples/verovio/augmentation.mei
@@ -1,5 +1,8 @@
-<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">
-   <meiHead meiversion="4.0.1">
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+   <meiHead>
       <fileDesc>
          <titleStmt>
             <title>Example of 'augmentation'</title>
@@ -12,50 +15,36 @@
          </notesStmt>
       </fileDesc>
    </meiHead>
-   <music meiversion="4.0.1">
+   <music>
       <body>
          <mdiv>
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1"
-                               label="voice"
-                               notationtype="mensural.white"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"
-                               modusminor="2"
-                               tempus="2"/>
-                     <staffDef n="2"
-                               label="reference"
-                               notationtype="mensural.white"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"
-                               modusminor="2"
-                               tempus="2"/>
+                     <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="2" mensur.sign="C" mensur.slash="1" />
+                     <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="2" mensur.sign="C" mensur.slash="1" />
                   </staffGrp>
                </scoreDef>
                <section>
                   <staff n="1">
-                            <?edit-start?>
-                     <layer>
-                        <note dur="longa" dur.quality="perfecta"/>
-                        <dot form="aug"/>
-                        <barLine form="dashed"/>
-                        <note dur="brevis"/>
-                        <barLine form="dashed"/>
+                     <?edit-start?>
+                     <layer n="1">
+                        <note dur="longa" dur.quality="perfecta" />
+                        <dot form="aug" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" />
+                        <barLine form="dashed" />
                      </layer>
                      <?edit-end?>
                   </staff>
                   <staff n="2">
-                     <layer>
-                        <note dur="brevis" pname="a" oct="4"/>
-                        <note dur="brevis" pname="a" oct="4"/>
-                        <note dur="brevis" pname="a" oct="4"/>
-                        <barLine form="dashed"/>
-                        <note dur="brevis" pname="a" oct="4"/>
-                        <barLine form="dashed"/>
+                     <layer n="1">
+                        <note dur="brevis" oct="4" pname="a" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <barLine form="dashed" />
                      </layer>
                   </staff>
                </section>

--- a/source/examples/verovio/imperfection.mei
+++ b/source/examples/verovio/imperfection.mei
@@ -1,5 +1,8 @@
-<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">
-   <meiHead meiversion="4.0.1">
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+   <meiHead>
       <fileDesc>
          <titleStmt>
             <title>Example of 'imperfection' and 'dot of division'</title>
@@ -12,56 +15,44 @@
          </notesStmt>
       </fileDesc>
    </meiHead>
-   <music meiversion="4.0.1">
+   <music>
       <body>
          <mdiv>
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1"
-                               label="voice"
-                               notationtype="mensural.white"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"
-                               modusminor="3"/>
-                     <staffDef n="2"
-                               label="reference"
-                               notationtype="mensural.white"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"
-                               modusminor="3"/>
+                     <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" />
+                     <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" />
                   </staffGrp>
                </scoreDef>
                <section>
                   <staff n="1">
-                            <?edit-start?>
-                     <layer>
-                        <note dur="longa" dur.quality="imperfecta"/>
-                        <barLine form="dashed"/>
-                        <note dur="brevis"/>
-                        <dot form="div"/>
-                        <barLine form="dashed"/>
-                        <note dur="brevis"/>
-                        <barLine form="dashed"/>
-                        <note dur="longa" dur.quality="imperfecta"/>
-                        <barLine form="dashed"/>
+                     <?edit-start?>
+                     <layer n="1">
+                        <note dur="longa" dur.quality="imperfecta" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" />
+                        <dot form="div" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" />
+                        <barLine form="dashed" />
+                        <note dur="longa" dur.quality="imperfecta" />
+                        <barLine form="dashed" />
                      </layer>
                      <?edit-end?>
                   </staff>
                   <staff n="2">
-                     <layer>
-                        <note dur="brevis" pname="a" oct="4"/>
-                        <note dur="brevis" pname="a" oct="4"/>
-                        <barLine form="dashed"/>
-                        <note dur="brevis" pname="a" oct="4"/>
-                        <barLine form="dashed"/>
-                        <note dur="brevis" pname="a" oct="4"/>
-                        <barLine form="dashed"/>
-                        <note dur="brevis" pname="a" oct="4"/>
-                        <note dur="brevis" pname="a" oct="4"/>
-                        <barLine form="dashed"/>
+                     <layer n="1">
+                        <note dur="brevis" oct="4" pname="a" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <barLine form="dashed" />
                      </layer>
                   </staff>
                </section>

--- a/source/examples/verovio/implicit-mensuration.mei
+++ b/source/examples/verovio/implicit-mensuration.mei
@@ -1,107 +1,58 @@
-<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">
-   <meiHead meiversion="4.0.1">
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+   <meiHead>
       <fileDesc>
          <titleStmt>
-            <title>
-                    Example of omitted mensuration signs
-                </title>
+            <title>Example of 'imperfection' and 'dot of division'</title>
          </titleStmt>
-         <pubStmt/>
+         <pubStmt>
+            <date>2019-11-15</date>
+         </pubStmt>
          <notesStmt>
-            <annot>In this choir book, only the verso parts have a mensuration sign, whereas Altus and Bassus on the recto don't.</annot>
+            <annot>The bottom staff, together with the dotted barlines, is used here to help visualizing the durational values of the notes in the upper staff.</annot>
          </notesStmt>
-         <sourceDesc>
-            <source>
-               <bibl>FlorPanc27, 79v-80r</bibl>
-            </source>
-         </sourceDesc>
       </fileDesc>
    </meiHead>
-   <music meiversion="4.0.1">
+   <music>
       <body>
          <mdiv>
             <score>
-                    <?edit-start?>
-               <scoreDef key.sig="1f">
+               <?edit-start?>
+               <scoreDef>
                   <staffGrp>
-                     <staffDef n="1"
-                               label="Cantus"
-                               lines="5"
-                               notationtype="mensural.white"
-                               clef.shape="C"
-                               clef.line="1"
-                               tempus="2"
-                               prolatio="2"
-                               mensur.sign="C"
-                               mensur.slash="1"/>
-                     <staffDef n="2"
-                               label="Tenor"
-                               lines="5"
-                               notationtype="mensural.white"
-                               clef.shape="C"
-                               clef.line="4"
-                               tempus="2"
-                               prolatio="2"
-                               mensur.sign="C"
-                               mensur.slash="1"/>
-                     <staffDef n="3"
-                               label="Altus"
-                               lines="5"
-                               notationtype="mensural.white"
-                               clef.shape="C"
-                               clef.line="3"
-                               tempus="2"
-                               prolatio="2"/>
-                     <staffDef n="4"
-                               label="Bassus"
-                               lines="5"
-                               notationtype="mensural.white"
-                               clef.shape="F"
-                               clef.line="4"
-                               tempus="2"
-                               prolatio="2"/>
+                     <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" />
+                     <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" />
                   </staffGrp>
                </scoreDef>
                <?edit-end?>
                <section>
                   <staff n="1">
-                     <layer>
-                        <note pname="b" oct="4" dur="brevis"/>
-                        <note pname="b" oct="4" dur="brevis"/>
-                        <note pname="a" oct="4" dur="brevis"/>
-                        <note pname="g" oct="4" dur="brevis"/>
-                        <note pname="g" oct="4" dur="semibrevis"/>
-                        <note pname="g" oct="4" dur="semibrevis"/>
+                     <layer n="1">
+                        <note dur="longa" dur.quality="imperfecta" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" />
+                        <dot form="div" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" />
+                        <barLine form="dashed" />
+                        <note dur="longa" dur.quality="imperfecta" />
+                        <barLine form="dashed" />
                      </layer>
                   </staff>
                   <staff n="2">
-                     <layer>
-                        <note pname="g" oct="3" dur="brevis"/>
-                        <note pname="b" oct="3" dur="brevis"/>
-                        <note pname="c" oct="4" dur="brevis"/>
-                        <note pname="c" oct="4" dur="brevis"/>
-                        <note pname="c" oct="4" dur="semibrevis"/>
-                        <note pname="c" oct="4" dur="semibrevis"/>
-                     </layer>
-                  </staff>
-                  <staff n="3">
-                     <layer>
-                        <note pname="d" oct="4" dur="brevis"/>
-                        <note pname="d" oct="4" dur="brevis"/>
-                        <note pname="f" oct="4" dur="brevis"/>
-                        <note pname="e" oct="4" dur="brevis"/>
-                        <note pname="e" oct="4" dur="semibrevis"/>
-                        <note pname="e" oct="4" dur="semibrevis"/>
-                     </layer>
-                  </staff>
-                  <staff n="4">
-                     <layer>
-                        <note pname="g" oct="2" dur="brevis"/>
-                        <note pname="g" oct="3" dur="brevis"/>
-                        <note pname="g" oct="3" dur="brevis"/>
-                        <note pname="c" oct="3" dur="brevis"/>
-                        <note pname="c" oct="3" dur="semibrevis"/>
-                        <note pname="c" oct="3" dur="semibrevis"/>
+                     <layer n="1">
+                        <note dur="brevis" oct="4" pname="a" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <barLine form="dashed" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <note dur="brevis" oct="4" pname="a" />
+                        <barLine form="dashed" />
                      </layer>
                   </staff>
                </section>

--- a/source/examples/verovio/mensuration_changes.mei
+++ b/source/examples/verovio/mensuration_changes.mei
@@ -1,5 +1,8 @@
-<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">
-   <meiHead meiversion="4.0.1">
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+   <meiHead>
       <fileDesc>
          <titleStmt>
             <title>Example of 'mensuration changes'</title>
@@ -9,34 +12,26 @@
          </pubStmt>
       </fileDesc>
    </meiHead>
-   <music meiversion="4.0.1">
+   <music>
       <body>
          <mdiv>
-                <?edit-start?>
+            <?edit-start?>
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1"
-                               notationtype="mensural"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"
-                               mensur.sign="O"
-                               mensur.dot="true"
-                               mensur.slash="1"
-                               mensur.color="red"/>
+                     <staffDef n="1" notationtype="mensural" lines="5" clef.shape="G" clef.line="2" mensur.color="red" mensur.dot="true" mensur.sign="O" mensur.slash="1" />
                   </staffGrp>
                </scoreDef>
                <section>
                   <staff n="1">
-                     <layer>
-                        <note/>
-                        <note/>
-                        <note/>
-                        <mensur loc="3" sign="C"/>
-                        <note/>
-                        <note/>
-                        <note/>
+                     <layer n="1">
+                        <note />
+                        <note />
+                        <note />
+                        <mensur sign="C" loc="3" />
+                        <note />
+                        <note />
+                        <note />
                      </layer>
                   </staff>
                </section>

--- a/source/examples/verovio/motet_fauvel_fol22r_triplum.mei
+++ b/source/examples/verovio/motet_fauvel_fol22r_triplum.mei
@@ -1,5 +1,8 @@
-<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">
-   <meiHead meiversion="4.0.1">
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+   <meiHead>
       <fileDesc>
          <titleStmt>
             <title>Systems 4 to 5 of the Triplum of the Motet Inflammatis invidia / Sicut de ligno parvulus generatur / Victimae paschali laudes (Fauvel, fol. 22r)</title>
@@ -12,94 +15,87 @@
          </notesStmt>
       </fileDesc>
    </meiHead>
-   <music meiversion="4.0.1">
+   <music>
       <body>
          <mdiv>
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1"
-                               lines="5"
-                               label="Triplum"
-                               clef.shape="C"
-                               clef.line="3"
-                               notationtype="mensural.black"
-                               modusminor="3"
-                               tempus="3"/>
+                     <staffDef label="Triplum" n="1" notationtype="mensural.black" lines="5" clef.shape="C" clef.line="3" modusminor="3" tempus="3" mensur.sign="O" mensur.slash="1" />
                   </staffGrp>
                </scoreDef>
                <section>
                   <staff n="1">
                      <layer n="1">
-                        <note dur="longa" oct="4" pname="c"/>
-                        <note dur="semibrevis" oct="4" pname="c"/>
-                        <note dur="semibrevis" oct="4" pname="d"/>
-                        <note dur="semibrevis" oct="4" pname="e"/>
-                        <note dur="brevis" oct="4" pname="f"/>
-                        <note dur="semibrevis" oct="4" pname="f"/>
-                        <note dur="semibrevis" oct="4" pname="e"/>
-                        <note dur="semibrevis" oct="4" pname="d"/>
+                        <note dur="longa" oct="4" pname="c" />
+                        <note dur="semibrevis" oct="4" pname="c" />
+                        <note dur="semibrevis" oct="4" pname="d" />
+                        <note dur="semibrevis" oct="4" pname="e" />
+                        <note dur="brevis" oct="4" pname="f" />
+                        <note dur="semibrevis" oct="4" pname="f" />
+                        <note dur="semibrevis" oct="4" pname="e" />
+                        <note dur="semibrevis" oct="4" pname="d" />
                         <ligature>
-                           <note dur="semibrevis" oct="4" pname="c"/>
-                           <note dur="semibrevis" oct="4" pname="d"/>
+                           <note dur="semibrevis" oct="4" pname="c" />
+                           <note dur="semibrevis" oct="4" pname="d" />
                         </ligature>
-                        <note dur="longa" oct="4" pname="e"/>
-                        <note dur="brevis" oct="4" pname="d"/>
+                        <note dur="longa" oct="4" pname="e" />
+                        <note dur="brevis" oct="4" pname="d" />
                         <?edit-start?>
-                        <rest dur="2B"/>
+                        <rest dur="2B" />
                         <ligature>
-                           <note dur="semibrevis" oct="4" pname="d"/>
-                           <note dur="semibrevis" oct="4" pname="c"/>
+                           <note dur="semibrevis" oct="4" pname="d" />
+                           <note dur="semibrevis" oct="4" pname="c" />
                         </ligature>
                         <ligature>
-                           <note dur="semibrevis" oct="4" pname="d"/>
-                           <note dur="semibrevis" oct="4" pname="e"/>
+                           <note dur="semibrevis" oct="4" pname="d" />
+                           <note dur="semibrevis" oct="4" pname="e" />
                         </ligature>
                         <ligature>
-                           <note dur="semibrevis" oct="4" pname="d"/>
-                           <note dur="semibrevis" oct="3" pname="a"/>
+                           <note dur="semibrevis" oct="4" pname="d" />
+                           <note dur="semibrevis" oct="3" pname="a" />
                         </ligature>
-                        <note dur="longa" oct="3" pname="b"/>
-                        <dot form="div"/>
+                        <note dur="longa" oct="3" pname="b" />
+                        <dot form="div" />
                         <ligature>
-                           <note dur="semibrevis" oct="4" pname="c"/>
-                           <note dur="semibrevis" oct="4" pname="d"/>
-                        </ligature>
-                        <ligature>
-                           <note dur="semibrevis" oct="4" pname="c"/>
-                           <note dur="semibrevis" oct="3" pname="b"/>
+                           <note dur="semibrevis" oct="4" pname="c" />
+                           <note dur="semibrevis" oct="4" pname="d" />
                         </ligature>
                         <ligature>
-                           <note dur="semibrevis" oct="3" pname="a"/>
-                           <note dur="semibrevis" oct="3" pname="g"/>
-                        </ligature>
-                        <note dur="longa" oct="3" pname="a"/>
-                        <note dur="semibrevis" oct="4" pname="d"/>
-                        <note dur="semibrevis" oct="4" pname="e"/>
-                        <barLine form="invis"/>
-                        <note dur="longa" oct="4" pname="f"/>
-                        <note dur="brevis" oct="4" pname="e"/>
-                        <dot form="div"/>
-                        <note dur="brevis" oct="4" pname="d"/>
-                        <ligature>
-                           <note dur="semibrevis" oct="4" pname="c"/>
-                           <note dur="semibrevis" oct="3" pname="b"/>
+                           <note dur="semibrevis" oct="4" pname="c" />
+                           <note dur="semibrevis" oct="3" pname="b" />
                         </ligature>
                         <ligature>
-                           <note dur="semibrevis" oct="4" pname="c"/>
-                           <note dur="semibrevis" oct="4" pname="d"/>
+                           <note dur="semibrevis" oct="3" pname="a" />
+                           <note dur="semibrevis" oct="3" pname="g" />
                         </ligature>
-                        <note dur="longa" oct="4" pname="e"/>
+                        <note dur="longa" oct="3" pname="a" />
+                        <note dur="semibrevis" oct="4" pname="d" />
+                        <note dur="semibrevis" oct="4" pname="e" />
+                        <barLine form="invis" />
+                        <note dur="longa" oct="4" pname="f" />
+                        <note dur="brevis" oct="4" pname="e" />
+                        <dot form="div" />
+                        <note dur="brevis" oct="4" pname="d" />
+                        <ligature>
+                           <note dur="semibrevis" oct="4" pname="c" />
+                           <note dur="semibrevis" oct="3" pname="b" />
+                        </ligature>
+                        <ligature>
+                           <note dur="semibrevis" oct="4" pname="c" />
+                           <note dur="semibrevis" oct="4" pname="d" />
+                        </ligature>
+                        <note dur="longa" oct="4" pname="e" />
                         <rest dur="3B"/>
                         <?edit-end?>
-                        <note dur="semibrevis" oct="4" pname="e"/>
-                        <note dur="semibrevis" oct="4" pname="f"/>
-                        <dot form="div"/>
-                        <note dur="semibrevis" oct="4" pname="e"/>
-                        <note dur="semibrevis" oct="4" pname="d"/>
-                        <note dur="brevis" oct="4" pname="e"/>
-                        <note dur="longa" oct="4" pname="g" accid="s"/>
-                        <note dur="brevis" oct="4" pname="g" accid.ges="s"/>
+                        <note dur="semibrevis" oct="4" pname="e" />
+                        <note dur="semibrevis" oct="4" pname="f" />
+                        <dot form="div" />
+                        <note dur="semibrevis" oct="4" pname="e" />
+                        <note dur="semibrevis" oct="4" pname="d" />
+                        <note dur="brevis" oct="4" pname="e" />
+                        <note dur="longa" oct="4" pname="g" accid="s" />
+                        <note dur="brevis" oct="4" pname="g" accid.ges="s" />
                      </layer>
                   </staff>
                </section>

--- a/source/examples/verovio/notes_rests.mei
+++ b/source/examples/verovio/notes_rests.mei
@@ -1,5 +1,8 @@
-<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">
-   <meiHead meiversion="4.0.1">
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+   <meiHead>
       <fileDesc>
          <titleStmt>
             <title>Notes and Rests</title>
@@ -12,50 +15,40 @@
          </notesStmt>
       </fileDesc>
    </meiHead>
-   <music meiversion="4.0.1">
+   <music>
       <body>
          <mdiv>
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1"
-                               label="notes"
-                               notationtype="mensural.white"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"/>
-                     <staffDef n="2"
-                               label="rests"
-                               notationtype="mensural.white"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"/>
+                     <staffDef label="notes" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" />
+                     <staffDef label="rests" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" />
                   </staffGrp>
                </scoreDef>
                <section>
                   <?edit-start?>
                   <staff n="1">
-                     <layer>
-                        <note dur="maxima"/>
-                        <note dur="longa"/>
-                        <note dur="brevis"/>
-                        <note dur="semibrevis"/>
-                        <note dur="minima"/>
-                        <note dur="semiminima"/>
-                        <note dur="fusa"/>
-                        <note dur="semifusa"/>
+                     <layer n="1">
+                        <note dur="maxima" />
+                        <note dur="longa" />
+                        <note dur="brevis" />
+                        <note dur="semibrevis" />
+                        <note dur="minima" />
+                        <note dur="semiminima" />
+                        <note dur="fusa" />
+                        <note dur="semifusa" />
                      </layer>
                   </staff>
                   <staff n="2">
-                     <layer>
-                        <rest dur="maxima"/>
-                        <rest dur="longa"/>
-                        <rest dur="brevis"/>
-                        <rest dur="semibrevis"/>
-                        <rest dur="minima"/>
-                        <rest dur="semiminima"/>
-                        <rest dur="fusa"/>
-                        <rest dur="semifusa"/>
+                     <layer n="1">
+                        <rest dur="maxima" />
+                        <rest dur="longa" />
+                        <rest dur="brevis" />
+                        <rest dur="semibrevis" />
+                        <rest dur="minima" />
+                        <rest dur="semiminima" />
+                        <rest dur="fusa" />
+                        <rest dur="semifusa" />
                      </layer>
                   </staff>
                   <?edit-end?>

--- a/source/examples/verovio/octave-shift-01.mei
+++ b/source/examples/verovio/octave-shift-01.mei
@@ -1,5 +1,8 @@
-<?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="http://music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
-   <meiHead meiversion="4.0.0">
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+   <meiHead>
       <fileDesc>
          <titleStmt>
             <title>Octave shift example</title>
@@ -9,17 +12,17 @@
          </pubStmt>
          <notesStmt>
             <annot>Example use of the "octave" element for octave shifts. For correct MIDI output, the
-          "oct.ges" attribute needs to be provided.</annot>
+               "oct.ges" attribute needs to be provided.</annot>
          </notesStmt>
       </fileDesc>
    </meiHead>
-   <music meiversion="4.0.0">
+   <music>
       <body>
          <mdiv>
             <score>
                <scoreDef n="1">
                   <staffGrp>
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2"/>
+                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
                   </staffGrp>
                </scoreDef>
                <?edit-start?>
@@ -27,12 +30,12 @@
                   <measure n="1">
                      <staff n="1">
                         <layer n="1">
-                           <note dur="2" oct="6" pname="e"/>
+                           <note dur="2" oct="6" pname="e" />
                            <beam>
-                              <note dur="8" oct="6" pname="f"/>
-                              <note dur="8" oct="6" pname="a"/>
-                              <note dur="8" oct="6" pname="g"/>
-                              <note dur="8" oct="6" pname="b"/>
+                              <note dur="8" oct="6" pname="f" />
+                              <note dur="8" oct="6" pname="a" />
+                              <note dur="8" oct="6" pname="g" />
+                              <note dur="8" oct="6" pname="b" />
                            </beam>
                         </layer>
                      </staff>
@@ -40,120 +43,112 @@
                   <measure right="dbl" n="2">
                      <staff n="1">
                         <layer n="1">
-                           <note dur="1" oct="7" pname="c"/>
+                           <note dur="1" oct="7" pname="c" />
                         </layer>
                      </staff>
                   </measure>
                   <measure n="3">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n1" dur="2" oct.ges="6" oct="5" pname="e"/>
+                           <note xml:id="n1" dur="2" oct.ges="6" oct="5" pname="e" />
                            <beam>
-                              <note dur="8" oct.ges="6" oct="5" pname="f"/>
-                              <note dur="8" oct.ges="6" oct="5" pname="a"/>
-                              <note dur="8" oct.ges="6" oct="5" pname="g"/>
-                              <note dur="8" oct.ges="6" oct="5" pname="b"/>
+                              <note dur="8" oct.ges="6" oct="5" pname="f" />
+                              <note dur="8" oct.ges="6" oct="5" pname="a" />
+                              <note dur="8" oct.ges="6" oct="5" pname="g" />
+                              <note dur="8" oct.ges="6" oct="5" pname="b" />
                            </beam>
                         </layer>
                      </staff>
-                     <octave startid="#n1" endid="#n2" dis="8" dis.place="above"/>
+                     <octave startid="#n1" endid="#n2" dis="8" dis.place="above" />
                   </measure>
                   <measure right="dbl" n="4">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n2" dur="1" oct.ges="7" oct="6" pname="c"/>
+                           <note xml:id="n2" dur="1" oct.ges="7" oct="6" pname="c" />
                         </layer>
                      </staff>
                   </measure>
                   <measure n="5">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n3" dur="2" oct.ges="2" oct="3" pname="e"/>
+                           <note xml:id="n3" dur="2" oct.ges="2" oct="3" pname="e" />
                            <beam>
-                              <note dur="8" oct.ges="2" oct="3" pname="f"/>
-                              <note dur="8" oct.ges="2" oct="3" pname="a"/>
-                              <note dur="8" oct.ges="2" oct="3" pname="g"/>
-                              <note dur="8" oct.ges="2" oct="3" pname="b"/>
+                              <note dur="8" oct.ges="2" oct="3" pname="f" />
+                              <note dur="8" oct.ges="2" oct="3" pname="a" />
+                              <note dur="8" oct.ges="2" oct="3" pname="g" />
+                              <note dur="8" oct.ges="2" oct="3" pname="b" />
                            </beam>
                         </layer>
                      </staff>
-                     <octave startid="#n3" endid="#n4" dis="8" dis.place="below"/>
+                     <octave startid="#n3" endid="#n4" dis="8" dis.place="below" />
                   </measure>
                   <measure right="dbl" n="6">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n4" dur="1" oct.ges="3" oct="4" pname="c"/>
+                           <note xml:id="n4" dur="1" oct.ges="3" oct="4" pname="c" />
                         </layer>
                      </staff>
                   </measure>
                   <measure n="7">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n3" dur="2" oct.ges="2" oct="4" pname="e"/>
+                           <note xml:id="n3" dur="2" oct.ges="2" oct="4" pname="e" />
                            <beam>
-                              <note dur="8" oct.ges="2" oct="4" pname="f"/>
-                              <note dur="8" oct.ges="2" oct="4" pname="a"/>
-                              <note dur="8" oct.ges="2" oct="4" pname="g"/>
-                              <note dur="8" oct.ges="2" oct="4" pname="b"/>
+                              <note dur="8" oct.ges="2" oct="4" pname="f" />
+                              <note dur="8" oct.ges="2" oct="4" pname="a" />
+                              <note dur="8" oct.ges="2" oct="4" pname="g" />
+                              <note dur="8" oct.ges="2" oct="4" pname="b" />
                            </beam>
                         </layer>
                      </staff>
-                     <octave startid="#n3" tstamp2="1m+4.0000" dis="15" dis.place="below"/>
+                     <octave startid="#n3" tstamp2="1m+4.0000" dis="15" dis.place="below" />
                   </measure>
                   <measure right="dbl" n="8">
                      <staff n="1">
                         <layer n="1">
-                           <note dur="1" oct.ges="3" oct="5" pname="c"/>
+                           <note dur="1" oct.ges="3" oct="5" pname="c" />
                         </layer>
                      </staff>
                   </measure>
                   <measure n="9">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n5" dur="2" oct.ges="2" oct="3" pname="e"/>
+                           <note xml:id="n5" dur="2" oct.ges="2" oct="3" pname="e" />
                            <beam>
-                              <note dur="8" oct.ges="2" oct="3" pname="f"/>
-                              <note dur="8" oct.ges="2" oct="3" pname="a"/>
-                              <note dur="8" oct.ges="2" oct="3" pname="g"/>
-                              <note dur="8" oct.ges="2" oct="3" pname="b"/>
+                              <note dur="8" oct.ges="2" oct="3" pname="f" />
+                              <note dur="8" oct.ges="2" oct="3" pname="a" />
+                              <note dur="8" oct.ges="2" oct="3" pname="g" />
+                              <note dur="8" oct.ges="2" oct="3" pname="b" />
                            </beam>
                         </layer>
                      </staff>
-                     <octave startid="#n5"
-                             endid="#n6"
-                             lwidth="0.5"
-                             dis="8"
-                             dis.place="below"/>
+                     <octave startid="#n5" endid="#n6" lwidth="0.5000vu" dis="8" dis.place="below" />
                   </measure>
                   <measure right="dbl" n="10">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n6" dur="1" oct.ges="3" oct="4" pname="c"/>
+                           <note xml:id="n6" dur="1" oct.ges="3" oct="4" pname="c" />
                         </layer>
                      </staff>
                   </measure>
                   <measure n="11">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="n7" dur="2" oct.ges="4" oct="3" pname="e"/>
+                           <note xml:id="n7" dur="2" oct.ges="4" oct="3" pname="e" />
                            <beam>
-                              <note dur="8" oct.ges="4" oct="3" pname="f"/>
-                              <note dur="8" oct.ges="4" oct="3" pname="a"/>
-                              <note dur="8" oct.ges="4" oct="3" pname="g"/>
-                              <note dur="8" oct.ges="4" oct="3" pname="b"/>
+                              <note dur="8" oct.ges="4" oct="3" pname="f" />
+                              <note dur="8" oct.ges="4" oct="3" pname="a" />
+                              <note dur="8" oct.ges="4" oct="3" pname="g" />
+                              <note dur="8" oct.ges="4" oct="3" pname="b" />
                            </beam>
                         </layer>
                      </staff>
-                     <octave startid="#n7"
-                             tstamp2="1m+4.0000"
-                             lform="solid"
-                             dis="8"
-                             dis.place="above"/>
+                     <octave startid="#n7" tstamp2="1m+4.0000" lform="solid" dis="8" dis.place="above" />
                   </measure>
                   <measure right="dbl" n="12">
                      <staff n="1">
                         <layer n="1">
-                           <note dur="1" oct.ges="5" oct="4" pname="c"/>
+                           <note dur="1" oct.ges="5" oct="4" pname="c" />
                         </layer>
                      </staff>
                   </measure>

--- a/source/examples/verovio/partial-imp-01-propinquam.mei
+++ b/source/examples/verovio/partial-imp-01-propinquam.mei
@@ -1,5 +1,8 @@
-<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">
-   <meiHead meiversion="4.0.1">
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+   <meiHead>
       <fileDesc>
          <titleStmt>
             <title>Example of "partial imperfection of an immediate part" (ad partem propinquam)</title>
@@ -12,51 +15,37 @@
          </notesStmt>
       </fileDesc>
    </meiHead>
-   <music meiversion="4.0.1">
+   <music>
       <body>
          <mdiv>
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1"
-                               label="voice"
-                               notationtype="mensural.white"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"
-                               modusminor="2"
-                               tempus="3"/>
-                     <staffDef n="2"
-                               label="reference"
-                               notationtype="mensural.white"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"
-                               modusminor="2"
-                               tempus="3"/>
+                     <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="3" mensur.sign="O" mensur.slash="1" />
+                     <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="3" mensur.sign="O" mensur.slash="1" />
                   </staffGrp>
                </scoreDef>
                <section>
                   <staff n="1">
-                            <?edit-start?>
-                     <layer>
-                        <note dur="longa" num="6" numbase="5"/>
-                        <barLine form="dotted"/>
-                        <note dur="semibrevis"/>
-                        <barLine form="dashed"/>
+                     <?edit-start?>
+                     <layer n="1">
+                        <note dur="longa" num="6" numbase="5" />
+                        <barLine form="dotted" />
+                        <note dur="semibrevis" />
+                        <barLine form="dashed" />
                      </layer>
                      <?edit-end?>
                   </staff>
                   <staff n="2">
-                     <layer>
-                        <note dur="semibrevis" pname="a" oct="4"/>
-                        <note dur="semibrevis" pname="a" oct="4"/>
-                        <note dur="semibrevis" pname="a" oct="4"/>
-                        <barLine form="dashed"/>
-                        <note dur="semibrevis" pname="a" oct="4"/>
-                        <note dur="semibrevis" pname="a" oct="4"/>
-                        <note dur="semibrevis" pname="a" oct="4"/>
-                        <barLine form="dashed"/>
+                     <layer n="1">
+                        <note dur="semibrevis" oct="4" pname="a" />
+                        <note dur="semibrevis" oct="4" pname="a" />
+                        <note dur="semibrevis" oct="4" pname="a" />
+                        <barLine form="dashed" />
+                        <note dur="semibrevis" oct="4" pname="a" />
+                        <note dur="semibrevis" oct="4" pname="a" />
+                        <note dur="semibrevis" oct="4" pname="a" />
+                        <barLine form="dashed" />
                      </layer>
                   </staff>
                </section>

--- a/source/examples/verovio/partial-imp-02-bilateral.mei
+++ b/source/examples/verovio/partial-imp-02-bilateral.mei
@@ -1,5 +1,8 @@
-<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">
-   <meiHead meiversion="4.0.1">
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+   <meiHead>
       <fileDesc>
          <titleStmt>
             <title>Example of "partial imperfection" from both sides (ad partes)</title>
@@ -12,53 +15,39 @@
          </notesStmt>
       </fileDesc>
    </meiHead>
-   <music meiversion="4.0.1">
+   <music>
       <body>
          <mdiv>
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1"
-                               label="voice"
-                               notationtype="mensural.white"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"
-                               modusminor="2"
-                               tempus="3"/>
-                     <staffDef n="2"
-                               label="reference"
-                               notationtype="mensural.white"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"
-                               modusminor="2"
-                               tempus="3"/>
+                     <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="3" mensur.sign="O" mensur.slash="1" />
+                     <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="3" mensur.sign="O" mensur.slash="1" />
                   </staffGrp>
                </scoreDef>
                <section>
                   <staff n="1">
-                            <?edit-start?>
-                     <layer>
-                        <note dur="semibrevis"/>
-                        <barLine form="dotted"/>
-                        <note dur="longa" num="6" numbase="4"/>
-                        <barLine form="dotted"/>
-                        <note dur="semibrevis"/>
-                        <barLine form="dashed"/>
+                     <?edit-start?>
+                     <layer n="1">
+                        <note dur="semibrevis" />
+                        <barLine form="dotted" />
+                        <note dur="longa" num="6" numbase="4" />
+                        <barLine form="dotted" />
+                        <note dur="semibrevis" />
+                        <barLine form="dashed" />
                      </layer>
                      <?edit-end?>
                   </staff>
                   <staff n="2">
-                     <layer>
-                        <note dur="semibrevis" pname="a" oct="4"/>
-                        <note dur="semibrevis" pname="a" oct="4"/>
-                        <note dur="semibrevis" pname="a" oct="4"/>
-                        <barLine form="dashed"/>
-                        <note dur="semibrevis" pname="a" oct="4"/>
-                        <note dur="semibrevis" pname="a" oct="4"/>
-                        <note dur="semibrevis" pname="a" oct="4"/>
-                        <barLine form="dashed"/>
+                     <layer n="1">
+                        <note dur="semibrevis" oct="4" pname="a" />
+                        <note dur="semibrevis" oct="4" pname="a" />
+                        <note dur="semibrevis" oct="4" pname="a" />
+                        <barLine form="dashed" />
+                        <note dur="semibrevis" oct="4" pname="a" />
+                        <note dur="semibrevis" oct="4" pname="a" />
+                        <note dur="semibrevis" oct="4" pname="a" />
+                        <barLine form="dashed" />
                      </layer>
                   </staff>
                </section>

--- a/source/examples/verovio/partial-imp-03-remotam.mei
+++ b/source/examples/verovio/partial-imp-03-remotam.mei
@@ -1,5 +1,8 @@
-<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">
-   <meiHead meiversion="4.0.1">
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+   <meiHead>
       <fileDesc>
          <titleStmt>
             <title>Example of "partial imperfection of a remote part" (ad partem remotam)</title>
@@ -12,61 +15,45 @@
          </notesStmt>
       </fileDesc>
    </meiHead>
-   <music meiversion="4.0.1">
+   <music>
       <body>
          <mdiv>
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1"
-                               label="voice"
-                               notationtype="mensural.white"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"
-                               modusminor="2"
-                               tempus="2"
-                               prolatio="3"/>
-                     <staffDef n="2"
-                               label="reference"
-                               notationtype="mensural.white"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"
-                               modusminor="2"
-                               tempus="2"
-                               prolatio="3"/>
+                     <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" prolatio="3" tempus="2" mensur.dot="true" mensur.sign="C" mensur.slash="1" />
+                     <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" prolatio="3" tempus="2" mensur.dot="true" mensur.sign="C" mensur.slash="1" />
                   </staffGrp>
                </scoreDef>
                <section>
                   <staff n="1">
-                            <?edit-start?>
-                     <layer>
-                        <note dur="longa" num="12" numbase="11"/>
-                        <barLine form="dotted"/>
-                        <note dur="minima"/>
-                        <barLine form="dashed"/>
+                     <?edit-start?>
+                     <layer n="1">
+                        <note dur="longa" num="12" numbase="11" />
+                        <barLine form="dotted" />
+                        <note dur="minima" />
+                        <barLine form="dashed" />
                      </layer>
-                     <?edit-end?>
+                     <?edit-ebd?>
                   </staff>
                   <staff n="2">
-                     <layer>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <barLine form="dotted"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <barLine form="dashed"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <barLine form="dotted"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <barLine form="dashed"/>
+                     <layer n="1">
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <barLine form="dotted" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <barLine form="dashed" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <barLine form="dotted" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <barLine form="dashed" />
                      </layer>
                   </staff>
                </section>

--- a/source/examples/verovio/partial-imp-04-remotam.mei
+++ b/source/examples/verovio/partial-imp-04-remotam.mei
@@ -1,5 +1,8 @@
-<?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="https://music-encoding.org/schema/4.0.1/mei-Mensural.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.1">
-   <meiHead meiversion="4.0.1">
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+   <meiHead>
       <fileDesc>
          <titleStmt>
             <title>Example of "partial imperfection of a remote part" (ad partem remotam)</title>
@@ -12,69 +15,53 @@
          </notesStmt>
       </fileDesc>
    </meiHead>
-   <music meiversion="4.0.1">
+   <music>
       <body>
          <mdiv>
             <score>
                <scoreDef>
                   <staffGrp>
-                     <staffDef n="1"
-                               label="voice"
-                               notationtype="mensural.white"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"
-                               modusminor="3"
-                               tempus="2"
-                               prolatio="3"/>
-                     <staffDef n="2"
-                               label="reference"
-                               notationtype="mensural.white"
-                               lines="5"
-                               clef.shape="G"
-                               clef.line="2"
-                               modusminor="3"
-                               tempus="2"
-                               prolatio="3"/>
+                     <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3" prolatio="3" tempus="2" mensur.dot="true" mensur.sign="C" mensur.slash="1" />
+                     <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3" prolatio="3" tempus="2" mensur.dot="true" mensur.sign="C" mensur.slash="1" />
                   </staffGrp>
                </scoreDef>
                <section>
                   <staff n="1">
-                            <?edit-start?>
-                     <layer>
-                        <note dur="longa" num="18" numbase="17"/>
-                        <barLine form="dotted"/>
-                        <note dur="minima"/>
-                        <barLine form="dashed"/>
+                     <?edit-start?>
+                     <layer n="1">
+                        <note dur="longa" num="18" numbase="17" />
+                        <barLine form="dotted" />
+                        <note dur="minima" />
+                        <barLine form="dashed" />
                      </layer>
                      <?edit-end?>
                   </staff>
                   <staff n="2">
-                     <layer>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <barLine form="dotted"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <barLine form="dashed"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <barLine form="dotted"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <barLine form="dashed"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <barLine form="dotted"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <note dur="minima" pname="a" oct="4"/>
-                        <barLine form="dashed"/>
+                     <layer n="1">
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <barLine form="dotted" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <barLine form="dashed" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <barLine form="dotted" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <barLine form="dashed" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <barLine form="dotted" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <note dur="minima" oct="4" pname="a" />
+                        <barLine form="dashed" />
                      </layer>
                   </staff>
                </section>

--- a/source/examples/verovio/tempo-01.mei
+++ b/source/examples/verovio/tempo-01.mei
@@ -1,5 +1,8 @@
-<?xml-model href="http://www.music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?><?xml-model href="http://www.music-encoding.org/schema/4.0.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?><mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
-   <meiHead meiversion="4.0.0">
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+   <meiHead>
       <fileDesc>
          <titleStmt>
             <title>Tempo example</title>
@@ -19,47 +22,43 @@
          </appInfo>
       </encodingDesc>
    </meiHead>
-   <music meiversion="4.0.0">
+   <music>
       <body>
          <mdiv>
             <score>
                <scoreDef meter.sym="cut">
                   <staffGrp>
-                     <staffDef n="1"
-                               label="Violino"
-                               lines="5"
-                               clef.line="2"
-                               clef.shape="G"/>
+                     <staffDef label="Violino" n="1" lines="5" clef.shape="G" clef.line="2" />
                   </staffGrp>
                </scoreDef>
                <section>
-                    	<?edit-start?>
+                  <?edit-start?>
                   <measure n="0" type="upbeat">
                      <staff n="1">
                         <layer n="1">
                            <beam>
-                              <note xml:id="m0_s2_e1" pname="e" oct="5" dur="8"/>
-                              <note xml:id="m0_s2_e2" pname="f" oct="5" dur="8"/>
+                              <note xml:id="m0_s2_e1" dur="8" oct="5" pname="e" />
+                              <note xml:id="m0_s2_e2" dur="8" oct="5" pname="f" />
                            </beam>
                         </layer>
                      </staff>
-                     <tempo tstamp="1" staff="1">Andante con moto <rend fontname="VerovioText"></rend> = 70 </tempo>
-                     <slur startid="#m0_s2_e1" endid="#m0_s2_e2"/>
+                     <tempo staff="1" tstamp="1.000000">Andante con moto <rend fontfam="smufl">&#xE1D3;</rend> = 70</tempo>
+                     <slur startid="#m0_s2_e1" endid="#m0_s2_e2" />
                   </measure>
-                  <?edit-end?>
+                  <?edit-start?>
                   <measure n="1">
                      <staff n="1">
                         <layer n="1">
-                           <note xml:id="m1_s2_e1" pname="g" oct="5" dur="4" dots="1"/>
-                           <note xml:id="m1_s2_e2" pname="g" oct="5" dur="8"/>
-                           <note xml:id="m1_s2_e3" pname="g" oct="5" dur="4"/>
+                           <note dots="1" dur="4" oct="5" pname="g" />
+                           <note dur="8" oct="5" pname="g" />
+                           <note dur="4" oct="5" pname="g" />
                            <beam>
-                              <note xml:id="m1_s2_e4" pname="g" oct="5" dur="8"/>
-                              <note xml:id="m1_s2_e5" pname="c" oct="6" dur="8"/>
+                              <note xml:id="m1_s2_e4" dur="8" oct="5" pname="g" />
+                              <note xml:id="m1_s2_e5" dur="8" oct="6" pname="c" />
                            </beam>
                         </layer>
                      </staff>
-                     <slur startid="#m1_s2_e4" endid="#m1_s2_e5"/>
+                     <slur startid="#m1_s2_e4" endid="#m1_s2_e5" />
                   </measure>
                </section>
             </score>


### PR DESCRIPTION
Does the following:
* Update the Schema to 5.0.0-dev
* Make formatting consistent
* Add `@n` to all `layer` elements
* Change `rend@fonfname="VerovioText"` to `rend@fontfam="smufl"` (Fixes #1146)

PS `rend@fontfam` will have to be changed to `rend@glyph.auth` once #1142 is implemented in Verovio