### PR TITLE
customizations: allow `breaksec` in MEI-Basic

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -222,7 +222,7 @@
                 <classSpec type="atts" ident="att.beaming.log" module="MEI.cmn" mode="delete"/>
                 <classSpec type="atts" ident="att.beamPresent" module="MEI.cmn" mode="delete"/>
                 <classSpec type="atts" ident="att.beamRend" module="MEI.cmn" mode="delete"/>
-                <classSpec type="atts" ident="att.beamSecondary" module="MEI.cmn" mode="delete"/>
+                <!--<classSpec type="atts" ident="att.beamSecondary" module="MEI.cmn" mode="delete"/>-->
                 <classSpec type="atts" ident="att.beamSpan.log" module="MEI.cmn" mode="delete"/>
                 <classSpec type="atts" ident="att.chord.ges.cmn" module="MEI.cmn" mode="delete"/>
                 <classSpec type="atts" ident="att.mNum.log" module="MEI.cmn" mode="delete"/>


### PR DESCRIPTION
The PR fixes the removal of `@breaksec` in MEI-Basic. This adds (back) the attribute on `chord`, `note,` and `rest`.