### PR TITLE
build: add comparison of MEI versions

### DIFF
--- a/BUILD_COMMANDLINE.md
+++ b/BUILD_COMMANDLINE.md
@@ -152,6 +152,6 @@ The following targets can be called using `ant <target>`:
 | `build-guidelines-pdf` | Builds the PDF version of the MEI guidelines. (Calls `build-guidelines-html` before execution.) |
 | `init` | Initializes the build environment, i.e., checks if saxon and xerces are available, and if not, downloads jar files for Saxon, Xerces and adds them to the `lib` folder. Checks if prince is available. |
 | `init-mei-classpath` | Initializes the mei.classpath, which is essential for the schema generation, by prepending the jar files contained in the lib directory to the java classpath. Will be called automatically if needed. |
-| `compare-versions` | Compares the canonicalized sources of the MEI dev version with the previous stable version and creates an HTML output; custom versions and output folder can be set via `-Dsource`, `-Dold` and `-Doutput` input params. <br> NB: path of old file is relative to `comparison.xsl`, while others are relative to `build.xml`. |
+| `compare-versions` | Compares the canonicalized sources of the MEI dev version with the previous stable version and creates an HTML output; custom versions and output folder can be set via `-Dsource`, `-Dold` and `-Doutput` input params. |
 | `clean` | Deletes the following directories: `build`, `dist` and `temp`. |
 | `reset` | Resets the build environment. Same as `clean`, but additionaly deletes the `lib` directory with the Saxon and Xerces jar files. |

--- a/BUILD_COMMANDLINE.md
+++ b/BUILD_COMMANDLINE.md
@@ -152,5 +152,6 @@ The following targets can be called using `ant <target>`:
 | `build-guidelines-pdf` | Builds the PDF version of the MEI guidelines. (Calls `build-guidelines-html` before execution.) |
 | `init` | Initializes the build environment, e.g., downloads jar files for Saxon, Xerces and adds them to the `lib` folder. |
 | `init-mei-classpath` | Initializes the mei.classpath which is essential for the schema generation. Will be called automatically if needed. |
+| `compare-versions` | Compares the canonicalized sources of the MEI dev version with the previous stable version and creates an HTML output; custom versions and output folder can be set via `-Dsource`, `-Dold` and `-Doutput` input params. <br> NB: path of old file is relative to `comparison.xml`, while others are relative to `build.xml`. |
 | `clean` | Deletes the following directories: `build`, `dist` and `temp`. |
 | `reset` | Resets the build environment. Same as `clean`, but additionaly deletes the `lib` directory with the Saxon and Xerces jar files. |

--- a/BUILD_COMMANDLINE.md
+++ b/BUILD_COMMANDLINE.md
@@ -152,6 +152,6 @@ The following targets can be called using `ant <target>`:
 | `build-guidelines-pdf` | Builds the PDF version of the MEI guidelines. (Calls `build-guidelines-html` before execution.) |
 | `init` | Initializes the build environment, i.e., checks if saxon and xerces are available, and if not, downloads jar files for Saxon, Xerces and adds them to the `lib` folder. Checks if prince is available. |
 | `init-mei-classpath` | Initializes the mei.classpath, which is essential for the schema generation, by prepending the jar files contained in the lib directory to the java classpath. Will be called automatically if needed. |
-| `compare-versions` | Compares the canonicalized sources of the MEI dev version with the previous stable version and creates an HTML output; custom versions and output folder can be set via `-Dsource`, `-Dold` and `-Doutput` input params. <br> NB: path of old file is relative to `comparison.xml`, while others are relative to `build.xml`. |
+| `compare-versions` | Compares the canonicalized sources of the MEI dev version with the previous stable version and creates an HTML output; custom versions and output folder can be set via `-Dsource`, `-Dold` and `-Doutput` input params. <br> NB: path of old file is relative to `comparison.xsl`, while others are relative to `build.xml`. |
 | `clean` | Deletes the following directories: `build`, `dist` and `temp`. |
 | `reset` | Resets the build environment. Same as `clean`, but additionaly deletes the `lib` directory with the Saxon and Xerces jar files. |

--- a/build.xml
+++ b/build.xml
@@ -421,11 +421,25 @@
         </condition>
         <echo>Using output folder: ${output.folder}</echo>
 
+        <!-- if old.default is picked, check if available, otherwise get -->
+        <condition property="old.default-and-available" value="true">
+            <and>
+                <equals arg1="${old.file}" arg2="${old.default}"/>
+                <available file="${old.file}"/>
+            </and>
+        </condition>
+
+        <get src="https://raw.githubusercontent.com/music-encoding/schema/main/4.0.1/mei-source_canonicalized_v4.0.1.xml" dest="${output.folder}${old.default}" unless:true="${old.default-and-available}"/>
+
         <!-- check if old.file is available -->
         <condition property="old.available" value="true" else="false">
+            <or>
               <available file="${old.file}"/>
+              <available file="${output.folder}${old.default}"/>
+            </or>
         </condition>
         <echo message="old.file is available: ${old.available}"></echo>
+
         <!-- compare versions -->
         <java classname="net.sf.saxon.Transform" classpathref="mei.classpath" failonerror="true" fork="true" if:true="${old.available}">
             <arg value="-s:${source.file}"/>

--- a/build.xml
+++ b/build.xml
@@ -401,7 +401,7 @@
         </condition>
         <echo>Using source.file: ${source.file}</echo>
 
-        <!-- set old file to compare with (relative to comparison.xml) -->
+        <!-- set old file to compare with (relative to comparison.xsl) -->
         <property name="old.default" value="mei-source_canonicalized_v4.0.1.xml"/>
         <echo level="verbose">old.default: ${old.default}</echo>
         <echo level="verbose">old user input: ${old}</echo>

--- a/build.xml
+++ b/build.xml
@@ -402,7 +402,7 @@
         <echo>Using source.file: ${source.file}</echo>
 
         <!-- set old file to compare with (relative to comparison.xsl) -->
-        <property name="old.default" value="mei-source_canonicalized_v4.0.1.xml"/>
+        <property name="old.default" value="/${dir.build}/mei-source_canonicalized_v4.0.1.xml"/>
         <echo level="verbose">old.default: ${old.default}</echo>
         <echo level="verbose">old user input: ${old}</echo>
 

--- a/build.xml
+++ b/build.xml
@@ -421,15 +421,22 @@
         </condition>
         <echo>Using output folder: ${output.folder}</echo>
 
+        <!-- check if old.file is available -->
+        <condition property="old.available" value="true" else="false">
+              <available file="${old.file}"/>
+        </condition>
+        <echo message="old.file is available: ${old.available}"></echo>
         <!-- compare versions -->
-        <java classname="net.sf.saxon.Transform" classpathref="mei.classpath" failonerror="true" fork="true">
+        <java classname="net.sf.saxon.Transform" classpathref="mei.classpath" failonerror="true" fork="true" if:true="${old.available}">
             <arg value="-s:${source.file}"/>
             <arg value="-xsl:${basedir}/utils/compare_versions/comparison.xsl"/>
             <arg value="-xi:on"/>
             <arg value="output.folder=${output.folder}"/>
             <arg value="old.version.filename=${old.file}"/>
         </java>
