### PR TITLE
guidelines: add some documentation about att.formework

### DIFF
--- a/source/docs/02-shared.xml
+++ b/source/docs/02-shared.xml
@@ -322,8 +322,10 @@
                      <specList>
                         <specDesc key="pgHead"/>
                         <specDesc key="pgFoot"/>
+                        <specDesc key="att.formework" atts="func"/>
                      </specList>
                   </p>
+                  <p>Both <gi scheme="MEI">pgHead</gi> and <gi scheme="MEI">pgFoot</gi> have a <att>func</att> that allows to specify to which page(s) the forme work element applies.</p>
                   <p>Columned layout can be captured with the following elements:</p>
                   <p>
                      <specList>

--- a/source/docs/02-shared.xml
+++ b/source/docs/02-shared.xml
@@ -325,7 +325,7 @@
                         <specDesc key="att.formework" atts="func"/>
                      </specList>
                   </p>
-                  <p>Both <gi scheme="MEI">pgHead</gi> and <gi scheme="MEI">pgFoot</gi> have a <att>func</att> that allows to specify to which page(s) the forme work element applies.</p>
+                  <p>Forme work" is the name for running elements (page headers and footers). Both <gi scheme="MEI">pgHead</gi> and <gi scheme="MEI">pgFoot</gi> have a <att>func</att> attribute that allows encoders to specify to which page(s) the forme work element applies. This includes alternating patterns.</p>
                   <p>Columned layout can be captured with the following elements:</p>
                   <p>
                      <specList>

--- a/source/docs/02-shared.xml
+++ b/source/docs/02-shared.xml
@@ -325,7 +325,7 @@
                         <specDesc key="att.formework" atts="func"/>
                      </specList>
                   </p>
-                  <p>Forme work" is the name for running elements (page headers and footers). Both <gi scheme="MEI">pgHead</gi> and <gi scheme="MEI">pgFoot</gi> have a <att>func</att> attribute that allows encoders to specify to which page(s) the forme work element applies. This includes alternating patterns.</p>
+                  <p>"Forme work" is the name for running elements (page headers and footers). Both <gi scheme="MEI">pgHead</gi> and <gi scheme="MEI">pgFoot</gi> have a <att>func</att> attribute that allows encoders to specify to which page(s) the forme work element applies. This includes alternating patterns.</p>
                   <p>Columned layout can be captured with the following elements:</p>
                   <p>
                      <specList>


### PR DESCRIPTION
Minimal documentation for att.formework with a reference to the attribute class.