### PR TITLE
Fixed: Use value of "schematron" for constraintSpec

### DIFF
--- a/customizations/mei-CMN.xml
+++ b/customizations/mei-CMN.xml
@@ -16,8 +16,8 @@
   
   CONTACT: info@music-encoding.org
 -->
-<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron">
   <teiHeader>
@@ -49,7 +49,7 @@
         start="mei meiHead meiCorpus music">
 
         <!-- Declare MEI and XLink namespaces for use in Schematron -->
-        <constraintSpec ident="set_ns" scheme="isoschematron" mode="add">
+        <constraintSpec ident="set_ns" scheme="schematron" mode="add">
           <constraint>
             <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="mei"
               uri="http://www.music-encoding.org/ns/mei"/>

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -16,8 +16,8 @@
   
   CONTACT: info@music-encoding.org
 -->
-<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron">
   <teiHeader>
@@ -49,7 +49,7 @@
         start="mei meiHead meiCorpus music">
 
         <!-- Declare MEI and XLink namespaces for use in Schematron -->
-        <constraintSpec ident="set_ns" scheme="isoschematron" mode="add">
+        <constraintSpec ident="set_ns" scheme="schematron" mode="add">
           <constraint>
             <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="mei"
               uri="http://www.music-encoding.org/ns/mei"/>
@@ -151,7 +151,7 @@
               </rng:choice>
             </rng:zeroOrMore>
           </content>
-          <constraintSpec ident="Check_restline" scheme="isoschematron">
+          <constraintSpec ident="Check_restline" scheme="schematron">
             <constraint>
               <sch:rule context="mei:rest[@line]">
                 <sch:let name="thisstaff" value="ancestor::mei:staff/@n"/>

--- a/customizations/mei-Neumes.xml
+++ b/customizations/mei-Neumes.xml
@@ -16,8 +16,8 @@
   
   CONTACT: info@music-encoding.org
 -->
-<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron">
   <teiHeader>
@@ -49,7 +49,7 @@
         start="mei meiHead meiCorpus music">
 
         <!-- Declare MEI and XLink namespaces for use in Schematron -->
-        <constraintSpec ident="set_ns" scheme="isoschematron" mode="add">
+        <constraintSpec ident="set_ns" scheme="schematron" mode="add">
           <constraint>
             <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="mei"
               uri="http://www.music-encoding.org/ns/mei"/>

--- a/customizations/mei-all.xml
+++ b/customizations/mei-all.xml
@@ -16,8 +16,8 @@
   
   CONTACT: info@music-encoding.org
 -->
-<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron"
   xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns="http://www.tei-c.org/ns/1.0">
@@ -55,7 +55,7 @@
         start="mei meiHead meiCorpus music">
 
         <!-- Declare MEI and XLink namespaces for use in Schematron -->
-        <constraintSpec ident="set_ns" scheme="isoschematron" mode="add">
+        <constraintSpec ident="set_ns" scheme="schematron" mode="add">
           <constraint>
             <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="mei"
               uri="http://www.music-encoding.org/ns/mei"/>

--- a/customizations/mei-all_anyStart.xml
+++ b/customizations/mei-all_anyStart.xml
@@ -16,8 +16,8 @@
   
   CONTACT: info@music-encoding.org
 -->
-<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns:rng="http://relaxng.org/ns/structure/1.0"
   xmlns:sch="http://purl.oclc.org/dsdl/schematron"
   xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns="http://www.tei-c.org/ns/1.0"

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://www.tei-c.org/release/xml/tei/custom/schema/relaxng/tei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0"
     xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <teiHeader>
@@ -37,7 +37,7 @@
             <schemaSpec ident="mei" start="mei" prefix="mei_" ns="http://www.music-encoding.org/ns/mei">
 
                 <!-- Declare MEI and XLink namespaces for use in Schematron -->
-                <constraintSpec ident="set_ns" scheme="isoschematron" mode="add">
+                <constraintSpec ident="set_ns" scheme="schematron" mode="add">
                     <constraint>
                         <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="mei"
                             uri="http://www.music-encoding.org/ns/mei"/>
@@ -742,7 +742,7 @@
                     <content autoPrefix="true">
                         <rng:empty/>
                     </content>
-                    <constraintSpec ident="fermata_start-type_attributes_required" scheme="isoschematron">
+                    <constraintSpec ident="fermata_start-type_attributes_required" scheme="schematron">
                         <constraint>
                             <sch:rule context="mei:fermata">
                                 <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of
@@ -1102,7 +1102,7 @@
                             <rng:ref name="grpSym"/>
                         </rng:zeroOrMore>-->
                     </content>
-                    <constraintSpec ident="Check_staffGrp_unique_staff_n_values" scheme="isoschematron">
+                    <constraintSpec ident="Check_staffGrp_unique_staff_n_values" scheme="schematron">
                         <constraint>
                             <sch:rule context="mei:staffGrp">
                                 <sch:let name="countstaves" value="count(descendant::mei:staffDef)"/>

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -245,7 +245,7 @@
         <datatype>
           <rng:ref name="data.BEAMPLACE"/>
         </datatype>
-        <constraintSpec ident="check_beam_place" scheme="isoschematron">
+        <constraintSpec ident="check_beam_place" scheme="schematron">
           <constraint>
             <sch:rule
               context="mei:beam[@place eq 'mixed' and not(descendant::mei:*[local-name() eq 'note' or local-name() eq 'chord'][@staff != ./@staff] or descendant::mei:*[local-name() eq 'note' or local-name() eq 'chord'][@staff != ancestor::mei:staff/@n])]">
@@ -1274,7 +1274,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="attacca_start-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="attacca_start-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:attacca[not(ancestor::mei:syllable)]">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -1315,7 +1315,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="When_not_copyof_beam_content" scheme="isoschematron">
+    <constraintSpec ident="When_not_copyof_beam_content" scheme="schematron">
       <constraint>
         <sch:rule context="mei:beam[not(@copyof or @sameas)]">
           <sch:assert
@@ -1349,7 +1349,7 @@
     <content>
       <rng:empty/>
     </content>
-    <constraintSpec ident="beamspan_start-_and_end-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="beamspan_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:beamSpan">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -1406,7 +1406,7 @@
     <content>
       <rng:empty/>
     </content>
-    <constraintSpec ident="bend_start-_and_end-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="bend_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:bend">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -1436,8 +1436,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="bracketSpan_start-_and_end-type_attributes_required"
-      scheme="isoschematron">
+    <constraintSpec ident="bracketSpan_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:bracketSpan">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -1472,7 +1471,7 @@
     <content>
       <rng:empty/>
     </content>
-    <constraintSpec ident="breath_start-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="breath_start-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:breath">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -1528,7 +1527,7 @@
     <content>
       <rng:empty/>
     </content>
-    <constraintSpec ident="fermata_start-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="fermata_start-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:fermata">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -1605,7 +1604,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="gliss_start-_and_end-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="gliss_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:gliss">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -1649,7 +1648,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="When_not_copyof_graceGrp_content" scheme="isoschematron">
+    <constraintSpec ident="When_not_copyof_graceGrp_content" scheme="schematron">
       <constraint>
         <sch:rule context="mei:graceGrp[not(@copyof)]">
           <sch:assert