-        <echo>Comparison done. See ${output.folder}/comparison.html for results.</echo>
+        <echo if:true="${old.available}">Comparison done. See ${output.folder}/comparison.html for results.</echo>
+        
+        <fail unless:true="${old.available}">Unfortunately the $old.file is not available at the specified location.</fail>
     </target>
 
     <target name="dist" description="Default main target; equivalent to calling ant without any target. Builds all artifacts, i.e., RNG and compiled ODDs of all customizations, guidelines html and PDF." depends="init-mei-classpath, canonicalize-source">

--- a/build.xml
+++ b/build.xml
@@ -433,7 +433,6 @@
     </target>
 
     <target name="dist" depends="init-mei-classpath, canonicalize-source">
-
         <classfileset refid="mei.classpath"/>
         <antcall target="build-customizations"/>
         <antcall target="build-compiled-odds"/>

--- a/build.xml
+++ b/build.xml
@@ -402,7 +402,7 @@
         <echo>Using source.file: ${source.file}</echo>
 
         <!-- set old file to compare with (relative to comparison.xml) -->
-        <property name="old.default" value="MEI_v4.0.1_canonicalized.xml"/>
+        <property name="old.default" value="mei-source_canonicalized_v4.0.1.xml"/>
         <echo level="verbose">old.default: ${old.default}</echo>
         <echo level="verbose">old user input: ${old}</echo>
 

--- a/build.xml
+++ b/build.xml
@@ -390,7 +390,7 @@
         </antcall>
     </target>
 
-    <target name="compare-versions" description="Compares the canonicalized sources of the MEI dev version with the previous stable version and creates an HTML output; custom versions and output folder can be set via -Dsource, -Dold and -Doutput input params. NB: path of old file is relative to comparison.xml, while others are relative to build.xml." depends="canonicalize-source">
+    <target name="compare-versions" description="Compares the canonicalized sources of the MEI dev version with the previous stable version and creates an HTML output; custom versions and output folder can be set via -Dsource, -Dold and -Doutput input params. NB: path of old file is relative to comparison.xsl, while others are relative to build.xml." depends="canonicalize-source">
         <!-- set source file (relative to build.xml) -->
         <property name="source.default" value="${dir.build}/mei-source_canonicalized.xml"/>
         <echo level="verbose">source.default: ${source.default}</echo>
@@ -401,7 +401,7 @@
         </condition>
         <echo>Using source.file: ${source.file}</echo>
 
-        <!-- set old file to compare with (relative to comparison.xsl) -->
+        <!-- set old file to compare with (absolute path needed for comparison.xsl) -->
         <property name="old.default" value="/${dir.build}/mei-source_canonicalized_v4.0.1.xml"/>
         <condition property="old.default-available" value="true">
                 <available file="${old.default}"/>
@@ -442,6 +442,7 @@
             <arg value="output.folder=${output.folder}"/>
             <arg value="old.version.filename=${old.file}"/>
         </java>
+
         <echo>Comparison done. See ${output.folder}/comparison.html for results.</echo>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -381,6 +381,48 @@
         </antcall>
     </target>
 
+    <target name="compare-versions" description="Compares the canonicalized sources of the MEI dev version with the previous stable version and creates an HTML output; custom versions and output folder can be set via -Dsource, -Dold and -Doutput input params. NB: path of old file is relative to comparison.xml, while others are relative to build.xml." depends="canonicalize-source">
+        <!-- set source file (relative to build.xml) -->
+        <property name="source.default" value="${dir.build}/mei-source_canonicalized.xml"/>
+        <echo level="verbose">source.default: ${source.default}</echo>
+        <echo level="verbose">source user input: ${source}</echo>
+
+        <condition property="source.file" value="${source}" else="${source.default}">
+            <isset property="source"/>
+        </condition>
+        <echo>Using source.file: ${source.file}</echo>
+
+        <!-- set old file to compare with (relative to comparison.xml) -->
+        <property name="old.default" value="MEI_v4.0.1_canonicalized.xml"/>
+        <echo level="verbose">old.default: ${old.default}</echo>
+        <echo level="verbose">old user input: ${old}</echo>
+
+        <condition property="old.file" value="${old}" else="${old.default}">
+            <isset property="old"/>
+        </condition>
+        <echo>Using old.file: ${old.file}</echo>
+
+        <!-- set ouput folder  (relative to build.xml) -->
+        <property name="output.default" value="./utils/compare_versions/"/>
+        <echo level="verbose">output.default: ${output.default}</echo>
+        <echo level="verbose">output user input: ${output}</echo>
+
+        <condition property="output.folder" value="${output}" else="${output.default}">
+            <isset property="output"/>
+        </condition>
+        <echo>Using output folder: ${output.folder}</echo>
+
+        <!-- compare versions -->
+        <java classname="net.sf.saxon.Transform" classpathref="mei.classpath" failonerror="true" fork="true">
+            <arg value="-s:${source.file}"/>
+            <arg value="-xsl:${basedir}/utils/compare_versions/comparison.xsl"/>
+            <arg value="-xi:on"/>
+            <arg value="output.folder=${output.folder}"/>
+            <arg value="old.version.filename=${old.file}"/>
+        </java>
+        <echo>Comparison done. See ${output.folder}/comparison.html for results.</echo>
+    </target>
+
     <target name="dist" depends="init-mei-classpath">
         <classfileset refid="mei.classpath"/>
         <antcall target="build-customizations"/>

--- a/build.xml
+++ b/build.xml
@@ -390,8 +390,8 @@
         </antcall>
     </target>
 
-    <target name="compare-versions" description="Compares the canonicalized sources of the MEI dev version with the previous stable version and creates an HTML output; custom versions and output folder can be set via -Dsource, -Dold and -Doutput input params. NB: path of old file is relative to comparison.xsl, while others are relative to build.xml." depends="canonicalize-source">
-        <!-- set source file (relative to build.xml) -->
+    <target name="compare-versions" description="Compares the canonicalized sources of the MEI dev version with the previous stable version and creates an HTML output; custom versions and output folder can be set via -Dsource, -Dold and -Doutput input params." depends="canonicalize-source">
+        <!-- set source file -->
         <property name="source.default" value="${dir.build}/mei-source_canonicalized.xml"/>
         <echo level="verbose">source.default: ${source.default}</echo>
         <echo level="verbose">source user input: ${source}</echo>
@@ -401,8 +401,8 @@
         </condition>
         <echo>Using source.file: ${source.file}</echo>
 
-        <!-- set old file to compare with (absolute path needed for comparison.xsl) -->
-        <property name="old.default" value="/${dir.build}/mei-source_canonicalized_v4.0.1.xml"/>
+        <!-- set old file to compare with -->
+        <property name="old.default" value="${dir.build}/mei-source_canonicalized_v4.0.1.xml"/>
         <condition property="old.default-available" value="true">
                 <available file="${old.default}"/>
         </condition>
@@ -424,7 +424,7 @@
 
         <fail unless:true="${old.available}">Unfortunately, the $old.file ${old.file} is not available at the specified location.</fail>
 
