### PR TITLE
customizations: adjust att.harm.vis in MEI Basic

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -379,7 +379,7 @@
                 <!--<classSpec type="atts" ident="att.fermata.vis" module="MEI.visual" mode="delete"/>-->
                 <classSpec type="atts" ident="att.fingGrp.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.fTrem.vis" module="MEI.visual" mode="delete"/>
-                <classSpec type="atts" ident="att.harm.vis" module="MEI.visual" mode="delete"/>
+                <!--<classSpec type="atts" ident="att.harm.vis" module="MEI.visual" mode="delete"/>-->
                 <classSpec type="atts" ident="att.instrDef.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.keySigDefault.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.mdiv.vis" module="MEI.visual" mode="delete"/>
@@ -857,6 +857,19 @@
                         <memberOf key="att.placementRelStaff"/>
                         <!--<memberOf key="att.typography"/>-->
                         <memberOf key="att.visualOffset"/>
+                        <!--<memberOf key="att.xy"/>-->
+                    </classes>
+                </classSpec>
+                
+                
+                <classSpec ident="att.harm.vis" module="MEI.visual" type="atts" mode="change">
+                    <desc xml:lang="en">Visual domain attributes.</desc>
+                    <classes>
+                        <memberOf key="att.extender"/>
+                        <memberOf key="att.placementRelStaff"/>
+                        <memberOf key="att.visualOffset"/>
+                        <memberOf key="att.visualOffset2.ho"/>
+                        <memberOf key="att.visualOffset2.to"/>
                         <!--<memberOf key="att.xy"/>-->
                     </classes>
                 </classSpec>


### PR DESCRIPTION
Current, `att.harm.vis` is deleted in MEI Basic. However, most of its attributes should be there, e.g., `@place`.

This PR preserve `att.harm.vis` in MEI Basic and adjust it to be inline with other control events.