@@ -1659,7 +1658,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="When_graced" scheme="isoschematron">
+    <constraintSpec ident="When_graced" scheme="schematron">
       <constraint>
         <sch:rule context="mei:graceGrp[@grace]">
           <sch:assert test="not(descendant::mei:*[@grace])">The grace attribute is not allowed on
@@ -1683,7 +1682,7 @@
     <content>
       <rng:empty/>
     </content>
-    <constraintSpec ident="hairpin_start-_and_end-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="hairpin_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:hairpin">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -1737,7 +1736,7 @@
     <content>
       <rng:empty/>
     </content>
-    <constraintSpec ident="harpPedal_start-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="harpPedal_start-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:harpPedal">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -1768,7 +1767,7 @@
         <rng:ref name="curve"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="lv_start-_and_end-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="lv_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:lv">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -1776,7 +1775,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="lv_containing_curve" scheme="isoschematron">
+    <constraintSpec ident="lv_containing_curve" scheme="schematron">
       <constraint>
         <sch:rule
           context="mei:lv[mei:curve[@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or @startho or @endho or @to or @startto or @endto or @vo or @startvo or              @endvo or @x or @y or @x2 or @y2]]">
@@ -1868,7 +1867,7 @@
         <rng:ref name="meterSig"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="check_meterSigGrpContent" scheme="isoschematron">
+    <constraintSpec ident="check_meterSigGrpContent" scheme="schematron">
       <constraint>
         <sch:rule context="mei:meterSigGrp[not(@copyof)]">
           <sch:assert test="count(mei:meterSig) &gt; 1">meterSigGrp must have at least 2 child
@@ -2046,7 +2045,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="octave_start-_and_end-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="octave_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:octave">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -2131,7 +2130,7 @@
         </rng:interleave>
       </rng:choice>
     </content>
-    <constraintSpec ident="Check_ossia" scheme="isoschematron">
+    <constraintSpec ident="Check_ossia" scheme="schematron">
       <constraint>
         <sch:pattern>
           <sch:rule context="mei:measure/mei:ossia">
@@ -2202,7 +2201,7 @@
     <content>
       <rng:empty/>
     </content>
-    <constraintSpec ident="pedal_start-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="pedal_start-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:pedal">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -2261,7 +2260,7 @@
         <rng:ref name="curve"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="slur_start-_and_end-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="slur_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:slur">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -2271,7 +2270,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="slur_containing_curve" scheme="isoschematron">
+    <constraintSpec ident="slur_containing_curve" scheme="schematron">
       <constraint>
         <sch:rule
           context="mei:slur[mei:curve[@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or @startho or @endho or @to or @startto or @endto or @vo or @startvo or @endvo or @x or @y or @x2 or @y2]]">
@@ -2320,7 +2319,7 @@
         <rng:ref name="curve"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="tie_start-_and_end-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="tie_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:tie">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -2330,7 +2329,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="tie_containing_curve" scheme="isoschematron">
+    <constraintSpec ident="tie_containing_curve" scheme="schematron">
       <constraint>
         <sch:rule
           context="mei:tie[mei:curve[@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or @startho or @endho or @to or @startto or @endto or @vo or @startvo or @endvo or @x or @y or @x2 or @y2]]">
@@ -2403,7 +2402,7 @@
       <rng:empty/>
     </content>
     <constraintSpec ident="tupletSpan_start-_and_end-type_attributes_required"
-      scheme="isoschematron">
+      scheme="schematron">
       <constraint>
         <sch:rule context="mei:tupletSpan">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the

--- a/source/modules/MEI.cmnOrnaments.xml
+++ b/source/modules/MEI.cmnOrnaments.xml
@@ -150,7 +150,7 @@
     <content>
       <rng:empty/>
     </content>
-    <constraintSpec ident="mordent_start-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="mordent_start-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:mordent">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -179,7 +179,7 @@
     <content>
       <rng:empty/>
     </content>
-    <constraintSpec ident="trill_start-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="trill_start-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:trill">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -213,7 +213,7 @@
     <content>
       <rng:empty/>
     </content>
-    <constraintSpec ident="turn_start-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="turn_start-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:turn">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the

--- a/source/modules/MEI.drama.xml
+++ b/source/modules/MEI.drama.xml
@@ -82,7 +82,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="sp_start-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="sp_start-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule
           context="mei:sp[ancestor::mei:layer or ancestor::mei:measure or ancestor::mei:staff][not(ancestor::mei:sp)]">
@@ -91,7 +91,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="sp_start-type_attributes_forbidden" scheme="isoschematron">
+    <constraintSpec ident="sp_start-type_attributes_forbidden" scheme="schematron">
       <constraint>
         <sch:rule
           context="mei:sp[not(ancestor::mei:layer or ancestor::mei:measure or ancestor::mei:staff)]">
@@ -136,7 +136,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="stageDir_start-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="stageDir_start-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule
           context="mei:stageDir[ancestor::mei:layer or ancestor::mei:measure or ancestor::mei:staff][not(ancestor::mei:sp)]">
@@ -145,7 +145,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="stageDir_start-type_attributes_forbidden" scheme="isoschematron">
+    <constraintSpec ident="stageDir_start-type_attributes_forbidden" scheme="schematron">
       <constraint>
         <sch:rule
           context="mei:stageDir[not(ancestor::mei:layer or ancestor::mei:measure or ancestor::mei:staff) or ancestor::mei:sp]">

--- a/source/modules/MEI.edittrans.xml
+++ b/source/modules/MEI.edittrans.xml
@@ -311,7 +311,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="cpMark_start-_and_end-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="cpMark_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:cpMark">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -572,7 +572,7 @@
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_newTarget" scheme="isoschematron">
+        <constraintSpec ident="check_newTarget" scheme="schematron">
           <constraint>
             <sch:rule context="@new">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@new attribute should
@@ -591,7 +591,7 @@
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_oldTarget" scheme="isoschematron">
+        <constraintSpec ident="check_oldTarget" scheme="schematron">
           <constraint>
             <sch:rule context="@old">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@old attribute should

--- a/source/modules/MEI.externalsymbols.xml
+++ b/source/modules/MEI.externalsymbols.xml
@@ -39,7 +39,7 @@
         <datatype>
           <rng:data type="string"/>
         </datatype>
-        <constraintSpec ident="check_glyph.name" scheme="isoschematron">
+        <constraintSpec ident="check_glyph.name" scheme="schematron">
           <constraint>
             <sch:rule context="@glyph.name">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@glyph.name attribute
@@ -54,7 +54,7 @@
         <datatype>
           <rng:ref name="data.HEXNUM"/>
         </datatype>
-        <constraintSpec ident="check_glyph.num" scheme="isoschematron">
+        <constraintSpec ident="check_glyph.num" scheme="schematron">
           <constraint>
             <sch:rule
               context="mei:*[@glyph.num and (lower-case(@glyph.auth) eq 'smufl' or @glyph.uri eq 'http://www.smufl.org/')]">

--- a/source/modules/MEI.facsimile.xml
+++ b/source/modules/MEI.facsimile.xml
@@ -16,7 +16,7 @@
         <datatype minOccurs="1" maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_facsTarget" scheme="isoschematron">
+        <constraintSpec ident="check_facsTarget" scheme="schematron">
           <constraint>
             <sch:rule context="@facs">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@facs attribute should

