### PR TITLE
 utils: fix display of facet tab contents in guidelines html

### DIFF
--- a/utils/guidelines_xslt/odd2html/htmlFile.xsl
+++ b/utils/guidelines_xslt/odd2html/htmlFile.xsl
@@ -280,9 +280,9 @@
                                 }
                             }
 
-                            function getDisplayStyle(dataDisplay) {
-                                // split dataDisplay string at underscore, e.g. 'attributes_full' to ['attributes','full']
-                                const [, displayStyle = ''] = dataDisplay.split('_');
+                            function getDisplayStyle(style) {
+                                // split dataDisplay string at underscore, e.g. 'attributes_full' to ['attributes','full'] and return the second part of the array
+                                const [_, displayStyle = 'compact'] = style.split('_');
                                 return displayStyle;
                             }
 

--- a/utils/guidelines_xslt/odd2html/htmlFile.xsl
+++ b/utils/guidelines_xslt/odd2html/htmlFile.xsl
@@ -270,7 +270,7 @@
                                 if(localStorage.getItem(storageName) === null) {
                                     setTabs(facetId,defaultDataDisplay?.trim());
                                 } else {
-                                    setTabs(facetId,localStorage.getItem(storageName)?.trim());
+                                    setTabs(facetId,`${facetId}_${localStorage.getItem(storageName)?.trim()}`);
                                 }
                                 
                                 const tabs = facetUl.querySelectorAll('.tab-item a');


### PR DESCRIPTION
As a follow-up of #1219, this PR addresses an overlooked issue with the facet tabs that now do not show up anymore. The style name to activate the current tab from the localStorage attribute was incorrect. This was overlooked sinced it worked when the style name was created from scratch (with localStorage items deleted) but not with already existing localStorage items. 

In other terms: The `setTabs` function received a correct value of `attributes_compact` if localStorage was not set before. But it received a wrong value of just `compact` if it got the value from the localStorage. This is now adjusted.

The PR also makes `compact` the default value of the display style, in case none is given.

Fixes #1265 