### PR TITLE
schema: allow repeated pgHead and pgFoot in scoreDef

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -7613,12 +7613,12 @@
       <rng:optional>
         <rng:ref name="model.meterSigLike"/>
       </rng:optional>
-      <rng:optional>
+      <rng:zeroOrMore>
         <rng:ref name="pgHead"/>
-      </rng:optional>
-      <rng:optional>
+      </rng:zeroOrMore>
+      <rng:zeroOrMore>
         <rng:ref name="pgFoot"/>
-      </rng:optional>
+      </rng:zeroOrMore>
       <rng:optional>
         <rng:ref name="instrGrp"/>
       </rng:optional>


### PR DESCRIPTION
Fix `scoreDef` following refactoring of page headers and footers. The problem is that it does not allow `pgHead` and `pgFoot` to be repeated. This is a problem since we have removed `pgHead2` and `pgFoot2` and replaced them with `@func` on `pgHead` and `pgFoot`. So instead of having before
```xml
<scoreDef>
   <pgHead/>
   <pgHead2/>
</scoreDef>
```
We now want to be able to do
```xml
<scoreDef>
   <pgHead func="first"/>
   <pgHead func="all"/>
</scoreDef>
```