### PR TITLE
Add `ending` to MEI-Basic

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -88,7 +88,7 @@
                 <moduleRef key="MEI.midi" include="instrDef" />
                 <moduleRef key="MEI.namesdates" include="persName" />
                 <moduleRef key="MEI.shared" 
-                    include="accid arranger artic body caesura chord clef clefGrp composer date dir dynam label labelAbbr layer lb lyricist mdiv mei music note ornam pb pgFoot pgHead pubPlace rend respStmt rest sb score scoreDef section space staff staffDef staffGrp syl tempo title "/>
+                    include="accid arranger artic body caesura chord clef clefGrp composer date dir dynam ending label labelAbbr layer lb lyricist mdiv mei music note ornam pb pgFoot pgHead pubPlace rend respStmt rest sb score scoreDef section space staff staffDef staffGrp syl tempo title "/>
                 <moduleRef key="MEI.stringtab"/>
                 <!--<moduleRef key="MEI.text"/>-->
                 <moduleRef key="MEI.visual"/>


### PR DESCRIPTION
The PR adds `<ending>` element to MEI-Basic. It is currently missing, probably because it has been overlooked at some point.

I did not think this change needed preliminary discussions since it is a quite common feature in CWMN. Please say so if you think it does need to be discussed.