### PR TITLE
fix(gh-actions): do not run deploy steps on forks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ on:
     branches: [develop]
 
 env:
+  REPO_OWNER: music-encoding
+
   # schema
   SCHEMA_REPO: ${{ github.repository_owner }}/schema
   SCHEMA_BRANCH: main
@@ -59,6 +61,7 @@ jobs:
 
       ### PUBLISHING THE SCHEMA ###
       - name: Checkout SCHEMA_REPO into SCHEMA_DIR
+        if: ${{ github.repository_owner == env.REPO_OWNER }}
         uses: actions/checkout@v3
         with:
           # repository to check out
@@ -72,6 +75,7 @@ jobs:
           path: ${{ env.SCHEMA_DIR }}
 
       - name: Copy built schema to SCHEMA_DIR
+        if: ${{ github.repository_owner == env.REPO_OWNER }}
         run: | 
           rm -r $SCHEMA_DIR/dev
           cp -r dist/schemata/ $SCHEMA_DIR/
@@ -79,12 +83,14 @@ jobs:
           cp -r build/mei-source_canonicalized.xml $SCHEMA_DIR/dev
 
       - name: Check git status before commit
+        if: ${{ github.repository_owner == env.REPO_OWNER }}
         working-directory: ${{ env.SCHEMA_DIR }}
         run: |
           git config --get remote.origin.url
           git status
 
       - name: Configure git
+        if: ${{ github.repository_owner == env.REPO_OWNER }}
         working-directory: ${{ env.SCHEMA_DIR }}
         run: |
           echo "Configuring git..."
@@ -92,6 +98,7 @@ jobs:
           git config user.email "github-actions@users.noreply.github.com"
 
       - name: Commit files
+        if: ${{ github.repository_owner == env.REPO_OWNER }}
         working-directory: ${{ env.SCHEMA_DIR }}
         run: |
           echo "Running git commit..."
@@ -99,11 +106,13 @@ jobs:
           git commit -m "Auto-commit of schema build for ${{ github.repository }}@${{ github.sha }}"
 
       - name: Push changes to SCHEMA
+        if: ${{ github.repository_owner == env.REPO_OWNER }}
         working-directory: ${{ env.SCHEMA_DIR }}
         run: git push origin HEAD:$SCHEMA_BRANCH
 
       ### PUBLISHING THE GUIDELINES ###
       - name: Checkout GUIDELINES_REPO into GUIDELINES_DIR
+        if: ${{ github.repository_owner == env.REPO_OWNER }}
         uses: actions/checkout@v3
         with:
           # repository to check out
@@ -117,6 +126,7 @@ jobs:
           path: ${{ env.GUIDELINES_DIR }}
 
       - name: Copy built guidelines to GUIDELINES_DIR
+        if: ${{ github.repository_owner == env.REPO_OWNER }}
         run: |
           rm -rf $GUIDELINES_DIR/dev 
           cp -r dist/guidelines/web $GUIDELINES_DIR/
@@ -124,12 +134,14 @@ jobs:
           cp -r dist/guidelines/pdf/MEI_Guidelines_v5.0.0-dev.pdf $GUIDELINES_DIR/dev/
 
       - name: Check git status before commit
+        if: ${{ github.repository_owner == env.REPO_OWNER }}
         working-directory: ${{ env.GUIDELINES_DIR }}
         run: |
           git config --get remote.origin.url
           git status
 
       - name: Configure git
+        if: ${{ github.repository_owner == env.REPO_OWNER }}
         working-directory: ${{ env.GUIDELINES_DIR }}
         run: |
           echo "Configuring git..."
@@ -137,6 +149,7 @@ jobs:
           git config user.email "github-actions@users.noreply.github.com"
 
       - name: Commit files
+        if: ${{ github.repository_owner == env.REPO_OWNER }}
         working-directory: ${{ env.GUIDELINES_DIR }}
         run: |
           echo "Running git commit..."
@@ -144,5 +157,6 @@ jobs:
           git commit -m "Auto-commit of guidelines build for ${{ github.repository }}@${{ github.sha }}"
 
       - name: Push changes to GUIDELINES
+        if: ${{ github.repository_owner == env.REPO_OWNER }}
         working-directory: ${{ env.GUIDELINES_DIR }}
         run: git push origin HEAD:$GUIDELINES_BRANCH


### PR DESCRIPTION
This PR prevents the build action to be run on forks where it throws an error.

Fixes #1185 

