### PR TITLE
schema: enhance meterSigGrp

### DIFF
--- a/source/docs/04-cmn.xml
+++ b/source/docs/04-cmn.xml
@@ -238,7 +238,7 @@
                      <p>
                         <figure>
                            <head>Alternating meters in Tchaikovsky's String Quartet in F major</head>
-                           <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="verovio code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/verovio/Tchaikovsky_scherzo.mei" parse="text"/></egXML>
+                           <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="verovio code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/verovio/tchaikovsky_scherzo.mei" parse="text"/></egXML>
                         </figure>
                      </p>
                </div>

--- a/source/docs/04-cmn.xml
+++ b/source/docs/04-cmn.xml
@@ -234,6 +234,13 @@
                         <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve" valid="true"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/cmn/cmn-layerMeter.txt" parse="text"/></egXML>
                      </figure>
                   </p>
+                     <p>When multiple time signatures appear next to each other the <gi scheme="MEI">meterSigGrp</gi> element has to be used.</p>
+                     <p>
+                        <figure>
+                           <head>Alternating meters</head>
+                           <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="verovio code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/verovio/tchaikovsky_scherzo.mei" parse="text"/></egXML>
+                        </figure>
+                     </p>
                </div>
                <div xml:id="cmnReDef" type="div3">
                   <head>Re-definition of Score Parameters</head>

--- a/source/docs/04-cmn.xml
+++ b/source/docs/04-cmn.xml
@@ -923,7 +923,7 @@
                      <p>For the repetition of a single note or chord, MEI offers the <gi scheme="MEI">bTrem</gi> (bowed tremolo) element, which is a member of the <ident type="class">model.eventLike.cmn</ident> class, meaning it is encoded following the normal course of musical events within a <gi scheme="MEI">layer</gi>. It holds exactly one <gi scheme="MEI">note</gi> or <gi scheme="MEI">chord</gi> element that is to be repeated.</p>
                      <p>
                         <figure>
-                           <head>Bowed tremolandi in Schubert’s last string quartet</head>
+                           <head>Bowed tremolandi in Schubert’s last String Quartet</head>
                            <graphic url="../images/ExampleImages/SchubertD887.png"/>
                         </figure>
                         <figure>
@@ -989,7 +989,7 @@
                      <p>In MEI, fermatas may be encoded using an attribute on elements like <gi scheme="MEI">note</gi>, <gi scheme="MEI">chord</gi> or <gi scheme="MEI">rest</gi>. This attribute allows placement of a fermata above or below the element to which it’s attached.</p>
                      <p>
                         <figure>
-                           <head>Fermatas in Mozart’s String quartet K. 428 indicating general pauses</head>
+                           <head>Fermatas in Mozart’s String Quartet K. 428 indicating general pauses</head>
                            <graphic url="../images/ExampleImages/MozartK428.4.png"/>
                         </figure>
                      </p>

--- a/source/docs/04-cmn.xml
+++ b/source/docs/04-cmn.xml
@@ -237,8 +237,8 @@
                      <p>When multiple time signatures appear next to each other the <gi scheme="MEI">meterSigGrp</gi> element has to be used.</p>
                      <p>
                         <figure>
-                           <head>Alternating meters</head>
-                           <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="verovio code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/verovio/tchaikovsky_scherzo.mei" parse="text"/></egXML>
+                           <head>Alternating meters in Tchaikovsky's String Quartet in F major</head>
+                           <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="verovio code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/verovio/Tchaikovsky_scherzo.mei" parse="text"/></egXML>
                         </figure>
                      </p>
                </div>

