### PR TITLE
fix(build): include oxygen-basic-utilites in lib

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -52,6 +52,7 @@
     <property name="saxon.jar.file" value="saxon-he-11.4.jar"/>
     <property name="xerces.version" value="25.1.0.1"/>
     <property name="xerces.jar.file" value="oxygen-patched-xerces-${xerces.version}.jar"/>
+    <property name="oxygen.basic.utilites.jar.file" value="oxygen-basic-utilities-${xerces.version}.jar"/>
     <path id="mei.classpath">
         <fileset dir="lib" erroronmissingdir="false">
             <include name="**/*.jar" />
@@ -142,6 +143,7 @@
     <target name="xerces-download" unless="${xerces-available}">
         <mkdir dir="${dir.lib.xerces}"/>
         <get src="https://www.oxygenxml.com/maven/com/oxygenxml/oxygen-patched-xerces/${xerces.version}/${xerces.jar.file}" dest="${dir.lib.xerces}"/>
+        <get src="https://www.oxygenxml.com/maven/com/oxygenxml/oxygen-basic-utilities/${xerces.version}/${oxygen.basic.utilites.jar.file}" dest="${dir.lib.xerces}"/>
     </target>
 
     <target name="canonicalize-source" description="Canonicalizes the mei-source.xml, i.e. resolves xincludes and puts result in dist/mei-source_canonicalized.xml" depends="init">


### PR DESCRIPTION
This PR adds the oxygen-basic-utilities for xerces in the lib folder when building with ant.

Fixes #1083 

