### PR TITLE
build.xml: introduce property `verbose`

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -72,6 +72,9 @@
     <property name="xerces.jar.file" value="oxygen-patched-xerces-${xerces.version}.jar"/>
     <property name="oxygen.basic.utilites.jar.file" value="oxygen-basic-utilities-${xerces.version}.jar"/>
     <path id="mei.classpath">
+    <condition property="verbose" value="true" else="false">
+        <contains string="${sun.java.command}" substring="-v" />
+    </condition>
         <fileset dir="lib" erroronmissingdir="false">
             <include name="**/*.jar" />
         </fileset>
@@ -180,7 +183,7 @@
             <property name="inputFile" value="${customization.path}"/>
             <property name="outputFile" value="${dir.dist.schemata}/${odd.basename}_compiled.odd"/>
             <property name="defaultSource" value="${canonicalized.source.path.cross_platform}"/>
-            <property name="verbose">true</property>
+            <property name="verbose" value="${verbose}"/>
             <property name="summaryDoc" value="false"/>
             <property name="suppressTEIexamples" value="true"/>
         </ant>
@@ -195,7 +198,7 @@
         <ant dir="submodules/Stylesheets/html5" antfile="build-to.xml" target="odd" inheritall="true">
             <property name="inputFile" value="${dir.dist.schemata}/${odd.basename}_compiled.odd"/>
             <property name="outputFile" value="${dir.dist.schemata}/${odd.basename}_compiled.html"/>
-            <property name="verbose">true</property>
+            <property name="verbose" value="${verbose}"/>
             <property name="processODD">true</property>
         </ant>
     </target>
@@ -209,7 +212,7 @@
             <property name="inputFile" value="${customization.path}"/>
             <property name="outputFile" value="${dir.dist.schemata}/${odd.basename}.rng"/>
             <property name="defaultSource" value="${canonicalized.source.path.cross_platform}"/>
-            <property name="verbose">true</property>
+            <property name="verbose" value="${verbose}"/>
         </ant>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -71,10 +71,10 @@
     <property name="xerces.version" value="25.1.0.1"/>
     <property name="xerces.jar.file" value="oxygen-patched-xerces-${xerces.version}.jar"/>
     <property name="oxygen.basic.utilites.jar.file" value="oxygen-basic-utilities-${xerces.version}.jar"/>
-    <path id="mei.classpath">
     <condition property="verbose" value="true" else="false">
         <contains string="${sun.java.command}" substring="-v" />
     </condition>
+    <path id="mei.classpath">
         <fileset dir="lib" erroronmissingdir="false">
             <include name="**/*.jar" />
         </fileset>

--- a/build.xml
+++ b/build.xml
@@ -29,7 +29,7 @@
     <property name="github.ref" value="">
         <!-- string    external    The branch or tag ref that triggered the workflow run. For branches this in the format refs/heads/<branch_name>, and for tags it is refs/tags/<tag_name> -->
     </property>
-    <loadresource property="github.ref-type">
+    <loadresource property="github.ref-type" quiet="true">
         <string value="${github.ref}"/>
         <filterchain>
             <tokenfilter>
@@ -37,7 +37,7 @@
             </tokenfilter>
         </filterchain>
     </loadresource>
-    <loadresource property="github.ref-name">
+    <loadresource property="github.ref-name" quiet="true">
         <string value="${github.ref}"/>
         <filterchain>
             <tokenfilter>
@@ -45,7 +45,7 @@
             </tokenfilter>
         </filterchain>
     </loadresource>
-    <loadresource property="windir">
+    <loadresource property="windir" quiet="true">
         <string value="${basedir}"/>
         <filterchain>
             <tokenfilter>


### PR DESCRIPTION
Before this commit the generation of schemata and compiled ODDs gave very verbose feedback. This resulted in a very long and hardly graspable output on the commandline. Especially in the GitHub Action context this made the build process hard to debug and required a lot of scrolling. This commit introduces the following changes:
* The property `verbose` will analyze whether Ant was called with the `-verbose` or `-v` option and store this as boolean; defaults to false.
* The `verbose` property will be propagated to the  `tei:anttasks` to make the verbosity of the schema and compiled-odd generation controllable.