--- a/source/examples/verovio/tchaikovsky_scherzo.mei
+++ b/source/examples/verovio/tchaikovsky_scherzo.mei
@@ -1,0 +1,274 @@
+<?xml-model href="https://music-encoding.org/schema/dev/mei-CMN.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-CMN.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
+   <meiHead>
+      <fileDesc>
+         <titleStmt>
+            <title>Scherzo from Tchaikovsky's String Quartet No. 2 (excerpt)</title>
+         </titleStmt>
+         <pubStmt>
+            <date isodate="2024">2024</date>
+            <respStmt>
+               <corpName>Music Encoding Initiative (MEI) Board</corpName>
+            </respStmt>
+            <availability>
+               <useRestrict label="license" auth="https://spdx.org/licenses/" codedval="ECL-2.0">
+                  <p>Educational Community License v2.0</p>
+               </useRestrict>
+            </availability>
+         </pubStmt>
+         <seriesStmt>
+            <title>MEI guidelines examples</title>
+         </seriesStmt>
+      </fileDesc>
+   </meiHead>
+   <music>
+      <body>
+         <mdiv>
+            <score>
+               <scoreDef>
+                  <staffGrp symbol="bracket">
+                     <staffDef n="1" lines="5" keysig="5f">
+                        <clef shape="G" line="2" />
+                        <?edit-start?>
+                        <meterSigGrp func="alternating">
+                           <meterSig count="6" unit="8" />
+                           <meterSig count="9" unit="8" />
+                        </meterSigGrp>
+                        <?edit-end?>
+                     </staffDef>
+                     <staffDef n="2" lines="5" keysig="5f">
+                        <clef shape="G" line="2" />
+                        <meterSigGrp func="alternating">
+                           <meterSig count="6" unit="8" />
+                           <meterSig count="9" unit="8" />
+                        </meterSigGrp>
+                     </staffDef>
+                     <staffDef n="3" lines="5" keysig="5f">
+                        <clef shape="C" line="3" />
+                        <meterSigGrp func="alternating">
+                           <meterSig count="6" unit="8" />
+                           <meterSig count="9" unit="8" />
+                        </meterSigGrp>
+                     </staffDef>
+                     <staffDef n="4" lines="5" keysig="5f">
+                        <clef shape="F" line="4" />
+                        <meterSigGrp func="alternating">
+                           <meterSig count="6" unit="8" />
+                           <meterSig count="9" unit="8" />
+                        </meterSigGrp>
+                     </staffDef>
+                  </staffGrp>
+               </scoreDef>
+               <section xml:id="s1">
+                  <pb />
+                  <measure n="1">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam>
+                              <note xml:id="n2apf6t" dur="8" pname="f" oct="5">
+                                 <artic artic="stacc" />
+                              </note>
+                              <note xml:id="n1v0onrr" dur="8" pname="f" oct="5">
+                                 <artic artic="stacc" />
+                              </note>
+                              <note xml:id="nmdfv6m" dur="8" pname="f" oct="5">
+                                 <artic artic="stacc" />
+                              </note>
+                           </beam>
+                           <note xml:id="n1v2c23j" dur="4" pname="e" oct="5">
+                              <artic artic="ten" />
+                              <accid accid.ges="f" />
+                           </note>
+                           <note xml:id="nz8c5kj" dur="8" pname="d" oct="5">
+                              <accid accid.ges="f" />
+                           </note>
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <rest xml:id="r12gwbz0" dur="4" />
+                           <rest xml:id="r1e6h2le" dur="8" />
+                           <chord xml:id="c1xfnie3" dots="1" dur="4">
+                              <note xml:id="n9stwxq" pname="d" oct="4">
+                                 <accid accid.ges="f" />
+                              </note>
+                              <note xml:id="n103nrpj" pname="a" oct="4">
+                                 <accid accid.ges="f" />
+                              </note>
+                           </chord>
+                        </layer>
+                     </staff>
+                     <staff n="3">
+                        <layer n="1">
+                           <rest xml:id="r1mvgy0y" dur="4" />
+                           <rest xml:id="rdxb3ed" dur="8" />
+                           <chord xml:id="coaoa77" dots="1" dur="4">
+                              <note xml:id="nzxzmqv" pname="a" oct="3">
+                                 <accid accid.ges="f" />
+                              </note>
+                              <note xml:id="n13ezv8b" pname="f" oct="4" />
+                           </chord>
+                        </layer>
+                     </staff>
+                     <staff n="4">
+                        <layer n="1">
+                           <rest xml:id="r16osj9l" dur="4" />
+                           <rest xml:id="r1d3bkrz" dur="8" />
+                           <note xml:id="n1oazq7y" dots="1" dur="4" pname="d" oct="3">
+                              <accid accid.ges="f" />
+                           </note>
+                        </layer>
+                     </staff>
+                     <tempo startid="#n2apf6t">Allegro giusto</tempo>
+                     <dynam startid="#n2apf6t">p</dynam>
+                     <hairpin form="cres" startid="#n2apf6t" endid="#nz8c5kj" />
+                     <slur startid="#n2apf6t" endid="#nmdfv6m" />
+                     <slur startid="#n1v2c23j" endid="#nz8c5kj" />
+                     <dynam startid="#c1xfnie3">p</dynam>
+                     <dynam startid="#coaoa77">p</dynam>
+                     <dynam startid="#n1oazq7y">p</dynam>
+                  </measure>
+                  <measure n="2">
+                     <staff n="1">
+                        <layer n="1">
+                           <beam>
+                              <note xml:id="nan1okp" dur="8" pname="b" oct="4">
+                                 <artic artic="stacc" />
+                                 <accid accid.ges="f" />
+                              </note>
+                              <note xml:id="nmhyqwo" dur="8" pname="b" oct="4">
+                                 <artic artic="stacc" />
+                                 <accid accid.ges="f" />
+                              </note>
+                              <note xml:id="nrwyx5f" dur="8" pname="b" oct="4">
+                                 <artic artic="stacc" />
+                                 <accid accid.ges="f" />
+                              </note>
+                           </beam>
+                           <note xml:id="n16xnlnh" dur="4" pname="c" oct="5">
+                              <artic artic="ten" />
+                           </note>
+                           <note xml:id="nfnijk8" dur="8" pname="d" oct="5">
+                              <accid accid.ges="f" />
+                           </note>
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <rest xml:id="r176694i" dots="1" dur="4" />
+                           <chord xml:id="cto373k" dots="1" dur="4">
+                              <note xml:id="n1jlp1q2" pname="c" oct="4">
+                                 <accid accid="s" />
+                              </note>
+                              <note xml:id="ndcmoqe" pname="a" oct="4">
+                                 <accid accid.ges="f" />
+                              </note>
+                           </chord>
+                        </layer>
+                     </staff>
+                     <staff n="3">
+                        <layer n="1">
+                           <rest xml:id="r1tk1ck5" dots="1" dur="4" />
+                           <chord xml:id="c1gchhku" dots="1" dur="4">
+                              <note xml:id="n1175x08" pname="a" oct="3">
+                                 <accid accid.ges="f" />
+                              </note>
+                              <note xml:id="n1q1lkl9" pname="f" oct="4" />
+                           </chord>
+                        </layer>
+                     </staff>
+                     <staff n="4">
+                        <layer n="1">
+                           <rest xml:id="r1j4frj4" dots="1" dur="4" />
+                           <note xml:id="n1h0fegz" dots="1" dur="4" pname="d" oct="3">
+                              <accid accid.ges="f" />
+                           </note>
+                        </layer>
+                     </staff>
+                     <slur startid="#nan1okp" endid="#nrwyx5f" />
+                     <slur startid="#n16xnlnh" endid="#nfnijk8" />
+                  </measure>
+                  <measure n="3">
+                     <staff n="1">
+                        <layer n="1">
+                           <note xml:id="n2epqtj" dots="1" dur="4" pname="c" oct="5">
+                              <artic artic="acc" />
+                           </note>
+                           <note xml:id="n1r7gnwc" dur="4" pname="a" oct="4">
+                              <accid accid.ges="f" />
+                           </note>
+                           <rest xml:id="ruly5ba" dur="8" />
+                           <note xml:id="n1ne7wug" dur="4" pname="a" oct="4">
+                              <accid accid.ges="f" />
+                           </note>
+                           <rest xml:id="rl5b8tj" dur="8" />
+                        </layer>
+                     </staff>
+                     <staff n="2">
+                        <layer n="1">
+                           <chord xml:id="c8kn0ob" dots="1" dur="4">
+                              <artic artic="acc" />
+                              <note xml:id="n1ao12g4" pname="a" oct="3">
+                                 <accid accid.ges="f" />
+                              </note>
+                              <note xml:id="n1wm5qw9" pname="f" oct="4" />
+                           </chord>
+                           <chord xml:id="crdll1f" dur="4">
+                              <note xml:id="n1pll3wi" pname="a" oct="3">
+                                 <accid accid.ges="f" />
+                              </note>
+                              <note xml:id="n1bemu9" pname="f" oct="4" />
+                           </chord>
+                           <rest xml:id="raqomnj" dur="8" />
+                           <chord xml:id="c1td3dqd" dur="4">
+                              <note xml:id="n1sv524p" pname="a" oct="3">
+                                 <accid accid.ges="f" />
+                              </note>
+                              <note xml:id="nqm4ker" pname="f" oct="4" />
+                           </chord>
+                           <rest xml:id="r1u9ez1g" dur="8" />
+                        </layer>
+                     </staff>
+                     <staff n="3">
+                        <layer n="1">
+                           <note xml:id="n2ajvkm" dots="1" dur="4" pname="c" oct="4">
+                              <artic artic="acc" />
+                           </note>
+                           <note xml:id="n1h0hgte" dur="4" pname="d" oct="4">
+                              <accid accid.ges="f" />
+                           </note>
+                           <rest xml:id="r1dwu9k9" dur="8" />
+                           <note xml:id="ncuhk1s" dur="4" pname="d" oct="4">
+                              <accid accid.ges="f" />
+                           </note>
+                           <rest xml:id="rx9fpiz" dur="8" />
+                        </layer>
+                     </staff>
+                     <staff n="4">
+                        <layer n="1">
+                           <note xml:id="ni3fhhf" dots="1" dur="4" pname="a" oct="2">
+                              <artic artic="acc" />
+                              <accid accid.ges="f" />
+                           </note>
+                           <note xml:id="n1iydcft" dots="1" dur="4" pname="d" oct="3">
+                              <accid accid.ges="f" />
+                           </note>
+                           <note xml:id="ntxmihg" dur="4" pname="d" oct="3">
+                              <accid accid.ges="f" />
+                           </note>
+                           <rest xml:id="r1haogp0" dur="8" />
+                        </layer>
+                     </staff>
+                     <slur startid="#n2epqtj" endid="#n1r7gnwc" />
+                     <slur startid="#c8kn0ob" curvedir="above" endid="#crdll1f" />
+                     <slur startid="#c8kn0ob" curvedir="below" endid="#crdll1f" />
+                     <slur startid="#n2ajvkm" endid="#n1h0hgte" />
+                     <slur startid="#ni3fhhf" endid="#n1iydcft" />
+                  </measure>
+               </section>
+            </score>
+         </mdiv>
+      </body>
+   </music>
+</mei>

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -1863,18 +1863,17 @@
       <memberOf key="model.meterSigLike"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