--- a/source/modules/MEI.figtable.xml
+++ b/source/modules/MEI.figtable.xml
@@ -123,7 +123,7 @@
         <rng:ref name="zone"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="graphic_attributes" scheme="isoschematron">
+    <constraintSpec ident="graphic_attributes" scheme="schematron">
       <constraint>
         <sch:rule context="mei:zone/mei:graphic">
           <sch:assert role="warning" test="count(mei:*) = 0">Graphic child of zone should not have

--- a/source/modules/MEI.fingering.xml
+++ b/source/modules/MEI.fingering.xml
@@ -68,7 +68,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="fing_start-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="fing_start-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:fing[not(ancestor::mei:fingGrp)]">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -76,7 +76,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="stack_exclusion" scheme="isoschematron">
+    <constraintSpec ident="stack_exclusion" scheme="schematron">
       <!-- Exclusion implemented using Schematron -->
       <constraint>
         <sch:rule context="mei:fing">
@@ -106,7 +106,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="require_fingeringLike_children" scheme="isoschematron">
+    <constraintSpec ident="require_fingeringLike_children" scheme="schematron">
       <constraint>
         <sch:rule context="mei:fingGrp">
           <sch:assert test="count(mei:fing) + count(mei:fingGrp) &gt; 1">At least 2 fing or fingGrp
@@ -114,7 +114,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="check_fingGrp_start-type_attributes" scheme="isoschematron">
+    <constraintSpec ident="check_fingGrp_start-type_attributes" scheme="schematron">
       <constraint>
         <sch:pattern>
           <sch:rule context="mei:fingGrp[not(ancestor::mei:fingGrp)][@tstamp or @startid]">

--- a/source/modules/MEI.gestural.xml
+++ b/source/modules/MEI.gestural.xml
@@ -21,7 +21,7 @@
         <datatype>
           <rng:ref name="data.ACCIDENTAL.GESTURAL"/>
         </datatype>
-        <constraintSpec ident="check_accid_duplication" scheme="isoschematron">
+        <constraintSpec ident="check_accid_duplication" scheme="schematron">
           <constraint>
             <sch:rule context="@accid.ges">
               <sch:assert role="warning" test="not(. eq ../@accid)">The value of @accid.ges should
@@ -497,7 +497,7 @@
       <memberOf key="att.note.ges.mensural"/>
       <memberOf key="att.stringtab"/>
     </classes>
-    <constraintSpec ident="extremis_disallows_gestural_pitch" scheme="isoschematron">
+    <constraintSpec ident="extremis_disallows_gestural_pitch" scheme="schematron">
       <constraint>
         <sch:rule context="mei:note[@extremis]">
           <sch:assert test="not(@pname.ges) and not(@oct.ges)">When the @extremis attribute is used,

--- a/source/modules/MEI.harmony.xml
+++ b/source/modules/MEI.harmony.xml
@@ -46,7 +46,7 @@
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_chordrefTarget" scheme="isoschematron">
+        <constraintSpec ident="check_chordrefTarget" scheme="schematron">
           <constraint>
             <sch:rule context="@chordref">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@chordref attribute
@@ -213,7 +213,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="harm_start-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="harm_start-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:harm">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -491,7 +491,7 @@
         <rng:ref name="desc"/>
       </rng:optional>
     </content>
-    <constraintSpec ident="context_attribute_requires_content" scheme="isoschematron">
+    <constraintSpec ident="context_attribute_requires_content" scheme="schematron">
       <constraint>
         <sch:rule context="@context">
           <sch:assert role="warning" test="not(normalize-space(.) eq '')">@context attribute should
@@ -652,7 +652,7 @@
         <rng:ref name="category"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="category_id" scheme="isoschematron">
+    <constraintSpec ident="category_id" scheme="schematron">
       <constraint>
         <sch:rule context="mei:category">
           <sch:assert test="@xml:id" role="warning">To be addressable, the category element must
@@ -720,7 +720,7 @@
         <rng:ref name="model.dateLike"/>
       </rng:optional>
     </content>
-    <constraintSpec ident="check_change" scheme="isoschematron">
+    <constraintSpec ident="check_change" scheme="schematron">
       <constraint>
         <sch:rule context="mei:change">
           <sch:assert test="@isodate or mei:date">The date of the change must be recorded in an
@@ -834,7 +834,7 @@
         </rng:choice>
       </rng:choice>
     </content>
-    <constraintSpec ident="checkComponentList" scheme="isoschematron">
+    <constraintSpec ident="checkComponentList" scheme="schematron">
       <constraint>
         <sch:rule context="mei:componentList">
           <sch:assert
@@ -845,7 +845,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="checkComponents" scheme="isoschematron">
+    <constraintSpec ident="checkComponents" scheme="schematron">
       <constraint>
         <sch:rule context="mei:componentList[mei:*[@comptype]]">
           <sch:assert role="warning"
@@ -927,7 +927,7 @@
         </rng:oneOrMore>
       </rng:choice>
     </content>
-    <constraintSpec ident="checkContentsLabels" scheme="isoschematron">
+    <constraintSpec ident="checkContentsLabels" scheme="schematron">
       <constraint>
         <sch:rule context="mei:contents[mei:label]">
           <sch:assert role="warning" test="count(mei:label) = count(mei:contentItem)">When labels
@@ -1467,7 +1467,7 @@
         <rng:ref name="hand"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="checkHandListLabels" scheme="isoschematron">
+    <constraintSpec ident="checkHandListLabels" scheme="schematron">
       <constraint>
         <sch:rule context="mei:handList[mei:label]">
           <sch:assert role="warning" test="count(mei:label) = count(mei:hand)">When labels are used,
@@ -1503,7 +1503,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="history_restriction" scheme="isoschematron">
+    <constraintSpec ident="history_restriction" scheme="schematron">
       <constraint>
         <sch:rule context="mei:history[parent::mei:work or parent::mei:expression or parent::mei:manifestation[not(@singleton='true')]]">
           <sch:assert test="not(mei:acquisition or mei:provenance or mei:exhibHist or mei:treatHist or mei:treatSched)">The elements acquisition, provenance, exhibHist, treatHist and treatSched are not permitted at the work or expression level and are only permitted at the manifestation level, if the manifestation is a manifestation singleton.</sch:assert>
@@ -1529,7 +1529,7 @@
     <content>
       <rng:text/>
     </content>
-    <constraintSpec ident="Check_incipCode_form_mimetype" scheme="isoschematron">
+    <constraintSpec ident="Check_incipCode_form_mimetype" scheme="schematron">
       <constraint>
         <sch:rule context="mei:incipCode">
           <sch:assert test="@form or @mimetype">incipCode must have a form or mimetype
@@ -2635,7 +2635,7 @@
         <rng:ref name="attUsage"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="context_attribute_requires_content" scheme="isoschematron">
+    <constraintSpec ident="context_attribute_requires_content" scheme="schematron">
       <constraint>
         <sch:rule context="@context">
           <sch:assert role="warning" test="not(normalize-space(.) eq '')">@context attribute should
@@ -2717,7 +2717,7 @@
         <rng:ref name="term"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="checkTermListLabels" scheme="isoschematron">