-        <!-- set ouput folder (relative to build.xml) -->
+        <!-- set ouput folder -->
         <property name="output.default" value="./utils/compare_versions/"/>
         <echo level="verbose">output.default: ${output.default}</echo>
         <echo level="verbose">output user input: ${output}</echo>
@@ -440,7 +440,7 @@
             <arg value="-xsl:${basedir}/utils/compare_versions/comparison.xsl"/>
             <arg value="-xi:on"/>
             <arg value="output.folder=${output.folder}"/>
-            <arg value="old.version.filename=${old.file}"/>
+            <arg value="old.version.filename=/${old.file}"/>
         </java>
 
         <echo>Comparison done. See ${output.folder}/comparison.html for results.</echo>

--- a/build.xml
+++ b/build.xml
@@ -416,7 +416,7 @@
         </condition>
         <echo>Using old.file: ${old.file}</echo>
 
-        <!-- check if old.file is available -->
+        <!-- check if old.file is available, otherwise fail early -->
         <condition property="old.available" value="true" else="false">
             <available file="${old.file}"/>
         </condition>

--- a/build.xml
+++ b/build.xml
@@ -440,7 +440,7 @@
             <arg value="-xsl:${basedir}/utils/compare_versions/comparison.xsl"/>
             <arg value="-xi:on"/>
             <arg value="output.folder=${output.folder}"/>
-            <arg value="old.version.filename=/${old.file}"/>
+            <arg value="old.version.filename=file:${old.file}"/>
         </java>
 
         <echo>Comparison done. See ${output.folder}/comparison.html for results.</echo>

--- a/build.xml
+++ b/build.xml
@@ -416,7 +416,15 @@
         </condition>
         <echo>Using old.file: ${old.file}</echo>
 
-        <!-- set ouput folder  (relative to build.xml) -->
+        <!-- check if old.file is available -->
+        <condition property="old.available" value="true" else="false">
+            <available file="${old.file}"/>
+        </condition>
+        <echo message="old.file available: ${old.available}"></echo>
+
+        <fail unless:true="${old.available}">Unfortunately, the $old.file ${old.file} is not available at the specified location.</fail>
+
+        <!-- set ouput folder (relative to build.xml) -->
         <property name="output.default" value="./utils/compare_versions/"/>
         <echo level="verbose">output.default: ${output.default}</echo>
         <echo level="verbose">output user input: ${output}</echo>

--- a/build.xml
+++ b/build.xml
@@ -403,6 +403,11 @@
 
         <!-- set old file to compare with (relative to comparison.xsl) -->
         <property name="old.default" value="/${dir.build}/mei-source_canonicalized_v4.0.1.xml"/>
+        <condition property="old.default-available" value="true">
+                <available file="${old.default}"/>
+        </condition>
+        <get src="https://raw.githubusercontent.com/music-encoding/schema/main/4.0.1/mei-source_canonicalized_v4.0.1.xml" dest="${old.default}" unless:true="${old.default-available}"/>
+
         <echo level="verbose">old.default: ${old.default}</echo>
         <echo level="verbose">old user input: ${old}</echo>
 

--- a/utils/compare_versions/comparison.xsl
+++ b/utils/compare_versions/comparison.xsl
@@ -50,15 +50,15 @@
         <xsl:result-document href="{$output}">
             ---
             layout: default
-            title: "Comparison of MEI <xsl:value-of select="$new.version"/> and <xsl:value-of select="$old.version"/>"
+            title: "Comparison of MEI v<xsl:value-of select="$new.version"/> and v<xsl:value-of select="$old.version"/>"
             ---
             <div>
                 <link rel="stylesheet" href="resources/css/main.css" />
                 <div id="headingArea">
                     <h1>MEI Comparison <br/>
                         <small>
-                            <span class=""><xsl:value-of select="$new.version"/></span> <span class=""> vs </span>
-                            <span class=""><xsl:value-of select="$old.version"/></span>
+                            <span class="">Version <xsl:value-of select="$new.version"/></span> <span class=""> vs </span>
+                            <span class="">Version <xsl:value-of select="$old.version"/></span>
                         </small>
                 </h1>
                 </div>

--- a/utils/compare_versions/comparison.xsl
+++ b/utils/compare_versions/comparison.xsl
@@ -227,7 +227,7 @@
                     or count($added.atts) gt 0
                     or count($removed.atts) gt 0
                     or count($changed.atts) gt 0">
-                    <tr class="c">
+                    <tr class="c" id="{$current.element}">
                         <td class="element ident"><xsl:value-of select="$current.element"/></td>
                         <td class="module"><xsl:value-of select="$new.element/@module"/></td>
                         <td class="desc">
@@ -318,7 +318,7 @@
             <xsl:for-each select="$added.elements">
                 <xsl:variable name="current.element" select="." as="xs:string"/>
                 <xsl:variable name="elementSpec" select="$new.file//tei:elementSpec[@ident = $current.element]" as="node()"/>
-                <tr class="a">
+                <tr class="a" id="{$current.element}">
                     <td class="element ident"><xsl:value-of select="$current.element"/></td>
                     <td class="module"><xsl:value-of select="$elementSpec/@module"/></td>
                     <td><xsl:value-of select="string-join($elementSpec/tei:desc//text(),' ')"/></td>
@@ -330,7 +330,7 @@
             <xsl:for-each select="$removed.elements">
                 <xsl:variable name="current.element" select="." as="xs:string"/>
                 <xsl:variable name="elementSpec" select="$old.file//tei:elementSpec[@ident = $current.element]" as="node()"/>
-                <tr class="r">
+                <tr class="r" id="{$current.element}">
                     <td class="element ident"><xsl:value-of select="$current.element"/></td>
                     <td class="module"><xsl:value-of select="$elementSpec/@module"/></td>
                     <td><xsl:value-of select="string-join($elementSpec/tei:desc//text(),' ')"/></td>
@@ -398,7 +398,7 @@
                     or count($casechanged.memberships) gt 0
                     or count($added.content) gt 0
                     or count($removed.content) gt 0">
-                    <tr class="c">
+                    <tr class="c" id="{$current.attribute}">
                         <td class="attClass ident"><xsl:value-of select="$current.attribute"/></td>
                         <td class="module"><xsl:value-of select="$new.attribute/@module"/></td>
                         <td class="desc">
@@ -465,7 +465,7 @@
             <xsl:for-each select="$added.attributes">
                 <xsl:variable name="current.element" select="." as="xs:string"/>
                 <xsl:variable name="elementSpec" select="$new.file//tei:classSpec[@type = 'atts' and @ident = $current.element]" as="node()"/>
-                <tr class="a">
+                <tr class="a" id="{$current.element}">
                     <td class="attClass ident"><xsl:value-of select="$current.element"/></td>
                     <td class="module"><xsl:value-of select="$elementSpec/@module"/></td>
                     <td><xsl:value-of select="string-join($elementSpec/tei:desc//text(),' ')"/></td>
@@ -477,7 +477,7 @@
             <xsl:for-each select="$removed.attributes">
                 <xsl:variable name="current.element" select="." as="xs:string"/>
                 <xsl:variable name="elementSpec" select="$old.file//tei:classSpec[@type = 'atts' and @ident = $current.element]" as="node()"/>
