### PR TITLE
fix data.PERCENT

### DIFF
--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3106,26 +3106,26 @@
     </content>
 </macroSpec>
   <macroSpec ident="data.PERCENT" module="MEI" type="dt">
-    <desc xml:lang="en">Positive decimal number plus '%', <abbr>i.e.</abbr>, [0-9]+(\.?[0-9]*)?\%.</desc>
+    <desc xml:lang="en">Positive decimal number plus '%', <abbr>i.e.</abbr>, [0-9]+(\.[0-9]*)?%.</desc>
     <content>
       <rng:data type="token">
-        <rng:param name="pattern">[0-9]+(\.?[0-9]*)?%</rng:param>
+        <rng:param name="pattern">[0-9]+(\.[0-9]*)?%</rng:param>
       </rng:data>
     </content>
   </macroSpec>
   <macroSpec ident="data.PERCENT.LIMITED" module="MEI" type="dt">
-    <desc xml:lang="en">Positive decimal number between 0 and 100, followed by a percent sign "%".</desc>
+    <desc xml:lang="en">Decimal number between 0 and 100, followed by a percent sign "%".</desc>
     <content>
       <rng:data type="token">
-        <rng:param name="pattern">(([0-9]|[1-9][0-9])(\.[0-9]+)?|100(\.0+)?)%</rng:param>
+        <rng:param name="pattern">(([0-9]|[1-9][0-9])(\.[0-9]*)?|100(\.0*)?)%</rng:param>
       </rng:data>
     </content>
   </macroSpec>
   <macroSpec ident="data.PERCENT.LIMITED.SIGNED" module="MEI" type="dt">
-    <desc xml:lang="en">Positive decimal number between -100 and 100, followed by a percent sign "%".</desc>
+    <desc xml:lang="en">Decimal number between -100 and 100, followed by a percent sign "%".</desc>
     <content>
       <rng:data type="token">
-        <rng:param name="pattern">(\+|-)?(([0-9]|[1-9][0-9])(\.[0-9]+)?|100(\.0+)?)%</rng:param>
+        <rng:param name="pattern">(\+|-)?(([0-9]|[1-9][0-9])(\.[0-9]*)?|100(\.0*)?)%</rng:param>
       </rng:data>
     </content>
   </macroSpec>


### PR DESCRIPTION
This removes the "Positive" from the descriptions of `data.PERCENT.LIMITED` and `data.PERCENT.LIMITED.SIGNED`.
Also it aligns the regular expressions to allow ending the decimal number with a dot like in `data.PERCENT`.

closes #1077