+    <constraintSpec ident="checkTermListLabels" scheme="schematron">
       <constraint>
         <sch:rule context="mei:termList[mei:label]">
           <sch:assert role="warning" test="count(mei:label) = count(mei:term)">When labels are used,
@@ -2915,7 +2915,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <constraintSpec ident="check_watermark_inline" scheme="isoschematron">
+    <constraintSpec ident="check_watermark_inline" scheme="schematron">
       <constraint>
         <sch:rule
           context="mei:watermark">

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -163,7 +163,7 @@
   </macroSpec>
   <classSpec ident="att.duration.quality" module="MEI.mensural" type="atts">
     <desc xml:lang="en">Attribute that expresses duration for a given mensural note symbol.</desc>
-    <constraintSpec ident="check_duplex_quality" scheme="isoschematron">
+    <constraintSpec ident="check_duplex_quality" scheme="schematron">
       <constraint>
         <sch:rule context="(mei:note|mei:space)[@dur.quality='duplex']">
           <sch:assert test="@dur='longa'">
@@ -172,7 +172,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="check_maiorminor_quality" scheme="isoschematron">
+    <constraintSpec ident="check_maiorminor_quality" scheme="schematron">
       <constraint>
         <sch:rule context="(mei:note|mei:space)[@dur.quality='maior' or @dur.quality='minor']">
           <sch:assert test="@dur='semibrevis'">
@@ -224,7 +224,7 @@
   </classSpec>
   <classSpec ident="att.mensural.shared" module="MEI.mensural" type="atts">
     <desc xml:lang="en">Shared attributes in the mensural repertoire.</desc>
-    <constraintSpec ident="mensuration_conflicting_attributes" scheme="isoschematron">
+    <constraintSpec ident="mensuration_conflicting_attributes" scheme="schematron">
       <constraint>
         <sch:rule context="mei:mensur[@divisio]">
           <sch:assert test="not(@tempus) and not(@prolatio)">
@@ -455,7 +455,7 @@
       <memberOf key="att.plica.ges"/>
       <memberOf key="att.plica.anl"/>
     </classes>
-    <constraintSpec ident="Check_plica" scheme="isoschematron">
+    <constraintSpec ident="Check_plica" scheme="schematron">
       <constraint>
         <sch:rule context="mei:plica">
           <sch:assert test="count(../mei:plica) &lt;= 1">Only one plica is allowed.</sch:assert>
@@ -499,7 +499,7 @@
     <content>
       <rng:empty/>
     </content>
-    <constraintSpec ident="Check_stem" scheme="isoschematron">
+    <constraintSpec ident="Check_stem" scheme="schematron">
       <constraint>
         <sch:rule context="mei:stem">
           <sch:assert test="not(ancestor::mei:note/@*[starts-with(local-name(),'stem.')])">A note with nested stem elements must not have @stem.* attributes.</sch:assert>

--- a/source/modules/MEI.midi.xml
+++ b/source/modules/MEI.midi.xml
@@ -48,7 +48,7 @@
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_instrTarget" scheme="isoschematron">
+        <constraintSpec ident="check_instrTarget" scheme="schematron">
           <constraint>
             <sch:rule context="@instr">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@instr attribute
@@ -83,7 +83,7 @@
   </classSpec>
   <classSpec ident="att.midiInstrument" module="MEI.midi" type="atts">
     <desc xml:lang="en">Attributes that record MIDI instrument information.</desc>
-    <constraintSpec ident="One_of_instrname_or_instrnum" scheme="isoschematron">
+    <constraintSpec ident="One_of_instrname_or_instrnum" scheme="schematron">
       <constraint>
         <sch:rule context="mei:*[@midi.instrname]">
           <sch:assert test="not(@midi.instrnum)">Only one of @midi.instrname and @midi.instrnum
@@ -91,7 +91,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="One_of_patchname_or_patchnum" scheme="isoschematron">
+    <constraintSpec ident="One_of_patchname_or_patchnum" scheme="schematron">
       <constraint>
         <sch:rule context="mei:*[@midi.patchname]">
           <sch:assert test="not(@midi.patchnum)">Only one of @midi.patchname and @midi.patchnum

--- a/source/modules/MEI.msDesc.xml
+++ b/source/modules/MEI.msDesc.xml
@@ -11,7 +11,7 @@
     <desc xml:lang="en">Attributes that express the relationship between a component and its host.</desc>
     <attList>
       <attDef ident="comptype" usage="opt">
-        <constraintSpec ident="checkComponentType" scheme="isoschematron">
+        <constraintSpec ident="checkComponentType" scheme="schematron">
           <constraint>
             <sch:rule context="mei:*[@comptype]">
               <sch:let name="elementName" value="local-name()"/>
@@ -160,7 +160,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <constraintSpec ident="check_catchwords_inline" scheme="isoschematron">
+    <constraintSpec ident="check_catchwords_inline" scheme="schematron">
       <constraint>
         <sch:rule
           context="mei:catchwords">
@@ -321,7 +321,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <constraintSpec ident="check_heraldry_inline" scheme="isoschematron">
+    <constraintSpec ident="check_heraldry_inline" scheme="schematron">
       <constraint>
         <sch:rule
           context="mei:heraldry">
@@ -458,7 +458,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="check_locus_inline" scheme="isoschematron">
+    <constraintSpec ident="check_locus_inline" scheme="schematron">
       <constraint>
         <sch:rule context="mei:locus">
           <sch:assert
@@ -512,7 +512,7 @@
         <rng:ref name="locus"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="check_locusGrp_inline" module="MEI.msDesc" scheme="isoschematron">
+    <constraintSpec ident="check_locusGrp_inline" module="MEI.msDesc" scheme="schematron">
       <constraint>
         <sch:rule context="mei:locusGrp">
           <sch:assert
@@ -718,7 +718,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <constraintSpec ident="check_secFolio_inline" scheme="isoschematron">
+    <constraintSpec ident="check_secFolio_inline" scheme="schematron">
       <constraint>
         <sch:rule
           context="mei:secFolio">
@@ -743,7 +743,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <constraintSpec ident="check_signatures_inline" scheme="isoschematron">
+    <constraintSpec ident="check_signatures_inline" scheme="schematron">
       <constraint>
         <sch:rule
           context="mei:signatures">

--- a/source/modules/MEI.performance.xml
+++ b/source/modules/MEI.performance.xml
@@ -9,7 +9,7 @@
   </moduleSpec>
   <classSpec ident="att.alignment" module="MEI.performance" type="atts">
     <desc xml:lang="en">Temporal alignment attributes.</desc>
-    <constraintSpec ident="check_whenTarget" scheme="isoschematron">
+    <constraintSpec ident="check_whenTarget" scheme="schematron">
       <constraint>
         <sch:rule context="@when">
           <sch:assert role="warning" test="not(normalize-space(.) eq '')">@when attribute should
@@ -47,7 +47,7 @@
         <rng:ref name="clip"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="avFile_child_of_clip" scheme="isoschematron">
+    <constraintSpec ident="avFile_child_of_clip" scheme="schematron">
       <constraint>
         <sch:rule context="mei:clip/mei:avFile">
           <sch:assert test="count(mei:*) = 0">An avFile child of clip cannot have
@@ -78,7 +78,7 @@
         <rng:ref name="when"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="betype_required_when_begin_or_end" scheme="isoschematron">
