### PR TITLE
gh-actions: fix hard-coded PDF name in deploy action, part 2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,7 +131,7 @@ jobs:
           rm -rf $GUIDELINES_DIR/dev
           cp -r dist/guidelines/web $GUIDELINES_DIR/
           mv $GUIDELINES_DIR/web $GUIDELINES_DIR/dev
-          cp -r dist/guidelines/pdf/MEI_Guidelines_v5.0.0-dev.pdf $GUIDELINES_DIR/dev/
+          find ${{ github.workspace }}/dist/guidelines/pdf -name 'MEI_Guidelines_*.pdf' -exec cp {} $GUIDELINES_DIR/dev/ \;
 
       - name: Check git status before commit
         if: ${{ github.repository_owner == env.REPO_OWNER }}


### PR DESCRIPTION
This PR is a follow-up to #1223 because a reference to the hard-coded PDF file name was overlooked. It provides another step for fixing #1125.

However, this reference here cannot be fixed by a wildcard glob since globs do not work with linux copy command `cp`. For that reason, the copy command gets piped through a `find` that will lookup the wildcard file name and hand it over to the `cp` process.

Finding and copying worked fine locally, we have to check how it works in the CI environment.