+      <rng:choice>
         <rng:ref name="meterSig"/>
-      </rng:zeroOrMore>
+        <rng:ref name="meterSigGrp"/>
+      </rng:choice>
+      <rng:oneOrMore>
+        <rng:choice>
+          <rng:ref name="meterSig"/>
+          <rng:ref name="meterSigGrp"/>
+        </rng:choice>
+      </rng:oneOrMore>
     </content>
-    <constraintSpec ident="check_meterSigGrpContent" scheme="schematron">
-      <constraint>
-        <sch:rule context="mei:meterSigGrp[not(@copyof)]">
-          <sch:assert test="count(mei:meterSig) &gt; 1">meterSigGrp must have at least 2 child
-            meterSig elements.</sch:assert>
-        </sch:rule>
-      </constraint>
-    </constraintSpec>
   </elementSpec>
   <elementSpec ident="mNum" module="MEI.cmn">
     <gloss versionDate="2022-05-18" xml:lang="en">measure number</gloss>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1181,6 +1181,10 @@
   </classSpec>
   <classSpec ident="att.meterSigGrp.vis" module="MEI.visual" type="atts">
     <desc xml:lang="en">Visual domain attributes.</desc>
+    <classes>
+      <memberOf key="att.enclosingChars"/>
+      <memberOf key="att.visibility"/>
+    </classes>
   </classSpec>
   <classSpec ident="att.mNum.vis" module="MEI.visual" type="atts">
     <desc xml:lang="en">Visual domain attributes.</desc>


### PR DESCRIPTION
This PR allows nesting of `meterSigGrp` elements, and makes `meterSigGrp` a part of `att.enclosingChars` and `att.visibility`. 

It also removes the schematron assertion rule and makes the rule for needing at least two children part of the schema itself.

A small example for `meterSigGrp` has been added to the documentation.

Closes #970

See https://github.com/music-encoding/music-encoding/issues/987#issuecomment-1221933906

Includes fix to resolve #1430