+    <constraintSpec ident="betype_required_when_begin_or_end" scheme="schematron">
       <constraint>
         <sch:rule context="mei:clip[@begin or @end]">
           <sch:assert role="warning" test="@betype or ancestor::mei:*[@betype]">When @begin or @end
@@ -129,7 +129,7 @@
         <rng:ref name="clip"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="betype_required_when_begin_or_end" scheme="isoschematron">
+    <constraintSpec ident="betype_required_when_begin_or_end" scheme="schematron">
       <constraint>
         <sch:rule context="mei:recording[@begin or @end]">
           <sch:assert role="warning" test="@betype">When @begin or @end is used, @betype should be
@@ -155,7 +155,7 @@
          <rng:ref name="extData"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="check_when_interval" scheme="isoschematron">
+    <constraintSpec ident="check_when_interval" scheme="schematron">
       <constraint>
         <sch:rule context="mei:when[@interval]">
           <sch:assert test="@since">@since must be present when @interval is used.</sch:assert>
@@ -174,7 +174,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="check_when_absolute" scheme="isoschematron">
+    <constraintSpec ident="check_when_absolute" scheme="schematron">
       <constraint>
         <sch:rule context="mei:when[@absolute]">
           <sch:assert role="warning" test="@abstype or ancestor::mei:*[@betype]">When @absolute is
@@ -224,7 +224,7 @@
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_sinceTarget" scheme="isoschematron">
+        <constraintSpec ident="check_sinceTarget" scheme="schematron">
           <constraint>
             <sch:rule context="@since">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@since attribute

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -249,7 +249,7 @@
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_attaccaTarget" scheme="isoschematron">
+        <constraintSpec ident="check_attaccaTarget" scheme="schematron">
           <constraint>
             <sch:rule context="mei:attacca/@target">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@target attribute
@@ -288,7 +288,7 @@
         <datatype>
           <rng:ref name="data.AUGMENTDOT"/>
         </datatype>
-        <constraintSpec ident="dots_attribute_requires_dur" scheme="isoschematron">
+        <constraintSpec ident="dots_attribute_requires_dur" scheme="schematron">
           <constraint>
             <sch:rule context="mei:*[@dots]">
               <sch:assert test="@dur">An element with a dots attribute must also have a dur
@@ -364,7 +364,7 @@
         <datatype>
           <rng:ref name="data.BARMETHOD"/>
         </datatype>
-        <constraintSpec ident="check_barmethod" scheme="isoschematron">
+        <constraintSpec ident="check_barmethod" scheme="schematron">
           <constraint>
             <sch:rule context="@bar.method[parent::*[matches(local-name(), '(staffDef|measure)')]]">
               <sch:assert test="not(. eq 'mensur')">"mensur" not allowed in this
@@ -486,7 +486,7 @@
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_classURI" scheme="isoschematron">
+        <constraintSpec ident="check_classURI" scheme="schematron">
           <constraint>
             <sch:rule context="@class">
               <sch:assert
@@ -520,7 +520,7 @@
   <classSpec ident="att.cleffing.log" module="MEI.shared" type="atts">
     <desc xml:lang="en">Used by staffDef and scoreDef to provide default values for attributes in the logical
       domain related to clefs.</desc>
-    <constraintSpec ident="clef_shape_requires_clef_line" scheme="isoschematron">
+    <constraintSpec ident="clef_shape_requires_clef_line" scheme="schematron">
       <constraint>
         <sch:rule context="mei:*[matches(@clef.shape, '[FCG]')]">
           <sch:assert test="@clef.line">An 'F', 'C', or 'G' clef requires that its position be
@@ -566,7 +566,7 @@
   </classSpec>
   <classSpec ident="att.clefShape" module="MEI.shared" type="atts">
     <desc xml:lang="en">Attributes that record the shape of a clef.</desc>
-    <constraintSpec ident="shape_requires_line" scheme="isoschematron">
+    <constraintSpec ident="shape_requires_line" scheme="schematron">
       <constraint>
         <sch:rule context="mei:clef[matches(@shape, '[FCG]')]">
           <sch:assert test="@line">When @shape is present, @line must also be
@@ -768,7 +768,7 @@
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_custosTarget" scheme="isoschematron">
+        <constraintSpec ident="check_custosTarget" scheme="schematron">
           <constraint>
             <sch:rule context="mei:custos/@target">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@target attribute
@@ -826,7 +826,7 @@
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_dataTarget" scheme="isoschematron">
+        <constraintSpec ident="check_dataTarget" scheme="schematron">
           <constraint>
             <sch:rule context="@data">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@data attribute should
@@ -858,7 +858,7 @@
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_declsTarget" scheme="isoschematron">
+        <constraintSpec ident="check_declsTarget" scheme="schematron">
           <constraint>
             <sch:rule context="@decls">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@decls attribute
@@ -1136,7 +1136,7 @@
         <datatype>
           <rng:data type="string"/>
         </datatype>
-        <constraintSpec ident="check_extent" scheme="isoschematron">
+        <constraintSpec ident="check_extent" scheme="schematron">
           <constraint>
             <sch:rule context="@extent[matches(normalize-space(.), '^\d+(\.\d+)?$')]">
               <sch:assert role="warning" test="../@unit">The @unit attribute is
@@ -1200,7 +1200,7 @@
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_handTarget" scheme="isoschematron">
+        <constraintSpec ident="check_handTarget" scheme="schematron">
           <constraint>
             <sch:rule context="@hand">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@hand attribute should
@@ -1276,7 +1276,7 @@
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_joinTarget" scheme="isoschematron">
+        <constraintSpec ident="check_joinTarget" scheme="schematron">
           <constraint>
             <sch:rule context="@join">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@join attribute should
@@ -1396,7 +1396,7 @@
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_defTarget_layer" scheme="isoschematron">
+        <constraintSpec ident="check_defTarget_layer" scheme="schematron">
           <constraint>
             <sch:rule context="mei:layer/@def">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@def attribute should
@@ -1504,7 +1504,7 @@
             <rng:param name="minInclusive">2</rng:param>
           </rng:data>
         </datatype>
-        <constraintSpec ident="check_lsegs" scheme="isoschematron">
+        <constraintSpec ident="check_lsegs" scheme="schematron">
           <constraint>
             <sch:rule context="@lsegs">
               <sch:assert test="matches(../@lform, '(dashed|dotted|wavy)')">@lform attribute
@@ -2026,7 +2026,7 @@
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_nymrefTarget" scheme="isoschematron">
+        <constraintSpec ident="check_nymrefTarget" scheme="schematron">
           <constraint>
             <sch:rule context="@nymref">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@nymref attribute
@@ -2120,7 +2120,7 @@
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_head.altsymTarget" scheme="isoschematron">
+        <constraintSpec ident="check_head.altsymTarget" scheme="schematron">
           <constraint>
             <sch:rule context="@head.altsym">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@head.altsym attribute
@@ -2139,7 +2139,7 @@
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
-        <constraintSpec ident="check_head.auth" scheme="isoschematron">
+        <constraintSpec ident="check_head.auth" scheme="schematron">
           <constraint>
             <sch:rule context="mei:*[lower-case(@head.auth) eq 'smufl']">
               <sch:assert test="matches(@head.shape, '^#x') or matches(@head.shape, '^U+')">When