-                <tr class="r">
+                <tr class="r" id="{$current.element}">
                     <td class="attClass ident"><xsl:value-of select="$current.element"/></td>
                     <td class="module"><xsl:value-of select="$elementSpec/@module"/></td>
                     <td><xsl:value-of select="string-join($elementSpec/tei:desc//text(),' ')"/></td>
@@ -493,7 +493,7 @@
             <xsl:for-each select="$unchanged.attributes">
                 <xsl:variable name="current.element" select="." as="xs:string"/>
                 <xsl:variable name="elementSpec" select="$new.file//tei:classSpec[@type = 'atts' and @ident = $current.element]" as="node()"/>
-                <tr class="u">
+                <tr class="u" id="{$current.element}">
                     <td class="attClass ident"><xsl:value-of select="$current.element"/></td>
                     <td class="module unchanged"><xsl:value-of select="$elementSpec/@module"/></td>
                     <td class="unchanged"><xsl:value-of select="string-join($elementSpec/tei:desc//text(),' ')"/></td>
@@ -533,7 +533,7 @@
                 <xsl:if test="count($added.memberships) gt 0 
                     or count($removed.memberships) gt 0 
                     or count($casechanged.memberships) gt 0">
-                    <tr class="c">
+                    <tr class="c" id="{$current.model}">
                         <td class="modelClass ident"><xsl:value-of select="$current.model"/></td>
                         <td class="module"><xsl:value-of select="$new.model/@module"/></td>
                         <td class="desc">
@@ -582,7 +582,7 @@
             <xsl:for-each select="$added.models">
                 <xsl:variable name="current.element" select="." as="xs:string"/>
                 <xsl:variable name="elementSpec" select="$new.file//tei:classSpec[@type = 'model' and @ident = $current.element]" as="node()"/>
-                <tr class="a">
+                <tr class="a" id="${$current.element}">
                     <td class="modelClass ident"><xsl:value-of select="$current.element"/></td>
                     <td class="module"><xsl:value-of select="$elementSpec/@module"/></td>
                     <td><xsl:value-of select="string-join($elementSpec/tei:desc//text(),' ')"/></td>
@@ -594,7 +594,7 @@
             <xsl:for-each select="$removed.models">
                 <xsl:variable name="current.element" select="." as="xs:string"/>
                 <xsl:variable name="elementSpec" select="$old.file//tei:classSpec[@type = 'model' and @ident = $current.element]" as="node()"/>
-                <tr class="r">
+                <tr class="r" id="{$current.element}">
                     <td class="modelClass ident"><xsl:value-of select="$current.element"/></td>
                     <td class="module"><xsl:value-of select="$elementSpec/@module"/></td>
                     <td><xsl:value-of select="string-join($elementSpec/tei:desc//text(),' ')"/></td>
@@ -610,7 +610,7 @@
             <xsl:for-each select="$unchanged.models">
                 <xsl:variable name="current.element" select="." as="xs:string"/>
                 <xsl:variable name="elementSpec" select="$new.file//tei:classSpec[@type = 'model' and @ident = $current.element]" as="node()"/>
-                <tr class="u">
+                <tr class="u" id="{$current.element}">
                     <td class="modelClass ident"><xsl:value-of select="$current.element"/></td>
                     <td class="module unchanged"><xsl:value-of select="$elementSpec/@module"/></td>
                     <td class="unchanged"><xsl:value-of select="string-join($elementSpec/tei:desc//text(),' ')"/></td>
@@ -666,7 +666,7 @@
                 <xsl:if test="count($added.content) gt 0 
                     or count($removed.content) gt 0 
                     or count($casechanged.content) gt 0">
-                    <tr class="c">
+                    <tr class="c" id="{$current.macro}">
                         <td class="macroClass ident"><xsl:value-of select="$current.macro"/></td>
                         <td class="module"><xsl:value-of select="$new.model/@module"/></td>
                         <td class="desc">
@@ -715,7 +715,7 @@
             <xsl:for-each select="$added.macros">
                 <xsl:variable name="current.element" select="." as="xs:string"/>
                 <xsl:variable name="elementSpec" select="$new.file//tei:macroSpec[@type = 'pe' and @ident = $current.element]" as="node()"/>
-                <tr class="a">
+                <tr class="a" id="${$current.element}">
                     <td class="macroClass ident"><xsl:value-of select="$current.element"/></td>
                     <td class="module"><xsl:value-of select="$elementSpec/@module"/></td>
                     <td><xsl:value-of select="string-join($elementSpec/tei:desc//text(),' ')"/></td>
@@ -727,7 +727,7 @@
             <xsl:for-each select="$removed.macros">
                 <xsl:variable name="current.element" select="." as="xs:string"/>
                 <xsl:variable name="elementSpec" select="$old.file//tei:macroSpec[@type = 'pe' and @ident = $current.element]" as="node()"/>
-                <tr class="r">
+                <tr class="r" id="{$current.element}">
                     <td class="macroClass ident"><xsl:value-of select="$current.element"/></td>
                     <td class="module"><xsl:value-of select="$elementSpec/@module"/></td>
                     <td><xsl:value-of select="string-join($elementSpec/tei:desc//text(),' ')"/></td>
@@ -743,7 +743,7 @@
             <xsl:for-each select="$unchanged.macros">
                 <xsl:variable name="current.element" select="." as="xs:string"/>
                 <xsl:variable name="elementSpec" select="$new.file//tei:macroSpec[@type = 'pe' and @ident = $current.element]" as="node()"/>
-                <tr class="u">
+                <tr class="u" id="{$current.element}">
                     <td class="macroClass ident"><xsl:value-of select="$current.element"/></td>
                     <td class="module unchanged"><xsl:value-of select="$elementSpec/@module"/></td>
                     <td class="unchanged"><xsl:value-of select="string-join($elementSpec/tei:desc//text(),' ')"/></td>
@@ -797,7 +797,7 @@
                     or count($casechanged.references) gt 0
                     or count($added.values) gt 0
                     or count($removed.values) gt 0">
-                    <tr class="c">
+                    <tr class="c" id="{$current.macro}">
                         <td class="macroSpec datatype ident"><xsl:value-of select="$current.macro"/></td>
                         <td class="module"><xsl:value-of select="$new.macro/@module"/></td>
                         <td class="desc">
@@ -864,7 +864,7 @@
             <xsl:for-each select="$added.models">
                 <xsl:variable name="current.element" select="." as="xs:string"/>
                 <xsl:variable name="macroSpec" select="$new.file//tei:macroSpec[@type = 'dt' and @ident = $current.element]" as="node()"/>
-                <tr class="a">
+                <tr class="a" id="{$current.element}">
                     <td class="macroSpec datatype ident"><xsl:value-of select="$current.element"/></td>
                     <td class="module"><xsl:value-of select="$macroSpec/@module"/></td>
                     <td><xsl:value-of select="string-join($macroSpec/tei:desc//text(),' ')"/></td>
@@ -876,7 +876,7 @@
             <xsl:for-each select="$removed.models">
                 <xsl:variable name="current.element" select="." as="xs:string"/>
                 <xsl:variable name="macroSpec" select="$old.file//tei:macroSpec[@type = 'dt' and @ident = $current.element]" as="node()"/>
