### PR TITLE
Allow <availability> within <imprint>

### DIFF
--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -536,7 +536,7 @@
       <memberOf key="att.bibl"/>
       <memberOf key="att.dataPointing"/>
       <memberOf key="model.pubStmtPart"/>
-      <memberOf key="model.titlePagePart"/>
+      <memberOf key="model.imprintPart"/>
     </classes>
     <content>
       <rng:ref name="macro.availabilityPart"/>
@@ -2867,6 +2867,7 @@
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
       <memberOf key="att.lang"/>
+      <memberOf key="model.imprintPart"/>
     </classes>
     <content>
       <rng:text/>


### PR DESCRIPTION
Remove `<availability>` from membership in model.titlePagePart and include it in model.imprintPart. Also make `<unpub>` a member of model.imprintPart.

Fixes #567