### PR TITLE
guidelines: fix and unify examples

### DIFF
--- a/source/examples/verovio/04-score-redefinition.mei
+++ b/source/examples/verovio/04-score-redefinition.mei
@@ -1,103 +1,111 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
-    <meiHead>
-        <fileDesc>
-            <titleStmt>
-                <title>Key changes example</title>
-            </titleStmt>
-            <pubStmt>
-                <date isodate="2017-05-09">2017-05-09</date>
-            </pubStmt>
-            <seriesStmt>
-                <title>Verovio test suite</title>
-            </seriesStmt>
-            <notesStmt>
-                <annot>Example taken from the Verovio Test Suite</annot>
-            </notesStmt>
-        </fileDesc>
-    </meiHead>
-    <music>
-        <body>
-            <mdiv>
-                <score>
-                    <?edit-start?>
-                    <scoreDef keysig="4f" meter.sym="common">
-                        <staffGrp>
-                            <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
-                        </staffGrp>
-                    </scoreDef>
-                    <section>
-                        <measure right="dbl" n="1">
-                            <staff n="1">
-                                <layer n="1">
-                                    <chord dur="1">
-                                        <note oct="4" pname="a" accid.ges="f" />
-                                        <note oct="5" pname="c" accid.ges="f" />
-                                        <note oct="5" pname="e" accid.ges="f" />
-                                    </chord>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <scoreDef key.sig="0" keysig.cancellaccid="none" />
-                        <measure right="dbl" n="4">
-                            <staff n="1">
-                                <layer n="1">
-                                    <chord dur="1">
-                                        <note oct="4" pname="a" />
-                                        <note oct="5" pname="c" />
-                                        <note oct="5" pname="e" />
-                                    </chord>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <scoreDef keysig="2s" keysig.cancellaccid="before" meter.sym="cut" />
-                        <measure n="2">
-                            <staff n="1">
-                                <layer n="1">
-                                    <chord dur="1">
-                                        <note oct="4" pname="b" />
-                                        <note oct="5" pname="d" />
-                                        <note oct="5" pname="f" accid.ges="s" />
-                                    </chord>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <measure right="dbl" n="3">
-                            <staff n="1">
-                                <layer n="1">
-                                    <multiRest num="3" />
-                                </layer>
-                            </staff>
-                        </measure>
-                        <scoreDef keysig.visible="false" keysig="5f" meter.count="4" meter.unit="4" />
-                        <measure right="dbl" n="5">
-                            <staff n="1">
-                                <layer n="1">
-                                    <chord dur="1">
-                                        <note oct="4" pname="g" />
-                                        <note oct="4" pname="b" accid.ges="f" />
-                                        <note oct="5" pname="d" />
-                                    </chord>
-                                </layer>
-                            </staff>
-                        </measure>
-                        <scoreDef keysig="2s" keysig.cancellaccid="before-bar" />
-                        <measure right="end" n="2">
-                            <staff n="1">
-                                <layer n="1">
-                                    <chord dur="1">
-                                        <note oct="4" pname="b" />
-                                        <note oct="5" pname="d" />
-                                        <note oct="5" pname="f" accid.ges="s" />
-                                    </chord>
-                                </layer>
-                            </staff>
-                        </measure>
-                    </section>
-                    <?edit-end?>
-                </score>
-            </mdiv>
-        </body>
-    </music>
+  <meiHead>
+    <fileDesc>
+      <titleStmt>
+        <title>Key changes example</title>
+      </titleStmt>
+      <pubStmt>
+        <date isodate="2023">2023</date>
+        <respStmt>
+          <corpName>Music Encoding Initiative (MEI) Board</corpName>
+        </respStmt>
+        <availability>
+          <useRestrict label="license" auth="https://spdx.org/licenses/" codedval="ECL-2.0">
+            <p>Educational Community License v2.0</p>
+          </useRestrict>
+        </availability>
+      </pubStmt>
+      <seriesStmt>
+        <title>MEI guidelines examples</title>
+      </seriesStmt>
+      <notesStmt>
+        <annot>Example taken from the Verovio Test Suite</annot>
+      </notesStmt>
+    </fileDesc>
+  </meiHead>
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <?edit-start?>
+          <scoreDef keysig="4f" meter.sym="common">
+            <staffGrp>
+              <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <measure right="dbl" n="1">
+              <staff n="1">
+                <layer n="1">
+                  <chord dur="1">
+                    <note oct="4" pname="a" accid.ges="f" />
+                    <note oct="5" pname="c" accid.ges="f" />
+                    <note oct="5" pname="e" accid.ges="f" />
+                  </chord>
+                </layer>
+              </staff>
+            </measure>
+            <scoreDef keysig="0" keysig.cancelaccid="none" />
+            <measure right="dbl" n="4">
+              <staff n="1">
+                <layer n="1">
+                  <chord dur="1">
+                    <note oct="4" pname="a" />
+                    <note oct="5" pname="c" />
+                    <note oct="5" pname="e" />
+                  </chord>
+                </layer>
+              </staff>
+            </measure>
+            <scoreDef keysig="2s" keysig.cancelaccid="before" meter.sym="cut" />
+            <measure n="2">
+              <staff n="1">
+                <layer n="1">
+                  <chord dur="1">
+                    <note oct="4" pname="b" />
+                    <note oct="5" pname="d" />
+                    <note oct="5" pname="f" accid.ges="s" />
+                  </chord>
+                </layer>
+              </staff>
+            </measure>
+            <measure right="dbl" n="3">
+              <staff n="1">
+                <layer n="1">
+                  <multiRest num="3" />
+                </layer>
+              </staff>
+            </measure>
+            <scoreDef keysig.visible="false" keysig="5f" meter.count="4" meter.unit="4" />
+            <measure right="dbl" n="5">
+              <staff n="1">
+                <layer n="1">
+                  <chord dur="1">
+                    <note oct="4" pname="g" />
+                    <note oct="4" pname="b" accid.ges="f" />
+                    <note oct="5" pname="d" />
+                  </chord>
+                </layer>
+              </staff>
+            </measure>
+            <scoreDef keysig="2s" keysig.cancelaccid="before-bar" />
+            <measure right="end" n="2">
+              <staff n="1">
+                <layer n="1">
+                  <chord dur="1">
+                    <note oct="4" pname="b" />
+                    <note oct="5" pname="d" />
+                    <note oct="5" pname="f" accid.ges="s" />
+                  </chord>
+                </layer>
+              </staff>
+            </measure>
+          </section>
+          <?edit-end?>
+        </score>
+      </mdiv>
+    </body>
+  </music>
 </mei>

--- a/source/examples/verovio/accid-03.mei
+++ b/source/examples/verovio/accid-03.mei
@@ -1,56 +1,67 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
-   <meiHead>
-      <fileDesc>
-         <titleStmt>
-            <title>Alignment of editorial accidentals</title>
-         </titleStmt>
-         <pubStmt>
-            <date>2017-05-17</date>
-         </pubStmt>
-         <notesStmt>
-            <annot>Editorial accidentals are aligned on the centre of the notehead.</annot>
-         </notesStmt>
-      </fileDesc>
-      <encodingDesc />
-   </meiHead>
-   <music>
-      <body>
-         <mdiv>
-            <score>
-               <scoreDef n="1">
-                  <staffGrp>
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
-                  </staffGrp>
-               </scoreDef>
-               <section>
-                  <measure right="end" n="1">
-                     <staff n="1">
-                        <?edit-start?>
-                        <layer n="1">
-                           <note dur="1" oct="5" pname="f">
-                              <accid accid="s" func="edit" />
-                           </note>
-                           <note dur="1" oct="5" pname="f">
-                              <accid accid="f" func="edit" />
-                           </note>
-                           <note dur="1" oct="5" pname="f">
-                              <accid accid="n" func="edit" />
-                           </note>
-                           <note dur="1" oct="5" pname="f">
-                              <accid accid="x" func="edit" />
-                           </note>
-                           <note dur="1" oct="5" pname="f">
-                              <accid accid="ff" func="edit" />
-                           </note>
-                        </layer>
-                        <?edit-end?>
-                     </staff>
-                  </measure>
-               </section>
-            </score>
-         </mdiv>
-      </body>
-   </music>
+  <meiHead>
+    <fileDesc>
+      <titleStmt>
+        <title>Alignment of editorial accidentals</title>
+      </titleStmt>
+      <pubStmt>
+        <date isodate="2023">2023</date>
+        <respStmt>
+          <corpName>Music Encoding Initiative (MEI) Board</corpName>
+        </respStmt>
+        <availability>
+          <useRestrict label="license" auth="https://spdx.org/licenses/" codedval="ECL-2.0">
+            <p>Educational Community License v2.0</p>
+          </useRestrict>
+        </availability>
+      </pubStmt>
+      <seriesStmt>
+        <title>MEI guidelines examples</title>
+      </seriesStmt>
+      <notesStmt>
+        <annot>Editorial accidentals are aligned on the centre of the notehead.</annot>
+      </notesStmt>
+    </fileDesc>
+    <encodingDesc />
+  </meiHead>
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef n="1">
+            <staffGrp>
+              <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <measure right="end" n="1">
+              <staff n="1">
+                <?edit-start?>
+                <layer n="1">
+                  <note dur="1" oct="5" pname="f">
+                    <accid accid="s" func="edit" />
+                  </note>
+                  <note dur="1" oct="5" pname="f">
+                    <accid accid="f" func="edit" />
+                  </note>
+                  <note dur="1" oct="5" pname="f">
+                    <accid accid="n" func="edit" />
+                  </note>
+                  <note dur="1" oct="5" pname="f">
+                    <accid accid="x" func="edit" />
+                  </note>
+                  <note dur="1" oct="5" pname="f">
+                    <accid accid="ff" func="edit" />
+                  </note>
+                </layer>
+                <?edit-end?>
+              </staff>
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
 </mei>

