### PR TITLE
utils: fix guidelines html

### DIFF
--- a/utils/guidelines_xslt/odd2html/generateWebsite.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsite.xsl
@@ -677,7 +677,7 @@
                             <li class="tab-item">
                                 <a data-display="{@id}" 
                                     id="{@id}_tab"
-                                    href="#{@id}"
+                                    href="#{@id}_tab"
                                     class="displayTab{if(position() = 1) then(' active') else()}"><xsl:value-of select="@data-label"/></a>
                             </li>
                         </xsl:for-each>

--- a/utils/guidelines_xslt/odd2html/htmlFile.xsl
+++ b/utils/guidelines_xslt/odd2html/htmlFile.xsl
@@ -253,10 +253,10 @@
                             const tabbedFacets = document.querySelectorAll('.facet ul.tab');
                             
                             const tabClick = function(e) {
-                                const style = e.target.getAttribute('data-display');
+                                const targetDataDisplay = e.target.getAttribute('data-display');
                                 const facetId = e.target.parentNode.parentNode.parentNode.parentNode.id;
-                                //console.log('clicked at ' + facetId + ' with style ' + style)
-                                setTabs(facetId,style)
+                                //console.log('clicked at ' + facetId + ' with data display ' + targetDataDisplay);
+                                setTabs(facetId,targetDataDisplay);
                             }
                             
                             console.log('[INFO] Javascript initialized')
@@ -264,11 +264,11 @@
                             for(let facetUl of tabbedFacets) {
                                 const facetElem = facetUl.parentNode.parentNode;
                                 const facetId = facetElem.id;
-                                const defaultValue = facetUl.children[0].children[0].getAttribute('data-display');
                                 const storageName = getStorageName(facetId);
+                                const defaultDataDisplay = facetUl.children[0]?.children[0]?.getAttribute('data-display');
                                 
                                 if(localStorage.getItem(storageName) === null) {
-                                    setTabs(facetElem.id,defaultValue);
+                                    setTabs(facetId,defaultDataDisplay);
                                 } else {
                                     setTabs(facetElem.id,localStorage.getItem(storageName));
                                 }

--- a/utils/guidelines_xslt/odd2html/htmlFile.xsl
+++ b/utils/guidelines_xslt/odd2html/htmlFile.xsl
@@ -264,8 +264,8 @@
                             for(let facetUl of tabbedFacets) {
                                 const facetElem = facetUl.parentNode.parentNode;
                                 const facetId = facetElem.id;
-                                const storageName = 'meiSpecs_' + facetId + '_display';
                                 const defaultValue = facetUl.children[0].children[0].getAttribute('data-display');
+                                const storageName = getStorageName(facetId);
                                 
                                 if(localStorage.getItem(storageName) === null) {
                                     setTabs(facetElem.id,defaultValue);
@@ -280,9 +280,13 @@
                                 }
                             }
                             
+                            function getStorageName(facetId) {
+                                return 'meiSpecs_' + facetId + '_display';
+                            }
+
                             function setTabs(facetId, style) {
-                                const storageName = 'meiSpecs_' + facetId + '_display';
                                 localStorage.setItem(storageName,style);
+                                const storageName = getStorageName(facetId);
                                 
                                 const facetElem = document.getElementById(facetId);
                                 

--- a/utils/guidelines_xslt/odd2html/htmlFile.xsl
+++ b/utils/guidelines_xslt/odd2html/htmlFile.xsl
@@ -279,14 +279,21 @@
                                     tab.addEventListener('click',tabClick);
                                 }
                             }
-                            
+
+                            function getDisplayStyle(dataDisplay) {
+                                // split dataDisplay string at underscore, e.g. 'attributes_full' to ['attributes','full']
+                                const [, displayStyle = ''] = dataDisplay.split('_');
+                                return displayStyle;
+                            }
+
                             function getStorageName(facetId) {
                                 return 'meiSpecs_' + facetId + '_display';
                             }
 
                             function setTabs(facetId, style) {
-                                localStorage.setItem(storageName,style);
                                 const storageName = getStorageName(facetId);
+                                const displayStyle = getDisplayStyle(style);
+                                localStorage.setItem(storageName,displayStyle);
                                 
                                 const facetElem = document.getElementById(facetId);
                                 

--- a/utils/guidelines_xslt/odd2html/htmlFile.xsl
+++ b/utils/guidelines_xslt/odd2html/htmlFile.xsl
@@ -262,15 +262,15 @@
                             console.log('[INFO] Javascript initialized')
                             
                             for(let facetUl of tabbedFacets) {
-                                const facetElem = facetUl.parentNode.parentNode;
+                                const facetElem = facetUl.parentNode?.parentNode;
                                 const facetId = facetElem.id;
                                 const storageName = getStorageName(facetId);
                                 const defaultDataDisplay = facetUl.children[0]?.children[0]?.getAttribute('data-display');
                                 
                                 if(localStorage.getItem(storageName) === null) {
-                                    setTabs(facetId,defaultDataDisplay);
+                                    setTabs(facetId,defaultDataDisplay?.trim());
                                 } else {
-                                    setTabs(facetElem.id,localStorage.getItem(storageName));
+                                    setTabs(facetId,localStorage.getItem(storageName)?.trim());
                                 }
                                 
                                 const tabs = facetUl.querySelectorAll('.tab-item a');
@@ -298,18 +298,26 @@
                                 const facetElem = document.getElementById(facetId);
                                 
                                 const oldTab = facetElem.querySelector('.displayTab.active');
-                                oldTab.classList.remove('active');
+                                if (oldTab) {
+                                    oldTab.classList.remove('active');
+                                }
                                 
                                 const newTab = document.getElementById(style + '_tab');
-                                newTab.classList.add('active');
+                                if (newTab) {
+                                    newTab.classList.add('active');
+                                }
                                 
                                 const oldBox = facetElem.querySelector('.active.facetTabbedContent');
-                                oldBox.classList.remove('active');
-                                oldBox.style.display = 'none';
+                                if (oldBox) {
+                                    oldBox.classList.remove('active');
+                                    oldBox.style.display = 'none';
+                                }
                                 
                                 const newBox = document.getElementById(style);
-                                newBox.classList.add('active');
-                                newBox.style.display = 'block';
+                                if(newBox) {
+                                    newBox.classList.add('active');
+                                    newBox.style.display = 'block';
+                                }
                             }
                             
                             const reducedLevels = <xsl:value-of select="if($reducedLevels = true()) then('true') else('false')"/>;


### PR DESCRIPTION
This PR tries to tackle issue #1199 . It introduces some null checks in the creation steps of the facet tabs of the html guidelines and adjusts the values used for the localStorage to be compatible again to those in v4.

It also adjust the anchor links of the tabs to not jump down to the tab content (and thus moving the tab headers out of the screen).

Fixes #1199