### PR TITLE
schema: remove duplicated attributes to ensure schema validity

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -915,34 +915,6 @@
                     </remarks>
                 </elementSpec>
                 
-                <!-- re-allow @stem.dir etc. on chords -->
-                <elementSpec ident="chord" module="MEI.shared" mode="change">
-                    <desc>A simultaneous sounding of two or more notes in the same layer *with the same
-                        duration*.</desc>
-                    <classes mode="replace">
-                        <memberOf key="att.common"/>
-                        <memberOf key="att.facsimile"/>
-                        <memberOf key="att.chord.log"/>
-                        <memberOf key="att.chord.vis"/>
-                        <memberOf key="att.chord.ges"/>
-                        <memberOf key="att.chord.anl"/>
-                        <memberOf key="att.stems" mode="add"/>
-                        <memberOf key="model.eventLike"/>
-                    </classes>
-                    <content>
-                        <rng:zeroOrMore>
-                            <rng:choice>
-                                <rng:ref name="model.chordPart"/>
-                                <rng:ref name="model.appLike"/>
-                                <rng:ref name="model.editLike"/>
-                                <rng:ref name="model.sylLike"/>
-                                <rng:ref name="model.transcriptionLike"/>
-                                <rng:ref name="model.verseLike"/>
-                            </rng:choice>
-                        </rng:zeroOrMore>
-                    </content>
-                </elementSpec>
-                
                 <!-- re-allow @n on selected elements -->
                 <elementSpec ident="measure" module="MEI.cmn" mode="change">
                     <desc>Unit of musical time consisting of a fixed number of note values of a given type, as

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -6989,14 +6989,6 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <attList>
-      <attDef ident="func" usage="opt">
-        <desc xml:lang="en">Records the function (i.e., placement) of the page footer.</desc>
-        <datatype>
-          <rng:ref name="data.PGFUNC"/>
-        </datatype>
-      </attDef>
-    </attList>
     <remarks xml:lang="en">
       <p>This element is used to capture the textual data that often appears in
         printed music. It may also be used for similarly formatted material in manuscripts. When
@@ -7030,14 +7022,6 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <attList>
-      <attDef ident="func" usage="opt">
-        <desc xml:lang="en">Records the function (i.e., placement) of the page header.</desc>
-        <datatype>
-          <rng:ref name="data.PGFUNC"/>
-        </datatype>
-      </attDef>
-    </attList>
     <remarks xml:lang="en">
       <p>This element is used to capture the textual data that often appears in
         printed music. It may also be used for similarly formatted material in manuscripts. When


### PR DESCRIPTION
This pull request addresses and closes #1260 and fixes:
* duplicate `@func` on `<pgHead>` and `<pgFoot>` by removing the unintentional reintroduction of a direct attribute definition in 7ce8ecd merging #1157
* deleting the `<elementSpec ident="chord">` from the mei-basic customization which duplicated the membership of `<chord>` in `att.stems`