--- a/source/examples/verovio/alteration.mei
+++ b/source/examples/verovio/alteration.mei
@@ -1,65 +1,77 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
-   <meiHead>
-      <fileDesc>
-         <titleStmt>
-            <title>Example of 'alteration'</title>
-         </titleStmt>
-         <pubStmt>
-            <date>2019-11-15</date>
-         </pubStmt>
-         <notesStmt>
-            <annot>The bottom staff, together with the dotted barlines, is used here to help visualizing the durational values of the notes in the upper staff.</annot>
-         </notesStmt>
-      </fileDesc>
-   </meiHead>
-   <music>
-      <body>
-         <mdiv>
-            <score>
-               <scoreDef>
-                  <staffGrp>
-                     <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3" />
-                     <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3" />
-                  </staffGrp>
-               </scoreDef>
-               <section>
-                  <staff n="1">
-                     <?edit-start?>
-                     <!-- mensuration encoded in <staffDef> element indicates @modusminor = 3 -->
-                     <layer n="1">
-                        <note dur="longa" dur.quality="perfecta" />
-                        <barLine form="dashed" />
-                        <note dur="brevis" />
-                        <barLine form="dashed" />
-                        <note dur="brevis" dur.quality="altera" />
-                        <barLine form="dashed" />
-                        <note dur="longa" dur.quality="perfecta" />
-                        <barLine form="dashed" />
-                     </layer>
-                     <?edit-end?>
-                  </staff>
-                  <staff n="2">
-                     <layer n="1">
-                        <note dur="brevis" oct="4" pname="a" />
-                        <note dur="brevis" oct="4" pname="a" />
-                        <note dur="brevis" oct="4" pname="a" />
-                        <barLine form="dashed" />
-                        <note dur="brevis" oct="4" pname="a" />
-                        <barLine form="dashed" />
-                        <note dur="brevis" oct="4" pname="a" />
-                        <note dur="brevis" oct="4" pname="a" />
-                        <barLine form="dashed" />
-                        <note dur="brevis" oct="4" pname="a" />
-                        <note dur="brevis" oct="4" pname="a" />
-                        <note dur="brevis" oct="4" pname="a" />
-                        <barLine form="dashed" />
-                     </layer>
-                  </staff>
-               </section>
-            </score>
-         </mdiv>
-      </body>
-   </music>
+  <meiHead>
+    <fileDesc>
+      <titleStmt>
+        <title>Example of 'alteration'</title>
+      </titleStmt>
+      <pubStmt>
+        <date isodate="2023">2023</date>
+        <respStmt>
+          <corpName>Music Encoding Initiative (MEI) Board</corpName>
+        </respStmt>
+        <availability>
+          <useRestrict label="license" auth="https://spdx.org/licenses/" codedval="ECL-2.0">
+            <p>Educational Community License v2.0</p>
+          </useRestrict>
+        </availability>
+      </pubStmt>
+      <seriesStmt>
+        <title>MEI guidelines examples</title>
+      </seriesStmt>
+      <notesStmt>
+        <annot>The bottom staff, together with the dotted barlines, is used here to help
+          visualizing the durational values of the notes in the upper staff.</annot>
+      </notesStmt>
+    </fileDesc>
+  </meiHead>
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef>
+            <staffGrp>
+              <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3" />
+              <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3" />
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <staff n="1">
+              <?edit-start?>
+              <!-- mensuration encoded in <staffDef> element indicates @modusminor = 3 -->
+              <layer n="1">
+                <note dur="longa" dur.quality="perfecta" />
+                <barLine form="dashed" />
+                <note dur="brevis" />
+                <barLine form="dashed" />
+                <note dur="brevis" dur.quality="altera" />
+                <barLine form="dashed" />
+                <note dur="longa" dur.quality="perfecta" />
+                <barLine form="dashed" />
+              </layer>
+              <?edit-end?>
+            </staff>
+            <staff n="2">
+              <layer n="1">
+                <note dur="brevis" oct="4" pname="a" />
+                <note dur="brevis" oct="4" pname="a" />
+                <note dur="brevis" oct="4" pname="a" />
+                <barLine form="dashed" />
+                <note dur="brevis" oct="4" pname="a" />
+                <barLine form="dashed" />
+                <note dur="brevis" oct="4" pname="a" />
+                <note dur="brevis" oct="4" pname="a" />
+                <barLine form="dashed" />
+                <note dur="brevis" oct="4" pname="a" />
+                <note dur="brevis" oct="4" pname="a" />
+                <note dur="brevis" oct="4" pname="a" />
+                <barLine form="dashed" />
+              </layer>
+            </staff>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
 </mei>

--- a/source/examples/verovio/ars_antiqua.mei
+++ b/source/examples/verovio/ars_antiqua.mei
@@ -1,76 +1,88 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
-   <meiHead>
-      <fileDesc>
-         <titleStmt>
-            <title>Example of 'imperfection' and 'dot of division'</title>
-         </titleStmt>
-         <pubStmt>
-            <date>2019-11-15</date>
-         </pubStmt>
-         <notesStmt>
-            <annot>The bottom staff, together with the dotted barlines, is used here to help visualizing the durational values of the notes in the upper staff.</annot>
-         </notesStmt>
-      </fileDesc>
-   </meiHead>
-   <music>
-      <body>
-         <mdiv>
-            <score>
-               <scoreDef>
-                  <staffGrp>
-                     <staffDef label="voice" n="1" notationtype="mensural.black" lines="5" clef.shape="G" clef.line="2" modusminor="3" tempus="3" />
-                     <staffDef label="reference" n="2" notationtype="mensural.black" lines="5" clef.shape="G" clef.line="2" modusminor="3" tempus="3" />
-                  </staffGrp>
-               </scoreDef>
-               <section>
-                  <staff n="1">
-                     <?edit-start?>
-                     <!-- mensuration encoded in <staffDef> element indicates @modusminor = 3 and @tempus = 3 -->
-                     <layer n="1">
-                        <note dur="longa" dur.quality="perfecta" />
-                        <barLine form="dashed" />
-                        <note dur="semibrevis" dur.quality="minor" />
-                        <note dur="semibrevis" dur.quality="minor" />
-                        <note dur="semibrevis" dur.quality="minor" />
-                        <dot form="div" />
-                        <barLine form="dashed" />
-                        <note dur="semibrevis" dur.quality="minor" />
-                        <note dur="semibrevis" dur.quality="maior" />
-                        <barLine form="dashed" />
-                        <note dur="brevis" />
-                        <barLine form="dashed" />
-                        <note dur="longa" dur.quality="duplex" />
-                        <barLine form="dashed" />
-                     </layer>  
-                     <?edit-end?>
-                  </staff>
-                  <staff n="2">
-                     <layer n="1">
-                        <note dur="brevis" />
-                        <note dur="brevis" />
-                        <note dur="brevis" />
-                        <barLine form="dashed" />
-                        <note dur="brevis" />
-                        <barLine form="dashed" />
-                        <note dur="brevis" />
-                        <barLine form="dashed" />
-                        <note dur="brevis" />
-                        <barLine form="dashed" />
-                        <note dur="brevis" />
-                        <note dur="brevis" />
-                        <note dur="brevis" />
-                        <barLine form="dashed" />
-                        <note dur="brevis" />
-                        <note dur="brevis" />
-                        <note dur="brevis" />
-                        <barLine form="dashed" />
-                     </layer>
-                  </staff>
-               </section>
-            </score>
-         </mdiv>
-      </body>
-   </music>
+  <meiHead>
+    <fileDesc>
+      <titleStmt>
+        <title>Example of 'imperfection' and 'dot of division'</title>
+      </titleStmt>
+      <pubStmt>
+        <date isodate="2023">2023</date>
+        <respStmt>
+          <corpName>Music Encoding Initiative (MEI) Board</corpName>
+        </respStmt>
+        <availability>
+          <useRestrict label="license" auth="https://spdx.org/licenses/" codedval="ECL-2.0">
+            <p>Educational Community License v2.0</p>
+          </useRestrict>
+        </availability>
+      </pubStmt>
+      <seriesStmt>
+        <title>MEI guidelines examples</title>
+      </seriesStmt>
+      <notesStmt>
+        <annot>The bottom staff, together with the dotted barlines, is used here to help visualizing
+          the durational values of the notes in the upper staff.</annot>
+      </notesStmt>
+    </fileDesc>
+  </meiHead>
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef>
+            <staffGrp>
+              <staffDef label="voice" n="1" notationtype="mensural.black" lines="5" clef.shape="G" clef.line="2" modusminor="3" tempus="3" />
+              <staffDef label="reference" n="2" notationtype="mensural.black" lines="5" clef.shape="G" clef.line="2" modusminor="3" tempus="3" />
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <staff n="1">
+              <?edit-start?>
+              <!-- mensuration encoded in <staffDef> element indicates @modusminor = 3 and @tempus = 3 -->
+              <layer n="1">
+                <note dur="longa" dur.quality="perfecta" />
+                <barLine form="dashed" />
+                <note dur="semibrevis" dur.quality="minor" />
+                <note dur="semibrevis" dur.quality="minor" />
+                <note dur="semibrevis" dur.quality="minor" />
+                <dot form="div" />
+                <barLine form="dashed" />
+                <note dur="semibrevis" dur.quality="minor" />
+                <note dur="semibrevis" dur.quality="maior" />
+                <barLine form="dashed" />
+                <note dur="brevis" />
+                <barLine form="dashed" />
+                <note dur="longa" dur.quality="duplex" />
+                <barLine form="dashed" />
+              </layer>
+              <?edit-end?>
+            </staff>
+            <staff n="2">
+              <layer n="1">
+                <note dur="brevis" />
+                <note dur="brevis" />
+                <note dur="brevis" />
+                <barLine form="dashed" />
+                <note dur="brevis" />
+                <barLine form="dashed" />
+                <note dur="brevis" />
+                <barLine form="dashed" />
+                <note dur="brevis" />
+                <barLine form="dashed" />
+                <note dur="brevis" />
+                <note dur="brevis" />
+                <note dur="brevis" />
+                <barLine form="dashed" />
+                <note dur="brevis" />
+                <note dur="brevis" />
+                <note dur="brevis" />
+                <barLine form="dashed" />
+              </layer>
+            </staff>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
 </mei>

