### PR TITLE
schema: create a `att.runningtext` attribute class

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -2501,17 +2501,6 @@
       <memberOf key="att.alignment"/>
     </classes>
   </classSpec>
-  <classSpec ident="att.pg.log" module="MEI.shared" type="atts">
-    <desc xml:lang="en">Attributes that record the function (i.e., placement) of page text elements.</desc>
-    <attList>
-      <attDef ident="func" usage="opt">
-        <desc xml:lang="en">Records the function (i.e., placement) of a page header or footer.</desc>
-        <datatype>
-          <rng:ref name="data.PGFUNC"/>
-        </datatype>
-      </attDef>
-    </attList>
-  </classSpec>
   <classSpec ident="att.phrase.log" module="MEI.shared" type="atts">
     <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
@@ -2815,6 +2804,17 @@
           data.DURATIONRESTS datatype.</desc>
         <datatype>
           <rng:ref name="data.DURATIONRESTS"/>
+        </datatype>
+      </attDef>
+    </attList>
+  </classSpec>
+  <classSpec ident="att.runningtext" module="MEI.shared" type="atts">
+    <desc xml:lang="en">Attributes that record the function (i.e., placement) of page running text elements.</desc>
+    <attList>
+      <attDef ident="func" usage="opt">
+        <desc xml:lang="en">Records the function (i.e., placement) of a page header or footer.</desc>
+        <datatype>
+          <rng:ref name="data.PGFUNC"/>
         </datatype>
       </attDef>
     </attList>
@@ -6951,9 +6951,9 @@
     <desc xml:lang="en">A running footer.</desc>
     <classes>
       <memberOf key="att.common"/>
-      <memberOf key="att.pg.log"/>
       <memberOf key="att.facsimile"/>
       <memberOf key="att.lang"/>
+      <memberOf key="att.runningtext"/>
     </classes>
     <content>
       <rng:zeroOrMore>
@@ -6991,9 +6991,9 @@
     <desc xml:lang="en">A running header.</desc>
     <classes>
       <memberOf key="att.common"/>
-      <memberOf key="att.pg.log"/>
       <memberOf key="att.facsimile"/>
       <memberOf key="att.lang"/>
+      <memberOf key="att.runningtext"/>
     </classes>
     <content>
       <rng:zeroOrMore>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -2501,6 +2501,17 @@
       <memberOf key="att.alignment"/>
     </classes>
   </classSpec>
+  <classSpec ident="att.pg.log" module="MEI.shared" type="atts">
+    <desc xml:lang="en">Attributes that record the function (i.e., placement) of page text elements.</desc>
+    <attList>
+      <attDef ident="func" usage="opt">
+        <desc xml:lang="en">Records the function (i.e., placement) of a page header or footer.</desc>
+        <datatype>
+          <rng:ref name="data.PGFUNC"/>
+        </datatype>
+      </attDef>
+    </attList>
+  </classSpec>
   <classSpec ident="att.phrase.log" module="MEI.shared" type="atts">
     <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
@@ -6940,6 +6951,7 @@
     <desc xml:lang="en">A running footer.</desc>
     <classes>
       <memberOf key="att.common"/>
+      <memberOf key="att.pg.log"/>
       <memberOf key="att.facsimile"/>
       <memberOf key="att.lang"/>
     </classes>
@@ -6963,12 +6975,6 @@
           <rng:ref name="data.HORIZONTALALIGNMENT"/>
         </datatype>
       </attDef>
-      <attDef ident="func" usage="opt">
-        <desc xml:lang="en">Records the function (i.e., placement) of the page footer.</desc>
-        <datatype>
-          <rng:ref name="data.PGFUNC"/>
-        </datatype>
-      </attDef>
     </attList>
     <remarks xml:lang="en">
       <p>This element is used to capture the textual data that often appears in
@@ -6985,6 +6991,7 @@
     <desc xml:lang="en">A running header.</desc>
     <classes>
       <memberOf key="att.common"/>
+      <memberOf key="att.pg.log"/>
       <memberOf key="att.facsimile"/>
       <memberOf key="att.lang"/>
     </classes>
@@ -7006,12 +7013,6 @@
         <desc xml:lang="en">Records horizontal alignment of the page header.</desc>
         <datatype>
           <rng:ref name="data.HORIZONTALALIGNMENT"/>
-        </datatype>
-      </attDef>
-      <attDef ident="func" usage="opt">
-        <desc xml:lang="en">Records the function (i.e., placement) of the page header.</desc>
-        <datatype>
-          <rng:ref name="data.PGFUNC"/>
         </datatype>
       </attDef>
     </attList>


### PR DESCRIPTION
This PR adds a `att.pg.log` class for the `@func` attribute that is currently duplicated as direct attribute in `pgHead` and `pgFoot`.

No change in the resulting Schema.