### PR TITLE
rename attribute reference in altId remark

### DIFF
--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -423,7 +423,7 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>One or the other of <gi scheme="MEI">altId</gi> or the <att>id</att> attribute on <gi
+      <p>One or the other of <gi scheme="MEI">altId</gi> or the <att>xml:id</att> attribute on <gi
         scheme="MEI">mei</gi> is required when applicable.</p>
     </remarks>
   </elementSpec>


### PR DESCRIPTION
the remark was referencing a `@id` attribute, not the correct `@xml:id` attribute