-                <tr class="r">
+                <tr class="r" id="{$current.element}">
                     <td class="macroSpec datatype ident"><xsl:value-of select="$current.element"/></td>
                     <td class="module"><xsl:value-of select="$macroSpec/@module"/></td>
                     <td><xsl:value-of select="string-join($macroSpec/tei:desc//text(),' ')"/></td>
@@ -892,7 +892,7 @@
             <xsl:for-each select="$unchanged.models">
                 <xsl:variable name="current.element" select="." as="xs:string"/>
                 <xsl:variable name="macroSpec" select="$new.file//tei:macroSpec[@type = 'dt' and @ident = $current.element]" as="node()"/>
-                <tr class="u">
+                <tr class="u" id="{$current.element}">
                     <td class="macroSpec datatype ident"><xsl:value-of select="$current.element"/></td>
                     <td class="module unchanged"><xsl:value-of select="$macroSpec/@module"/></td>
                     <td class="unchanged"><xsl:value-of select="string-join($macroSpec/tei:desc//text(),' ')"/></td>

--- a/utils/compare_versions/comparison.xsl
+++ b/utils/compare_versions/comparison.xsl
@@ -43,6 +43,11 @@
     <xsl:variable name="old.file" select="doc($old.version.filename)//tei:back" as="node()"/>
     <xsl:variable name="old.version" select="doc($old.version.filename)//tei:attDef[@ident='meiversion']//tei:defaultVal" as="xs:string"/>
     <xsl:variable name="old.version.major" select="concat('v',tokenize($old.version, '\.')[1])" as="xs:string"/>
+
+    <xsl:variable name="html.guidelines" select="'https://music-encoding.org/guidelines/'"/>
+    <xsl:variable name="new.guidelines" select="concat($html.guidelines,$new.version.major)"/>
+    <xsl:variable name="old.guidelines" select="concat($html.guidelines,$old.version.major)"/>
+
     <xsl:param name="output.folder" select="''" as="xs:string"/>
     <xsl:variable name="output" select="concat($output.folder,'comparison_',$new.version.major,'_vs_',$old.version.major, '.html')" />
     
@@ -307,11 +312,11 @@
                                     <xsl:variable name="current.att" select="." as="xs:string"/>
                                     <xsl:choose>
                                         <xsl:when test="$current.att = $added.atts/@ident">
-                                            <li class="added" title="added attribute"><span class="attribute"><a href="https://music-encoding.org/guidelines/v{$new.version.major}/elements/{$current.element}.html" target="_blank"><xsl:value-of select="$current.att"/></a></span></li>
+                                            <li class="added" title="added attribute"><span class="attribute"><a href="{$new.guidelines}/elements/{$current.element}.html" target="_blank"><xsl:value-of select="$current.att"/></a></span></li>
                                             <!-- TODO linking does not work here since there is no target to point to -->
                                         </xsl:when>
                                         <xsl:when test="$current.att = $changed.atts/@ident">
-                                            <li class="changed" title="changed attribute"><span class="attribute"><a href="https://music-encoding.org/guidelines/v{$new.version.major}/elements/{$current.element}.html" target="_blank"><xsl:value-of select="$current.att"/></a></span></li>
+                                            <li class="changed" title="changed attribute"><span class="attribute"><a href="{$new.guidelines}/elements/{$current.element}.html" target="_blank"><xsl:value-of select="$current.att"/></a></span></li>
                                         </xsl:when>
                                         <xsl:otherwise>
                                             <li class="unchanged"><span class="attribute"><xsl:value-of select="$current.att"/></span></li>
@@ -319,7 +324,7 @@
                                     </xsl:choose>
                                 </xsl:for-each>
                                 <xsl:for-each select="$removed.atts/@ident">
-                                    <li class="removed" title="removed attribute"><span class="attribute"><a href="https://music-encoding.org/guidelines/v{$old.version.major}/elements/{lower-case($current.element)}.html" target="_blank"><xsl:value-of select="."/></a></span></li>
+                                    <li class="removed" title="removed attribute"><span class="attribute"><a href="{$old.guidelines}/elements/{lower-case($current.element)}.html" target="_blank"><xsl:value-of select="."/></a></span></li>
                                 </xsl:for-each>
                             </ul>
                         </td>
@@ -338,10 +343,10 @@
                 <xsl:variable name="current.element" select="." as="xs:string"/>
                 <xsl:variable name="elementSpec" select="$new.file//tei:elementSpec[@ident = $current.element]" as="node()"/>
                 <tr class="a" id="{$current.element}">
-                    <td class="element ident"><a href="https://music-encoding.org/guidelines/v{$new.version.major}/elements/{$current.element}.html" target="_blank"><xsl:value-of select="$current.element"/></a></td>
+                    <td class="element ident"><a href="{$new.guidelines}/elements/{$current.element}.html" target="_blank"><xsl:value-of select="$current.element"/></a></td>
                     <td class="module"><xsl:value-of select="$elementSpec/@module"/></td>
                     <td><xsl:value-of select="string-join($elementSpec/tei:desc//text(),' ')"/></td>
-                    <td><a href="https://music-encoding.org/guidelines/v{$new.version.major}/elements/{$current.element}.html" target="_blank">visit guidelines</a></td>
+                    <td><a href="{$new.guidelines}/elements/{$current.element}.html" target="_blank">visit guidelines</a></td>
                 </tr>
             </xsl:for-each>
         </table>
@@ -354,7 +359,7 @@
                     <td class="element ident"><xsl:value-of select="$current.element"/></td>
                     <td class="module"><xsl:value-of select="$elementSpec/@module"/></td>
                     <td><xsl:value-of select="string-join($elementSpec/tei:desc//text(),' ')"/></td>
-                    <td><a href="https://music-encoding.org/guidelines/v{$old.version.major}/elements/{lower-case($current.element)}.html" target="_blank">visit guidelines</a></td>
+                    <td><a href="{$old.guidelines}/elements/{lower-case($current.element)}.html" target="_blank">visit guidelines</a></td>
                 </tr>
             </xsl:for-each>
         </table>
@@ -460,7 +465,7 @@
                                     <xsl:variable name="current.content" select="." as="xs:string"/>
                                     <xsl:choose>
                                         <xsl:when test="$current.content= $added.content">
-                                            <li class="added" title="added attribute"><span class="attribute"><a href="https://music-encoding.org/guidelines/v{$new.version.major}/attribute-classes/{$current.attribute}.html" target="_blank"><xsl:value-of select="$current.content"/></a></span></li>
+                                            <li class="added" title="added attribute"><span class="attribute"><a href="{$new.guidelines}/attribute-classes/{$current.attribute}.html" target="_blank"><xsl:value-of select="$current.content"/></a></span></li>
                                         </xsl:when>
                                         <xsl:otherwise>
                                             <li class="unchanged"><span class="attribute"><xsl:value-of select="$current.content"/></span></li>
@@ -468,7 +473,7 @@
                                     </xsl:choose>
                                 </xsl:for-each>
                                 <xsl:for-each select="$removed.content">