--- a/source/examples/verovio/augmentation.mei
+++ b/source/examples/verovio/augmentation.mei
@@ -1,55 +1,67 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
-   <meiHead>
-      <fileDesc>
-         <titleStmt>
-            <title>Example of 'augmentation'</title>
-         </titleStmt>
-         <pubStmt>
-            <date>2019-11-15</date>
-         </pubStmt>
-         <notesStmt>
-            <annot>The bottom staff, together with the dotted barlines, is used here to help visualizing the durational values of the notes in the upper staff.</annot>
-         </notesStmt>
-      </fileDesc>
-   </meiHead>
-   <music>
-      <body>
-         <mdiv>
-            <score>
-               <scoreDef>
-                  <staffGrp>
-                     <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="2" />
-                     <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="2" />
-                  </staffGrp>
-               </scoreDef>
-               <section>
-                  <staff n="1">
-                     <?edit-start?>
-                     <!-- mensuration encoded in <staffDef> element indicates @modusminor = 2 and @tempus = 2 -->
-                     <layer n="1">
-                        <note dur="longa" dur.quality="perfecta" />
-                        <dot form="aug" />
-                        <barLine form="dashed" />
-                        <note dur="brevis" />
-                        <barLine form="dashed" />
-                     </layer>
-                     <?edit-end?>
-                  </staff>
-                  <staff n="2">
-                     <layer n="1">
-                        <note dur="brevis" oct="4" pname="a" />
-                        <note dur="brevis" oct="4" pname="a" />
-                        <note dur="brevis" oct="4" pname="a" />
-                        <barLine form="dashed" />
-                        <note dur="brevis" oct="4" pname="a" />
-                        <barLine form="dashed" />
-                     </layer>
-                  </staff>
-               </section>
-            </score>
-         </mdiv>
-      </body>
-   </music>
+  <meiHead>
+    <fileDesc>
+      <titleStmt>
+        <title>Example of 'augmentation'</title>
+      </titleStmt>
+      <pubStmt>
+        <date isodate="2023">2023</date>
+        <respStmt>
+          <corpName>Music Encoding Initiative (MEI) Board</corpName>
+        </respStmt>
+        <availability>
+          <useRestrict label="license" auth="https://spdx.org/licenses/" codedval="ECL-2.0">
+            <p>Educational Community License v2.0</p>
+          </useRestrict>
+        </availability>
+      </pubStmt>
+      <seriesStmt>
+        <title>MEI guidelines examples</title>
+      </seriesStmt>
+      <notesStmt>
+        <annot>The bottom staff, together with the dotted barlines, is used here to help visualizing
+          the durational values of the notes in the upper staff.</annot>
+      </notesStmt>
+    </fileDesc>
+  </meiHead>
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef>
+            <staffGrp>
+              <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="2" />
+              <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="2" />
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <staff n="1">
+              <?edit-start?>
+              <!-- mensuration encoded in <staffDef> element indicates @modusminor = 2 and @tempus = 2 -->
+              <layer n="1">
+                <note dur="longa" dur.quality="perfecta" />
+                <dot form="aug" />
+                <barLine form="dashed" />
+                <note dur="brevis" />
+                <barLine form="dashed" />
+              </layer>
+              <?edit-end?>
+            </staff>
+            <staff n="2">
+              <layer n="1">
+                <note dur="brevis" oct="4" pname="a" />
+                <note dur="brevis" oct="4" pname="a" />
+                <note dur="brevis" oct="4" pname="a" />
+                <barLine form="dashed" />
+                <note dur="brevis" oct="4" pname="a" />
+                <barLine form="dashed" />
+              </layer>
+            </staff>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
 </mei>

--- a/source/examples/verovio/imperfection.mei
+++ b/source/examples/verovio/imperfection.mei
@@ -1,63 +1,75 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
-   <meiHead>
-      <fileDesc>
-         <titleStmt>
-            <title>Example of 'imperfection' and 'dot of division'</title>
-         </titleStmt>
-         <pubStmt>
-            <date>2019-11-15</date>
-         </pubStmt>
-         <notesStmt>
-            <annot>The bottom staff, together with the dotted barlines, is used here to help visualizing the durational values of the notes in the upper staff.</annot>
-         </notesStmt>
-      </fileDesc>
-   </meiHead>
-   <music>
-      <body>
-         <mdiv>
-            <score>
-               <scoreDef>
-                  <staffGrp>
-                     <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3" />
-                     <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3" />
-                  </staffGrp>
-               </scoreDef>
-               <section>
-                  <staff n="1">
-                     <?edit-start?>
-                     <!-- mensuration encoded in <staffDef> element indicates @modusminor = 3 -->
-                     <layer n="1">
-                        <note dur="longa" dur.quality="imperfecta" />
-                        <barLine form="dashed" />
-                        <note dur="brevis" />
-                        <dot form="div" />
-                        <barLine form="dashed" />
-                        <note dur="brevis" />
-                        <barLine form="dashed" />
-                        <note dur="longa" dur.quality="imperfecta" />
-                        <barLine form="dashed" />
-                     </layer>
-                     <?edit-end?>
-                  </staff>
-                  <staff n="2">
-                     <layer n="1">
-                        <note dur="brevis" oct="4" pname="a" />
-                        <note dur="brevis" oct="4" pname="a" />
-                        <barLine form="dashed" />
-                        <note dur="brevis" oct="4" pname="a" />
-                        <barLine form="dashed" />
-                        <note dur="brevis" oct="4" pname="a" />
-                        <barLine form="dashed" />
-                        <note dur="brevis" oct="4" pname="a" />
-                        <note dur="brevis" oct="4" pname="a" />
-                        <barLine form="dashed" />
-                     </layer>
-                  </staff>
-               </section>
-            </score>
-         </mdiv>
-      </body>
-   </music>
+  <meiHead>
+    <fileDesc>
+      <titleStmt>
+        <title>Example of 'imperfection' and 'dot of division'</title>
+      </titleStmt>
+      <pubStmt>
+        <date isodate="2023">2023</date>
+        <respStmt>
+          <corpName>Music Encoding Initiative (MEI) Board</corpName>
+        </respStmt>
+        <availability>
+          <useRestrict label="license" auth="https://spdx.org/licenses/" codedval="ECL-2.0">
+            <p>Educational Community License v2.0</p>
+          </useRestrict>
+        </availability>
+      </pubStmt>
+      <seriesStmt>
+        <title>MEI guidelines examples</title>
+      </seriesStmt>
+      <notesStmt>
+        <annot>The bottom staff, together with the dotted barlines, is used here to help visualizing
+          the durational values of the notes in the upper staff.</annot>
+      </notesStmt>
+    </fileDesc>
+  </meiHead>
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef>
+            <staffGrp>
+              <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3" />
+              <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3" />
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <staff n="1">
+              <?edit-start?>
+              <!-- mensuration encoded in <staffDef> element indicates @modusminor = 3 -->
+              <layer n="1">
+                <note dur="longa" dur.quality="imperfecta" />
+                <barLine form="dashed" />
+                <note dur="brevis" />
+                <dot form="div" />
+                <barLine form="dashed" />
+                <note dur="brevis" />
+                <barLine form="dashed" />
+                <note dur="longa" dur.quality="imperfecta" />
+                <barLine form="dashed" />
+              </layer>
+              <?edit-end?>
+            </staff>
+            <staff n="2">
+              <layer n="1">
+                <note dur="brevis" oct="4" pname="a" />
+                <note dur="brevis" oct="4" pname="a" />
+                <barLine form="dashed" />
+                <note dur="brevis" oct="4" pname="a" />
+                <barLine form="dashed" />
+                <note dur="brevis" oct="4" pname="a" />
+                <barLine form="dashed" />
+                <note dur="brevis" oct="4" pname="a" />
+                <note dur="brevis" oct="4" pname="a" />
+                <barLine form="dashed" />
+              </layer>
+            </staff>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
 </mei>

