### PR TITLE
customizations: adjustment to MEI Basic

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -779,6 +779,22 @@
                 </classSpec>
                 
                 
+                <classSpec ident="att.caesura.vis" module="MEI.visual" type="atts" mode="change">
+                    <desc xml:lang="en">Visual domain attributes.</desc>
+                    <classes>
+                        <memberOf key="att.altSym"/>
+                        <memberOf key="att.color"/>
+                        <memberOf key="att.extSym"/>
+                        <!--<memberOf key="att.placementRelStaff"/>-->
+                        <!--<memberOf key="att.staffLoc"/>-->
+                        <!--<memberOf key="att.staffLoc.pitched"/>-->
+                        <!--<memberOf key="att.typography"/>-->
+                        <memberOf key="att.visualOffset"/>
+                        <!--<memberOf key="att.xy"/>-->
+                    </classes>
+                </classSpec>
+                
+                
                 <classSpec ident="att.fermata.vis" module="MEI.visual" type="atts" mode="change">
                     <desc xml:lang="en">Visual domain attributes.</desc>
                     <classes>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -373,7 +373,7 @@
                 <classSpec type="atts" ident="att.chordMember.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.cleffing.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.clefGrp.vis" module="MEI.visual" mode="delete"/>
-                <classSpec type="atts" ident="att.fermata.vis" module="MEI.visual" mode="delete"/>
+                <!--<classSpec type="atts" ident="att.fermata.vis" module="MEI.visual" mode="delete"/>-->
                 <classSpec type="atts" ident="att.fingGrp.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.fTrem.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.harm.vis" module="MEI.visual" mode="delete"/>
@@ -762,6 +762,22 @@
                     </remarks>
                 </classSpec>
                 
+                
+                <classSpec ident="att.fermata.vis" module="MEI.visual" type="atts" mode="change">
+                    <desc xml:lang="en">Visual domain attributes.</desc>
+                    <classes>
+                        <memberOf key="att.altSym"/>
+                        <memberOf key="att.color"/>
+                        <!--<memberOf key="att.enclosingChars"/>-->
+                        <memberOf key="att.extSym"/>
+                        <!--<memberOf key="att.placementRelStaff"/>-->
+                        <!--<memberOf key="att.typography"/>-->
+                        <memberOf key="att.visualOffset"/>
+                        <!--<memberOf key="att.xy"/>-->
+                    </classes>
+                </classSpec>
+                
+                
                 <classSpec ident="att.symbol.vis" module="MEI.visual" type="atts" mode="change">
                     <desc xml:lang="en">Visual domain attributes.</desc>
                     <classes>
@@ -786,7 +802,7 @@
                         <memberOf key="att.facsimile"/>
                         <memberOf key="att.fermata.log"/>
                         <memberOf key="att.fermata.vis"/>
-                        <memberOf key="att.fermata.ges"/>
+                        <!--<memberOf key="att.fermata.ges"/>-->
                         <memberOf key="att.fermata.anl"/>
                         <memberOf key="model.controlEventLike.cmn"/>
                         <memberOf key="att.placement" mode="add"/>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -766,7 +766,7 @@
                 <classSpec ident="att.breath.vis" module="MEI.visual" type="atts" mode="change">
                     <desc xml:lang="en">Visual domain attributes.</desc>
                     <classes>
-                        <memberOf key="att.altSym"/>
+                        <!--<memberOf key="att.altSym"/>-->
                         <memberOf key="att.color"/>
                         <memberOf key="att.extSym"/>
                         <!--<memberOf key="att.placementRelStaff"/>-->
@@ -782,7 +782,7 @@
                 <classSpec ident="att.caesura.vis" module="MEI.visual" type="atts" mode="change">
                     <desc xml:lang="en">Visual domain attributes.</desc>
                     <classes>
-                        <memberOf key="att.altSym"/>
+                        <!--<memberOf key="att.altSym"/>-->
                         <memberOf key="att.color"/>
                         <memberOf key="att.extSym"/>
                         <!--<memberOf key="att.placementRelStaff"/>-->
@@ -798,7 +798,7 @@
                 <classSpec ident="att.fermata.vis" module="MEI.visual" type="atts" mode="change">
                     <desc xml:lang="en">Visual domain attributes.</desc>
                     <classes>
-                        <memberOf key="att.altSym"/>
+                        <!--<memberOf key="att.altSym"/>-->
                         <memberOf key="att.color"/>
                         <!--<memberOf key="att.enclosingChars"/>-->
                         <memberOf key="att.extSym"/>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -363,7 +363,7 @@
                 <classSpec type="atts" ident="att.xy" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.xy2" module="MEI.shared" mode="delete"/>
 
-                <classSpec type="atts" ident="att.accid.vis" module="MEI.visual" mode="delete"/>
+                <!--<classSpec type="atts" ident="att.accid.vis" module="MEI.visual" mode="delete"/>-->
                 <classSpec type="atts" ident="att.ambitus.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.ambNote.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.beaming.vis" module="MEI.visual" mode="delete"/>
@@ -653,9 +653,9 @@
                         <!--<memberOf key="att.rest.vis.mensural"/>-->
                         <memberOf key="att.staffLoc"/>
                         <memberOf key="att.staffLoc.pitched"/>
-                        <memberOf key="att.typography"/>
+                        <!--<memberOf key="att.typography"/>-->
                         <memberOf key="att.visualOffset"/>
