### PR TITLE
build: make init-mei-classpath depend on init target

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -163,8 +163,7 @@
         <echo>initialized</echo>
     </target>
     
-    <target name="init-mei-classpath" description="Initialize classpath: initializes the mei.classpath by prepending the jar files contained in the lib directory to the java classpath.">
-        <antcall target="init"/>
+    <target name="init-mei-classpath" description="Initialize classpath: initializes the mei.classpath by prepending the jar files contained in the lib directory to the java classpath." depends="init">
         <path id="mei.classpath">
             <fileset dir="lib" erroronmissingdir="false">
                 <include name="**/*.jar" />


### PR DESCRIPTION
Before this commit, the properties set in the init target were only available in this target. Consequently, they would not be available in the dist target, so the build-guidelines-pdf target was never called.