### PR TITLE
schema: align description with guidelines

### DIFF
--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3071,8 +3071,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.OCTAVE" module="MEI" type="dt">
-    <desc xml:lang="en">Oct attribute values. The default values conform to Acoustical Society of America
-      representation. Read, p. 44.</desc>
+    <desc xml:lang="en">Oct attribute values. The default values conform to the Scientific Pitch Notation (SPN).</desc>
     <content>
       <rng:data type="nonNegativeInteger">
         <rng:param name="maxInclusive">9</rng:param>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3071,7 +3071,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.OCTAVE" module="MEI" type="dt">
-    <desc xml:lang="en">Oct attribute values. The default values conform to the Scientific Pitch Notation (SPN).</desc>
+    <desc xml:lang="en">Octave number. The default values conform to the Scientific Pitch Notation (SPN).</desc>
     <content>
       <rng:data type="nonNegativeInteger">
         <rng:param name="maxInclusive">9</rng:param>


### PR DESCRIPTION
Small PR to align the data type description with the Guidelines (which is more accessible).