### PR TITLE
guidelines: fix style typo in chapter 1

### DIFF
--- a/source/docs/01-introduction.xml
+++ b/source/docs/01-introduction.xml
@@ -486,7 +486,7 @@
                      </specList>
                   </p>
                   <p>Because of potential inconsistencies, an encoding should not offer both
-                        <att>startid</att> and <hi rend="italic">tstamp</hi> or <att>endid</att> and
+                        <att>startid</att> and <att>tstamp</att> or <att>endid</att> and
                         <att>tstamp2</att>. Though not being recommendable, it is possible to mix
                         <att>startid</att> with <att>tstamp2</att> and <att>tstamp</att> with
                         <att>endid</att>. In general, it is easier for software to process


### PR DESCRIPTION
This mini PR replaces an `<em>` with  an `<att>`  at an attribute mention in chapter 1 that was probably overlooked before.