--- a/source/examples/verovio/implicit-mensuration.mei
+++ b/source/examples/verovio/implicit-mensuration.mei
@@ -1,82 +1,98 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
-   <meiHead>
-      <fileDesc>
-         <titleStmt>
-            <title>Example of omitted mensuration signs</title>
-         </titleStmt>
-         <pubStmt>
-            <date>2019-11-15</date>
-         </pubStmt>
-         <notesStmt>
-            <annot>In this choir book, only the verso parts have a mensuration sign, whereas Altus and Bassus on the recto don't.</annot>
-         </notesStmt>
-         <sourceDesc>
-            <source>
-               <bibl>FlorPanc27, 79v-80r</bibl>
-            </source>
-         </sourceDesc>
-      </fileDesc>
-   </meiHead>
-   <music>
-      <body>
-         <mdiv>
-            <?edit-start?>
-            <score>
-               <scoreDef key.sig="1f">
-                  <staffGrp>
-                     <staffDef n="1" label="Cantus" lines="5" notationtype="mensural.white" clef.shape="C" clef.line="1" mensur.sign="C" mensur.slash="1" prolatio="2" tempus="2" />
-                     <staffDef n="2" label="Tenor" lines="5" notationtype="mensural.white" clef.shape="C" clef.line="4" mensur.sign="C" mensur.slash="1" prolatio="2" tempus="2" />
-                     <staffDef n="3" label="Altus" lines="5" notationtype="mensural.white" clef.shape="C" clef.line="3" prolatio="2" tempus="2" />
-                     <staffDef n="4" label="Bassus" lines="5" notationtype="mensural.white" clef.shape="F" clef.line="4" prolatio="2" tempus="2" />
-                  </staffGrp>
-               </scoreDef>
-               <section>
-                  <staff n="1">
-                     <layer>
-                        <note pname="b" oct="4" dur="brevis"/>
-                        <note pname="b" oct="4" dur="brevis"/>
-                        <note pname="a" oct="4" dur="brevis"/>
-                        <note pname="g" oct="4" dur="brevis"/>
-                        <note pname="g" oct="4" dur="semibrevis"/>
-                        <note pname="g" oct="4" dur="semibrevis"/>
-                     </layer>
-                  </staff>
-                  <staff n="2">
-                     <layer>
-                        <note pname="g" oct="3" dur="brevis"/>
-                        <note pname="b" oct="3" dur="brevis"/>
-                        <note pname="c" oct="4" dur="brevis"/>
-                        <note pname="c" oct="4" dur="brevis"/>
-                        <note pname="c" oct="4" dur="semibrevis"/>
-                        <note pname="c" oct="4" dur="semibrevis"/>
-                     </layer>
-                  </staff>
-                  <staff n="3">
-                     <layer>
-                        <note pname="d" oct="4" dur="brevis"/>
-                        <note pname="d" oct="4" dur="brevis"/>
-                        <note pname="f" oct="4" dur="brevis"/>
-                        <note pname="e" oct="4" dur="brevis"/>
-                        <note pname="e" oct="4" dur="semibrevis"/>
-                        <note pname="e" oct="4" dur="semibrevis"/>
-                     </layer>
-                  </staff>
-                  <staff n="4">
-                     <layer>
-                        <note pname="g" oct="2" dur="brevis"/>
-                        <note pname="g" oct="3" dur="brevis"/>
-                        <note pname="g" oct="3" dur="brevis"/>
-                        <note pname="c" oct="3" dur="brevis"/>
-                        <note pname="c" oct="3" dur="semibrevis"/>
-                        <note pname="c" oct="3" dur="semibrevis"/>
-                     </layer>
-                  </staff>
-               </section>
-            </score>
-            <?edit-end?>
-         </mdiv>
-      </body>
-   </music>
+  <meiHead>
+    <fileDesc>
+      <titleStmt>
+        <title>Example of omitted mensuration signs</title>
+      </titleStmt>
+      <pubStmt>
+        <date isodate="2023">2023</date>
+        <respStmt>
+          <corpName>Music Encoding Initiative (MEI) Board</corpName>
+        </respStmt>
+        <availability>
+          <useRestrict label="license" auth="https://spdx.org/licenses/" codedval="ECL-2.0">
+            <p>Educational Community License v2.0</p>
+          </useRestrict>
+        </availability>
+      </pubStmt>
+      <seriesStmt>
+        <title>MEI guidelines examples</title>
+      </seriesStmt>
+      <notesStmt>
+        <annot>In this choir book, only the verso parts have a mensuration sign, whereas Altus and
+          Bassus on the recto don't.</annot>
+      </notesStmt>
+      <sourceDesc>
+        <source>
+          <bibl>FlorPanc27, 79v-80r</bibl>
+        </source>
+      </sourceDesc>
+    </fileDesc>
+  </meiHead>
+  <music>
+    <body>
+      <mdiv>
+        <?edit-start?>
+        <score>
+          <scoreDef keysig="1f">
+            <staffGrp>
+              <staffDef n="1" label="Cantus" lines="5" notationtype="mensural.white" clef.shape="C"
+                clef.line="1" mensur.sign="C" mensur.slash="1" prolatio="2" tempus="2" />
+              <staffDef n="2" label="Tenor" lines="5" notationtype="mensural.white" clef.shape="C"
+                clef.line="4" mensur.sign="C" mensur.slash="1" prolatio="2" tempus="2" />
+              <staffDef n="3" label="Altus" lines="5" notationtype="mensural.white" clef.shape="C"
+                clef.line="3" prolatio="2" tempus="2" />
+              <staffDef n="4" label="Bassus" lines="5" notationtype="mensural.white" clef.shape="F"
+                clef.line="4" prolatio="2" tempus="2" />
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <staff n="1">
+              <layer>
+                <note pname="b" oct="4" dur="brevis" />
+                <note pname="b" oct="4" dur="brevis" />
+                <note pname="a" oct="4" dur="brevis" />
+                <note pname="g" oct="4" dur="brevis" />
+                <note pname="g" oct="4" dur="semibrevis" />
+                <note pname="g" oct="4" dur="semibrevis" />
+              </layer>
+            </staff>
+            <staff n="2">
+              <layer>
+                <note pname="g" oct="3" dur="brevis" />
+                <note pname="b" oct="3" dur="brevis" />
+                <note pname="c" oct="4" dur="brevis" />
+                <note pname="c" oct="4" dur="brevis" />
+                <note pname="c" oct="4" dur="semibrevis" />
+                <note pname="c" oct="4" dur="semibrevis" />
+              </layer>
+            </staff>
+            <staff n="3">
+              <layer>
+                <note pname="d" oct="4" dur="brevis" />
+                <note pname="d" oct="4" dur="brevis" />
+                <note pname="f" oct="4" dur="brevis" />
+                <note pname="e" oct="4" dur="brevis" />
+                <note pname="e" oct="4" dur="semibrevis" />
+                <note pname="e" oct="4" dur="semibrevis" />
+              </layer>
+            </staff>
+            <staff n="4">
+              <layer>
+                <note pname="g" oct="2" dur="brevis" />
+                <note pname="g" oct="3" dur="brevis" />
+                <note pname="g" oct="3" dur="brevis" />
+                <note pname="c" oct="3" dur="brevis" />
+                <note pname="c" oct="3" dur="semibrevis" />
+                <note pname="c" oct="3" dur="semibrevis" />
+              </layer>
+            </staff>
+          </section>
+        </score>
+        <?edit-end?>
+      </mdiv>
+    </body>
+  </music>
 </mei>

--- a/source/examples/verovio/mensuration_changes.mei
+++ b/source/examples/verovio/mensuration_changes.mei
@@ -1,42 +1,53 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
-   <meiHead>
-      <fileDesc>
-         <titleStmt>
-            <title>Example of 'mensuration changes'</title>
-         </titleStmt>
-         <pubStmt>
-            <date>2020-03-03</date>
-         </pubStmt>
-      </fileDesc>
-   </meiHead>
-   <music>
-      <body>
-         <mdiv>
-            <?edit-start?>
-            <score>
-               <scoreDef>
-                  <staffGrp>
-                     <staffDef n="1" notationtype="mensural" lines="5" clef.shape="G" clef.line="2" mensur.color="red" mensur.dot="true" mensur.sign="O" mensur.slash="1" />
-                  </staffGrp>
-               </scoreDef>
-               <section>
-                  <staff n="1">
-                     <layer n="1">
-                        <note />
-                        <note />
-                        <note />
-                        <mensur sign="C" loc="3" />
-                        <note />
-                        <note />
-                        <note />
-                     </layer>
-                  </staff>
-               </section>
-            </score>
-            <?edit-end?>
-         </mdiv>
-      </body>
-   </music>
+  <meiHead>
+    <fileDesc>
+      <titleStmt>
+        <title>Example of 'mensuration changes'</title>
+      </titleStmt>
+      <pubStmt>
+        <date isodate="2023">2023</date>
+        <respStmt>
+          <corpName>Music Encoding Initiative (MEI) Board</corpName>
+        </respStmt>
+        <availability>
+          <useRestrict label="license" auth="https://spdx.org/licenses/" codedval="ECL-2.0">
+            <p>Educational Community License v2.0</p>
+          </useRestrict>
+        </availability>
+      </pubStmt>
+      <seriesStmt>
+        <title>MEI guidelines examples</title>
+      </seriesStmt>
+    </fileDesc>
+  </meiHead>
+  <music>
+    <body>
+      <mdiv>
+        <?edit-start?>
+        <score>
+          <scoreDef>
+            <staffGrp>
+              <staffDef n="1" notationtype="mensural" lines="5" clef.shape="G" clef.line="2" mensur.color="red" mensur.dot="true" mensur.sign="O" mensur.slash="1" />
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <staff n="1">
+              <layer n="1">
+                <note />
+                <note />
+                <note />
+                <mensur sign="C" loc="3" />
+                <note />
+                <note />
+                <note />
+              </layer>
+            </staff>
+          </section>
+        </score>
+        <?edit-end?>
+      </mdiv>
+    </body>
+  </music>
 </mei>

