### PR TITLE
Add "fences" as a notehead modifier

### DIFF
--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3014,7 +3014,7 @@
         <valItem ident="circle">
           <desc xml:lang="en">Enclosing circle.</desc>
         </valItem>
-        <valItem ident="dblwhole">
+        <valItem ident="fences">
           <desc xml:lang="en">Enclosing "fences".</desc>
         </valItem>
       </valList>


### PR DESCRIPTION
This PR changes the notehead modifier list to add the value of `fences` (and removes `dblwhole`). This is as a result of the discussions in #867 and discussions at the MEI Developers Meeting 25.05.2023. 

Refs #865.