### PR TITLE
guidelines: remove references to removed literature from chapter 6

### DIFF
--- a/source/docs/06-neumes.xml
+++ b/source/docs/06-neumes.xml
@@ -1101,10 +1101,7 @@
                <p>
                   <ref target="https://sites.google.com/fcsh.unl.pt/elsadeluca/">De Luca, Elsa</ref>, Jennifer Bain, Inga Behrendt, Ichiro Fujinaga, Kate Helsen, Alessandra Ignesti, Debra Lacoste, and Sarah Long. “Capturing Early Notations in MEI: The Case of Old Hispanic Neumes”. <hi rend="italic">Musiktheorie-Zeitschrift für Musikwissenschaft 2</hi>, 2019: 229-49.</p>
                <p>Helsen, Kate, Inga Behrendt, and Jennifer Bain. 2017. “<ref target="https://hrcak.srce.hr/index.php?show=clanak&amp;id_clanak_jezik=284211">A Morphology of Medieval Notations in the Optical Neume Recognition Project</ref>.” <hi rend="italic">Arti musices: Croatian Musicological Review</hi> 48/2: 241–266.</p>
-               <p>MEI Guidelines v3, ch. 6: <ref target="https://music-encoding.org/guidelines/v3/content/neumes.html">Neume Notation</ref>.</p>
                <p>MEI Guidelines v4, ch. 6: <ref target="https://music-encoding.org/guidelines/v4/content/neumes.html">Neume Notation</ref> introducing <gi scheme="MEI">nc</gi> as “neume component”.</p>
-               <p>Morent, Stefan and Gregor Schräder. 2008. Demo: <ref target="http://www.dimused.uni-tuebingen.de/hildegard/?SCREEN=1560x686">MEI Neumes Viewer Hildegard</ref>.</p>
-               <p>Morent, Stefan. 2011. “Digitalisierungskonzepte für Neumen-Notationen - die Projekte TüBingen und e-sequence.” <hi rend="italic">Perspektiven Digitaler Musikedition. Die Tonkunst</hi> 3: 277–83.</p>
             </div>
          </div>
       </body>


### PR DESCRIPTION
As a follow-up to PR #1230, this PR removes the literature references that were removed there as discussed in https://github.com/music-encoding/music-encoding/pull/1230#discussion_r1232929029