### PR TITLE
Initial script for generating images using a python script instead of…

### DIFF
--- a/BUILD_COMMANDLINE.md
+++ b/BUILD_COMMANDLINE.md
@@ -8,7 +8,7 @@
    |----|----------------|
    |Java| 17 (at least Java 8 at runtime to support Apache Ant™)|
    |Apache Ant|1.10.13|
-   |Verovio Toolkit|3.9|
+   |Verovio Toolkit|3.15|
    |Prince XML|15.1|
    |Saxon HE*| 11.4 |
    |Xerces*|Synchrosoft patched version 25.1.0.1|
@@ -54,6 +54,14 @@
 
      We recommend using the latest stable release of Apache Ant™. If your system has an older version of Apache Ant™ installed you might still give it a try though. If the prompt returns an empty string, please refer to the [Apache Ant™ Installation Instructions](https://ant.apache.org/manual/install.html).
 
+  * Is Verovio installed for generating example images locally?
+
+    To build the images with Verovio, you need Python3 to be installed with the `verovio` and `lxml` modules. These can be installed with
+
+    ```shell
+    pip install verovio lxml
+    ```
+
 2. Initialize the build process
 
    * Switch to your clone’s directory:
@@ -77,6 +85,11 @@
      ```
 
      The results of this build can be found in the web folder (`music-encoding/dist/guidelines/dev/web`). The guidelines are stored in the `index.html` file.
+
+     To generate the example images with Verovio, you need to run:
+     ```shell
+     ant generate-images-py
+     ```
 
    * Build a specific customization's RNG schema:
 

--- a/BUILD_COMMANDLINE.md
+++ b/BUILD_COMMANDLINE.md
@@ -56,7 +56,7 @@
 
   * Is Verovio installed for generating example images locally?
 
-    To build the images with Verovio, you need Python3 to be installed with the `verovio` and `lxml` modules. These can be installed with
+    To build the images with Verovio, you need Python3 to be installed with the `verovio` module. These can be installed with
 
     ```shell
     pip install verovio lxml

--- a/BUILD_COMMANDLINE.md
+++ b/BUILD_COMMANDLINE.md
@@ -56,12 +56,22 @@
 
   * Is Verovio installed for generating example images locally?
 
-    To build the images with Verovio, you need Python3 to be installed with the `verovio` module. These can be installed with
+    Optional: If you wish, you can use a Python virtual environment to manage your dependencies. Before installing
+    Verovio, create and activate a virtual environment. 
+    
+    ```shell
+    python3 -m venv ./.venv
+    source ./.venv/bin/activate
+    ```
+    
+    This will install your Python libraries in the local `.venv` directory. Once your virtual environment is active you can continue to installing Verovio.
+
+    To build the images with Verovio, you need Python3 to be installed with the `verovio` module. This can be installed with:
 
     ```shell
-    pip install verovio lxml
+    pip install verovio
     ```
-
+    
 2. Initialize the build process
 
    * Switch to your clone’s directory:
@@ -90,6 +100,12 @@
      ```shell
      ant generate-images-py
      ```
+
+     **Note:** If you have installed your dependencies in a virtual environment, be sure to activate it prior to calling the Ant task. Activate it using:
+     
+     ```shell
+     source ./.venv/bin/activate
+     ```     
 
    * Build a specific customization's RNG schema:
 

--- a/build.xml
+++ b/build.xml
@@ -269,6 +269,13 @@
             <arg value="index.js"/>
         </exec>
     </target>
+    
+    <target name="generate-images-py">
+        <exec executable="python3" logerror="true" dir="${basedir}/utils/examples" failifexecutionfails="true" failonerror="true">
+            <arg value="generate-examples.py"/>
+            <arg value="--clean"/>
+        </exec>
+    </target>
 
     <target name="copy-generated-images" description="copy generated images to dist after they're created by running Docker image">
         <copy todir="${dir.dist.guidelines}/assets/images/GeneratedImages">

--- a/build.xml
+++ b/build.xml
@@ -276,6 +276,7 @@
         <exec executable="python3" logerror="true" dir="${basedir}/utils/examples" failifexecutionfails="true" failonerror="true">
             <arg value="generate-examples.py"/>
             <arg value="--clean"/>
+            <arg value="--verbose"/>
         </exec>
     </target>
 

--- a/utils/examples/generate-examples.py
+++ b/utils/examples/generate-examples.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
 
     for file in os.listdir(IMAGES_PATH):
         # Skip everything that is not an .mei or .xml file
-        if not file.endswith(".mei") and not file.endswith(".xml"): 
+        if not file.endswith(".mei"): 
             continue
 
         mei_file = os.path.join(IMAGES_PATH, file)

--- a/utils/examples/generate-examples.py
+++ b/utils/examples/generate-examples.py
@@ -103,7 +103,7 @@ if __name__ == "__main__":
         if meta:
             # Overwrite any pre-defined options with the options from the MEI file.
             log.info("Found some locally-defined meta options: %s", meta)
-            metaOptions = meta
+            meta_options = meta
             options.update(metaOptions)
 
         log.debug("Running Verovio with the following options: %s", pprint.pformat(options))

--- a/utils/examples/generate-examples.py
+++ b/utils/examples/generate-examples.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
 
         log.debug("Running Verovio with the following options: %s", pprint.pformat(options))
         tk.setOptions(options)
-        if not(tk.loadData(mei_example)):
+        if not tk.loadData(mei_example):
             log.error("Failed to load %s", mei_file)
             success = False
             continue

--- a/utils/examples/generate-examples.py
+++ b/utils/examples/generate-examples.py
@@ -71,7 +71,8 @@ if __name__ == "__main__":
 
     for file in os.listdir(IMAGES_PATH):
         # Skip everything that is not an .mei or .xml file
-        if not(file.endswith(".mei")) and not(file.endswith(".xml")): continue
+        if not(file.endswith(".mei")) and not(file.endswith(".xml")): 
+            continue
         
         options: Dict = defaultOptions.copy()
 

--- a/utils/examples/generate-examples.py
+++ b/utils/examples/generate-examples.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     log.info("Using Verovio %s", tk.getVersion())
 
     # keep all the options to be able to reset them for each example
-    defaultOptions: Dict = tk.getDefaultOptions()
+    default_options: dict = tk.getDefaultOptions()
     # Overwrite the default options with our locally-defined options
     defaultOptions.update(VRV_OPTIONS)
 

--- a/utils/examples/generate-examples.py
+++ b/utils/examples/generate-examples.py
@@ -12,7 +12,7 @@ IMAGES_PATH = "../../build/assets/images/GeneratedImages"
 
 MEI_NS: Dict = {'mei': 'http://www.music-encoding.org/ns/mei'}
 
-VRV_OPTIONS: Dict = {
+VRV_OPTIONS: dict = {
    'scale': 10,
    'pageWidth': 1500,
    'adjustPageHeight': True,

--- a/utils/examples/generate-examples.py
+++ b/utils/examples/generate-examples.py
@@ -1,0 +1,119 @@
+import argparse
+import os
+import sys
+import pprint
+from typing import Dict
+import logging
+
+import verovio
+from lxml import etree
+
+IMAGES_PATH = "../../build/assets/images/GeneratedImages"
+
+MEI_NS: Dict = {'mei': 'http://www.music-encoding.org/ns/mei'}
+
+VRV_OPTIONS: Dict = {
+   'scale': 10,
+   'pageWidth': 1500,
+   'adjustPageHeight': True,
+   'adjustPageWidth': True,
+   'footer': 'none',
+   'header':'none',
+   'openControlEvents': True,
+   'outputFormatRaw': True,
+   'removeIds': True,
+   'svgFormatRaw': True,
+   'svgHtml5': True,
+   'svgRemoveXlink': True,
+   'svgViewBox': True,
+    'xmlIdSeed': 1
+}
+
+if __name__ == "__main__":
+    description = """
+        Renders SVG for the MEI examples. Will generate any new examples found; to
+        re-generate all examples use the '--clean' option.
+    """
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument("--clean", action="store_true", help="Re-generate all examples.")
+    verbose_group = parser.add_mutually_exclusive_group()
+    verbose_group.add_argument("--verbose", "-v", action="store_true")
+    verbose_group.add_argument("--debug", "-d", action="store_true")
+
+    args = parser.parse_args()
+    if args.debug:
+        level_msg: str = "Debug"
+        level = logging.DEBUG
+    elif args.verbose:
+        level_msg: str = "Info"
+        level = logging.INFO
+    else:
+        level_msg: str = "Error"
+        level = logging.ERROR
+
+    logging.basicConfig(format="[%(asctime)s] [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)",
+                        level=level)
+    log = logging.getLogger(__name__)
+    log.info("Running at logging level %s", level_msg)
+
+    verovio.enableLog(verovio.LOG_DEBUG)
+    tk = verovio.toolkit()
+    # version of the toolkit
+    log.info("Using Verovio %s", tk.getVersion())
+
+    # keep all the options to be able to reset them for each example
+    defaultOptions: Dict = tk.getDefaultOptions()
+    # Overwrite the default options with our locally-defined options
+    defaultOptions.update(VRV_OPTIONS)
+
+    # Will remove extraneous whitespace
+    et_parser = etree.XMLParser(remove_blank_text=True)
+
+    for file in os.listdir(IMAGES_PATH):
+        # Skip everything that is not an .mei or .xml file
+        if not(file.endswith(".mei")) and not(file.endswith(".xml")): continue
+        
+        options: Dict = defaultOptions.copy()
+
+        mei_file = os.path.join(IMAGES_PATH, file)
+        svg_file = os.path.join(IMAGES_PATH, f"{file}.svg")
+
+        if os.path.exists(svg_file) and os.path.exists(mei_file) and not args.clean:
+            log.info("This example already exists, and we're not running in cleaning mode. Skipping.")
+            continue
+
+        # Download the MEI file from the given url
+        mei_example: str = ""
+        with open(mei_file) as file:
+            mei_example = file.read()
+
+        # parse the MEI file to XML
+        log.debug("Parsing downloaded text to XML")
+        tree = None
+        meta = None
+        try:
+            tree = etree.fromstring(bytes(mei_example.encode("utf-8")), parser=et_parser)
+            # try to get the extMeta tag and load the options if existing
+            meta = tree.findtext(".//mei:meiHead/mei:extMeta", namespaces=MEI_NS)
+        except:
+            log.info("Could not parse file")
+
+        # This is currently not used be in-place of having rendering options in <extMeta>
+        if meta:
+            # Overwrite any pre-defined options with the options from the MEI file.
+            log.info("Found some locally-defined meta options: %s", meta)
+            metaOptions = meta
+            options.update(metaOptions)
+
+        log.debug("Running Verovio with the following options: %s", pprint.pformat(options))
+        tk.setOptions(options)
+        tk.loadData(mei_example)
+
+        svg: str = tk.renderToSVG(1)
+
+        with open(svg_file, 'w') as f:
+            f.write(svg)
+
+        log.debug("Finished processing %s", mei_file)
+
+    sys.exit()

--- a/utils/examples/generate-examples.py
+++ b/utils/examples/generate-examples.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
             # try to get the extMeta tag and load the options if existing
             meta = tree.findtext(".//mei:meiHead/mei:extMeta", namespaces=MEI_NS)
         except:
-            log.info("Could not parse file")
+            log.info("Could not extract extMeta from %s", mei_file)
 
         # This is currently not used be in-place of having rendering options in <extMeta>
         if meta:

--- a/utils/examples/generate-examples.py
+++ b/utils/examples/generate-examples.py
@@ -59,17 +59,13 @@ if __name__ == "__main__":
     # version of the toolkit
     log.info("Using Verovio %s", tk.getVersion())
 
-    # keep all the options to be able to reset them for each example
-    default_options: dict = tk.getDefaultOptions()
-    # Overwrite the default options with our locally-defined options
-    default_options.update(VRV_OPTIONS)
+    log.debug("Running Verovio with the following options: %s", pprint.pformat(VRV_OPTIONS))
+    tk.setOptions(VRV_OPTIONS)
 
     for file in os.listdir(IMAGES_PATH):
         # Skip everything that is not an .mei or .xml file
         if not file.endswith(".mei") and not file.endswith(".xml"): 
             continue
-        
-        options: dict = default_options.copy()
 
         mei_file = os.path.join(IMAGES_PATH, file)
         svg_file = os.path.join(IMAGES_PATH, f"{file}.svg")
@@ -83,8 +79,6 @@ if __name__ == "__main__":
         with open(mei_file) as f:
             mei_example = f.read()
 
-        log.debug("Running Verovio with the following options: %s", pprint.pformat(options))
-        tk.setOptions(options)
         if not tk.loadData(mei_example):
             log.error("Failed to load %s", mei_file)
             success = False

--- a/utils/examples/generate-examples.py
+++ b/utils/examples/generate-examples.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
         if not(file.endswith(".mei")) and not(file.endswith(".xml")): 
             continue
         
-        options: Dict = defaultOptions.copy()
+        options: dict = default_options.copy()
 
         mei_file = os.path.join(IMAGES_PATH, file)
         svg_file = os.path.join(IMAGES_PATH, f"{file}.svg")

--- a/utils/examples/generate-examples.py
+++ b/utils/examples/generate-examples.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
 
         log.debug("Finished processing %s", mei_file)
     
-    if not(success):
+    if not success:
         sys.exit(1)
 
     sys.exit()

--- a/utils/examples/generate-examples.py
+++ b/utils/examples/generate-examples.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
 
     for file in os.listdir(IMAGES_PATH):
         # Skip everything that is not an .mei or .xml file
-        if not(file.endswith(".mei")) and not(file.endswith(".xml")): 
+        if not file.endswith(".mei") and not file.endswith(".xml"): 
             continue
         
         options: dict = default_options.copy()

--- a/utils/examples/generate-examples.py
+++ b/utils/examples/generate-examples.py
@@ -95,6 +95,7 @@ if __name__ == "__main__":
         if len(svg):
             with open(svg_file, 'w') as f:
                 f.write(svg)
+                log.info("Successfully rendered %s", svg_file)
         else:
             log.error("Failed to render %s", mei_file)
             success = False

--- a/utils/examples/generate-examples.py
+++ b/utils/examples/generate-examples.py
@@ -2,7 +2,6 @@ import argparse
 import os
 import sys
 import pprint
-from typing import Dict
 import logging
 
 import verovio

--- a/utils/examples/generate-examples.py
+++ b/utils/examples/generate-examples.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
 
         svg: str = tk.renderToSVG(1)
 
-        if len(svg):
+        if svg:
             with open(svg_file, 'w') as f:
                 f.write(svg)
                 log.info("Successfully rendered %s", svg_file)

--- a/utils/examples/generate-examples.py
+++ b/utils/examples/generate-examples.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     # keep all the options to be able to reset them for each example
     default_options: dict = tk.getDefaultOptions()
     # Overwrite the default options with our locally-defined options
-    defaultOptions.update(VRV_OPTIONS)
+    default_options.update(VRV_OPTIONS)
 
     # Will remove extraneous whitespace
     et_parser = etree.XMLParser(remove_blank_text=True)

--- a/utils/examples/generate-examples.py
+++ b/utils/examples/generate-examples.py
@@ -104,7 +104,7 @@ if __name__ == "__main__":
             # Overwrite any pre-defined options with the options from the MEI file.
             log.info("Found some locally-defined meta options: %s", meta)
             meta_options = meta
-            options.update(metaOptions)
+            options.update(meta_options)
 
         log.debug("Running Verovio with the following options: %s", pprint.pformat(options))
         tk.setOptions(options)


### PR DESCRIPTION
This PR adds a Python script offering an alternative to the [node script ](https://github.com/music-encoding/docker-mei/blob/main/index.js) for generating images with Verovio outside Docker.

The Python scripts dependencies are standard ones plus:
```python
import verovio
```
Both can be installed with `pip`

The script can be run through a new `ant` a new target `generate-images-py` (guidelines should have been built beforehand):
```bash
ant generate-images-py
```