@@ -2191,7 +2191,7 @@
         <datatype>
           <rng:ref name="data.HEADSHAPE"/>
         </datatype>
-        <constraintSpec ident="check_headshape_num" scheme="isoschematron">
+        <constraintSpec ident="check_headshape_num" scheme="schematron">
           <constraint>
             <sch:rule
               context="mei:*[(matches(@head.shape, '#x') or matches(@head.shape, 'U+')) and (lower-case(@head.auth) eq 'smufl')]">
@@ -2343,7 +2343,7 @@
         <datatype>
           <rng:ref name="data.MEASUREBEAT"/>
         </datatype>
-        <constraintSpec ident="origin.tstamp2_requires_origin.tstamp" scheme="isoschematron">
+        <constraintSpec ident="origin.tstamp2_requires_origin.tstamp" scheme="schematron">
           <constraint>
             <sch:rule context="mei:*[@origin.tstamp2]">
               <sch:assert test="@origin.tstamp">When @origin.tstamp2 is used @origin.tstamp must
@@ -2557,7 +2557,7 @@
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_plistTarget" scheme="isoschematron">
+        <constraintSpec ident="check_plistTarget" scheme="schematron">
           <constraint>
             <sch:rule context="@plist">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@plist attribute
@@ -2700,7 +2700,7 @@
         <datatype>
           <rng:ref name="data.CONFIDENCE"/>
         </datatype>
-        <constraintSpec ident="check_confidence" scheme="isoschematron">
+        <constraintSpec ident="check_confidence" scheme="schematron">
           <constraint>
             <sch:rule context="mei:*[@confidence]">
               <sch:assert test="@min and @max">The attributes @min and @max are required when
@@ -2722,7 +2722,7 @@
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_respTarget" scheme="isoschematron">
+        <constraintSpec ident="check_respTarget" scheme="schematron">
           <constraint>
             <sch:rule context="@resp">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@resp attribute should
@@ -2915,7 +2915,7 @@
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_defTarget_staff" scheme="isoschematron">
+        <constraintSpec ident="check_defTarget_staff" scheme="schematron">
           <constraint>
             <sch:rule context="mei:staff/@def">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@def attribute should
@@ -3059,7 +3059,7 @@
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_endidTarget" scheme="isoschematron">
+        <constraintSpec ident="check_endidTarget" scheme="schematron">
           <constraint>
             <sch:rule context="@endid">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@endid attribute
@@ -3083,7 +3083,7 @@
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_startidTarget" scheme="isoschematron">
+        <constraintSpec ident="check_startidTarget" scheme="schematron">
           <constraint>
             <sch:rule context="@startid">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@startid attribute
@@ -3138,7 +3138,7 @@
         <datatype maxOccurs="1">
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_stem.sameasTarget" scheme="isoschematron">
+        <constraintSpec ident="check_stem.sameasTarget" scheme="schematron">
           <constraint>
             <sch:rule context="@stem.sameas">
               <sch:let name="layer.n" value="self::node()/ancestor::mei:layer/@n"/>
@@ -4388,7 +4388,7 @@
         </rng:zeroOrMore>
       </rng:choice>
     </content>
-    <constraintSpec ident="Check_annot_data" scheme="isoschematron">
+    <constraintSpec ident="Check_annot_data" scheme="schematron">
       <constraint>
         <sch:rule context="mei:annot[@data]">
           <sch:assert test="ancestor::mei:notesStmt">The @data attribute may only occur on an
@@ -4578,7 +4578,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="checkBiblLabels" scheme="isoschematron">
+    <constraintSpec ident="checkBiblLabels" scheme="schematron">
       <constraint>
         <sch:rule context="mei:biblList[mei:label]">
           <sch:assert role="warning" test="count(mei:label) = count(mei:bibl)">When labels are used,
@@ -4704,7 +4704,7 @@
     <content>
       <rng:empty/>
     </content>
-    <constraintSpec ident="caesura_start-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="caesura_start-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:caesura">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -4840,7 +4840,7 @@
         <datatype>
           <rng:data type="positiveInteger"/>
         </datatype>
-        <constraintSpec ident="check_cb" scheme="isoschematron">
+        <constraintSpec ident="check_cb" scheme="schematron">
           <constraint>
             <sch:rule context="mei:cb">
               <sch:let name="totalColumns" value="preceding::mei:colLayout[1]/@cols"/>
@@ -4901,7 +4901,7 @@
     <content>
       <rng:empty/>
     </content>
-    <constraintSpec ident="Clef_position_lines" scheme="isoschematron">
+    <constraintSpec ident="Clef_position_lines" scheme="schematron">
       <constraint>
         <sch:rule context="mei:clef[matches(@shape, '[FCG]')][ancestor::mei:staffDef[@lines]]">
           <sch:let name="thisstaff" value="ancestor::mei:staffDef/@n"/>
@@ -4912,7 +4912,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="Clef_position_nolines" scheme="isoschematron">
+    <constraintSpec ident="Clef_position_nolines" scheme="schematron">
       <constraint>
         <sch:rule context="mei:clef[ancestor::mei:staffDef[not(@lines)]]">
           <sch:let name="thisstaff" value="ancestor::mei:staffDef/@n"/>
@@ -5012,7 +5012,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="check_contributor_role" scheme="isoschematron">
+    <constraintSpec ident="check_contributor_role" scheme="schematron">
       <constraint>
         <sch:rule context="mei:contributor">
           <sch:assert
@@ -5133,7 +5133,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="check_dedicatee" scheme="isoschematron">
+    <constraintSpec ident="check_dedicatee" scheme="schematron">
       <constraint>
         <sch:rule context="mei:dedicatee">
           <sch:assert test="not(ancestor::mei:dedicatee)">The dedicatee element may not be
@@ -5273,7 +5273,7 @@
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
-    <constraintSpec ident="check_dimensions" scheme="isoschematron">
+    <constraintSpec ident="check_dimensions" scheme="schematron">
       <constraint>
         <sch:rule context="mei:physDesc/mei:dimensions">
           <sch:assert test="not(count(mei:depth) &gt; 1)">The depth element may only appear
@@ -5324,7 +5324,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="dir_start-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="dir_start-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:dir[not(ancestor::mei:syllable)]">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -5508,7 +5508,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="dynam_start-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="dynam_start-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:dynam">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real"> Must have one of
@@ -5516,7 +5516,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="dynam_end-type_attributes" scheme="isoschematron">
+    <constraintSpec ident="dynam_end-type_attributes" scheme="schematron">
       <constraint>
         <sch:rule context="mei:dynam[@val2]">
           <sch:assert test="@dur or @dur.ges or @endid or @tstamp2">When @val2 is present, either
@@ -5885,7 +5885,7 @@
         <rng:ref name="model.labelLike"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="check_grpSym_attributes_scoreDef" scheme="isoschematron">
+    <constraintSpec ident="check_grpSym_attributes_scoreDef" scheme="schematron">
       <constraint>
         <sch:rule context="mei:grpSym[parent::mei:scoreDef]">
           <sch:assert test="@startid and @endid and @level">In scoreDef, grpSym must have startid,
