### PR TITLE
Improve init target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -134,17 +134,15 @@
         <antcall target="clean"/>
     </target>
     
+    <target name="init" description="Initialize: checks if saxon and xerces are available, if not downloads them." unless="${docker}">
         <available property="xerces-available" file="${dir.lib.xerces}/${xerces.jar.file}"/>
         <available property="xerces-available" classname="org.apache.xerces.jaxp.SAXParserFactoryImpl"/>
+        <echo message="xerces available: ${xerces-available}"/>
         <available property="saxon-available" file="${dir.lib.saxon}/${saxon.jar.file}"/>
-        <mkdir dir="${dir.lib}"/>
-        <antcall target="saxon-prepare"/>
         <available property="saxon-available" classname="net.sf.saxon.Transform"/>
         <echo message="saxon available: ${saxon-available}"/>
-        <available file="${dir.lib}" property="lib-available"/>
-        <echo message="lib directory available: ${lib-available}"/>
-        <mkdir dir="${dir.lib}" unless:true="${lib-available}"/>
         <antcall target="saxon-prepare" unless:true="${saxon-available}"/>
+        <antcall target="xerces-download" unless:true="${xerces-available}"/>
         <echo>initialized</echo>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -134,12 +134,17 @@
         <antcall target="clean"/>
     </target>
     
-    <target name="init" description="initializes the build environment, e.g., downloads saxon" unless="${docker}">
         <available property="xerces-available" file="${dir.lib.xerces}/${xerces.jar.file}"/>
+        <available property="xerces-available" classname="org.apache.xerces.jaxp.SAXParserFactoryImpl"/>
         <available property="saxon-available" file="${dir.lib.saxon}/${saxon.jar.file}"/>
         <mkdir dir="${dir.lib}"/>
         <antcall target="saxon-prepare"/>
-        <antcall target="xerces-download"/>
+        <available property="saxon-available" classname="net.sf.saxon.Transform"/>
+        <echo message="saxon available: ${saxon-available}"/>
+        <available file="${dir.lib}" property="lib-available"/>
+        <echo message="lib directory available: ${lib-available}"/>
+        <mkdir dir="${dir.lib}" unless:true="${lib-available}"/>
+        <antcall target="saxon-prepare" unless:true="${saxon-available}"/>
         <echo>initialized</echo>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -134,7 +134,7 @@
         <antcall target="clean"/>
     </target>
     
-    <target name="init" description="Initialize: checks if saxon and xerces are available, if not downloads them." unless="${docker}">
+    <target name="init" description="Initialize: checks if saxon and xerces are available, and if not, downloads them." unless="${docker}">
         <available property="xerces-available" file="${dir.lib.xerces}/${xerces.jar.file}"/>
         <available property="xerces-available" classname="org.apache.xerces.jaxp.SAXParserFactoryImpl"/>
         <echo message="xerces available: ${xerces-available}"/>


### PR DESCRIPTION
This PR improves the init target of the build.xml file as follows:

Nice for local development with xerces and saxon on java.classpath
* adds a classpath search to check if saxon is available
* adds a classpath search to check if xerces is available
* only call the targets to download saxon or xerces if not available --> reduces verbosity of terminal output
* adds human readable feedback of the availability checks
* removes the creation of lib folder as xerces or saxon download create it if needed
* Makes description more precise