--- a/source/examples/verovio/motet_fauvel_fol22r_triplum.mei
+++ b/source/examples/verovio/motet_fauvel_fol22r_triplum.mei
@@ -1,105 +1,116 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
-   <meiHead>
-      <fileDesc>
-         <titleStmt>
-            <title>Systems 4 to 5 of the Triplum of the Motet Inflammatis invidia / Sicut de ligno parvulus generatur / Victimae paschali laudes (Fauvel, fol. 22r)</title>
-         </titleStmt>
-         <pubStmt>
-            <date>2020-03-02</date>
-         </pubStmt>
-         <notesStmt>
-            <annot>Example of the encoding of the music content of a voice (including 2-breve and 3-breve rests).</annot>
-         </notesStmt>
-      </fileDesc>
-   </meiHead>
-   <music>
-      <body>
-         <mdiv>
-            <score>
-               <scoreDef>
-                  <staffGrp>
-                     <staffDef label="Triplum" n="1" notationtype="mensural.black" lines="5" clef.shape="C" clef.line="3" modusminor="3" tempus="3" mensur.sign="O" mensur.slash="1" />
-                  </staffGrp>
-               </scoreDef>
-               <section>
-                  <staff n="1">
-                     <layer n="1">
-                        <note dur="longa" oct="4" pname="c" />
-                        <note dur="semibrevis" oct="4" pname="c" />
-                        <note dur="semibrevis" oct="4" pname="d" />
-                        <note dur="semibrevis" oct="4" pname="e" />
-                        <note dur="brevis" oct="4" pname="f" />
-                        <note dur="semibrevis" oct="4" pname="f" />
-                        <note dur="semibrevis" oct="4" pname="e" />
-                        <note dur="semibrevis" oct="4" pname="d" />
-                        <ligature>
-                           <note dur="semibrevis" oct="4" pname="c" />
-                           <note dur="semibrevis" oct="4" pname="d" />
-                        </ligature>
-                        <note dur="longa" oct="4" pname="e" />
-                        <note dur="brevis" oct="4" pname="d" />
-                        <?edit-start?>
-                        <rest dur="2B" />
-                        <ligature>
-                           <note dur="semibrevis" oct="4" pname="d" />
-                           <note dur="semibrevis" oct="4" pname="c" />
-                        </ligature>
-                        <ligature>
-                           <note dur="semibrevis" oct="4" pname="d" />
-                           <note dur="semibrevis" oct="4" pname="e" />
-                        </ligature>
-                        <ligature>
-                           <note dur="semibrevis" oct="4" pname="d" />
-                           <note dur="semibrevis" oct="3" pname="a" />
-                        </ligature>
-                        <note dur="longa" oct="3" pname="b" />
-                        <dot form="div" />
-                        <ligature>
-                           <note dur="semibrevis" oct="4" pname="c" />
-                           <note dur="semibrevis" oct="4" pname="d" />
-                        </ligature>
-                        <ligature>
-                           <note dur="semibrevis" oct="4" pname="c" />
-                           <note dur="semibrevis" oct="3" pname="b" />
-                        </ligature>
-                        <ligature>
-                           <note dur="semibrevis" oct="3" pname="a" />
-                           <note dur="semibrevis" oct="3" pname="g" />
-                        </ligature>
-                        <note dur="longa" oct="3" pname="a" />
-                        <note dur="semibrevis" oct="4" pname="d" />
-                        <note dur="semibrevis" oct="4" pname="e" />
-                        <barLine form="invis" />
-                        <note dur="longa" oct="4" pname="f" />
-                        <note dur="brevis" oct="4" pname="e" />
-                        <dot form="div" />
-                        <note dur="brevis" oct="4" pname="d" />
-                        <ligature>
-                           <note dur="semibrevis" oct="4" pname="c" />
-                           <note dur="semibrevis" oct="3" pname="b" />
-                        </ligature>
-                        <ligature>
-                           <note dur="semibrevis" oct="4" pname="c" />
-                           <note dur="semibrevis" oct="4" pname="d" />
-                        </ligature>
-                        <note dur="longa" oct="4" pname="e" />
-                        <rest dur="3B"/>
-                        <?edit-end?>
-                        <note dur="semibrevis" oct="4" pname="e" />
-                        <note dur="semibrevis" oct="4" pname="f" />
-                        <dot form="div" />
-                        <note dur="semibrevis" oct="4" pname="e" />
-                        <note dur="semibrevis" oct="4" pname="d" />
-                        <note dur="brevis" oct="4" pname="e" />
-                        <note dur="longa" oct="4" pname="g" accid="s" />
-                        <note dur="brevis" oct="4" pname="g" accid.ges="s" />
-                     </layer>
-                  </staff>
-               </section>
-            </score>
-         </mdiv>
-      </body>
-   </music>
+  <meiHead>
+    <fileDesc>
+      <titleStmt>
+        <title>Systems 4 to 5 of the Triplum of the Motet Inflammatis invidia / Sicut de ligno parvulus generatur / Victimae paschali laudes (Fauvel, fol. 22r)</title>
+      </titleStmt>
+      <pubStmt>
+        <date isodate="2023">2023</date>
+        <respStmt>
+          <corpName>Music Encoding Initiative (MEI) Board</corpName>
+        </respStmt>
+        <availability>
+          <useRestrict label="license" auth="https://spdx.org/licenses/" codedval="ECL-2.0">
+            <p>Educational Community License v2.0</p>
+          </useRestrict>
+        </availability>
+      </pubStmt>
+      <seriesStmt>
+        <title>MEI guidelines examples</title>
+      </seriesStmt>
+      <notesStmt>
+        <annot>Example of the encoding of the music content of a voice (including 2-breve and 3-breve rests).</annot>
+      </notesStmt>
+    </fileDesc>
+  </meiHead>
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef>
+            <staffGrp>
+              <staffDef label="Triplum" n="1" notationtype="mensural.black" lines="5" clef.shape="C" clef.line="3" modusminor="3" tempus="3" mensur.sign="O" mensur.slash="1" />
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <staff n="1">
+              <layer n="1">
+                <note dur="longa" oct="4" pname="c" />
+                <note dur="semibrevis" oct="4" pname="c" />
+                <note dur="semibrevis" oct="4" pname="d" />
+                <note dur="semibrevis" oct="4" pname="e" />
+                <note dur="brevis" oct="4" pname="f" />
+                <note dur="semibrevis" oct="4" pname="f" />
+                <note dur="semibrevis" oct="4" pname="e" />
+                <note dur="semibrevis" oct="4" pname="d" />
+                <ligature>
+                  <note dur="semibrevis" oct="4" pname="c" />
+                  <note dur="semibrevis" oct="4" pname="d" />
+                </ligature>
+                <note dur="longa" oct="4" pname="e" />
+                <note dur="brevis" oct="4" pname="d" />
+                <?edit-start?>
+                <rest dur="2B" />
+                <ligature>
+                  <note dur="semibrevis" oct="4" pname="d" />
+                  <note dur="semibrevis" oct="4" pname="c" />
+                </ligature>
+                <ligature>
+                  <note dur="semibrevis" oct="4" pname="d" />
+                  <note dur="semibrevis" oct="4" pname="e" />
+                </ligature>
+                <ligature>
+                  <note dur="semibrevis" oct="4" pname="d" />
+                  <note dur="semibrevis" oct="3" pname="a" />
+                </ligature>
+                <note dur="longa" oct="3" pname="b" />
+                <dot form="div" />
+                <ligature>
+                  <note dur="semibrevis" oct="4" pname="c" />
+                  <note dur="semibrevis" oct="4" pname="d" />
+                </ligature>
+                <ligature>
+                  <note dur="semibrevis" oct="4" pname="c" />
+                  <note dur="semibrevis" oct="3" pname="b" />
+                </ligature>
+                <ligature>
+                  <note dur="semibrevis" oct="3" pname="a" />
+                  <note dur="semibrevis" oct="3" pname="g" />
+                </ligature>
+                <note dur="longa" oct="3" pname="a" />
+                <note dur="semibrevis" oct="4" pname="d" />
+                <note dur="semibrevis" oct="4" pname="e" />
+                <barLine form="invis" />
+                <note dur="longa" oct="4" pname="f" />
+                <note dur="brevis" oct="4" pname="e" />
+                <dot form="div" />
+                <note dur="brevis" oct="4" pname="d" />
+                <ligature>
+                  <note dur="semibrevis" oct="4" pname="c" />
+                  <note dur="semibrevis" oct="3" pname="b" />
+                </ligature>
+                <ligature>
+                  <note dur="semibrevis" oct="4" pname="c" />
+                  <note dur="semibrevis" oct="4" pname="d" />
+                </ligature>
+                <note dur="longa" oct="4" pname="e" />
+                <rest dur="3B" />
+                <?edit-end?>
+                <note dur="semibrevis" oct="4" pname="e" />
+                <note dur="semibrevis" oct="4" pname="f" />
+                <dot form="div" />
+                <note dur="semibrevis" oct="4" pname="e" />
+                <note dur="semibrevis" oct="4" pname="d" />
+                <note dur="brevis" oct="4" pname="e" />
+                <note dur="longa" oct="4" pname="g" accid="s" />
+                <note dur="brevis" oct="4" pname="g" accid.ges="s" />
+              </layer>
+            </staff>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
 </mei>

--- a/source/examples/verovio/notes_rests.mei
+++ b/source/examples/verovio/notes_rests.mei
@@ -1,59 +1,71 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
-   <meiHead>
-      <fileDesc>
-         <titleStmt>
-            <title>Notes and Rests</title>
-         </titleStmt>
-         <pubStmt>
-            <date>2020-03-02</date>
-         </pubStmt>
-         <notesStmt>
-            <annot>The upper staff shows the different mensural note shapes and the lower staff shows the different mensural rests.</annot>
-         </notesStmt>
-      </fileDesc>
-   </meiHead>
-   <music>
-      <body>
-         <mdiv>
-            <score>
-               <scoreDef>
-                  <staffGrp>
-                     <staffDef label="notes" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" />
-                     <staffDef label="rests" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" />
-                  </staffGrp>
-               </scoreDef>
-               <section>
-                  <?edit-start?>
-                  <staff n="1">
-                     <layer n="1">
-                        <note dur="maxima" />
-                        <note dur="longa" />
-                        <note dur="brevis" />
-                        <note dur="semibrevis" />
-                        <note dur="minima" />
-                        <note dur="semiminima" />
-                        <note dur="fusa" />
-                        <note dur="semifusa" />
-                     </layer>
-                  </staff>
-                  <staff n="2">
-                     <layer n="1">
-                        <rest dur="maxima" />
-                        <rest dur="longa" />
-                        <rest dur="brevis" />
-                        <rest dur="semibrevis" />
-                        <rest dur="minima" />
-                        <rest dur="semiminima" />
-                        <rest dur="fusa" />
-                        <rest dur="semifusa" />
-                     </layer>
-                  </staff>
-                  <?edit-end?>
-               </section>
-            </score>
-         </mdiv>
-      </body>
-   </music>
+  <meiHead>
+    <fileDesc>
+      <titleStmt>
+        <title>Notes and Rests</title>
+      </titleStmt>
+      <pubStmt>
+        <date isodate="2023">2023</date>
+        <respStmt>
+          <corpName>Music Encoding Initiative (MEI) Board</corpName>
+        </respStmt>
+        <availability>
+          <useRestrict label="license" auth="https://spdx.org/licenses/" codedval="ECL-2.0">
+            <p>Educational Community License v2.0</p>
+          </useRestrict>
+        </availability>
+      </pubStmt>
+      <seriesStmt>
+        <title>MEI guidelines examples</title>
+      </seriesStmt>
+      <notesStmt>
+        <annot>The upper staff shows the different mensural note shapes and the lower staff shows
+          the different mensural rests.</annot>
+      </notesStmt>
+    </fileDesc>
+  </meiHead>
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef>
+            <staffGrp>
+              <staffDef label="notes" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" />
+              <staffDef label="rests" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" />
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <?edit-start?>
+            <staff n="1">
+              <layer n="1">
+                <note dur="maxima" />
+                <note dur="longa" />
+                <note dur="brevis" />
+                <note dur="semibrevis" />
+                <note dur="minima" />
+                <note dur="semiminima" />
+                <note dur="fusa" />
+                <note dur="semifusa" />
+              </layer>
+            </staff>
+            <staff n="2">
+              <layer n="1">
+                <rest dur="maxima" />
+                <rest dur="longa" />
+                <rest dur="brevis" />
+                <rest dur="semibrevis" />
+                <rest dur="minima" />
+                <rest dur="semiminima" />
+                <rest dur="fusa" />
+                <rest dur="semifusa" />
+              </layer>
+            </staff>
+            <?edit-end?>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
 </mei>

