### PR TITLE
Update to use Saxon release from GitHub

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -66,8 +66,8 @@
     <property name="dir.lib" value="lib"/>
     <property name="dir.lib.saxon" value="${dir.lib}/saxon"/>
     <property name="dir.lib.xerces" value="${dir.lib}/xerces"/>
-    <property name="saxon.download.version" value="Saxon-HE/11/Java/SaxonHE11-4J"/>
-    <property name="saxon.jar.file" value="saxon-he-11.4.jar"/>
+    <property name="saxon.download.version" value="SaxonHE11-5"/>
+    <property name="saxon.jar.file" value="saxon-he-11.5.jar"/>
     <property name="xerces.version" value="25.1.0.1"/>
     <property name="xerces.jar.file" value="oxygen-patched-xerces-${xerces.version}.jar"/>
     <property name="oxygen.basic.utilites.jar.file" value="oxygen-basic-utilities-${xerces.version}.jar"/>
@@ -88,7 +88,7 @@
         <echo/>
         <echo>To build distribution of canonicalized source, compiled ODDs and customization RNGs run:</echo>
         <echo>ant init</echo>
-        <echo>ant -lib lib/saxon/saxon-he-11.4.jar</echo>
+        <echo>ant -lib lib/saxon/saxon-he-12.2.jar</echo>
         <echo/>
         <echo>run 'ant -projecthelp' or 'ant -p' to get more information on the available build targets</echo>
         <echo/>
@@ -145,7 +145,7 @@
 
     <target name="saxon-download" unless="${saxon-available}">
         <mkdir dir="temp"/>
-        <get src="https://sourceforge.net/projects/saxon/files/${saxon.download.version}.zip/download" dest="temp/"/>
+        <get src="https://github.com/Saxonica/Saxon-HE/releases/download/${saxon.download.version}/${saxon.download.version}J.zip" dest="temp/download"/>
         <!-- TODO check for newer releases-->
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -88,7 +88,7 @@
         <echo/>
         <echo>To build distribution of canonicalized source, compiled ODDs and customization RNGs run:</echo>
         <echo>ant init</echo>
-        <echo>ant -lib lib/saxon/saxon-he-12.2.jar</echo>
+        <echo>ant -lib lib/saxon/saxon-he-11.5.jar</echo>
         <echo/>
         <echo>run 'ant -projecthelp' or 'ant -p' to get more information on the available build targets</echo>
         <echo/>


### PR DESCRIPTION
This updates the `build.xml` to use the latest release of Saxon 11 from GitHub. 

NB: I also tested with Saxon 12.2, which runs fine, but Saxon 11.5 is marked as "latest production release".