### PR TITLE
Adjust MEI- Basic customization to use att.duration.log for rest

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -53,7 +53,7 @@
             <change n="2" when="2019-10-26" who="#JK">
                 <desc>Revisions following the discussions on GitHub, and at the Nashville Hackathon.</desc>
             </change>
-            <change n="3" when="2023-05-24" who="#LP">
+            <change n="3" when="2023-06-12" who="#LP">
                 <desc>Revisions at the MEI Developers Conference, Charlottesville.</desc>
             </change>
         </revisionDesc>
@@ -628,6 +628,17 @@
                             </datatype>
                         </attDef>
                     </attList>
+                </classSpec>
+                
+                <classSpec ident="att.rest.log" module="MEI.shared" type="atts" mode="change">
+                    <desc xml:lang="en">Logical domain attributes.</desc>
+                    <classes>
+                        <memberOf key="att.augmentDots"/>
+                        <memberOf key="att.cue"/>
+                        <memberOf key="att.duration.log"/><!-- changed from att.restduration.log -->
+                        <memberOf key="att.event"/>
+                        <memberOf key="att.rest.log.cmn"/>
+                    </classes>
                 </classSpec>
 
                 <classSpec ident="att.rest.vis" module="MEI.visual" type="atts" mode="change">

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -53,7 +53,7 @@
             <change n="2" when="2019-10-26" who="#JK">
                 <desc>Revisions following the discussions on GitHub, and at the Nashville Hackathon.</desc>
             </change>
-            <change n="3" when="2023-06-12" who="#LP">
+            <change n="3" from="2023-05-24" to="2023-06-12" who="#LP">
                 <desc>Revisions at the MEI Developers Conference, Charlottesville.</desc>
             </change>
         </revisionDesc>


### PR DESCRIPTION
This PR adjusts `att.rest.log` in MEI-Basic to use `att.duration.log` instead of `att.restduration.log`. 

The reason for this change is that `att.restduration.log` is meaningless in MEI-Basic since it exists essentially to allow for additional rest durations in mensural notation which are not available in MEI-Basic.

The change in the customization yields no modification to the resulting MEI-Basic schema and is only intended to simplify handling of rests with code generated directly from the MEI-Basic ODD.