--- a/source/examples/verovio/octave-shift-01.mei
+++ b/source/examples/verovio/octave-shift-01.mei
@@ -1,160 +1,171 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
-   <meiHead>
-      <fileDesc>
-         <titleStmt>
-            <title>Octave shift example</title>
-         </titleStmt>
-         <pubStmt>
-            <date>2017-05-09</date>
-         </pubStmt>
-         <notesStmt>
-            <annot>Example use of the "octave" element for octave shifts. For correct MIDI output, the
-               "oct.ges" attribute needs to be provided.</annot>
-         </notesStmt>
-      </fileDesc>
-   </meiHead>
-   <music>
-      <body>
-         <mdiv>
-            <score>
-               <scoreDef n="1">
-                  <staffGrp>
-                     <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
-                  </staffGrp>
-               </scoreDef>
-               <?edit-start?>
-               <section>
-                  <measure n="1">
-                     <staff n="1">
-                        <layer n="1">
-                           <note dur="2" oct="6" pname="e" />
-                           <beam>
-                              <note dur="8" oct="6" pname="f" />
-                              <note dur="8" oct="6" pname="a" />
-                              <note dur="8" oct="6" pname="g" />
-                              <note dur="8" oct="6" pname="b" />
-                           </beam>
-                        </layer>
-                     </staff>
-                  </measure>
-                  <measure right="dbl" n="2">
-                     <staff n="1">
-                        <layer n="1">
-                           <note dur="1" oct="7" pname="c" />
-                        </layer>
-                     </staff>
-                  </measure>
-                  <measure n="3">
-                     <staff n="1">
-                        <layer n="1">
-                           <note xml:id="n1" dur="2" oct.ges="6" oct="5" pname="e" />
-                           <beam>
-                              <note dur="8" oct.ges="6" oct="5" pname="f" />
-                              <note dur="8" oct.ges="6" oct="5" pname="a" />
-                              <note dur="8" oct.ges="6" oct="5" pname="g" />
-                              <note dur="8" oct.ges="6" oct="5" pname="b" />
-                           </beam>
-                        </layer>
-                     </staff>
-                     <octave startid="#n1" endid="#n2" dis="8" dis.place="above" />
-                  </measure>
-                  <measure right="dbl" n="4">
-                     <staff n="1">
-                        <layer n="1">
-                           <note xml:id="n2" dur="1" oct.ges="7" oct="6" pname="c" />
-                        </layer>
-                     </staff>
-                  </measure>
-                  <measure n="5">
-                     <staff n="1">
-                        <layer n="1">
-                           <note xml:id="n3" dur="2" oct.ges="2" oct="3" pname="e" />
-                           <beam>
-                              <note dur="8" oct.ges="2" oct="3" pname="f" />
-                              <note dur="8" oct.ges="2" oct="3" pname="a" />
-                              <note dur="8" oct.ges="2" oct="3" pname="g" />
-                              <note dur="8" oct.ges="2" oct="3" pname="b" />
-                           </beam>
-                        </layer>
-                     </staff>
-                     <octave startid="#n3" endid="#n4" dis="8" dis.place="below" />
-                  </measure>
-                  <measure right="dbl" n="6">
-                     <staff n="1">
-                        <layer n="1">
-                           <note xml:id="n4" dur="1" oct.ges="3" oct="4" pname="c" />
-                        </layer>
-                     </staff>
-                  </measure>
-                  <measure n="7">
-                     <staff n="1">
-                        <layer n="1">
-                           <note xml:id="n3" dur="2" oct.ges="2" oct="4" pname="e" />
-                           <beam>
-                              <note dur="8" oct.ges="2" oct="4" pname="f" />
-                              <note dur="8" oct.ges="2" oct="4" pname="a" />
-                              <note dur="8" oct.ges="2" oct="4" pname="g" />
-                              <note dur="8" oct.ges="2" oct="4" pname="b" />
-                           </beam>
-                        </layer>
-                     </staff>
-                     <octave startid="#n3" tstamp2="1m+4.0000" dis="15" dis.place="below" />
-                  </measure>
-                  <measure right="dbl" n="8">
-                     <staff n="1">
-                        <layer n="1">
-                           <note dur="1" oct.ges="3" oct="5" pname="c" />
-                        </layer>
-                     </staff>
-                  </measure>
-                  <measure n="9">
-                     <staff n="1">
-                        <layer n="1">
-                           <note xml:id="n5" dur="2" oct.ges="2" oct="3" pname="e" />
-                           <beam>
-                              <note dur="8" oct.ges="2" oct="3" pname="f" />
-                              <note dur="8" oct.ges="2" oct="3" pname="a" />
-                              <note dur="8" oct.ges="2" oct="3" pname="g" />
-                              <note dur="8" oct.ges="2" oct="3" pname="b" />
-                           </beam>
-                        </layer>
-                     </staff>
-                     <octave startid="#n5" endid="#n6" lwidth="0.5000vu" dis="8" dis.place="below" />
-                  </measure>
-                  <measure right="dbl" n="10">
-                     <staff n="1">
-                        <layer n="1">
-                           <note xml:id="n6" dur="1" oct.ges="3" oct="4" pname="c" />
-                        </layer>
-                     </staff>
-                  </measure>
-                  <measure n="11">
-                     <staff n="1">
-                        <layer n="1">
-                           <note xml:id="n7" dur="2" oct.ges="4" oct="3" pname="e" />
-                           <beam>
-                              <note dur="8" oct.ges="4" oct="3" pname="f" />
-                              <note dur="8" oct.ges="4" oct="3" pname="a" />
-                              <note dur="8" oct.ges="4" oct="3" pname="g" />
-                              <note dur="8" oct.ges="4" oct="3" pname="b" />
-                           </beam>
-                        </layer>
-                     </staff>
-                     <octave startid="#n7" tstamp2="1m+4.0000" lform="solid" dis="8" dis.place="above" />
-                  </measure>
-                  <measure right="dbl" n="12">
-                     <staff n="1">
-                        <layer n="1">
-                           <note dur="1" oct.ges="5" oct="4" pname="c" />
-                        </layer>
-                     </staff>
-                  </measure>
-               </section>
-               <?edit-end?>
-            </score>
-         </mdiv>
-      </body>
-   </music>
+  <meiHead>
+    <fileDesc>
+      <titleStmt>
+        <title>Octave shift example</title>
+      </titleStmt>
+      <pubStmt>
+        <date isodate="2023">2023</date>
+        <respStmt>
+          <corpName>Music Encoding Initiative (MEI) Board</corpName>
+        </respStmt>
+        <availability>
+          <useRestrict label="license" auth="https://spdx.org/licenses/" codedval="ECL-2.0">
+            <p>Educational Community License v2.0</p>
+          </useRestrict>
+        </availability>
+      </pubStmt>
+      <seriesStmt>
+        <title>MEI guidelines examples</title>
+      </seriesStmt>
+      <notesStmt>
+        <annot>Example use of the "octave" element for octave shifts. For correct MIDI output, the
+          "oct.ges" attribute needs to be provided.</annot>
+      </notesStmt>
+    </fileDesc>
+  </meiHead>
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef n="1">
+            <staffGrp>
+              <staffDef n="1" lines="5" clef.shape="G" clef.line="2" />
+            </staffGrp>
+          </scoreDef>
+          <?edit-start?>
+          <section>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note dur="2" oct="6" pname="e" />
+                  <beam>
+                    <note dur="8" oct="6" pname="f" />
+                    <note dur="8" oct="6" pname="a" />
+                    <note dur="8" oct="6" pname="g" />
+                    <note dur="8" oct="6" pname="b" />
+                  </beam>
+                </layer>
+              </staff>
+            </measure>
+            <measure right="dbl" n="2">
+              <staff n="1">
+                <layer n="1">
+                  <note dur="1" oct="7" pname="c" />
+                </layer>
+              </staff>
+            </measure>
+            <measure n="3">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="n1" dur="2" oct.ges="6" oct="5" pname="e" />
+                  <beam>
+                    <note dur="8" oct.ges="6" oct="5" pname="f" />
+                    <note dur="8" oct.ges="6" oct="5" pname="a" />
+                    <note dur="8" oct.ges="6" oct="5" pname="g" />
+                    <note dur="8" oct.ges="6" oct="5" pname="b" />
+                  </beam>
+                </layer>
+              </staff>
+              <octave startid="#n1" endid="#n2" dis="8" dis.place="above" />
+            </measure>
+            <measure right="dbl" n="4">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="n2" dur="1" oct.ges="7" oct="6" pname="c" />
+                </layer>
+              </staff>
+            </measure>
+            <measure n="5">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="n3" dur="2" oct.ges="2" oct="3" pname="e" />
+                  <beam>
+                    <note dur="8" oct.ges="2" oct="3" pname="f" />
+                    <note dur="8" oct.ges="2" oct="3" pname="a" />
+                    <note dur="8" oct.ges="2" oct="3" pname="g" />
+                    <note dur="8" oct.ges="2" oct="3" pname="b" />
+                  </beam>
+                </layer>
+              </staff>
+              <octave startid="#n3" endid="#n4" dis="8" dis.place="below" />
+            </measure>
+            <measure right="dbl" n="6">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="n4" dur="1" oct.ges="3" oct="4" pname="c" />
+                </layer>
+              </staff>
+            </measure>
+            <measure n="7">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="n5" dur="2" oct.ges="2" oct="4" pname="e" />
+                  <beam>
+                    <note dur="8" oct.ges="2" oct="4" pname="f" />
+                    <note dur="8" oct.ges="2" oct="4" pname="a" />
+                    <note dur="8" oct.ges="2" oct="4" pname="g" />
+                    <note dur="8" oct.ges="2" oct="4" pname="b" />
+                  </beam>
+                </layer>
+              </staff>
+              <octave startid="#n5" tstamp2="1m+4.0000" dis="15" dis.place="below" />
+            </measure>
+            <measure right="dbl" n="8">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="n6" dur="1" oct.ges="3" oct="5" pname="c" />
+                </layer>
+              </staff>
+            </measure>
+            <measure n="9">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="n7" dur="2" oct.ges="2" oct="3" pname="e" />
+                  <beam>
+                    <note dur="8" oct.ges="2" oct="3" pname="f" />
+                    <note dur="8" oct.ges="2" oct="3" pname="a" />
+                    <note dur="8" oct.ges="2" oct="3" pname="g" />
+                    <note dur="8" oct.ges="2" oct="3" pname="b" />
+                  </beam>
+                </layer>
+              </staff>
+              <octave startid="#n7" endid="#n8" lwidth="0.5000vu" dis="8" dis.place="below" />
+            </measure>
+            <measure right="dbl" n="10">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="n8" dur="1" oct.ges="3" oct="4" pname="c" />
+                </layer>
+              </staff>
+            </measure>
+            <measure n="11">
+              <staff n="1">
+                <layer n="1">
+                  <note xml:id="n9" dur="2" oct.ges="4" oct="3" pname="e" />
+                  <beam>
+                    <note dur="8" oct.ges="4" oct="3" pname="f" />
+                    <note dur="8" oct.ges="4" oct="3" pname="a" />
+                    <note dur="8" oct.ges="4" oct="3" pname="g" />
+                    <note dur="8" oct.ges="4" oct="3" pname="b" />
+                  </beam>
+                </layer>
+              </staff>
+              <octave startid="#n9" tstamp2="1m+4.0000" lform="solid" dis="8" dis.place="above" />
+            </measure>
+            <measure right="dbl" n="12">
+              <staff n="1">
+                <layer n="1">
+                  <note dur="1" oct.ges="5" oct="4" pname="c" />
+                </layer>
+              </staff>
+            </measure>
+          </section>
+          <?edit-end?>
+        </score>
+      </mdiv>
+    </body>
+  </music>
 </mei>

