### PR TITLE
Fixed: MEI Basic Schema not validating

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -12,6 +12,10 @@
                     <name xml:id="JK">Johannes Kepper</name>
                 </respStmt>
                 <respStmt>
+                    <resp>Revisions</resp>
+                    <name xml:id="LP">Laurent Pugin</name>
+                </respStmt>
+                <respStmt>
                     <resp>In collaboration with</resp>
                     <name>The MEI Community</name>
                 </respStmt>
@@ -30,6 +34,10 @@
             <change n="2" when="2019-10-26" who="#JK">
                 <desc>Revisions following the discussions on GitHub, and at the Nashville Hackathon.</desc>
             </change>
+            <change n="3" when="2023-05-24" who="#LP">
+                <desc>Revisions at the MEI Developers Conference, Charlottesville.</desc>
+            </change>
+            
         </revisionDesc>
     </teiHeader>
     <text>
@@ -204,10 +212,7 @@
                 <classSpec type="atts" ident="att.rest.log.cmn" module="MEI.cmn" mode="delete"/>
                 <classSpec type="atts" ident="att.slurRend" module="MEI.cmn" mode="delete"/>
                 <classSpec type="atts" ident="att.space.log.cmn" module="MEI.cmn" mode="delete"/>
-                <classSpec type="atts" ident="att.tieRend" module="MEI.cmn" mode="delete"/>
-                
-                <classSpec type="atts" ident="att.rdg.log" module="MEI.critapp" mode="delete"/>
-                
+                <classSpec type="atts" ident="att.tieRend" module="MEI.cmn" mode="delete"/>                
                 <classSpec type="atts" ident="att.ambitus.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.ambNote.ges" module="MEI.gestural" mode="delete"/>
                 <classSpec type="atts" ident="att.anchoredText.ges" module="MEI.gestural" mode="delete"/>


### PR DESCRIPTION
The MEI.critapp module was not included, so the app.rdg.log class deletion was giving an error because it could not be found.

Additionally, added Laurent to the contributors and an entry in the revision log to reflect the changes from the MEI Developers Conference.