### PR TITLE
customizations: do not delete att.curveRend in MEI Basic

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -313,7 +313,7 @@
                 <classSpec type="atts" ident="att.clefGrp.log" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.color" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.coloration" module="MEI.shared" mode="delete"/>
-                <classSpec type="atts" ident="att.curveRend" module="MEI.shared" mode="delete"/>
+                <!--<classSpec type="atts" ident="att.curveRend" module="MEI.shared" mode="delete"/>-->
                 <classSpec type="atts" ident="att.distances" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.duration.default" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.enclosingChars" module="MEI.shared" mode="delete"/>


### PR DESCRIPTION
* Attributes on `ending` have been removed in the duplication clean-up

Fixes #1273 