--- a/source/examples/verovio/partial-imp-01-propinquam.mei
+++ b/source/examples/verovio/partial-imp-01-propinquam.mei
@@ -1,56 +1,68 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
-   <meiHead>
-      <fileDesc>
-         <titleStmt>
-            <title>Example of "partial imperfection of an immediate part" (ad partem propinquam)</title>
-         </titleStmt>
-         <pubStmt>
-            <date>2020-03-03</date>
-         </pubStmt>
-         <notesStmt>
-            <annot>The bottom staff, together with the dotted barlines, is used here to help visualizing the durational values of the notes in the upper staff.</annot>
-         </notesStmt>
-      </fileDesc>
-   </meiHead>
-   <music>
-      <body>
-         <mdiv>
-            <score>
-               <scoreDef>
-                  <staffGrp>
-                     <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="3" />
-                     <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="3" />
-                  </staffGrp>
-               </scoreDef>
-               <section>
-                  <staff n="1">
-                     <?edit-start?>
-                     <!-- mensuration encoded in <staffDef> element indicates @modusminor = 2 and @tempus = 3 -->
-                     <layer n="1">
-                        <note dur="longa" num="6" numbase="5" />
-                        <barLine form="dotted" />
-                        <note dur="semibrevis" />
-                        <barLine form="dashed" />
-                     </layer>
-                     <?edit-end?>
-                  </staff>
-                  <staff n="2">
-                     <layer n="1">
-                        <note dur="semibrevis" oct="4" pname="a" />
-                        <note dur="semibrevis" oct="4" pname="a" />
-                        <note dur="semibrevis" oct="4" pname="a" />
-                        <barLine form="dashed" />
-                        <note dur="semibrevis" oct="4" pname="a" />
-                        <note dur="semibrevis" oct="4" pname="a" />
-                        <note dur="semibrevis" oct="4" pname="a" />
-                        <barLine form="dashed" />
-                     </layer>
-                  </staff>
-               </section>
-            </score>
-         </mdiv>
-      </body>
-   </music>
+  <meiHead>
+    <fileDesc>
+      <titleStmt>
+        <title>Example of "partial imperfection of an immediate part" (ad partem propinquam)</title>
+      </titleStmt>
+      <pubStmt>
+        <date isodate="2023">2023</date>
+        <respStmt>
+          <corpName>Music Encoding Initiative (MEI) Board</corpName>
+        </respStmt>
+        <availability>
+          <useRestrict label="license" auth="https://spdx.org/licenses/" codedval="ECL-2.0">
+            <p>Educational Community License v2.0</p>
+          </useRestrict>
+        </availability>
+      </pubStmt>
+      <seriesStmt>
+        <title>MEI guidelines examples</title>
+      </seriesStmt>
+      <notesStmt>
+        <annot>The bottom staff, together with the dotted barlines, is used here to help visualizing
+          the durational values of the notes in the upper staff.</annot>
+      </notesStmt>
+    </fileDesc>
+  </meiHead>
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef>
+            <staffGrp>
+              <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="3" />
+              <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="3" />
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <staff n="1">
+              <?edit-start?>
+              <!-- mensuration encoded in <staffDef> element indicates @modusminor = 2 and @tempus = 3 -->
+              <layer n="1">
+                <note dur="longa" num="6" numbase="5" />
+                <barLine form="dotted" />
+                <note dur="semibrevis" />
+                <barLine form="dashed" />
+              </layer>
+              <?edit-end?>
+            </staff>
+            <staff n="2">
+              <layer n="1">
+                <note dur="semibrevis" oct="4" pname="a" />
+                <note dur="semibrevis" oct="4" pname="a" />
+                <note dur="semibrevis" oct="4" pname="a" />
+                <barLine form="dashed" />
+                <note dur="semibrevis" oct="4" pname="a" />
+                <note dur="semibrevis" oct="4" pname="a" />
+                <note dur="semibrevis" oct="4" pname="a" />
+                <barLine form="dashed" />
+              </layer>
+            </staff>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
 </mei>

--- a/source/examples/verovio/partial-imp-02-bilateral.mei
+++ b/source/examples/verovio/partial-imp-02-bilateral.mei
@@ -1,58 +1,70 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
-   <meiHead>
-      <fileDesc>
-         <titleStmt>
-            <title>Example of "partial imperfection" from both sides (ad partes)</title>
-         </titleStmt>
-         <pubStmt>
-            <date>2020-03-03</date>
-         </pubStmt>
-         <notesStmt>
-            <annot>The bottom staff, together with the dotted barlines, is used here to help visualizing the durational values of the notes in the upper staff.</annot>
-         </notesStmt>
-      </fileDesc>
-   </meiHead>
-   <music>
-      <body>
-         <mdiv>
-            <score>
-               <scoreDef>
-                  <staffGrp>
-                     <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="3" />
-                     <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="3" />
-                  </staffGrp>
-               </scoreDef>
-               <section>
-                  <staff n="1">
-                     <?edit-start?>
-                     <!-- mensuration encoded in <staffDef> element indicates @modusminor = 2 and @tempus = 3 -->
-                     <layer n="1">
-                        <note dur="semibrevis" />
-                        <barLine form="dotted" />
-                        <note dur="longa" num="6" numbase="4" />
-                        <barLine form="dotted" />
-                        <note dur="semibrevis" />
-                        <barLine form="dashed" />
-                     </layer>
-                     <?edit-end?>
-                  </staff>
-                  <staff n="2">
-                     <layer n="1">
-                        <note dur="semibrevis" oct="4" pname="a" />
-                        <note dur="semibrevis" oct="4" pname="a" />
-                        <note dur="semibrevis" oct="4" pname="a" />
-                        <barLine form="dashed" />
-                        <note dur="semibrevis" oct="4" pname="a" />
-                        <note dur="semibrevis" oct="4" pname="a" />
-                        <note dur="semibrevis" oct="4" pname="a" />
-                        <barLine form="dashed" />
-                     </layer>
-                  </staff>
-               </section>
-            </score>
-         </mdiv>
-      </body>
-   </music>
+  <meiHead>
+    <fileDesc>
+      <titleStmt>
+        <title>Example of "partial imperfection" from both sides (ad partes)</title>
+      </titleStmt>
+      <pubStmt>
+        <date isodate="2023">2023</date>
+        <respStmt>
+          <corpName>Music Encoding Initiative (MEI) Board</corpName>
+        </respStmt>
+        <availability>
+          <useRestrict label="license" auth="https://spdx.org/licenses/" codedval="ECL-2.0">
+            <p>Educational Community License v2.0</p>
+          </useRestrict>
+        </availability>
+      </pubStmt>
+      <seriesStmt>
+        <title>MEI guidelines examples</title>
+      </seriesStmt>
+      <notesStmt>
+        <annot>The bottom staff, together with the dotted barlines, is used here to help visualizing
+          the durational values of the notes in the upper staff.</annot>
+      </notesStmt>
+    </fileDesc>
+  </meiHead>
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef>
+            <staffGrp>
+              <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="3" />
+              <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" tempus="3" />
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <staff n="1">
+              <?edit-start?>
+              <!-- mensuration encoded in <staffDef> element indicates @modusminor = 2 and @tempus = 3 -->
+              <layer n="1">
+                <note dur="semibrevis" />
+                <barLine form="dotted" />
+                <note dur="longa" num="6" numbase="4" />
+                <barLine form="dotted" />
+                <note dur="semibrevis" />
+                <barLine form="dashed" />
+              </layer>
+              <?edit-end?>
+            </staff>
+            <staff n="2">
+              <layer n="1">
+                <note dur="semibrevis" oct="4" pname="a" />
+                <note dur="semibrevis" oct="4" pname="a" />
+                <note dur="semibrevis" oct="4" pname="a" />
+                <barLine form="dashed" />
+                <note dur="semibrevis" oct="4" pname="a" />
+                <note dur="semibrevis" oct="4" pname="a" />
+                <note dur="semibrevis" oct="4" pname="a" />
+                <barLine form="dashed" />
+              </layer>
+            </staff>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
 </mei>

--- a/source/examples/verovio/partial-imp-03-remotam.mei
+++ b/source/examples/verovio/partial-imp-03-remotam.mei
@@ -1,64 +1,78 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
-   <meiHead>
-      <fileDesc>
-         <titleStmt>
-            <title>Example of "partial imperfection of a remote part" (ad partem remotam)</title>
-         </titleStmt>
-         <pubStmt>
-            <date>2020-03-03</date>
-         </pubStmt>
-         <notesStmt>
-            <annot>The bottom staff, together with the dotted and dashed barlines, is used here to help visualizing the durational values of the notes in the upper staff. Dotted barlines in the bottom staff show the minim groups equivalent to a semibreve, and the dashed barlines show the groups of semibreves equivalent to a breve.</annot>
-         </notesStmt>
-      </fileDesc>
-   </meiHead>
-   <music>
-      <body>
-         <mdiv>
-            <score>
-               <scoreDef>
-                  <staffGrp>
-                     <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" prolatio="3" tempus="2" />
-                     <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" prolatio="3" tempus="2" />
-                  </staffGrp>
-               </scoreDef>
-               <section>
-                  <staff n="1">
-                     <?edit-start?>
-                     <!-- mensuration encoded in <staffDef> element indicates @modusminor = 2, @tempus = 2, and @prolatio = 3 -->
-                     <layer n="1">
-                        <note dur="longa" num="12" numbase="11" />
-                        <barLine form="dotted" />
-                        <note dur="minima" />
-                        <barLine form="dashed" />
-                     </layer>
-                     <?edit-end?>
-                  </staff>
-                  <staff n="2">
-                     <layer n="1">
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <barLine form="dotted" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <barLine form="dashed" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <barLine form="dotted" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <barLine form="dashed" />
-                     </layer>
-                  </staff>
-               </section>
-            </score>
-         </mdiv>
-      </body>
-   </music>
+  <meiHead>
+    <fileDesc>
+      <titleStmt>
+        <title>Example of "partial imperfection of a remote part" (ad partem remotam)</title>
+      </titleStmt>
+      <pubStmt>
+        <date isodate="2023">2023</date>
+        <respStmt>
+          <corpName>Music Encoding Initiative (MEI) Board</corpName>
+        </respStmt>
+        <availability>
+          <useRestrict label="license" auth="https://spdx.org/licenses/" codedval="ECL-2.0">
+            <p>Educational Community License v2.0</p>
+          </useRestrict>
+        </availability>
+      </pubStmt>
+      <seriesStmt>
+        <title>MEI guidelines examples</title>
+      </seriesStmt>
+      <notesStmt>
+        <annot>The bottom staff, together with the dotted and dashed barlines, is used here to help
+          visualizing the durational values of the notes in the upper staff. Dotted barlines in the
+          bottom staff show the minim groups equivalent to a semibreve, and the dashed barlines show
+          the groups of semibreves equivalent to a breve.</annot>
+      </notesStmt>
+    </fileDesc>
+  </meiHead>
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef>
+            <staffGrp>
+              <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" prolatio="3" tempus="2" />
+              <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="2" prolatio="3" tempus="2" />
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <staff n="1">
+              <?edit-start?>
+              <!-- mensuration encoded in <staffDef> element indicates @modusminor = 2, @tempus = 2, and @prolatio = 3 -->
+              <layer n="1">
+                <note dur="longa" num="12" numbase="11" />
+                <barLine form="dotted" />
+                <note dur="minima" />
+                <barLine form="dashed" />
+              </layer>
+              <?edit-end?>
+            </staff>
+            <staff n="2">
+              <layer n="1">
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <barLine form="dotted" />
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <barLine form="dashed" />
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <barLine form="dotted" />
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <barLine form="dashed" />
+              </layer>
+            </staff>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
 </mei>

