### PR TITLE
guidelines: fix caption for curve shape

### DIFF
--- a/source/docs/02-shared.xml
+++ b/source/docs/02-shared.xml
@@ -829,7 +829,7 @@
                      <p>The interpolation points are calculated as follows: If <att>bulge</att> provides <hi rend="italic">n</hi> distance values, the connection line is divided into <hi rend="italic">n+1</hi> subsegments of equal length. The interpolation points are found by drawing a perpendicular line of the respective length at each subsegment joint. Positive distance values are drawn to the left of the connection line (left when traveling from start to end), negative ones to the right.</p>
                      <p>
                         <figure>
-                           <head>Rendering a bulge attribute with value \</head>
+                           <head>Rendering a bulge attribute with value "-2 1"</head>
                            <graphic url="../images/modules/usersymbols/bulge.png"/>
                         </figure>
                      </p>


### PR DESCRIPTION
I noticed that this caption was missing the numeric values. I found the original in the MEI 4 documentation. Not sure if this is an anomaly or a systematic problem.