### PR TITLE
fix(source): fix typos

### DIFF
--- a/source/docs/10-analysisharm.xml
+++ b/source/docs/10-analysisharm.xml
@@ -468,7 +468,7 @@
                               <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/harmony/harmony-sample270.txt" parse="text"/></egXML>
                            </figure>
                         </p>
-                        <p>You may use 6\ and 6/ for numerals that should be shown with a backslash and slash, respectively. An alternative would be to use the "bslash" (backward slash) and "fslash" (forward slash) on the <gi scheme="MEI">rend></gi> element.</p>
+                        <p>You may use 6\ and 6/ for numerals that should be shown with a backslash and slash, respectively. An alternative would be to use the "bslash" (backward slash) and "fslash" (forward slash) on the <gi scheme="MEI">rend</gi> element.</p>
                         <p>
                            <figure>
                               <head>Figured bass with chromatically altered figure</head>

--- a/source/examples/verovio/tempo-01.mei
+++ b/source/examples/verovio/tempo-01.mei
@@ -11,7 +11,7 @@
             <date>2019-10-25</date>
          </pubStmt>
          <notesStmt>
-            <annot>Verovio supports "tempo" elements. Horizontal positioning can be specified. By default, tempi indications are placed above the staff. The "rend" element can used within the text, for example for specifying metronome values.</annot>
+            <annot>Verovio supports "tempo" elements. Horizontal positioning can be specified. By default, tempi indications are placed above the staff. The "rend" element can be used within the text, for example for specifying metronome values.</annot>
          </notesStmt>
       </fileDesc>
       <encodingDesc>


### PR DESCRIPTION
This PR fixes a typo that threw a warning in the build process, cf. https://github.com/music-encoding/music-encoding/issues/1175#issuecomment-1565703299. There was a wrong additional closing bracket in the docs for figured bass.

Fixing an annot in `tempo-01.mei` as well.