--- a/source/examples/verovio/partial-imp-04-remotam.mei
+++ b/source/examples/verovio/partial-imp-04-remotam.mei
@@ -1,72 +1,86 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
-   <meiHead>
-      <fileDesc>
-         <titleStmt>
-            <title>Example of "partial imperfection of a remote part" (ad partem remotam)</title>
-         </titleStmt>
-         <pubStmt>
-            <date>2020-03-03</date>
-         </pubStmt>
-         <notesStmt>
-            <annot>The bottom staff, together with the dotted barlines, is used here to help visualizing the durational values of the notes in the upper staff. Dotted barlines in the bottom staff show the minim groups equivalent to a semibreve, and the dashed barlines show the groups of semibreves equivalent to a breve.</annot>
-         </notesStmt>
-      </fileDesc>
-   </meiHead>
-   <music>
-      <body>
-         <mdiv>
-            <score>
-               <scoreDef>
-                  <staffGrp>
-                     <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3" prolatio="3" tempus="2" />
-                     <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3" prolatio="3" tempus="2" />
-                  </staffGrp>
-               </scoreDef>
-               <section>
-                  <staff n="1">
-                     <?edit-start?>
-                     <!-- mensuration encoded in <staffDef> element indicates @modusminor = 3, @tempus = 2, and @prolatio = 3 -->
-                     <layer n="1">
-                        <note dur="longa" num="18" numbase="17" />
-                        <barLine form="dotted" />
-                        <note dur="minima" />
-                        <barLine form="dashed" />
-                     </layer>
-                     <?edit-end?>
-                  </staff>
-                  <staff n="2">
-                     <layer n="1">
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <barLine form="dotted" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <barLine form="dashed" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <barLine form="dotted" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <barLine form="dashed" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <barLine form="dotted" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <note dur="minima" oct="4" pname="a" />
-                        <barLine form="dashed" />
-                     </layer>
-                  </staff>
-               </section>
-            </score>
-         </mdiv>
-      </body>
-   </music>
+  <meiHead>
+    <fileDesc>
+      <titleStmt>
+        <title>Example of "partial imperfection of a remote part" (ad partem remotam)</title>
+      </titleStmt>
+      <pubStmt>
+        <date isodate="2023">2023</date>
+        <respStmt>
+          <corpName>Music Encoding Initiative (MEI) Board</corpName>
+        </respStmt>
+        <availability>
+          <useRestrict label="license" auth="https://spdx.org/licenses/" codedval="ECL-2.0">
+            <p>Educational Community License v2.0</p>
+          </useRestrict>
+        </availability>
+      </pubStmt>
+      <seriesStmt>
+        <title>MEI guidelines examples</title>
+      </seriesStmt>
+      <notesStmt>
+        <annot>The bottom staff, together with the dotted barlines, is used here to help
+          visualizing the durational values of the notes in the upper staff. Dotted
+          barlines in the bottom staff show the minim groups equivalent to a semibreve,
+          and the dashed barlines show the groups of semibreves equivalent to a breve.</annot>
+      </notesStmt>
+    </fileDesc>
+  </meiHead>
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef>
+            <staffGrp>
+              <staffDef label="voice" n="1" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3" prolatio="3" tempus="2" />
+              <staffDef label="reference" n="2" notationtype="mensural.white" lines="5" clef.shape="G" clef.line="2" modusminor="3" prolatio="3" tempus="2" />
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <staff n="1">
+              <?edit-start?>
+              <!-- mensuration encoded in <staffDef> element indicates @modusminor = 3, @tempus = 2, and @prolatio = 3 -->
+              <layer n="1">
+                <note dur="longa" num="18" numbase="17" />
+                <barLine form="dotted" />
+                <note dur="minima" />
+                <barLine form="dashed" />
+              </layer>
+              <?edit-end?>
+            </staff>
+            <staff n="2">
+              <layer n="1">
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <barLine form="dotted" />
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <barLine form="dashed" />
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <barLine form="dotted" />
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <barLine form="dashed" />
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <barLine form="dotted" />
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <note dur="minima" oct="4" pname="a" />
+                <barLine form="dashed" />
+              </layer>
+            </staff>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
 </mei>

--- a/source/examples/verovio/tempo-01.mei
+++ b/source/examples/verovio/tempo-01.mei
@@ -1,67 +1,80 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
-   <meiHead>
-      <fileDesc>
-         <titleStmt>
-            <title>Tempo example</title>
-         </titleStmt>
-         <pubStmt>
-            <date>2019-10-25</date>
-         </pubStmt>
-         <notesStmt>
-            <annot>Verovio supports "tempo" elements. Horizontal positioning can be specified. By default, tempi indications are placed above the staff. The "rend" element can be used within the text, for example for specifying metronome values.</annot>
-         </notesStmt>
-      </fileDesc>
-      <encodingDesc>
-         <appInfo>
-            <application version="0.9.13">
-               <name>Verovio</name>
-            </application>
-         </appInfo>
-      </encodingDesc>
-   </meiHead>
-   <music>
-      <body>
-         <mdiv>
-            <score>
-               <scoreDef meter.sym="cut">
-                  <staffGrp>
-                     <staffDef label="Violino" n="1" lines="5" clef.shape="G" clef.line="2" />
-                  </staffGrp>
-               </scoreDef>
-               <section>
-                  <?edit-start?>
-                  <measure n="0" type="upbeat">
-                     <staff n="1">
-                        <layer n="1">
-                           <beam>
-                              <note xml:id="m0_s2_e1" dur="8" oct="5" pname="e" />
-                              <note xml:id="m0_s2_e2" dur="8" oct="5" pname="f" />
-                           </beam>
-                        </layer>
-                     </staff>
-                     <tempo staff="1" tstamp="1.000000">Andante con moto <rend fontfam="smufl">&#xE1D3;</rend> = 70</tempo>
-                     <slur startid="#m0_s2_e1" endid="#m0_s2_e2" />
-                  </measure>
-                  <?edit-start?>
-                  <measure n="1">
-                     <staff n="1">
-                        <layer n="1">
-                           <note dots="1" dur="4" oct="5" pname="g" />
-                           <note dur="8" oct="5" pname="g" />
-                           <note dur="4" oct="5" pname="g" />
-                           <beam>
-                              <note xml:id="m1_s2_e4" dur="8" oct="5" pname="g" />
-                              <note xml:id="m1_s2_e5" dur="8" oct="6" pname="c" />
-                           </beam>
-                        </layer>
-                     </staff>
-                     <slur startid="#m1_s2_e4" endid="#m1_s2_e5" />
-                  </measure>
-               </section>
-            </score>
-         </mdiv>
-      </body>
-   </music>
+  <meiHead>
+    <fileDesc>
+      <titleStmt>
+        <title>Tempo example</title>
+      </titleStmt>
+      <pubStmt>
+        <date isodate="2023">2023</date>
+        <respStmt>
+          <corpName>Music Encoding Initiative (MEI) Board</corpName>
+        </respStmt>
+        <availability>
+          <useRestrict label="license" auth="https://spdx.org/licenses/" codedval="ECL-2.0">
+            <p>Educational Community License v2.0</p>
+          </useRestrict>
+        </availability>
+      </pubStmt>
+      <seriesStmt>
+        <title>MEI guidelines examples</title>
+      </seriesStmt>
+      <notesStmt>
+        <annot>Verovio supports "tempo" elements. Horizontal positioning can be specified.
+          By default, tempi indications are placed above the staff. The "rend" element can
+          be used within the text, for example for specifying metronome values.</annot>
+      </notesStmt>
+    </fileDesc>
+    <encodingDesc>
+      <appInfo>
+        <application version="0.9.13">
+          <name>Verovio</name>
+        </application>
+      </appInfo>
+    </encodingDesc>
+  </meiHead>
+  <music>
+    <body>
+      <mdiv>
+        <score>
+          <scoreDef meter.sym="cut">
+            <staffGrp>
+              <staffDef label="Violino" n="1" lines="5" clef.shape="G" clef.line="2" />
+            </staffGrp>
+          </scoreDef>
+          <section>
+            <?edit-start?>
+            <measure n="0" type="upbeat">
+              <staff n="1">
+                <layer n="1">
+                  <beam>
+                    <note xml:id="m0_s2_e1" dur="8" oct="5" pname="e" />
+                    <note xml:id="m0_s2_e2" dur="8" oct="5" pname="f" />
+                  </beam>
+                </layer>
+              </staff>
+              <tempo staff="1" tstamp="1.000000">Andante con moto <rend fontfam="smufl">&#xE1D3;</rend> = 70</tempo>
+              <slur startid="#m0_s2_e1" endid="#m0_s2_e2" />
+            </measure>
+            <?edit-start?>
+            <measure n="1">
+              <staff n="1">
+                <layer n="1">
+                  <note dots="1" dur="4" oct="5" pname="g" />
+                  <note dur="8" oct="5" pname="g" />
+                  <note dur="4" oct="5" pname="g" />
+                  <beam>
+                    <note xml:id="m1_s2_e4" dur="8" oct="5" pname="g" />
+                    <note xml:id="m1_s2_e5" dur="8" oct="6" pname="c" />
+                  </beam>
+                </layer>
+              </staff>
+              <slur startid="#m1_s2_e4" endid="#m1_s2_e5" />
+            </measure>
+          </section>
+        </score>
+      </mdiv>
+    </body>
+  </music>
 </mei>


### PR DESCRIPTION
This PR fixes all encoding errors in the new examples in the Verovio folder and add some more, which have been used for Chapter 4 in the Guidelines. 

All files have now the same `pubStmt` with proper license and a unified `seriesStmt`.