### PR TITLE
Remove "italic" and "oblique" values from data.TEXTRENDITIONLIST

### DIFF
--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3568,12 +3568,6 @@
         <valItem ident="quotedbl">
           <desc xml:lang="en">Surrounded by double quotes.</desc>
         </valItem>
-        <valItem ident="italic">
-          <desc xml:lang="en">Italicized (slanted to right).</desc>
-        </valItem>
-        <valItem ident="oblique">
-          <desc xml:lang="en">Oblique (slanted to left).</desc>
-        </valItem>
         <valItem ident="smcaps">
           <desc xml:lang="en">Small capitals.</desc>
         </valItem>


### PR DESCRIPTION
The values "italic" and "oblique" duplicate values available in data.FONTSTYLE.

Fixes #1102