### PR TITLE
schema: add missing values for double accidentals

### DIFF
--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -107,6 +107,18 @@
         <valItem ident="nd">
           <desc xml:lang="en">Natural note lowered by quarter tone (natural modified by arrow).</desc>
         </valItem>
+        <valItem ident="xu">
+          <desc xml:lang="en">Double sharp note raised by quarter tone (double sharp modified by arrow).</desc>
+        </valItem>
+        <valItem ident="xd">
+          <desc xml:lang="en">Double sharp note lowered by quarter tone (double sharp modified by arrow).</desc>
+        </valItem>
+        <valItem ident="ffu">
+          <desc xml:lang="en">Double flat note raised by quarter tone (double flat modified by arrow).</desc>
+        </valItem>
+        <valItem ident="ffd">
+          <desc xml:lang="en">Double flat note lowered by quarter tone (double flat modified by arrow).</desc>
+        </valItem>
         <!-- 1qf, 3qf, 1qs, 3qs represent fixed symbols (Gould, p. 96) -->
         <valItem ident="1qf">
           <desc xml:lang="en">1/4-tone flat accidental.</desc>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -239,6 +239,12 @@
         <valItem ident="fd">
           <desc xml:lang="en">Three quarter-tones flat.</desc>
         </valItem>
+        <valItem ident="xu">
+          <desc xml:lang="en">Five quarter-tones sharp.</desc>
+        </valItem>
+        <valItem ident="ffd">
+          <desc xml:lang="en">Five quarter-tones flat.</desc>
+        </valItem>
       </valList>
     </content>
   </macroSpec>


### PR DESCRIPTION
From the Gould arrow quartertone accidentals (with arrows) the double sharps and double flats were missing. This PR adds these values to `data.ACCIDENTAL.WRITTEN.extended` and introduces corresponding values for five-quartertones to the gestural range.