-                                    <li class="removed" title="removed attribute"><span class="attribute"><a href="https://music-encoding.org/guidelines/v{$old.version.major}/attribute-classes/{lower-case($current.attribute)}.html" target="_blank"><xsl:value-of select="."/></a></span></li>
+                                    <li class="removed" title="removed attribute"><span class="attribute"><a href="{$old.guidelines}/attribute-classes/{lower-case($current.attribute)}.html" target="_blank"><xsl:value-of select="."/></a></span></li>
                                 </xsl:for-each>
                             </ul>
                         </td>

--- a/utils/compare_versions/comparison.xsl
+++ b/utils/compare_versions/comparison.xsl
@@ -27,6 +27,8 @@
     <xsl:variable name="new.file" select="//tei:back" as="node()"/>
     <xsl:variable name="new.version" select="//tei:fileDesc/tei:editionStmt/tei:edition/text()" as="xs:string"/>
     <xsl:variable name="old.version" select="doc($old.version.filename)//tei:fileDesc/tei:editionStmt/tei:edition/text()" as="xs:string"/>
+    <xsl:variable name="new.version.major" select="tokenize((//tei:attDef[@ident='meiversion']//tei:valItem/@ident)[1], '\.')[1]" as="xs:string"/>
+    <xsl:variable name="old.version.major" select="tokenize((doc($old.version.filename)//tei:attDef[@ident='meiversion']//tei:valItem/@ident)[1], '\.')[1]" as="xs:string"/>
     
     <xsl:template match="/">
         <xsl:result-document href="{$output}">

--- a/utils/compare_versions/comparison.xsl
+++ b/utils/compare_versions/comparison.xsl
@@ -25,10 +25,10 @@
     <xsl:param name="old.version.filename" select="''" as="xs:string"/>
     <xsl:variable name="old.file" select="doc($old.version.filename)//tei:back" as="node()"/>
     <xsl:variable name="new.file" select="//tei:back" as="node()"/>
+    <xsl:variable name="new.version" select="//tei:fileDesc/tei:editionStmt/tei:edition/text()" as="xs:string"/>
+    <xsl:variable name="old.version" select="doc($old.version.filename)//tei:fileDesc/tei:editionStmt/tei:edition/text()" as="xs:string"/>
     
     <xsl:template match="/">
-        <xsl:variable name="new.version" select="//tei:fileDesc/tei:editionStmt/tei:edition/text()" as="xs:string"/>
-        <xsl:variable name="old.version" select="doc($old.version.filename)//tei:fileDesc/tei:editionStmt/tei:edition/text()" as="xs:string"/>
         <xsl:result-document href="{$output}">
             ---
             layout: default

--- a/utils/compare_versions/comparison.xsl
+++ b/utils/compare_versions/comparison.xsl
@@ -246,11 +246,11 @@
                                 <xsl:for-each select="$new.memberships">
                                     <xsl:variable name="current.class" select="." as="xs:string"/>
                                     <xsl:choose>
-                                        <xsl:when test="$current.class= $added.memberships">
-                                            <li class="added" title="added class"><xsl:value-of select="$current.class"/></li>
+                                        <xsl:when test="$current.class = $added.memberships">
+                                            <li class="added" title="added class"><a href="#{$current.class}"><xsl:value-of select="$current.class"/></a></li>
                                         </xsl:when>
                                         <xsl:when test="$current.class = $casechanged.memberships">
-                                            <li class="casechanged" title="was: {$old.memberships[lower-case(.) = lower-case($current.class)]}"><xsl:value-of select="$current.class"/></li>
+                                            <li class="casechanged" title="was: {$old.memberships[lower-case(.) = lower-case($current.class)]}"><a href="#{$current.class}"><xsl:value-of select="$current.class"/></a></li>
                                         </xsl:when>
                                         <xsl:otherwise>
                                             <li class="unchanged"><xsl:value-of select="$current.class"/></li>
@@ -258,7 +258,7 @@
                                     </xsl:choose>
                                 </xsl:for-each>
                                 <xsl:for-each select="$removed.memberships">
-                                    <li class="removed" title="removed class"><xsl:value-of select="."/></li>
+                                    <li class="removed" title="removed class"><a href="#{.}"><xsl:value-of select="."/></a></li>
                                 </xsl:for-each>
                             </ul>
                         </td>
@@ -268,10 +268,10 @@
                                     <xsl:variable name="current.content" select="." as="xs:string"/>
                                     <xsl:choose>
                                         <xsl:when test="$current.content= $added.content">
-                                            <li class="added" title="added content"><xsl:value-of select="$current.content"/></li>
+                                            <li class="added" title="added content"><a href="#{$current.content}"><xsl:value-of select="$current.content"/></a></li>
                                         </xsl:when>
                                         <xsl:when test="$current.content = $casechanged.content">
-                                            <li class="casechanged" title="was: {$old.content[lower-case(.) = lower-case($current.content)]}"><xsl:value-of select="$current.content"/></li>
+                                            <li class="casechanged" title="was: {$old.content[lower-case(.) = lower-case($current.content)]}"><a href="#{$current.content}"><xsl:value-of select="$current.content"/></a></li>
                                         </xsl:when>
                                         <xsl:otherwise>
                                             <li class="unchanged"><xsl:value-of select="$current.content"/></li>
@@ -279,7 +279,7 @@
                                     </xsl:choose>
                                 </xsl:for-each>
                                 <xsl:for-each select="$removed.content">
-                                    <li class="removed" title="removed content"><xsl:value-of select="."/></li>
+                                    <li class="removed" title="removed content"><a href="#{.}"><xsl:value-of select="."/></a></li>
                                 </xsl:for-each>
                             </ul>
                         </td>
@@ -289,10 +289,11 @@
                                     <xsl:variable name="current.att" select="." as="xs:string"/>
                                     <xsl:choose>
                                         <xsl:when test="$current.att = $added.atts/@ident">
-                                            <li class="added" title="added attribute"><span class="attribute"><xsl:value-of select="$current.att"/></span></li>
+                                            <li class="added" title="added attribute"><span class="attribute"><a href="https://music-encoding.org/guidelines/v{$new.version.major}/elements/{$current.element}.html" target="_blank"><xsl:value-of select="$current.att"/></a></span></li>
+                                            <!-- TODO linking does not work here since there is no target to point to -->
                                         </xsl:when>
                                         <xsl:when test="$current.att = $changed.atts/@ident">
-                                            <li class="changed" title="changed attribute"><span class="attribute"><xsl:value-of select="$current.att"/></span></li>
+                                            <li class="changed" title="changed attribute"><span class="attribute"><a href="https://music-encoding.org/guidelines/v{$new.version.major}/elements/{$current.element}.html" target="_blank"><xsl:value-of select="$current.att"/></a></span></li>
                                         </xsl:when>
                                         <xsl:otherwise>
                                             <li class="unchanged"><span class="attribute"><xsl:value-of select="$current.att"/></span></li>
@@ -300,7 +301,7 @@
                                     </xsl:choose>
                                 </xsl:for-each>
                                 <xsl:for-each select="$removed.atts/@ident">
