### PR TITLE
allow tstamp2.ges and tstamp2.real on metaMark

### DIFF
--- a/source/modules/MEI.gestural.xml
+++ b/source/modules/MEI.gestural.xml
@@ -397,6 +397,7 @@
     <desc xml:lang="en">Gestural domain attributes.</desc>
     <classes>
       <memberOf key="att.duration.ges"/>
+      <memberOf key="att.timestamp2.ges"/>
     </classes>
   </classSpec>
   <classSpec ident="att.meterSig.ges" module="MEI.gestural" type="atts">


### PR DESCRIPTION
In #797 and #767 we were too fast in removing `@tstamp2.ges` and `@tstamp2.real` from `<metaMark>`, which was found when evaluating the diff of v4 and v5. Adding them back in, as agreed on the Charlottesville dev meeting.