@@ -5893,7 +5893,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="check_grpSym_attributes_staffDef" scheme="isoschematron">
+    <constraintSpec ident="check_grpSym_attributes_staffDef" scheme="schematron">
       <constraint>
         <sch:rule context="mei:grpSym[parent::mei:staffGrp]">
           <sch:assert test="not(@startid or @endid or @level)">In staffGrp, grpSym must not have
@@ -6080,7 +6080,7 @@
     <content>
       <rng:empty/>
     </content>
-    <constraintSpec ident="Check_keyAccidPlacement" scheme="isoschematron">
+    <constraintSpec ident="Check_keyAccidPlacement" scheme="schematron">
       <constraint>
         <sch:rule context="mei:keyAccid">
           <sch:assert test="(@x and @y) or @pname or @loc">One of the following is required: @x and
@@ -6128,7 +6128,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="check_keyAccid_oct" scheme="isoschematron">
+    <constraintSpec ident="check_keyAccid_oct" scheme="schematron">
       <constraint>
         <sch:rule context="mei:keySig[mei:keyAccid[@oct]]">
           <sch:assert test="count(mei:keyAccid[@oct]) = count(mei:keyAccid)">If the @oct attribute
@@ -6137,7 +6137,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="check_keySig_editorial" scheme="isoschematron">
+    <constraintSpec ident="check_keySig_editorial" scheme="schematron">
       <constraint>
         <sch:rule
           context="mei:keySig/mei:*[local-name() eq 'add' or local-name() eq 'corr'             or local-name() eq 'damage' or local-name() eq 'del' or local-name() eq 'orig' or              local-name() eq 'reg' or local-name() eq 'restore' or local-name() eq 'sic' or              local-name() eq 'supplied' or local-name() eq 'unclear']">
@@ -6420,7 +6420,7 @@
       <rng:ref name="meiHead"/>
       <rng:ref name="music"/>
     </content>
-    <constraintSpec ident="Check_staff" scheme="isoschematron">
+    <constraintSpec ident="Check_staff" scheme="schematron">
       <constraint>
         <sch:rule context="mei:*[@staff]">
           <sch:assert
@@ -6558,7 +6558,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="nameParts" scheme="isoschematron">
+    <constraintSpec ident="nameParts" scheme="schematron">
       <constraint>
         <sch:rule context="mei:name">
           <sch:assert role="warning" test="not(mei:geogName or mei:persName or mei:corpName)"
@@ -6717,7 +6717,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="ornam_start-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="ornam_start-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:ornam">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -6993,7 +6993,7 @@
         <rng:ref name="curve"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="phrase_start-_and_end-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="phrase_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:phrase">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -7003,7 +7003,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="phrase_containing_curve" scheme="isoschematron">
+    <constraintSpec ident="phrase_containing_curve" scheme="schematron">
       <constraint>
         <sch:rule
           context="mei:phrase[mei:curve[@bezier or @bulge or @curvedir or @lform or @lwidth or @ho or              @startho or @endho or @to or @startto or @endto or @vo or @startvo or @endvo or @x or @y or @x2 or @y2]]">
@@ -7179,7 +7179,7 @@
     <content>
       <rng:empty/>
     </content>
-    <constraintSpec ident="FRBR_relation" scheme="isoschematron">
+    <constraintSpec ident="FRBR_relation" scheme="schematron">
       <constraint>
         <!-- See http://vocab.org/frbr/core for more-precise entity-to-entity constraints -->
         <sch:rule
@@ -7392,7 +7392,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="check_respStmt" scheme="isoschematron">
+    <constraintSpec ident="check_respStmt" scheme="schematron">
       <constraint>
         <sch:rule context="mei:respStmt[not(ancestor::mei:change)]">
           <sch:assert
@@ -7429,7 +7429,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="Check_restline" scheme="isoschematron">
+    <constraintSpec ident="Check_restline" scheme="schematron">
       <constraint>
         <sch:rule context="mei:rest[@line]">
           <sch:let name="thisstaff" value="ancestor::mei:staff/@n"/>
@@ -7619,7 +7619,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="Check_sectionexpansion" scheme="isoschematron">
+    <constraintSpec ident="Check_sectionexpansion" scheme="schematron">
       <constraint>
         <sch:rule context="mei:section[mei:expansion]">
           <sch:assert test="descendant::mei:section|descendant::mei:ending|descendant::mei:rdg">A
@@ -7808,7 +7808,7 @@
       </rng:zeroOrMore>
     </content>
     <!--
-        <constraintSpec ident="staffOrganization" scheme="isoschematron">
+        <constraintSpec ident="staffOrganization" scheme="schematron">
           <constraint>
             <sch:rule context="mei:staff">
               <sch:assert test="not(descendant::mei:staff)">A staff cannot have staff
@@ -7817,7 +7817,7 @@
           </constraint>
         </constraintSpec>
       -->
-    <constraintSpec ident="checkStaff_n" scheme="isoschematron">
+    <constraintSpec ident="checkStaff_n" scheme="schematron">
       <constraint>
         <sch:rule context="mei:staff[@n]">
           <sch:let name="thisstaff" value="@n"/>
@@ -7870,7 +7870,7 @@
         <rng:ref name="ambitus"/>
       </rng:optional>
     </content>
-    <constraintSpec ident="Check_staffDefn" scheme="isoschematron">
+    <constraintSpec ident="Check_staffDefn" scheme="schematron">
       <constraint>
         <sch:rule context="mei:staffDef[not(ancestor::mei:staff)]">
           <sch:let name="thisstaff" value="@n"/>
@@ -7883,7 +7883,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="Check_ancestor_staff" scheme="isoschematron">
+    <constraintSpec ident="Check_ancestor_staff" scheme="schematron">
       <constraint>
         <sch:rule context="mei:staffDef[ancestor::mei:staff and @n]">
           <sch:let name="thisstaff" value="@n"/>
@@ -7892,7 +7892,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="Check_ancestor_staff_lines" scheme="isoschematron">
+    <constraintSpec ident="Check_ancestor_staff_lines" scheme="schematron">
       <constraint>
         <sch:rule context="mei:staffDef[ancestor::mei:staff and not(@n)]">
           <sch:let name="thisstaff" value="ancestor::mei:staff/@n"/>
@@ -7902,7 +7902,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="Check_clef_position_staffDef" scheme="isoschematron">
+    <constraintSpec ident="Check_clef_position_staffDef" scheme="schematron">
       <constraint>
         <sch:rule context="mei:staffDef[@clef.line and @lines]">
           <sch:assert test="number(@clef.line) &lt;= number(@lines)">The clef position must be less
@@ -7910,7 +7910,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="Check_clef_position_staffDef_nolines" scheme="isoschematron">
+    <constraintSpec ident="Check_clef_position_staffDef_nolines" scheme="schematron">
       <constraint>
         <sch:rule context="mei:staffDef[@clef.line and not(@lines)]">
           <sch:let name="thisstaff" value="@n"/>
@@ -7921,7 +7921,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="Check_tab_strings_lines" scheme="isoschematron">
+    <constraintSpec ident="Check_tab_strings_lines" scheme="schematron">
       <constraint>
         <sch:rule context="mei:staffDef[@tab.strings and @lines]">
           <sch:let name="countTokens" value="count(tokenize(normalize-space(@tab.strings), '\s'))"/>
