### PR TITLE
Fixed: instrDef was misspelled

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -59,7 +59,7 @@
                 <moduleRef key="MEI.header" include="meiHead fileDesc titleStmt pubStmt availability composer lyricist arranger"/>
                 <moduleRef key="MEI.lyrics"/>
                 <!--<moduleRef key="MEI.msDesc"/>-->
-                <moduleRef key="MEI.midi" include="instDef" />
+                <moduleRef key="MEI.midi" include="instrDef" />
                 <moduleRef key="MEI.namesdates" include="persName" />
                 <moduleRef key="MEI.shared" include="accid artic body caesura chord clef clefGrp date dir dynam label labelAbbr layer lb mdiv mei music note ornam pb pgFoot pgHead pubPlace rend respStmt rest sb score scoreDef section space staff staffDef staffGrp syl tempo title "/>
                 <moduleRef key="MEI.stringtab"/>


### PR DESCRIPTION
The instrDef element was requested as part of MEI Basic, but it was misspelled so it was not included.

Fixes #1112