### PR TITLE
build: avoid multiple runs of initial targets and improve logging

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -138,31 +138,36 @@
     
     <target name="init" description="Initialize: checks if saxon and xerces are available, and if not, downloads them. Checks if prince is available.">
         <!-- check if xerces is available -->
-        <condition  property="xerces-available" value="true" else="false">
+        <condition property="xerces-available">
             <or>
                 <available file="${dir.lib.xerces}/${xerces.jar.file}"/>
                 <available classname="org.apache.xerces.jaxp.SAXParserFactoryImpl"/>
             </or>
         </condition>
-        <echo message="xerces available: ${xerces-available}"/>
+        <echo if:set="xerces-available" message="xerces available: ${xerces-available}"/>
+        <echo unless:set="xerces-available" message="xerces available: false"/>
         <!-- check if saxon is available -->
-        <condition  property="saxon-available" value="true" else="false">
+        <condition property="saxon-available">
             <or>
                 <available file="${dir.lib.saxon}/${saxon.jar.file}"/>
                 <available classname="net.sf.saxon.Transform"/>
             </or>
         </condition>
-        <echo message="saxon available: ${saxon-available}"/>
+        <echo if:set="saxon-available" message="saxon available: ${saxon-available}"/>
+        <echo unless:set="saxon-available" message="saxon available: false"/>
         <!-- check for prince -->
-        <condition property="prince-available" value="true" else="false">
+        <condition property="prince-available">
             <available file="prince" filepath="${env.PATH}" />
         </condition>
-        <echo message="prince available: ${prince-available}"/>
+        <echo if:set="prince-available" message="prince available: ${prince-available}"/>
+        <echo unless:set="prince-available" message="prince available: false"/>
+
         <antcall target="saxon-prepare" unless:true="${saxon-available}"/>
         <antcall target="xerces-download" unless:true="${xerces-available}"/>
+
         <echo>initialized</echo>
     </target>
-    
+
     <target name="init-mei-classpath" description="Initialize classpath: initializes the mei.classpath by prepending the jar files contained in the lib directory to the java classpath." depends="init">
         <path id="mei.classpath">
             <fileset dir="lib" erroronmissingdir="false">

--- a/build.xml
+++ b/build.xml
@@ -199,12 +199,13 @@
     </target>
 
     <target name="canonicalize-source" description="Canonicalizes the mei-source.xml, i.e. resolves xincludes and puts result in dist/mei-source_canonicalized.xml" depends="init-mei-classpath">
-        <java classname="net.sf.saxon.Transform" classpathref="mei.classpath" failonerror="true" fork="true">
+        <java unless:set="canonicalize-source.done" classname="net.sf.saxon.Transform" classpathref="mei.classpath" failonerror="true" fork="true">
             <arg value="-s:${basedir}/source/mei-source.xml"/>
             <arg value="-xsl:${basedir}/utils/canonicalization/copy.xsl"/>
             <arg value="-o:${dir.build}/mei-source_canonicalized.xml"/>
             <arg value="-xi:on"/>
         </java>
+        <property name="canonicalize-source.done" value="true"/>
     </target>
 
     <target name="build-compiled-odd" depends="canonicalize-source">

--- a/build.xml
+++ b/build.xml
@@ -198,7 +198,7 @@
         <get src="https://www.oxygenxml.com/maven/com/oxygenxml/oxygen-basic-utilities/${xerces.version}/${oxygen.basic.utilites.jar.file}" dest="${dir.lib.xerces}"/>
     </target>
 
-    <target name="canonicalize-source" description="Canonicalizes the mei-source.xml, i.e. resolves xincludes and puts result in dist/mei-source_canonicalized.xml" depends="init-mei-classpath">
+    <target name="canonicalize-source" description="Canonicalizes the mei-source.xml, i.e. resolves xincludes and puts result in build/mei-source_canonicalized.xml" depends="init-mei-classpath" >
         <java unless:set="canonicalize-source.done" classname="net.sf.saxon.Transform" classpathref="mei.classpath" failonerror="true" fork="true">
             <arg value="-s:${basedir}/source/mei-source.xml"/>
             <arg value="-xsl:${basedir}/utils/canonicalization/copy.xsl"/>

--- a/build.xml
+++ b/build.xml
@@ -345,7 +345,7 @@
         </copy>
     </target>
 
-    <target name="build-customizations">
+    <target name="build-customizations" depends="canonicalize-source">
         <antcall target="build-rng">
             <param name="customization.path" value="${basedir}/customizations/mei-all.xml"/>
         </antcall>
@@ -366,7 +366,7 @@
         </antcall>
     </target>
 
-    <target name="build-compiled-odds">
+    <target name="build-compiled-odds" depends="canonicalize-source">
         <antcall target="build-compiled-odd">
             <param name="customization.path" value="${basedir}/customizations/mei-all.xml"/>
         </antcall>
@@ -387,7 +387,7 @@
         </antcall>
     </target>
 
-    <target name="dist" depends="init-mei-classpath">
+    <target name="dist" depends="init-mei-classpath, canonicalize-source">
         <classfileset refid="mei.classpath"/>
         <antcall target="build-customizations"/>
         <antcall target="build-compiled-odds"/>

--- a/build.xml
+++ b/build.xml
@@ -175,6 +175,7 @@
             </fileset>
             <pathelement path="${java.class.path}"/>
         </path>
+        <echo>mei.classpath set</echo>
     </target>
 
     <target name="saxon-download" unless="${saxon-available}">
@@ -199,6 +200,7 @@
     </target>
 
     <target name="canonicalize-source" description="Canonicalizes the mei-source.xml, i.e. resolves xincludes and puts result in build/mei-source_canonicalized.xml" depends="init-mei-classpath" >
+        <echo unless:set="canonicalize-source.done">canonicalizing source...</echo>
         <java unless:set="canonicalize-source.done" classname="net.sf.saxon.Transform" classpathref="mei.classpath" failonerror="true" fork="true">
             <arg value="-s:${basedir}/source/mei-source.xml"/>
             <arg value="-xsl:${basedir}/utils/canonicalization/copy.xsl"/>
@@ -206,6 +208,7 @@
             <arg value="-xi:on"/>
         </java>
         <property name="canonicalize-source.done" value="true"/>
+        <echo>canonicalized source available: ${canonicalize-source.done}</echo>
     </target>
 
     <target name="build-compiled-odd" depends="canonicalize-source">


### PR DESCRIPTION
This PR improves performance and logging of the build.xml by running `canonicalize-source` only once and not with every sub build target again. It also does improve the handling of the availability checks in `init` which are immutable ant properties and did not update on subsequent runs. This means, the condition itself cannot be set to true OR false, but will be set to true if a condition is met, otherwise stays unset. With `if:set` resp. `unless:set`, the output of the echo message and the content of the property are then updated correctly.

Fixes #1262
Fixes #1263