@@ -7930,7 +7930,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="Check_tab_strings_nolines" scheme="isoschematron">
+    <constraintSpec ident="Check_tab_strings_nolines" scheme="schematron">
       <constraint>
         <sch:rule context="mei:staffDef[@tab.strings and not(@lines)]">
           <sch:let name="countTokens" value="count(tokenize(normalize-space(@tab.strings), '\s'))"/>
@@ -7942,7 +7942,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="Check_lines_color" scheme="isoschematron">
+    <constraintSpec ident="Check_lines_color" scheme="schematron">
       <constraint>
         <sch:pattern>
           <sch:rule context="mei:staffDef[@lines.color and @lines]">
@@ -7962,7 +7962,7 @@
         </sch:pattern>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="Check_staff_ppq_ancestor" scheme="isoschematron">
+    <constraintSpec ident="Check_staff_ppq_ancestor" scheme="schematron">
       <constraint>
         <sch:pattern>
           <sch:rule context="mei:staffDef[@ppq][ancestor::mei:scoreDef[@ppq]]">
@@ -7974,7 +7974,7 @@
         </sch:pattern>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="Check_staff_ppq_preceding" scheme="isoschematron">
+    <constraintSpec ident="Check_staff_ppq_preceding" scheme="schematron">
       <constraint>
         <sch:pattern>
           <sch:rule context="mei:staffDef[@ppq][preceding::mei:scoreDef[@ppq]]">
@@ -8020,7 +8020,7 @@
         <rng:ref name="grpSym"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="Check_staffGrp_unique_staff_n_values" scheme="isoschematron">
+    <constraintSpec ident="Check_staffGrp_unique_staff_n_values" scheme="schematron">
       <constraint>
         <sch:rule context="mei:staffGrp">
           <sch:let name="countstaves" value="count(descendant::mei:staffDef)"/>
@@ -8080,7 +8080,7 @@
     <content>
       <rng:empty/>
     </content>
-    <constraintSpec ident="symbolDef_symbol_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="symbolDef_symbol_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:symbol[ancestor::mei:symbolDef]">
           <sch:assert test="@startid or (@x and @y)">In the symbolDef context, symbol must have
@@ -8127,7 +8127,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="tempo_in_header_disallow_most_attrs" scheme="isoschematron">
+    <constraintSpec ident="tempo_in_header_disallow_most_attrs" scheme="schematron">
       <constraint>
         <sch:rule context="mei:tempo[not(ancestor::mei:score or ancestor::mei:part)]">
           <sch:assert
@@ -8138,7 +8138,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="tempo_start-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="tempo_start-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule
           context="mei:tempo[not(ancestor::mei:syllable) and not(ancestor::mei:work) and not(ancestor::mei:expression) and not(count(ancestor::mei:*) = 0)]">
@@ -8165,7 +8165,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="Check_term_dataTarget" scheme="isoschematron">
+    <constraintSpec ident="Check_term_dataTarget" scheme="schematron">
       <constraint>
         <sch:rule context="mei:term[@data]">
           <sch:assert test="ancestor::mei:classification">The @data attribute may only occur on a

--- a/source/modules/MEI.text.xml
+++ b/source/modules/MEI.text.xml
@@ -273,7 +273,7 @@
         <rng:ref name="li"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="list_type_constraint" scheme="isoschematron">
+    <constraintSpec ident="list_type_constraint" scheme="schematron">
       <constraint>
         <sch:rule context="mei:list[contains(@type,'gloss')]">
           <sch:assert test="count(mei:label) = count(mei:li)">In a list of type "gloss" all items

--- a/source/modules/MEI.usersymbols.xml
+++ b/source/modules/MEI.usersymbols.xml
@@ -16,7 +16,7 @@
         <datatype>
           <rng:ref name="data.URI"/>
         </datatype>
-        <constraintSpec ident="check_altsymTarget" scheme="isoschematron">
+        <constraintSpec ident="check_altsymTarget" scheme="schematron">
           <constraint>
             <sch:rule context="@altsym">
               <sch:assert role="warning" test="not(normalize-space(.) eq '')">@altsym attribute
@@ -157,7 +157,7 @@
     <content>
       <rng:empty/>
     </content>
-    <constraintSpec ident="symbolDef_curve_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="symbolDef_curve_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:curve[ancestor::mei:symbolDef]">
           <sch:assert test="@startid or (@x and @y)">In the symbolDef context, curve must have
@@ -203,7 +203,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="line_start-_and_end-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="line_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:line[ancestor::mei:symbolDef]">
           <sch:assert test="@startid or (@x and @y)">When used in the symbolDef context, must have

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -616,7 +616,7 @@
         <datatype>
           <rng:data type="nonNegativeInteger"/>
         </datatype>
-        <constraintSpec ident="check_beams.floating" scheme="isoschematron">
+        <constraintSpec ident="check_beams.floating" scheme="schematron">
           <constraint>
             <sch:rule context="mei:fTrem[@beams and @beams.float]">
               <sch:assert test="@beams.float &lt;= @beams">The number of floating beams must be less
@@ -1818,7 +1818,7 @@
     </classes>
     <!-- Is this constraint true in all cases? -->
     <!-- 
-      <constraintSpec ident="check_sylAncestor" scheme="isoschematron">
+      <constraintSpec ident="check_sylAncestor" scheme="schematron">
         <constraint>
           <sch:rule context="mei:syl[@place]">
             <sch:assert test="not(ancestor::mei:verse or ancestor::mei:refrain)">When syl is a

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -339,7 +339,7 @@
         </valItem>
       </valList>
     </content>
-    <constraintSpec ident="warn_deprecated" scheme="isoschematron">
+    <constraintSpec ident="warn_deprecated" scheme="schematron">
       <constraint>
         <sch:rule context="@artic">
           <sch:assert role="warning"
@@ -3203,7 +3203,7 @@
         <rng:ref name="data.NMTOKEN"/>
       </rng:choice>
     </content>
-    <constraintSpec ident="constrain_place" scheme="isoschematron">
+    <constraintSpec ident="constrain_place" scheme="schematron">
       <constraint>
         <sch:rule context="@place">
           <sch:assert
@@ -3379,7 +3379,7 @@
         <rng:ref name="data.STAFFREL.extended"/>
       </rng:choice>
     </content>
-    <constraintSpec ident="between_requires_adjacent_staves" scheme="isoschematron">
+    <constraintSpec ident="between_requires_adjacent_staves" scheme="schematron">
       <constraint>
         <sch:rule context="mei:*[@place eq 'between']">
           <sch:assert test="count(tokenize(normalize-space(string(@staff)), '\s+')) = 2">The @staff
@@ -3781,7 +3781,7 @@
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>
-        <constraintSpec ident="When_notationsubtype" scheme="isoschematron">
+        <constraintSpec ident="When_notationsubtype" scheme="schematron">
           <constraint>
             <sch:rule context="mei:*[@notationsubtype]">
               <sch:assert test="@notationtype">An element with a notationsubtype attribute must have


### PR DESCRIPTION
The TEI has changed the value of "schematron" in its RNG, but the MEI RNG allows both "isoschematron" and "schematron".

If we're thinking about moving towards pure ODD this change will mean one less thing that breaks when we update.

Also fixed an issue where the customizations were using the TEI RNG, but the sources were pointing to the (older) MEI RNG. These were normalized to the MEI RNG so that all source and customizations use the same ODD schema.

Fixes #1158