### PR TITLE
schema: fix visibility of mRest and multiRest

### DIFF
--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1253,6 +1253,7 @@
       <memberOf key="att.staffLoc.pitched"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.width"/>
+      <memberOf key="att.visibility"/>
     </classes>
     <attList>
       <attDef ident="block" usage="opt">

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1252,8 +1252,8 @@
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.staffLoc.pitched"/>
       <memberOf key="att.typography"/>
-      <memberOf key="att.width"/>
       <memberOf key="att.visibility"/>
+      <memberOf key="att.width"/>
     </classes>
     <attList>
       <attDef ident="block" usage="opt">

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1210,7 +1210,6 @@
       <memberOf key="att.staffLoc.pitched"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.visualOffset"/>
-      <memberOf key="att.visibility"/>
       <memberOf key="att.xy"/>
     </classes>
   </classSpec>


### PR DESCRIPTION
`rest` is not a member of `att.visibility`, because we have [`space`](https://music-encoding.org/guidelines/dev/content/shared.html#sharedNoteSpacing). So that `mRest` actually is a member of `att.visibility` seems wrong, because we have `mSpace`.

`multiRest` on the other hand was indeed missing the `visible` attribute.