### PR TITLE
gh-actions: include styles in labeler

### DIFF
--- a/.github/pr-labeler_config.yml
+++ b/.github/pr-labeler_config.yml
@@ -16,6 +16,9 @@
 "Component: Images":
 - source/images/**/*
 
+"Component: Style":
+- source/assets/css/**/*
+
 "Component: Utils":
 - utils/**/*
 


### PR DESCRIPTION
This PR includes the CSS path of the assets in the labeler config to trigger the `Component:Style` label