### PR TITLE
feat(build): describe ant targets in BUILD_COMMANDLINE

### DIFF
--- a/BUILD_COMMANDLINE.md
+++ b/BUILD_COMMANDLINE.md
@@ -76,7 +76,7 @@
      ant -lib lib/saxon/saxon-he-11.4.jar build-guidelines-html
      ```
 
-     The results of this build can be found in the web folder (`music-encoding/dist/guidelines/dev/web`). The guidelines are stored in the `index.html` file.
+     The results of this build can be found in the web folder (`music-encoding/dist/guidelines/web`). The guidelines are stored in the `index.html` file.
 
    * Build the RNG schema of a specific customization:
 

--- a/BUILD_COMMANDLINE.md
+++ b/BUILD_COMMANDLINE.md
@@ -89,3 +89,20 @@
      ```shell
      ant -lib lib/saxon/saxon-he-11.4.jar
      ```
+## Available Targets
+
+The following targets can be called using `ant <target>`:
+
+| target | description |
+|----|-----------------|
+| `dist` (or no target) | Default main target; equivalent to calling ant without any target. Builds all artifacts, i.e., RNG and compiled ODDs of all customizations, guidelines html and PDF.  |
+| `canonicalize-source` | Creates a canonicalized version of the mei-source.xml. This target will be triggered before all `build-...` targets. |
+| `build-compiled-odds` | Builds the compiled ODD files for all MEI customizations: `mei-all`, `mei-all_anyStart`, `mei-basic`, `mei-CMN`, `mei-Mensural` and `mei-Neumes`. |
+| `build-compiled-odd -Dcustomization.path="[ABSOLUTE/PATH/TO/YOUR/CUSTOMIZATION]"` | Builds the compiled ODD of a specific customization. |
+| `build-customizations` | Builds the RNG schemata for all MEI customizations. |
+| `build-rng -Dcustomization.path="[ABSOLUTE/PATH/TO/YOUR/CUSTOMIZATION]"` | Builds the RNG schema of a specific customization. |
+| `build-guidelines-html` | Builds the HTML version of the MEI guidelines. |
+| `build-guidelines-pdf` | Builds the PDF version of the MEI guidelines. (Calls `build-guidelines-html` before execution.) |
+| `init` | Initializes the build environment, e.g., downloads jar files for Saxon, Xerces and adds them to the `lib` folder.
+| `clean` | Deletes the following directories: `build`, `dist` and `temp`. |
+| `reset` | Resets the build environment. Same as `clean`, but additionaly deletes the `lib` directory with the Saxon and Xerces jar files. |

--- a/BUILD_COMMANDLINE.md
+++ b/BUILD_COMMANDLINE.md
@@ -78,10 +78,10 @@
 
      The results of this build can be found in the web folder (`music-encoding/dist/guidelines/dev/web`). The guidelines are stored in the `index.html` file.
 
-   * Build a specific customization's RNG schema:
+   * Build the RNG schema of a specific customization:
 
      ```shell
-     ant -lib lib/saxon/saxon-he-11.4.jar -Dcustomization.path="[PATH/TO/YOUR/CUSTOMIZATION]" build-rng
+     ant -lib lib/saxon/saxon-he-11.4.jar -Dcustomization.path="[ABSOLUTE/PATH/TO/YOUR/CUSTOMIZATION]" build-rng
      ```
 
    * Build everything (all customizations shipped with this repository, compiled ODDs for each customization, guidelines HTML):

--- a/BUILD_COMMANDLINE.md
+++ b/BUILD_COMMANDLINE.md
@@ -81,7 +81,7 @@
    * Build the RNG schema of a specific customization:
 
      ```shell
-     ant -lib lib/saxon/saxon-he-11.4.jar -Dcustomization.path="[ABSOLUTE/PATH/TO/YOUR/CUSTOMIZATION]" build-rng
+     ant -lib lib/saxon/saxon-he-11.4.jar -Dcustomization.path="[/ABSOLUTE/PATH/TO/YOUR/CUSTOMIZATION]" build-rng
      ```
 
    * Build everything (all customizations shipped with this repository, compiled ODDs for each customization, guidelines HTML):

--- a/build.xml
+++ b/build.xml
@@ -115,7 +115,7 @@
         <antcall target="clean"/>
     </target>
     
-    <target name="init" description="initializes the build environment, e.g. downloads saxon" unless="${docker}">
+    <target name="init" description="initializes the build environment, e.g., downloads saxon" unless="${docker}">
         <available property="xerces-available" file="${dir.lib.xerces}/${xerces.jar.file}"/>
         <available property="saxon-available" file="${dir.lib.saxon}/${saxon.jar.file}"/>
         <mkdir dir="${dir.lib}"/>


### PR DESCRIPTION
This PR adds a section to the BUILD_COMMANDLINE.md to describe the available ant targets. This should make it easier to use the different targets than looking them up directly from the build.xml.

The PR also addresses some unprecise statements in the same file.

FIxes #1166