### PR TITLE
guidelines: add `@n` to layer in examples

### DIFF
--- a/source/examples/verovio/implicit-mensuration.mei
+++ b/source/examples/verovio/implicit-mensuration.mei
@@ -50,7 +50,7 @@
           </scoreDef>
           <section>
             <staff n="1">
-              <layer>
+              <layer n="1">
                 <note pname="b" oct="4" dur="brevis" />
                 <note pname="b" oct="4" dur="brevis" />
                 <note pname="a" oct="4" dur="brevis" />
@@ -60,7 +60,7 @@
               </layer>
             </staff>
             <staff n="2">
-              <layer>
+              <layer n="1">
                 <note pname="g" oct="3" dur="brevis" />
                 <note pname="b" oct="3" dur="brevis" />
                 <note pname="c" oct="4" dur="brevis" />
@@ -70,7 +70,7 @@
               </layer>
             </staff>
             <staff n="3">
-              <layer>
+              <layer n="1">
                 <note pname="d" oct="4" dur="brevis" />
                 <note pname="d" oct="4" dur="brevis" />
                 <note pname="f" oct="4" dur="brevis" />
@@ -80,7 +80,7 @@
               </layer>
             </staff>
             <staff n="4">
-              <layer>
+              <layer n="1">
                 <note pname="g" oct="2" dur="brevis" />
                 <note pname="g" oct="3" dur="brevis" />
                 <note pname="g" oct="3" dur="brevis" />


### PR DESCRIPTION
Avoids Verovio to yield a warning.

Fixes #1255