-                                    <li class="removed" title="removed attribute"><span class="attribute"><xsl:value-of select="."/></span></li>
+                                    <li class="removed" title="removed attribute"><span class="attribute"><a href="https://music-encoding.org/guidelines/v{$old.version.major}/elements/{lower-case($current.element)}.html" target="_blank"><xsl:value-of select="."/></a></span></li>
                                 </xsl:for-each>
                             </ul>
                         </td>
@@ -319,9 +320,10 @@
                 <xsl:variable name="current.element" select="." as="xs:string"/>
                 <xsl:variable name="elementSpec" select="$new.file//tei:elementSpec[@ident = $current.element]" as="node()"/>
                 <tr class="a" id="{$current.element}">
-                    <td class="element ident"><xsl:value-of select="$current.element"/></td>
+                    <td class="element ident"><a href="https://music-encoding.org/guidelines/v{$new.version.major}/elements/{$current.element}.html" target="_blank"><xsl:value-of select="$current.element"/></a></td>
                     <td class="module"><xsl:value-of select="$elementSpec/@module"/></td>
                     <td><xsl:value-of select="string-join($elementSpec/tei:desc//text(),' ')"/></td>
+                    <td><a href="https://music-encoding.org/guidelines/v{$new.version.major}/elements/{$current.element}.html" target="_blank">visit guidelines</a></td>
                 </tr>
             </xsl:for-each>
         </table>
@@ -334,6 +336,7 @@
                     <td class="element ident"><xsl:value-of select="$current.element"/></td>
                     <td class="module"><xsl:value-of select="$elementSpec/@module"/></td>
                     <td><xsl:value-of select="string-join($elementSpec/tei:desc//text(),' ')"/></td>
+                    <td><a href="https://music-encoding.org/guidelines/v{$old.version.major}/elements/{lower-case($current.element)}.html" target="_blank">visit guidelines</a></td>
                 </tr>
             </xsl:for-each>
         </table>
@@ -417,8 +420,8 @@
                                 <xsl:for-each select="$new.memberships">
                                     <xsl:variable name="current.class" select="." as="xs:string"/>
                                     <xsl:choose>
-                                        <xsl:when test="$current.class= $added.memberships">
-                                            <li class="added" title="added class"><xsl:value-of select="$current.class"/></li>
+                                        <xsl:when test="$current.class = $added.memberships">
+                                            <li class="added" title="added class"><a href="#{$current.class}"><xsl:value-of select="$current.class"/></a></li>
                                         </xsl:when>
                                         <xsl:when test="$current.class = $casechanged.memberships">
                                             <li class="casechanged" title="was: {$old.memberships[lower-case(.) = lower-case($current.class)]}"><xsl:value-of select="$current.class"/></li>
@@ -429,7 +432,7 @@
                                     </xsl:choose>
                                 </xsl:for-each>
                                 <xsl:for-each select="$removed.memberships">
-                                    <li class="removed" title="removed class"><xsl:value-of select="."/></li>
+                                    <li class="removed" title="removed class"><a href="#{.}"><xsl:value-of select="."/></a></li>
                                 </xsl:for-each>
                             </ul>
                         </td>
@@ -439,7 +442,7 @@
                                     <xsl:variable name="current.content" select="." as="xs:string"/>
                                     <xsl:choose>
                                         <xsl:when test="$current.content= $added.content">
-                                            <li class="added" title="added attribute"><span class="attribute"><xsl:value-of select="$current.content"/></span></li>
+                                            <li class="added" title="added attribute"><span class="attribute"><a href="https://music-encoding.org/guidelines/v{$new.version.major}/attribute-classes/{$current.attribute}.html" target="_blank"><xsl:value-of select="$current.content"/></a></span></li>
                                         </xsl:when>
                                         <xsl:otherwise>
                                             <li class="unchanged"><span class="attribute"><xsl:value-of select="$current.content"/></span></li>
@@ -447,7 +450,7 @@
                                     </xsl:choose>
                                 </xsl:for-each>
                                 <xsl:for-each select="$removed.content">
-                                    <li class="removed" title="removed attribute"><span class="attribute"><xsl:value-of select="."/></span></li>
+                                    <li class="removed" title="removed attribute"><span class="attribute"><a href="https://music-encoding.org/guidelines/v{$old.version.major}/attribute-classes/{lower-case($current.attribute)}.html" target="_blank"><xsl:value-of select="."/></a></span></li>
                                 </xsl:for-each>
                             </ul>
                         </td>

--- a/utils/compare_versions/comparison.xsl
+++ b/utils/compare_versions/comparison.xsl
@@ -24,8 +24,7 @@
     
     <xsl:output method="html" indent="yes"/>
     
-    <xsl:param name="output.folder" select="''" as="xs:string"/>
-    <xsl:variable name="output" select="concat($output.folder,'comparison.html')" />
+    <xsl:variable name="new.file" select="//tei:back" as="node()"/>
     <xsl:variable name="new.version" select="//tei:attDef[@ident='meiversion']//tei:defaultVal" as="xs:string"/>
     <xsl:variable name="new.version.major" as="xs:string*">
         <xsl:choose>
@@ -42,9 +41,10 @@
     
     <xsl:param name="old.version.filename" select="''" as="xs:string"/>
     <xsl:variable name="old.file" select="doc($old.version.filename)//tei:back" as="node()"/>
-    <xsl:variable name="new.file" select="//tei:back" as="node()"/>
     <xsl:variable name="old.version" select="doc($old.version.filename)//tei:attDef[@ident='meiversion']//tei:defaultVal" as="xs:string"/>
     <xsl:variable name="old.version.major" select="concat('v',tokenize($old.version, '\.')[1])" as="xs:string"/>
+    <xsl:param name="output.folder" select="''" as="xs:string"/>
+    <xsl:variable name="output" select="concat($output.folder,'comparison_',$new.version.major,'_vs_',$old.version.major, '.html')" />
     
     <xsl:template match="/">
         <xsl:result-document href="{$output}">

--- a/utils/compare_versions/comparison.xsl
+++ b/utils/compare_versions/comparison.xsl
@@ -27,12 +27,24 @@
     <xsl:param name="output.folder" select="''" as="xs:string"/>
     <xsl:variable name="output" select="concat($output.folder,'comparison.html')" />
     <xsl:variable name="new.version" select="//tei:attDef[@ident='meiversion']//tei:defaultVal" as="xs:string"/>
+    <xsl:variable name="new.version.major" as="xs:string*">
+        <xsl:choose>
+            <xsl:when test="tokenize($new.version, '-')[2] = 'dev'">
+                <!-- use 'dev' if version contains dev -->
+                <xsl:value-of select="'dev'"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <!-- otherwise use major version number with leading 'v', e.g. v5 -->
+                <xsl:value-of select="concat('v',tokenize($new.version, '\.')[1])"/>
+            </xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+    
     <xsl:param name="old.version.filename" select="''" as="xs:string"/>
     <xsl:variable name="old.file" select="doc($old.version.filename)//tei:back" as="node()"/>
     <xsl:variable name="new.file" select="//tei:back" as="node()"/>
