### PR TITLE
fix(guidelines): improve spacing of attribute usage

### DIFF
--- a/source/assets/css/print/mei.css
+++ b/source/assets/css/print/mei.css
@@ -823,10 +823,6 @@ section.specSection h2 {
     display: inline;
 }
 
-.specSection .specs .facet .attributeUsage {
-    padding: 0 .2rem 0 .1rem;
-}
-
 .specSection .specs .facet .breadcrumb {
     display: block;
     margin: 0;

--- a/source/assets/css/screen/mei-website.css
+++ b/source/assets/css/screen/mei-website.css
@@ -4907,7 +4907,8 @@ ul.nav li.nav-item:first-child a {
  background:unset
 }
 .attributeDef .attributeUsage,
-.attributeDef .attributeDesc {
+.attributeDef .attributeDesc,
+.classContent .attributeDesc {
  margin-left:.3rem
 }
 .attributeDef .attributeClasses {


### PR DESCRIPTION
This PR improves the spacing of the attribute usage in the attribute sections of the guidelines, both HTML (by class and by module tab) and PDF. Before the spacing was too small.

| type | before | after | 
|------|--------|------| 
| HTML | ![HTML_before](https://github.com/music-encoding/music-encoding/assets/21059419/8f86c642-cab2-4584-a0eb-4899290b1b77) | ![HTML_after](https://github.com/music-encoding/music-encoding/assets/21059419/44c3fc90-5535-49f9-af69-d28c709373f2) |
| PDF | ![PDF_before](https://github.com/music-encoding/music-encoding/assets/21059419/69ee3eaf-a182-4723-ab39-c5a3df112b16) | ![PDF_after](https://github.com/music-encoding/music-encoding/assets/21059419/0de5e044-09db-4012-a4f1-72de9f36b81c) |


Fixes #1169

