### PR TITLE
pureODD: change rng:empty to tei:empty

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -1234,7 +1234,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The modern arpeggiation symbol is a vertical wavy line preceding the chord. When the notes
@@ -1347,7 +1347,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="beamspan_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
@@ -1382,7 +1382,7 @@
       <memberOf key="model.eventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p> <gi scheme="MEI">beatRpt</gi> may also be used in guitar or rhythm parts to indicate where
@@ -1404,7 +1404,7 @@
       <memberOf key="model.controlEventLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="bend_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
@@ -1469,7 +1469,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="breath_start-type_attributes_required" scheme="schematron">
       <constraint>
@@ -1525,7 +1525,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="fermata_start-type_attributes_required" scheme="schematron">
       <constraint>
@@ -1680,7 +1680,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="hairpin_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
@@ -1718,7 +1718,7 @@
       <memberOf key="model.eventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="harpPedal" module="MEI.cmn">
@@ -1734,7 +1734,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="harpPedal_start-type_attributes_required" scheme="schematron">
       <constraint>
@@ -1847,7 +1847,7 @@
       <memberOf key="model.meterSigLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="meterSigGrp" module="MEI.cmn">
@@ -1917,7 +1917,7 @@
       <memberOf key="model.eventLike.measureFilling"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>Automatically-generated numbering of consecutive measures of rest may be controlled via the
@@ -1938,7 +1938,7 @@
       <memberOf key="model.eventLike.measureFilling"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The automated numbering of consecutive measures of rest may be controlled via the
@@ -1960,7 +1960,7 @@
       <memberOf key="model.eventLike.measureFilling"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="mSpace" module="MEI.cmn">
@@ -1976,7 +1976,7 @@
       <memberOf key="model.eventLike.measureFilling"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The automated numbering of consecutive measures of space may be controlled via the
@@ -1998,7 +1998,7 @@
       <memberOf key="model.eventLike.measureFilling"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <!--<remarks xml:lang="en"><p>The num attribute can used to store a number to be rendered along with
         the note. See Read, p. 102-105.</p></remarks>-->
@@ -2016,7 +2016,7 @@
       <memberOf key="model.eventLike.measureFilling"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>In modern publishing practice, repeats of more than two measures should be written out
@@ -2199,7 +2199,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="pedal_start-type_attributes_required" scheme="schematron">
       <constraint>
@@ -2447,7 +2447,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="tupletSpan_start-_and_end-type_attributes_required"
       scheme="schematron">

--- a/source/modules/MEI.cmnOrnaments.xml
+++ b/source/modules/MEI.cmnOrnaments.xml
@@ -148,7 +148,7 @@
       <memberOf key="model.ornamentLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="mordent_start-type_attributes_required" scheme="schematron">
       <constraint>
@@ -177,7 +177,7 @@
       <memberOf key="model.ornamentLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="trill_start-type_attributes_required" scheme="schematron">
       <constraint>
@@ -211,7 +211,7 @@
       <memberOf key="model.ornamentLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="turn_start-type_attributes_required" scheme="schematron">
       <constraint>

--- a/source/modules/MEI.edittrans.xml
+++ b/source/modules/MEI.edittrans.xml
@@ -523,7 +523,7 @@
       <memberOf key="model.transcriptionLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>When material is omitted because it is illegible or inaudible, <gi scheme="MEI"
@@ -557,7 +557,7 @@
       <memberOf key="model.transcriptionLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="character" usage="opt">

--- a/source/modules/MEI.harmony.xml
+++ b/source/modules/MEI.harmony.xml
@@ -120,7 +120,7 @@
       <memberOf key="att.chordMember.vis"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The <att>string</att>, <att>fret</att>, and <att>fing</att> attributes are provided in

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -437,7 +437,7 @@
       <memberOf key="model.staffDefPart.mensural"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The <gi scheme="MEI">mensur</gi> element is provided for the encoding of mensural notation.
@@ -477,7 +477,7 @@
       <memberOf key="model.staffDefPart.mensural"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The proport element is provided for the encoding of mensural notation. It allows the
@@ -497,7 +497,7 @@
       <memberOf key="att.stem.anl"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="Check_stem" scheme="schematron">
       <constraint>

--- a/source/modules/MEI.midi.xml
+++ b/source/modules/MEI.midi.xml
@@ -239,7 +239,7 @@
       <memberOf key="att.midiValue"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The <att>num</att> attribute specifies a MIDI parameter number, while <att>val</att>
@@ -254,7 +254,7 @@
       <memberOf key="att.midi.event"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="num" usage="req">
