### PR TITLE
guidelines: bring back at-sign for attributes in PDF guidelines

### DIFF
--- a/source/assets/css/print/mei.css
+++ b/source/assets/css/print/mei.css
@@ -737,7 +737,7 @@ div.facet.attributes div.classItem > label {
     display: none;
 }
 
-div.facet div.classItem span.ident.attribute:before {
+div.facet div.classItem span.ident.attribute:before, span.att:before {
     content: '@';
 }
 


### PR DESCRIPTION
This PR adds a CSS rule to print css to bring back the missing @ sign in front of the attributes mentioned in the text of the PDF guidelines.

Fixes #1227 