-    <xsl:variable name="new.version.major" select="tokenize((//tei:attDef[@ident='meiversion']//tei:valItem/@ident)[1], '\.')[1]" as="xs:string"/>
-    <xsl:variable name="old.version.major" select="tokenize((doc($old.version.filename)//tei:attDef[@ident='meiversion']//tei:valItem/@ident)[1], '\.')[1]" as="xs:string"/>
     <xsl:variable name="old.version" select="doc($old.version.filename)//tei:attDef[@ident='meiversion']//tei:defaultVal" as="xs:string"/>
+    <xsl:variable name="old.version.major" select="concat('v',tokenize($old.version, '\.')[1])" as="xs:string"/>
     
     <xsl:template match="/">
         <xsl:result-document href="{$output}">

--- a/utils/compare_versions/comparison.xsl
+++ b/utils/compare_versions/comparison.xsl
@@ -42,12 +42,14 @@
             ---
             <div>
                 <link rel="stylesheet" href="resources/css/main.css" />
-                <h1>MEI Comparison <br/>
-                    <small>
-                        <span class=""><xsl:value-of select="$new.version"/></span> <span class=""> vs </span>
-                        <span class=""><xsl:value-of select="$old.version"/></span>
-                    </small>
+                <div id="headingArea">
+                    <h1>MEI Comparison <br/>
+                        <small>
+                            <span class=""><xsl:value-of select="$new.version"/></span> <span class=""> vs </span>
+                            <span class=""><xsl:value-of select="$old.version"/></span>
+                        </small>
                 </h1>
+                </div>
                 <div id="chartArea">
                     <div id="chartsBox">
                         <div id="elementsChart" class="chartBox"><label>Elements</label></div>

--- a/utils/compare_versions/comparison.xsl
+++ b/utils/compare_versions/comparison.xsl
@@ -18,6 +18,10 @@
         </xd:desc>
     </xd:doc>
     
+    <!-- TODO content link to text has no target -->
+    <!-- TODO content link to empty has no target -->
+    <!-- TODO linking v4 element-names are lowercase while v5 are uppercase, this might change in the future, so maybe checking availability or switching between version instead of making a general decision would be beneficial. -->
+    
     <xsl:output method="html" indent="yes"/>
     
     <xsl:param name="output.folder" select="''" as="xs:string"/>

--- a/utils/compare_versions/comparison.xsl
+++ b/utils/compare_versions/comparison.xsl
@@ -26,13 +26,13 @@
     
     <xsl:param name="output.folder" select="''" as="xs:string"/>
     <xsl:variable name="output" select="concat($output.folder,'comparison.html')" />
+    <xsl:variable name="new.version" select="//tei:attDef[@ident='meiversion']//tei:defaultVal" as="xs:string"/>
     <xsl:param name="old.version.filename" select="''" as="xs:string"/>
     <xsl:variable name="old.file" select="doc($old.version.filename)//tei:back" as="node()"/>
     <xsl:variable name="new.file" select="//tei:back" as="node()"/>
-    <xsl:variable name="new.version" select="//tei:fileDesc/tei:editionStmt/tei:edition/text()" as="xs:string"/>
-    <xsl:variable name="old.version" select="doc($old.version.filename)//tei:fileDesc/tei:editionStmt/tei:edition/text()" as="xs:string"/>
     <xsl:variable name="new.version.major" select="tokenize((//tei:attDef[@ident='meiversion']//tei:valItem/@ident)[1], '\.')[1]" as="xs:string"/>
     <xsl:variable name="old.version.major" select="tokenize((doc($old.version.filename)//tei:attDef[@ident='meiversion']//tei:valItem/@ident)[1], '\.')[1]" as="xs:string"/>
+    <xsl:variable name="old.version" select="doc($old.version.filename)//tei:attDef[@ident='meiversion']//tei:defaultVal" as="xs:string"/>
     
     <xsl:template match="/">
         <xsl:result-document href="{$output}">

--- a/utils/compare_versions/comparison.xsl
+++ b/utils/compare_versions/comparison.xsl
@@ -20,14 +20,16 @@
     
     <xsl:output method="html" indent="yes"/>
     
-    <xsl:param name="old.version.filename" select="'MEI_v4.0.1_canonicalized.xml'" as="xs:string"/>
+    <xsl:param name="output.folder" select="''" as="xs:string"/>
+    <xsl:variable name="output" select="concat($output.folder,'comparison.html')" />
+    <xsl:param name="old.version.filename" select="''" as="xs:string"/>
     <xsl:variable name="old.file" select="doc($old.version.filename)//tei:back" as="node()"/>
     <xsl:variable name="new.file" select="//tei:back" as="node()"/>
     
     <xsl:template match="/">
         <xsl:variable name="new.version" select="//tei:fileDesc/tei:editionStmt/tei:edition/text()" as="xs:string"/>
         <xsl:variable name="old.version" select="doc($old.version.filename)//tei:fileDesc/tei:editionStmt/tei:edition/text()" as="xs:string"/>
-        <xsl:result-document href="comparison.html">
+        <xsl:result-document href="{$output}">
             ---
             layout: default
             title: "Comparison of MEI <xsl:value-of select="$new.version"/> and <xsl:value-of select="$old.version"/>"

--- a/utils/compare_versions/resources/css/main.css
+++ b/utils/compare_versions/resources/css/main.css
@@ -1,14 +1,14 @@
-.added {
+.added, .added a {
     color: #32c20e;
     fill: #32c20e;
 }
 
-.removed {
+.removed, .removed a {
     color: #c4370a;
     fill: #c4370a;
 }
 
-.casechanged, .changed {
+.casechanged, .casechanged a, .changed, .changed a {
     color: #c47f0a;
     fill: #c47f0a;
 }

--- a/utils/compare_versions/resources/css/main.css
+++ b/utils/compare_versions/resources/css/main.css
@@ -109,3 +109,38 @@ td.classes ul li.changed:before, td.content ul li.changed:before, td.atts ul li.
     text-align: center;
     padding-bottom: .2rem;
 }
+
+#headingArea {;
+    position: sticky;
+    background-color: #ffffff;
+    top: 0;
+    left: 0;
+    right: 0;
+    margin:0 -8px;
+    padding: 8px;
+    z-index: 3;
+    height: 10rem;
+    display:block;
+    box-shadow: 0px 0px 15px  gray;
+}
+
+h1 {;
+    position: sticky;
+    background-color: #ffffff;
+    top: 0;
+    z-index: 4;
+}
+
+h2 {
+    position: sticky;
+    top: 6.5rem;
+    background-color: #ffffff;
+    z-index: 4;
+}
+
+h3 {
+    position: sticky;
+    top: 8.5rem;
+    background-color: #ffffff;
+    z-index: 4;
+}

--- a/utils/compare_versions/resources/css/main.css
+++ b/utils/compare_versions/resources/css/main.css
@@ -22,6 +22,14 @@
     content: '@';
 }
 
+.element:before {
+    content: '<';
+}
+
+.element:after {
+    content: '>';
+}
+
 .block {
     display: block;
 }


### PR DESCRIPTION
This PR adds an Ant target to run the MEI version comparison from build.xml. This prepares to include the comparison in the CI build process and gives the ability to include the comparison output file with releases and commits (for the dev branch).
By default, the target compares the current version (dev) to the previous version (MEI 4.0.1), but any other version can be compared via customized inputs.

New ant target tested locally and with docker.

Closes #1256 