-                        <memberOf key="att.xy"/>
+                        <!--<memberOf key="att.xy"/>-->
                     </classes>
                 </classSpec>
 
@@ -697,11 +697,11 @@
                         <memberOf key="att.enclosingChars"/>
                         <memberOf key="att.extSym"/>
                         <memberOf key="att.stems"/>
-                        <memberOf key="att.typography"/>
+                        <!--<memberOf key="att.typography"/>-->
                         <memberOf key="att.visibility"/>
                         <memberOf key="att.visualOffset.ho"/>
                         <memberOf key="att.visualOffset.to"/>
-                        <memberOf key="att.xy"/>
+                        <!--<memberOf key="att.xy"/>-->
                         <memberOf key="att.chord.vis.cmn"/>
                     </classes>
                 </classSpec>
@@ -760,6 +760,55 @@
                                 target="https://r12a.github.io/apps/subtags"
                             >https://r12a.github.io/apps/subtags</ref>.</p>
                     </remarks>
+                </classSpec>
+                
+                
+                <classSpec ident="att.accid.vis" module="MEI.visual" type="atts" mode="change">
+                    <desc xml:lang="en">Visual domain attributes.</desc>
+                    <classes>
+                        <!--<memberOf key="att.altSym"/>-->
+                        <memberOf key="att.color"/>
+                        <memberOf key="att.enclosingChars"/>
+                        <memberOf key="att.extSym"/>
+                        <!--<memberOf key="att.placementOnStaff"/>-->
+                        <!--<memberOf key="att.placementRelEvent"/>-->
+                        <!--<memberOf key="att.staffLoc"/>-->
+                        <!--<memberOf key="att.staffLoc.pitched"/>-->
+                        <!--<memberOf key="att.typography"/>-->
+                        <memberOf key="att.visualOffset.ho"/>
+                        <memberOf key="att.visualOffset.vo"/>
+                        <!--<memberOf key="att.xy"/>-->
+                    </classes>
+                </classSpec>    
+             
+             
+                <classSpec ident="att.artic.vis" module="MEI.visual" type="atts" mode="change">
+                    <desc xml:lang="en">Visual domain attributes.</desc>
+                    <classes>
+                        <!--<memberOf key="att.altSym"/>-->
+                        <memberOf key="att.color"/>
+                        <memberOf key="att.enclosingChars"/>
+                        <memberOf key="att.extSym"/>
+                        <!--<memberOf key="att.placementOnStaff"/>-->
+                        <memberOf key="att.placementRelEvent"/>
+                        <!--<memberOf key="att.staffLoc"/>-->
+                        <!--<memberOf key="att.staffLoc.pitched"/>-->
+                        <!--<memberOf key="att.typography"/>-->
+                        <memberOf key="att.visualOffset"/>
+                        <!--<memberOf key="att.xy"/>-->
+                    </classes>
+                </classSpec>
+                
+                
+                <classSpec ident="att.beatRpt.vis" module="MEI.visual" type="atts" mode="change">
+                    <desc xml:lang="en">Visual domain attributes.</desc>
+                    <classes>
+                        <!--<memberOf key="att.altSym"/>-->
+                        <memberOf key="att.color"/>
+                        <memberOf key="att.expandable"/>
+                        <memberOf key="att.extSym"/>
+                        <!--<memberOf key="att.typography"/>-->
+                    </classes>
                 </classSpec>
                 
 

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -762,6 +762,22 @@
                     </remarks>
                 </classSpec>
                 
+
+                <classSpec ident="att.breath.vis" module="MEI.visual" type="atts" mode="change">
+                    <desc xml:lang="en">Visual domain attributes.</desc>
+                    <classes>
+                        <memberOf key="att.altSym"/>
+                        <memberOf key="att.color"/>
+                        <memberOf key="att.extSym"/>
+                        <!--<memberOf key="att.placementRelStaff"/>-->
+                        <!--<memberOf key="att.staffLoc"/>-->
+                        <!--<memberOf key="att.staffLoc.pitched"/>-->
+                        <!--<memberOf key="att.typography"/>-->
+                        <memberOf key="att.visualOffset"/>
+                        <!--<memberOf key="att.xy"/>-->
+                    </classes>
+                </classSpec>
+                
                 
                 <classSpec ident="att.fermata.vis" module="MEI.visual" type="atts" mode="change">
                     <desc xml:lang="en">Visual domain attributes.</desc>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -316,7 +316,7 @@
                 <classSpec type="atts" ident="att.enclosingChars" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.endings" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.evidence" module="MEI.shared" mode="delete"/>
-                <classSpec type="atts" ident="att.extender" module="MEI.shared" mode="delete"/>
+                <!--<classSpec type="atts" ident="att.extender" module="MEI.shared" mode="delete"/>-->
                 <classSpec type="atts" ident="att.fermataPresent" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.filing" module="MEI.shared" mode="delete"/>
                 <!--<classSpec type="atts" ident="att.labelled" module="MEI.shared" mode="delete"/>-->


### PR DESCRIPTION
The PR does two things

**Unify visual attribute classes**

There was different discrepancies in the visual attribute classes (e.g., att.typography available in some cases but not other, and same for att.visualOffset`). The PR unifies them.

**Add att.extender**

This attribute classes was deleted and was missing for encoding dynamic or tempo extenders, something that should definitely be possible in MEI-Basic 