### PR TITLE
style: fix thickened border in boxed boxes

### DIFF
--- a/source/assets/css/screen/mei-screen.css
+++ b/source/assets/css/screen/mei-screen.css
@@ -179,6 +179,10 @@
 	overflow: visible;
 }
 
+.classBox .classBox {
+	border-right: 0;
+}
+
 .specPage .classBox .classHeading {
 	background-color: #f5f5f5;
 	padding: 0 .5rem .1rem .5rem;


### PR DESCRIPTION
On the spec pages with each sub-box the right border grows thicker. This PR addresses this behavior. 

### before
<img width="77" alt="image" src="https://github.com/music-encoding/music-encoding/assets/7693447/7c8f3014-854d-4240-81ed-92e04c994544">

### after
<img width="75" alt="image" src="https://github.com/music-encoding/music-encoding/assets/7693447/3db747c2-3746-4b9b-9f92-d641dfd4e745">
