### PR TITLE
schema: fix mixing visual and gestural values in keySig

### DIFF
--- a/source/modules/MEI.analytical.xml
+++ b/source/modules/MEI.analytical.xml
@@ -245,10 +245,24 @@
   <classSpec ident="att.keySig.anl" module="MEI.analytical" type="atts">
     <desc xml:lang="en">Analytical domain attributes.</desc>
     <classes>
-      <memberOf key="att.accidental"/>
-      <memberOf key="att.keyMode"/>
       <memberOf key="att.pitch"/>
     </classes>
+    <attList>
+      <attDef ident="accid" usage="opt">
+        <gloss versionDate="2023-06-14" xml:lang="en">accidental</gloss>
+        <desc xml:lang="en">Contains an accidental for the tonic key, if one is required, <abbr>e.g.</abbr>, if <att>pname</att>
+          equals <val>c</val> and <att>accid</att> equals <val>s</val>, then a tonic of C# is indicated.</desc>
+        <datatype>
+          <rng:ref name="data.ACCIDENTAL.GESTURAL.basic"/>
+        </datatype>
+      </attDef>
+      <attDef ident="mode" usage="opt">
+        <desc xml:lang="en">Indicates major, minor, or other tonality.</desc>
+        <datatype>
+          <rng:ref name="data.MODE"/>
+        </datatype>
+      </attDef>
+    </attList>
   </classSpec>
   <classSpec ident="att.keySigDefault.anl" module="MEI.analytical" type="atts">
     <desc xml:lang="en">Used by staffDef and scoreDef to provide default values for attributes in the analytical
@@ -258,7 +272,7 @@
         <desc xml:lang="en">Contains an accidental for the tonic key, if one is required, <abbr>e.g.</abbr>, if <att>key.pname</att>
           equals <val>c</val> and <att>key.accid</att> equals <val>s</val>, then a tonic of C# is indicated.</desc>
         <datatype>
-          <rng:ref name="data.ACCIDENTAL.GESTURAL"/>
+          <rng:ref name="data.ACCIDENTAL.GESTURAL.basic"/>
         </datatype>
       </attDef>
       <attDef ident="key.mode" usage="opt">

--- a/source/modules/MEI.analytical.xml
+++ b/source/modules/MEI.analytical.xml
@@ -249,7 +249,7 @@
     </classes>
     <attList>
       <attDef ident="accid" usage="opt">
-        <gloss versionDate="2023-06-14" xml:lang="en">accidental</gloss>
+        <gloss xml:lang="en">accidental</gloss>
         <desc xml:lang="en">Contains an accidental for the tonic key, if one is required, <abbr>e.g.</abbr>, if <att>pname</att>
           equals <val>c</val> and <att>accid</att> equals <val>s</val>, then a tonic of C# is indicated.</desc>
         <datatype>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -1622,10 +1622,8 @@
     <desc xml:lang="en">Key captures information about tonal center and mode.</desc>
     <classes>
       <memberOf key="att.common"/>
-      <memberOf key="att.accidental"/>
       <memberOf key="att.bibl"/>
-      <memberOf key="att.keyMode"/>
-      <memberOf key="att.pitch"/>
+      <memberOf key="att.keySig.anl"/>
       <memberOf key="model.workIdent"/>
     </classes>
     <content>


### PR DESCRIPTION
This PR aligns `att.keySig.anl` with `att.keySigDefault.anl` (as it is supposed to be). 

Now `key@accid`, `keySig@accid`, `scoreDef@key.accid`, and `staffDef@key.accid` all require  a value from `data.ACCIDENTAL.GESTURAL.basic`.

closes #590

refers to #1157
