### PR TITLE
schema: remove curveRend in favor of lineRend.base

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -313,7 +313,6 @@
                 <classSpec type="atts" ident="att.clefGrp.log" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.color" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.coloration" module="MEI.shared" mode="delete"/>
-                <!--<classSpec type="atts" ident="att.curveRend" module="MEI.shared" mode="delete"/>-->
                 <classSpec type="atts" ident="att.distances" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.duration.default" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.enclosingChars" module="MEI.shared" mode="delete"/>

--- a/source/docs/02-shared.xml
+++ b/source/docs/02-shared.xml
@@ -856,7 +856,7 @@
                   </list>
                   <p>These values are also qualitative, however, they are also relative. That is, 'narrow' is the default value, 'medium' is twice as wide as 'narrow', and 'wide' is twice as wide as 'medium'.</p>
                   <p>In addition to textual values, the <att>width</att> attribute may contain a numeric value and an optional unit, <abbr>e.g.</abbr>, <val>2mm</val>. If the unit value is not provided, MEI virtual units are presumed.</p>
-                  <p>The same applies for <gi scheme="MEI">curve</gi> elements with the <att>lform</att> and <att>lwidth</att> attributes from the <ident type="class">att.curveRend</ident> class.</p>
+                  <p>The same applies for <gi scheme="MEI">curve</gi> elements with the <att>lform</att> and <att>lwidth</att> attributes from the <ident type="class">att.lineRend.base</ident> class.</p>
                   <p>The <att>startsym</att> and <att>endsym</att> attributes name the symbol that may start and/or end a <gi scheme="MEI">line</gi>, while <att>startsymsize</att> and <att>endsymsize</att> indicate the relative size of the symbol using a numeric value in the range from 1 to 9.</p>
                </div>
                <div xml:id="usersymbolsLimitations" type="div3">

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -959,7 +959,7 @@
     <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.curvature"/>
-      <memberOf key="att.curveRend"/>
+      <memberOf key="att.lineRend.base"/>
     </classes>
   </classSpec>
   <classSpec ident="att.pianoPedals" module="MEI.cmn" type="atts">

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -775,23 +775,6 @@
       </attDef>
     </attList>
   </classSpec>
-  <classSpec ident="att.curveRend" module="MEI.shared" type="atts">
-    <desc xml:lang="en">Attributes that record the visual rendition of curves.</desc>
-    <attList>
-      <attDef ident="lform" usage="opt">
-        <desc xml:lang="en">Describes the line style of a curve.</desc>
-        <datatype>
-          <rng:ref name="data.LINEFORM"/>
-        </datatype>
-      </attDef>
-      <attDef ident="lwidth" usage="opt">
-        <desc xml:lang="en">Width of a curved line.</desc>
-        <datatype>
-          <rng:ref name="data.LINEWIDTH"/>
-        </datatype>
-      </attDef>
-    </attList>
-  </classSpec>
   <classSpec ident="att.custos.log" module="MEI.shared" type="atts">
     <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
@@ -1540,15 +1523,24 @@
   </classSpec>
   <classSpec ident="att.lineRend.base" module="MEI.shared" type="atts">
     <desc xml:lang="en">Attributes that record the basic visual rendition of lines.</desc>
-    <classes>
-      <memberOf key="att.curveRend"/>
-    </classes>
     <attList>
       <!-- @llength not necessary:
             @llength implies we know the direction of the vector which we
             can't know without establishing an end point, which in turn makes
             @llength redundant. -->
-      <attDef ident="lsegs" usage="opt">
+        <attDef ident="lform" usage="opt">
+          <desc xml:lang="en">Describes the style of a line.</desc>
+          <datatype>
+            <rng:ref name="data.LINEFORM"/>
+          </datatype>
+        </attDef>
+        <attDef ident="lwidth" usage="opt">
+          <desc xml:lang="en">Width of a line.</desc>
+          <datatype>
+            <rng:ref name="data.LINEWIDTH"/>
+          </datatype>
+        </attDef>
+        <attDef ident="lsegs" usage="opt">
         <desc xml:lang="en">Describes the number of segments into which a dashed or dotted line may be divided, or
           the number of "peaks" of a wavy line; a pair of space-separated values (minimum and
           maximum, respectively) provides a range between which a rendering system-supplied value

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -283,12 +283,12 @@
       attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
+      <memberOf key="att.curvature"/>
+      <memberOf key="att.lineRend.base"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2"/>
       <memberOf key="att.xy"/>
       <memberOf key="att.xy2"/>
-      <memberOf key="att.curvature"/>
-      <memberOf key="att.curveRend"/>
     </classes>
   </classSpec>
   <classSpec ident="att.bracketSpan.vis" module="MEI.visual" type="atts">
@@ -441,7 +441,7 @@
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.curvature"/>
-      <memberOf key="att.curveRend"/>
+      <memberOf key="att.lineRend.base"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2"/>
       <memberOf key="att.xy"/>
@@ -1015,12 +1015,12 @@
       beats.</desc>
     <classes>
       <memberOf key="att.color"/>
+      <memberOf key="att.curvature"/>
+      <memberOf key="att.lineRend.base"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2"/>
       <memberOf key="att.xy"/>
       <memberOf key="att.xy2"/>
-      <memberOf key="att.curvature"/>
-      <memberOf key="att.curveRend"/>
     </classes>
   </classSpec>
   <classSpec ident="att.lyrics.vis" module="MEI.visual" type="atts">
@@ -1659,12 +1659,12 @@
       normal position) of the entire rendered slur/phrase mark.</desc>
     <classes>
       <memberOf key="att.color"/>
+      <memberOf key="att.curvature"/>
+      <memberOf key="att.lineRend.base"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2"/>
       <memberOf key="att.xy"/>
       <memberOf key="att.xy2"/>
-      <memberOf key="att.curvature"/>
-      <memberOf key="att.curveRend"/>
     </classes>
   </classSpec>
   <classSpec ident="att.sp.vis" module="MEI.visual" type="atts">
@@ -1907,12 +1907,12 @@
       beats.</desc>
     <classes>
       <memberOf key="att.color"/>
+      <memberOf key="att.curvature"/>
+      <memberOf key="att.lineRend.base"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2"/>
       <memberOf key="att.xy"/>
       <memberOf key="att.xy2"/>
-      <memberOf key="att.curvature"/>
-      <memberOf key="att.curveRend"/>
     </classes>
   </classSpec>
   <classSpec ident="att.trill.vis" module="MEI.visual" type="atts">


### PR DESCRIPTION
This is another follow up for #1157 (and #1273).

`att.curveRend` and `att.lineRend.base` is used now in places where the former was in use. 

`att.curveRend` was using `@lform` and `@lwidth` (instead of `@cform` and `@cwidth`), yet in the attribute description the term "curve" was used. Furthermore it is unclear why you could say a curve is dashed, but were not allowed to encode how many dashes there are actually (@lsegs). 

This intends to improve consistency in the schema a bit. Everything should work as before with the addition of `@lsegs` to `bend`, `curve`, `lv`, `phrase`, `slur`, and `tie`.
