### PR TITLE
customizations: fix `chord@breaksec` missing in MEI Basic

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -368,7 +368,7 @@
                 <classSpec type="atts" ident="att.ambNote.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.beaming.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.barLine.vis" module="MEI.visual" mode="delete"/>
-                <classSpec type="atts" ident="att.chord.vis" module="MEI.visual" mode="delete"/>
+                <!--<classSpec type="atts" ident="att.chord.vis" module="MEI.visual" mode="delete"/>-->
                 <classSpec type="atts" ident="att.chordDef.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.chordMember.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.cleffing.vis" module="MEI.visual" mode="delete"/>
@@ -686,7 +686,7 @@
                     </classes>
                 </classSpec>
 
-                <classSpec ident="att.chord.vis" module="MEI.visual" type="atts" mode="replace">
+                <classSpec ident="att.chord.vis" module="MEI.visual" type="atts" mode="change">
                     <desc>Visual domain attributes for chord. The slur, slur.dir, slur.rend, tie, tie.dir, and tie.rend
                         attributes here are syntactic sugar for these attributes on each of the chord's individual
                         notes. The values here apply to all the notes in the chord. If some notes are slurred or tied


### PR DESCRIPTION
Because of a `delete` / `replace` in the MEI-basic customization, the `att.chord.vis.cmn` (`chord@breaksec`) was missing.

This is fixed by using `mode="change"` instead.