@@ -274,7 +274,7 @@
       <memberOf key="att.midiNumber"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The value of the <att>num</att> attribute must be in the range 0-127.</p>
@@ -322,7 +322,7 @@
       <memberOf key="model.instrDefLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>This element provides a starting or default instrument declaration for a staff, a group of
@@ -406,7 +406,7 @@
       <memberOf key="att.midiNumber"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="noteOn" module="MEI.midi">
@@ -417,7 +417,7 @@
       <memberOf key="att.midiNumber"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="port" module="MEI.midi">
@@ -428,7 +428,7 @@
       <memberOf key="att.midiNumber"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="prog" module="MEI.midi">
@@ -440,7 +440,7 @@
       <memberOf key="att.midiNumber"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="seqNum" module="MEI.midi">
@@ -451,7 +451,7 @@
       <memberOf key="att.midi.event"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="num" usage="req">
@@ -485,7 +485,7 @@
       <memberOf key="att.midiNumber"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="form" usage="req">

--- a/source/modules/MEI.neumes.xml
+++ b/source/modules/MEI.neumes.xml
@@ -282,7 +282,7 @@
       <memberOf key="model.neumeModifierLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="liquescent" module="MEI.neumes">

--- a/source/modules/MEI.ptrref.xml
+++ b/source/modules/MEI.ptrref.xml
@@ -26,7 +26,7 @@
       <memberOf key="model.locrefLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>Unlike the <gi scheme="MEI">ref</gi> element, <gi scheme="MEI">ptr</gi> cannot contain text

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -4236,7 +4236,7 @@
       <memberOf key="model.syllablePart"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>An accidental may raise a pitch by one or two semitones or it may cancel a previous
@@ -4347,7 +4347,7 @@
       <memberOf key="att.ambNote.anl"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="analytic" module="MEI.shared">
@@ -4476,7 +4476,7 @@
       <memberOf key="model.noteModifierLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>Articulations typically affect duration, such as staccato marks, or the force of attack,
@@ -4525,7 +4525,7 @@
       <memberOf key="model.eventLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>This element is provided for repertoires, such as mensural notation, that lack measures.
@@ -4733,7 +4733,7 @@
       <memberOf key="model.controlEventLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="caesura_start-type_attributes_required" scheme="schematron">
       <constraint>
@@ -4863,7 +4863,7 @@
       <memberOf key="model.milestoneLike.text"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="n" usage="req">
@@ -4930,7 +4930,7 @@
       <memberOf key="model.syllablePart"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="Clef_position_lines" scheme="schematron">
       <constraint>
@@ -4993,7 +4993,7 @@
       <memberOf key="model.milestoneLike.text"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="cols" usage="req">
@@ -5506,7 +5506,7 @@
       <memberOf key="model.eventLike.mensural"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>This element provides an alternative to the <att>dots</att> attribute on <gi scheme="MEI"
@@ -5760,7 +5760,7 @@
       <memberOf key="att.targetEval"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The <att>plist</att> attribute contains an ordered list of identifiers of descendant <gi
@@ -6108,7 +6108,7 @@
       <memberOf key="model.keyAccidLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="Check_keyAccidPlacement" scheme="schematron">
       <constraint>
@@ -6310,7 +6310,7 @@
       <memberOf key="model.lbLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The <att>n</att> attribute should be used to record a number associated with this textual
@@ -6803,7 +6803,7 @@
       <memberOf key="model.eventLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="part" module="MEI.shared">
@@ -7207,7 +7207,7 @@
       <memberOf key="model.relationLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="FRBR_relation" scheme="schematron">
       <constraint>
@@ -7529,7 +7529,7 @@
       <memberOf key="model.milestoneLike.music"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>Do not confuse this element with the <gi scheme="MEI">lb</gi> element, which performs a
@@ -7708,7 +7708,7 @@
       <memberOf key="model.eventLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="speaker" module="MEI.shared">
@@ -8108,7 +8108,7 @@
       <memberOf key="model.textPhraseLike.limited"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="symbolDef_symbol_attributes_required" scheme="schematron">
       <constraint>

--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -70,7 +70,7 @@
       <memberOf key="att.startEndId"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="fret" usage="opt">

--- a/source/modules/MEI.usersymbols.xml
+++ b/source/modules/MEI.usersymbols.xml
@@ -155,7 +155,7 @@
       <memberOf key="model.graphicPrimitiveLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="symbolDef_curve_attributes_required" scheme="schematron">
       <constraint>


### PR DESCRIPTION
In light of #1161 this now makes perhaps more sense. Supersedes #1050. 

Tiny change to move the `empty` element from rng into tei namespace.