### PR TITLE
guidelines: update introduction chapter

### DIFF
--- a/source/docs/01-introduction.xml
+++ b/source/docs/01-introduction.xml
@@ -124,6 +124,95 @@
                take it down.</p>
             <div xml:id="about" type="div2">
                <head>About these Guidelines</head>
+               <div xml:id="aboutVersion" type="div3">
+                  <head>About version 5.0</head>
+                  <p>Release 5.0 of MEI focusses mostly on infrastructure and consistency, with only
+                     limited conceptual changes to the specifications. Perhaps the most important 
+                     additions are the introduction of the MEI Basic customization, and the availability 
+                     of an auto-generated PDF version of the Guidelines (see below for both).</p>
+                  <div xml:id="meiBasic" type="div4">
+                     <head>MEI Basic</head>
+                     <p>As a framework to encode music, MEI offers great flexibility to encode music
+                     documents of various kinds. For scholarly research, this flexibility is necessary 
+                     and is one of the greatest strengths of MEI. At the same time, this flexibility 
+                     makes it harder to interface with MEI as a data format. Accordingly, MEI has not 
+                     seen a great deal of adoption by current score-writing applications. With the 
+                     release of MEI 5, a new customization of MEI, called MEI Basic, becomes available, 
+                     which addresses this situation by reducing the MEI framework to a subset that 
+                     reflects the capabilities of other XML standards in the field.  MEI Basic offers 
+                     only one approach for each music feature, making it significantly easier to 
+                     support in software. We hope that this customization facilitates data interchange, 
+                     to share data between MEI-based projects, and to share data between MEI and other 
+                     data formats. This way, not every data import and export pipeline to and from MEI 
+                     has to deal with the complexities of MEI, and the responsibility to address such 
+                     complexities moves from generic tools to each project, which should know best how 
+                     their internal data model maps to a shared profile such as MEI Basic. MEI Basic 
+                     is a strict subset of MEI, intentionally starting with a relatively small footprint 
+                     of supported features. However, the subset of included features may be expanded if
+                     need be.</p>
+                  </div>
+                  <div xml:id="pdfGuidelines" type="div4">
+                     <head>PDF Guidelines</head>
+                     <p>With MEI 5, we reintroduce a PDF version of the MEI Guidelines. With a total
+                     of more than 5700 pages, this PDF clearly isn't intended to be printed, but may 
+                     serve as a single-file reference to the current release of MEI. The PDF is 
+                     interactive, so can be used like the online version of the Guidelines in offline 
+                     settings. While the largest part of the PDF is taken up by the formal specification 
+                     of the format, there are also more than 370 pages of prose documentation and 
+                     examples of how to use the MEI framework for various purposes. The PDF therefore 
+                     gives a good impression of the huge effort that went into the development of MEI. 
+                     Accordingly, it gives proper credit to all 40+ contributors actively involved in 
+                     the preparation of this release of MEI. Many of them are early-career researchers, 
+                     investing significant time and effort into the MEI Framework. Due to the open 
+                     nature of this community work, happening alongside conferences, workshops, and 
+                     other meetings, others may not be listed properly because of rather informal, 
+                     but no less important, contributions. Without the joint effort of all those involved, 
+                     an undertaking like MEI would not be possible.</p>
+                  </div>
+                  <div xml:id="modelChanges" type="div4">
+                     <head>Model changes in MEI</head>
+                     <p>MEI 5 introduces three new elements: <gi scheme="MEI">plica</gi> and 
+                     <gi scheme="MEI">stem</gi>, for the encoding of documents written in Mensural 
+                     notation, and <gi scheme="MEI">divLine</gi> for Neumes documents. It technically 
+                     removes the &lt;fingerprint&gt; element, which has been deprecated for ten years. 
+                     It also removes the elements &lt;pgHead2&gt; and &lt;pgFoot2&gt;, which are now 
+                     superseded by the <att>func</att> attribute on <gi scheme="MEI">pgHead</gi> and 
+                     <gi scheme="MEI">pgFoot</gi> respectively. Most other changes affect more 
+                     specific aspects in the model of MEI, usually expressed in attributes. These can 
+                     be traced in the detailed Release Notes auto-generated from the Pull Requests on 
+                     GitHub. A larger group of changes affects the internal class structure of MEI only, 
+                     where significant effort went into improved consistency in naming things. While 
+                     this set of changes does not affect end users of MEI during validation of their 
+                     files, they may have consequences for local customizations which reference classes 
+                     not available anymore. If you have advanced local customizations based on MEI v4 or
+                     older releases, please check that the rules provided still work as expected under v5. 
+                     A very helpful addition for this task may be the validation for MEI customizations, 
+                     which is now available and used for all customizations officially provided by MEI.</p>
+                  </div>
+                  <div xml:id="infrastructuralChanges" type="div4">
+                     <head>Infrastructural changes</head>
+                     <p>A lot of effort went into an updated workflow on how these release assets are 
+                     generated automatically. That setup is explained in great detail in 
+                     <ref target="https://github.com/music-encoding/music-encoding/blob/develop/README.md">https://github.com/music-encoding/music-encoding/blob/develop/README.md</ref>. 
+                     Please also consider <ref target="https://github.com/music-encoding/music-encoding/blob/develop/CONTRIBUTING.md">https://github.com/music-encoding/music-encoding/blob/develop/CONTRIBUTING.md</ref> 
+                     and other MarkDown files in the <ref target="https://github.com/music-encoding/music-encoding">https://github.com/music-encoding/music-encoding</ref> repository.</p>
+                     <p>In summary, MEI is now expressed in ODD again, going away from the MarkDown-based 
+                     approached used in the preparation of MEI v4 documentation. This reintroduces greater 
+                     compatibility with the TEI toolset again. The source code for both the Guidelines and 
+                     the Specification is now jointly contained in the <ref target="https://github.com/music-encoding/music-encoding">https://github.com/music-encoding/music-encoding</ref> 
+                     repository, which simplifies validation across both parts of MEI. All assets – web 
+                     documentation, PDF Guidelines, and schemata – are automatically generated from there. 
+                     A multi-platform Docker image for running these processes locally is also provided. 
+                     Setting up these technical workflows has taken considerable effort, but should now 
+                     simplify future development and releases considerably.</p>
+                  </div>
+                  <p>To see all of the changes made for this revision, please visit the Git repositories 
+                  <ref target="https://github.com/music-encoding/music-encoding">https://github.com/music-encoding/music-encoding</ref>, 
+                  <ref target="https://github.com/music-encoding/encoding-tools">https://github.com/music-encoding/encoding-tools</ref>, 
+                  and <ref target="https://github.com/music-encoding/sample-encodings">https://github.com/music-encoding/sample-encodings</ref>.</p>
+                  <p>The editors wish to thank everyone who participated in this process. Of course, 
+                  errors are the sole responsibility of the editors.</p>
+               </div>
                <div xml:id="designprinciples" type="div3">
                   <head>MEI Design Principles</head>
                   <p>This section of the Guidelines defines principles and criteria for designing,

--- a/source/docs/01-introduction.xml
+++ b/source/docs/01-introduction.xml
@@ -266,111 +266,112 @@
                   <p>The editors wish to thank everyone who participated in this process. Of course, 
                   errors are the sole responsibility of the editors.</p>
                </div>
-               <div xml:id="designprinciples" type="div3">
-                  <head>MEI Design Principles</head>
-                  <p>This section of the Guidelines defines principles and criteria for designing,
-                     developing, and maintaining an XML-based encoding scheme for music notation
+            </div>
+            <div xml:id="designPrinciples" type="div2">
+               <head>MEI Design Principles</head>
+               <p>This section of the Guidelines defines principles and criteria for designing,
+                  developing, and maintaining an XML-based encoding scheme for music notation
+                  documents.</p>
+               <div xml:id="definitionsAndParameters" type="div3">
+                  <head>Definitions and Parameters</head>
+                  <p>A music notation document is one that contains music notation; that is, any
+                     one of a number of "visual analogues of musical sound, either as a record of
+                     sound heard or imagined, or as a set of visual instructions for performers."
+                     (Ian D. Bent, et al. "Notation." Grove Music Online. Oxford Music Online. 25
+                     May 2010. <ref
+                        target="http://www.oxfordmusiconline.com/subscriber/article/grove/music/20114"
+                        >http://www.oxfordmusiconline.com/subscriber/article/grove/music/20114</ref>.)
+                     However, MEI’s understanding is more inclusive than this restrictive
+                     definition, <abbr>i.e.</abbr>, Braille certainly qualifies as music notation
                      documents.</p>
-                  <div xml:id="definitionsAndParameters" type="div3">
-                     <head>Definitions and Parameters</head>
-                     <p>A music notation document is one that contains music notation; that is, any
-                        one of a number of "visual analogues of musical sound, either as a record of
-                        sound heard or imagined, or as a set of visual instructions for performers."
-                        (Ian D. Bent, et al. "Notation." Grove Music Online. Oxford Music Online. 25
-                        May 2010. <ref
-                           target="http://www.oxfordmusiconline.com/subscriber/article/grove/music/20114"
-                           >http://www.oxfordmusiconline.com/subscriber/article/grove/music/20114</ref>.)
-                        However, MEI’s understanding is more inclusive than this restrictive
-                        definition, <abbr>i.e.</abbr>, Braille certainly qualifies as music notation
-                        documents.</p>
-                     <p>The encoding scheme permits both the creation of new music notation
-                        documents and the conversion of existing ones from print and other
-                        electronic formats. However, conversion of existing documents may require
-                        revisions in content or rearrangement of information.</p>
-                  </div>
-                  <div xml:id="generalPrinciples" type="div3">
-                     <head>General Principles</head>
-                     <p>MEI may be used to encode both primary sources of music notation, such as an
-                        autograph or published score, and secondary sources, such as a scholarly
-                        edition based on one or more primary sources. The format encompasses both
-                        use cases, and the encoder must choose the elements and attributes most
-                        appropriate in each case. These Guidelines aim to provide guidance on that
-                        task.</p>
-                     <p>As an encoded representation of one or more music notation documents, an MEI
-                        file may be employed as a surrogate for the original materials.</p>
-                     <p>Although the encoding scheme does not define or prescribe intellectual
-                        content for music notation documents, it does define content designation and
-                        is intended to be used with available data content standards. MEI identifies
-                        the essential data elements within music notation documents and establishes
-                        codes and conventions necessary for capturing and distinguishing information
-                        within those elements for future action or manipulation. While there are a
-                        few elements that ought to appear in any MEI document, various intellectual,
-                        technical, and economic factors influence the level of detail of analysis
-                        and encoding actually undertaken. Taking this into consideration, the
-                        encoding scheme is designed with a minimum of required elements and allows
-                        for progressively more detailed levels of description as desired.</p>
-                     <p>The encoding scheme preserves and enhances the current functionality of
-                        existing music notation documents. It permits identification of document
-                        structures and content that support description, navigation, analysis, and
-                        online and print presentation.</p>
-                     <p>The encoding scheme is intended to facilitate interchange between notational
-                        tools. It aims to assist in the creation of more effective and consistent
-                        encoding, encourage the creation of cooperatively-created and widely
-                        available databases of music notation documents, and permit the reuse of
-                        encoded data for multiple output purposes. It will also ensure that
-                        machine-readable music notation documents will outlive changing hardware and
-                        software environments because they are based on a platform-independent
-                        standard.</p>
-                  </div>
-                  <div xml:id="structuralFeatures" type="div3">
-                     <head>Structural Features</head>
-                     <p>The encoding scheme is based on eXtensible Markup Language (XML), a
-                        text-based format for representing structured information. It is expressed
-                        as a One Document Does-it-all (ODD) document. For more information on ODD,
-                        please refer to <ptr target="#meiCustomization"/>, existing notation encoding schemes,
-                        etc. have been consulted and employed as appropriate. For example, the data
-                        model includes a header that is comparable to the TEI header, and TEI and
-                        EAD naming conventions and tag structures have been used whenever feasible.
-                        However, while some feature names are similar, or even the same, it is
-                        important to recognize that MEI and TEI have different semantic scope.
-                        Obviously, a note element in MEI does not carry the same meaning as the
-                        element of the same name in TEI. Perhaps less obviously, a phrase in music
-                        notation is unrelated to a textual phrase.</p>
-                     <p>With respect to metadata, MEI recognizes the close relationship between the
-                        metadata content found in the MEI header and that of catalog records,
-                        authority records, and finding aids. Therefore MEI provides ways of
-                        indicating in the encoding the corresponding fields of other metadata
-                        standards.</p>
-                     <p>To ensure broad international and multi-repertoire application of MEI,
-                        existing musical terminology was used in building the data model where
-                        practical. When appropriate, a more neutral terminology was used to
-                        facilitate sharing of concepts and thus stressing the commonalities between
-                        different repertoires. Finally, extensive use of attributes and
-                        clearly-defined classification mechanisms in the schema permits the
-                        refinement of element meanings within specific musical, geographic, or
-                        temporal contexts.</p>
-                  </div>
-                  <div xml:id="controlAndMaintenance" type="div3">
-                     <head>Control and Maintenance</head>
-                     <p>The Music Encoding Initiative Community has given itself <ref
-                           target="https://music-encoding.org/community/mei-by-laws.html"
-                           >By-laws</ref>, which regulate all essential properties and procedures.
-                        The community elects a <ref
-                           target="https://music-encoding.org/community/mei-board.html">Board</ref>,
-                        which in turn governs and represents the community. The Board consists of
-                        nine elected members, with three seats standing for election for three year
-                        terms each year. Everyone registered to the <ref
-                           target="https://music-encoding.org/community/community-contacts.html"
-                           >MEI-L</ref> mailing list is eligible to vote for the Board.</p>
-                     <p>In addition to the Board, there is a <ref
-                           target="https://music-encoding.org/community/technical-team.html"
-                           >Technical Team</ref>, which is open for anyone interested to work on the
-                        maintenance and improvement of MEI itself. The Technical team will assist
-                        Interest Groups and other interested community members in an advisory
-                        capacity on how to further develop MEI for both existing and new fields of
-                        application.</p>
-                  </div>
+                  <p>The encoding scheme permits both the creation of new music notation
+                     documents and the conversion of existing ones from print and other
+                     electronic formats. However, conversion of existing documents may require
+                     revisions in content or rearrangement of information.</p>
                </div>
+               <div xml:id="generalPrinciples" type="div3">
+                  <head>General Principles</head>
+                  <p>MEI may be used to encode both primary sources of music notation, such as an
+                     autograph or published score, and secondary sources, such as a scholarly
+                     edition based on one or more primary sources. The format encompasses both
+                     use cases, and the encoder must choose the elements and attributes most
+                     appropriate in each case. These Guidelines aim to provide guidance on that
+                     task.</p>
+                  <p>As an encoded representation of one or more music notation documents, an MEI
+                     file may be employed as a surrogate for the original materials.</p>
+                  <p>Although the encoding scheme does not define or prescribe intellectual
+                     content for music notation documents, it does define content designation and
+                     is intended to be used with available data content standards. MEI identifies
+                     the essential data elements within music notation documents and establishes
+                     codes and conventions necessary for capturing and distinguishing information
+                     within those elements for future action or manipulation. While there are a
+                     few elements that ought to appear in any MEI document, various intellectual,
+                     technical, and economic factors influence the level of detail of analysis
+                     and encoding actually undertaken. Taking this into consideration, the
+                     encoding scheme is designed with a minimum of required elements and allows
+                     for progressively more detailed levels of description as desired.</p>
+                  <p>The encoding scheme preserves and enhances the current functionality of
+                     existing music notation documents. It permits identification of document
+                     structures and content that support description, navigation, analysis, and
+                     online and print presentation.</p>
+                  <p>The encoding scheme is intended to facilitate interchange between notational
+                     tools. It aims to assist in the creation of more effective and consistent
+                     encoding, encourage the creation of cooperatively-created and widely
+                     available databases of music notation documents, and permit the reuse of
+                     encoded data for multiple output purposes. It will also ensure that
+                     machine-readable music notation documents will outlive changing hardware and
+                     software environments because they are based on a platform-independent
+                     standard.</p>
+               </div>
+               <div xml:id="structuralFeatures" type="div3">
+                  <head>Structural Features</head>
+                  <p>The encoding scheme is based on eXtensible Markup Language (XML), a
+                     text-based format for representing structured information. It is expressed
+                     as a One Document Does-it-all (ODD) document. For more information on ODD,
+                     please refer to <ptr target="#meiCustomization"/>, existing notation encoding schemes,
+                     etc. have been consulted and employed as appropriate. For example, the data
+                     model includes a header that is comparable to the TEI header, and TEI and
+                     EAD naming conventions and tag structures have been used whenever feasible.
+                     However, while some feature names are similar, or even the same, it is
+                     important to recognize that MEI and TEI have different semantic scope.
+                     Obviously, a note element in MEI does not carry the same meaning as the
+                     element of the same name in TEI. Perhaps less obviously, a phrase in music
+                     notation is unrelated to a textual phrase.</p>
+                  <p>With respect to metadata, MEI recognizes the close relationship between the
+                     metadata content found in the MEI header and that of catalog records,
+                     authority records, and finding aids. Therefore MEI provides ways of
+                     indicating in the encoding the corresponding fields of other metadata
+                     standards.</p>
+                  <p>To ensure broad international and multi-repertoire application of MEI,
+                     existing musical terminology was used in building the data model where
+                     practical. When appropriate, a more neutral terminology was used to
+                     facilitate sharing of concepts and thus stressing the commonalities between
+                     different repertoires. Finally, extensive use of attributes and
+                     clearly-defined classification mechanisms in the schema permits the
+                     refinement of element meanings within specific musical, geographic, or
+                     temporal contexts.</p>
+               </div>
+               <div xml:id="controlAndMaintenance" type="div3">
+                  <head>Control and Maintenance</head>
+                  <p>The Music Encoding Initiative Community has given itself <ref
+                        target="https://music-encoding.org/community/mei-by-laws.html"
+                        >By-laws</ref>, which regulate all essential properties and procedures.
+                     The community elects a <ref
+                        target="https://music-encoding.org/community/mei-board.html">Board</ref>,
+                     which in turn governs and represents the community. The Board consists of
+                     nine elected members, with three seats standing for election for three year
+                     terms each year. Everyone registered to the <ref
+                        target="https://music-encoding.org/community/community-contacts.html"
+                        >MEI-L</ref> mailing list is eligible to vote for the Board.</p>
+                  <p>In addition to the Board, there is a <ref
+                        target="https://music-encoding.org/community/technical-team.html"
+                        >Technical Team</ref>, which is open for anyone interested to work on the
+                     maintenance and improvement of MEI itself. The Technical team will assist
+                     Interest Groups and other interested community members in an advisory
+                     capacity on how to further develop MEI for both existing and new fields of
+                     application.</p>
+               </div>
+            </div>
             <div xml:id="basicConcepts" type="div2">
                <head>Basic Concepts of MEI</head>
                <p>This chapter is intended to explain basic concepts of MEI, like events vs.

--- a/source/docs/01-introduction.xml
+++ b/source/docs/01-introduction.xml
@@ -124,6 +124,59 @@
                take it down.</p>
             <div xml:id="about" type="div2">
                <head>About these Guidelines</head>
+               <div xml:id="acknowledgments" type="div3">
+                  <head>Acknowledgments</head>
+                  <p>Many institutions and individuals assisted in the preparation of these
+                     Guidelines and in the overall development of the Music Encoding Initiative
+                     framework and community.</p>
+                  <p>Grateful acknowledgment is given to the following institutions for their
+                     generous contributions: the Akademie der Wissenschaften und der Literatur (AdW)
+                     in Mainz for serving as hosting institution for the MEI Community, and the
+                     National Endowment for the Humanities (NEH) and the Deutsche
+                     Forschungsgemeinschaft (DFG) for their joint financial support of the MEI
+                     project in its early stages. We thank several institutions that hosted Music
+                     Encoding Conferences or other MEI-related meetings in the past: The AdW Mainz,
+                     the University of Virginia Library, the Biblioteca Umanistica of the
+                     Università degli Studi Firenze, McGill University Montréal, the Centre
+                     d’études supérieures de la Renaissance Tours, the Maryland Institute for
+                     Technology in the Humanities (MITH) in College Park, the Oxford e-Research
+                     Centre, the Universität Paderborn and the Österreichische Akademie der
+                     Wissenschaften Wien in conjunction with the Universität Wien and the Mozarteum
+                     Salzburg. We also thank all other institutions that allow their researchers to
+                     invest time into both the community and the encoding framework. It is their
+                     interest that makes MEI an incredible platform for interchange and scholarly
+                     progress.</p>
+                  <p>The Text Encoding Initiative is also owed a special debt of gratitude. In
+                     addition to providing much of the inspiration for MEI, the TEI organization
+                     supplied funding for the MEI Technical Group in its efforts to adopt ODD. The
+                     editors of these Guidelines are grateful for those of the TEI, which provided a
+                     stellar exemplar and from which we have borrowed shamelessly.</p>
+                  <p>MEI has been a community-driven effort for more than a decade, and many
+                     individuals have provided significant and much-appreciated commitments of time
+                     and energy to the development of MEI: Nikolaos Beer; Vincent Besson; Benjamin
+                     W. Bohl; Margrethe Bue; Donald Byrd; Irmlind Capelle; Tim Crawford; David A.
+                     Day; Giuliano Di Bacco; Norbert Dubowy; Richard Freedman; Ichiro Fujinaga;
+                     Andrew Hankinson; Maja Hartwig; Kristin Herold; Franz Kelnreiter; Johannes
+                     Kepper; Robert Klugseder; Zoltán Kőmíves; David Lewis; Urs Liska; Elsa De Luca;
+                     Erin Mayhood; Stefan Morent; Stefan Münnich; Markus Neuwirth; Kevin Page;
+                     Daniel Pitti; Laurent Pugin; Klaus Rettinghaus; Kristina Richts; Daniel
+                     Röwenstrunk; Perry Roland; Craig Sapp; Agnes Seipelt; Eleanor Selfridge-Field;
+                     Christine Siegert; Peter Stadler; Axel Teich Geertinger; Martha Thomae; Joachim
+                     Veit; Raffaele Viglianti; Thomas Weber; and Sonia Wronkowska.</p>
+                  <p>Thanks to Bernhard R. Appel; Richard Chesser; Morgan Cundiff; J. Stephen
+                     Downie; Oliver Huck; Fotis Jannidis; John Rink; Federica Riva; Frans Wiering
+                     and Barbara Wiermann for providing expertise on a wide range of topics related
+                     to music notation modelling.</p>
+                  <p>Also thanks to Syd Bauman, Terry Catapano, and Sebastian Rahtz for their
+                     invaluable problem-solving assistance during the development of the 2010 RNG
+                     schema. Thanks to Sebastian Rahtz and James Cummings of the Text Encoding
+                     Initiative (TEI) for their help with making ODD work with MEI, their assistance
+                     in more closely aligning MEI and TEI, and their quick responses to questions
+                     and Roma bug reports.</p>
+                  <p>Finally, the members of the Music Encoding Initiative would like to thank Perry
+                     Roland for his foresight, engagement and dedication in laying the foundations
+                     of this initiative.</p>
+               </div>
                <div xml:id="aboutVersion" type="div3">
                   <head>About version 5.0</head>
                   <p>Release 5.0 of MEI focusses mostly on infrastructure and consistency, with only
@@ -318,60 +371,6 @@
                         application.</p>
                   </div>
                </div>
-               <div xml:id="acknowledgments" type="div3">
-                  <head>Acknowledgments</head>
-                  <p>Many institutions and individuals assisted in the preparation of these
-                     Guidelines and in the overall development of the Music Encoding Initiative
-                     framework and community.</p>
-                  <p>Grateful acknowledgment is given to the following institutions for their
-                     generous contributions: the Akademie der Wissenschaften und der Literatur (AdW)
-                     in Mainz for serving as hosting institution for the MEI Community, and the
-                     National Endowment for the Humanities (NEH) and the Deutsche
-                     Forschungsgemeinschaft (DFG) for their joint financial support of the MEI
-                     project in its early stages. We thank several institutions that hosted Music
-                     Encoding Conferences or other MEI-related meetings in the past: The AdW Mainz,
-                     the University of Virginia Library, the Biblioteca Umanistica of the
-                     Università degli Studi Firenze, McGill University Montréal, the Centre
-                     d’études supérieures de la Renaissance Tours, the Maryland Institute for
-                     Technology in the Humanities (MITH) in College Park, the Oxford e-Research
-                     Centre, the Universität Paderborn and the Österreichische Akademie der
-                     Wissenschaften Wien in conjunction with the Universität Wien and the Mozarteum
-                     Salzburg. We also thank all other institutions that allow their researchers to
-                     invest time into both the community and the encoding framework. It is their
-                     interest that makes MEI an incredible platform for interchange and scholarly
-                     progress.</p>
-                  <p>The Text Encoding Initiative is also owed a special debt of gratitude. In
-                     addition to providing much of the inspiration for MEI, the TEI organization
-                     supplied funding for the MEI Technical Group in its efforts to adopt ODD. The
-                     editors of these Guidelines are grateful for those of the TEI, which provided a
-                     stellar exemplar and from which we have borrowed shamelessly.</p>
-                  <p>MEI has been a community-driven effort for more than a decade, and many
-                     individuals have provided significant and much-appreciated commitments of time
-                     and energy to the development of MEI: Nikolaos Beer; Vincent Besson; Benjamin
-                     W. Bohl; Margrethe Bue; Donald Byrd; Irmlind Capelle; Tim Crawford; David A.
-                     Day; Giuliano Di Bacco; Norbert Dubowy; Richard Freedman; Ichiro Fujinaga;
-                     Andrew Hankinson; Maja Hartwig; Kristin Herold; Franz Kelnreiter; Johannes
-                     Kepper; Robert Klugseder; Zoltán Kőmíves; David Lewis; Urs Liska; Elsa De Luca;
-                     Erin Mayhood; Stefan Morent; Stefan Münnich; Markus Neuwirth; Kevin Page;
-                     Daniel Pitti; Laurent Pugin; Klaus Rettinghaus; Kristina Richts; Daniel
-                     Röwenstrunk; Perry Roland; Craig Sapp; Agnes Seipelt; Eleanor Selfridge-Field;
-                     Christine Siegert; Peter Stadler; Axel Teich Geertinger; Martha Thomae; Joachim
-                     Veit; Raffaele Viglianti; Thomas Weber; and Sonia Wronkowska.</p>
-                  <p>Thanks to Bernhard R. Appel; Richard Chesser; Morgan Cundiff; J. Stephen
-                     Downie; Oliver Huck; Fotis Jannidis; John Rink; Federica Riva; Frans Wiering
-                     and Barbara Wiermann for providing expertise on a wide range of topics related
-                     to music notation modelling.</p>
-                  <p>Also thanks to Syd Bauman, Terry Catapano, and Sebastian Rahtz for their
-                     invaluable problem-solving assistance during the development of the 2010 RNG
-                     schema. Thanks to Sebastian Rahtz and James Cummings of the Text Encoding
-                     Initiative (TEI) for their help with making ODD work with MEI, their assistance
-                     in more closely aligning MEI and TEI, and their quick responses to questions
-                     and Roma bug reports.</p>
-                  <p>Finally, the members of the Music Encoding Initiative would like to thank Perry
-                     Roland for his foresight, engagement and dedication in laying the foundations
-                     of this initiative.</p>
-               </div>
-            </div>
             <div xml:id="basicConcepts" type="div2">
                <head>Basic Concepts of MEI</head>
                <p>This chapter is intended to explain basic concepts of MEI, like events vs.

--- a/source/docs/01-introduction.xml
+++ b/source/docs/01-introduction.xml
@@ -98,7 +98,9 @@
                Initiative’s framework for describing music notation documents. This includes both a
                technical specification of the XML-based implementation of MEI and an explanatory
                description of its concepts.</p>
-            <p>The MEI Guidelines are intended to serve as a reference tool for music encoders.
+            <div xml:id="about" type="div2">
+               <head>About these Guidelines</head>
+               <p>The MEI Guidelines are intended to serve as a reference tool for music encoders.
                Through the use of natural-language definitions and examples, this documentation
                assists users of MEI in achieving effective and consistent markup. Despite
                translating XML and RNG terminology and concepts into more accessible language, it is
@@ -122,8 +124,6 @@
                examples. If you find material that possibly offends copyright, please <ref
                   target="mailto:info@music-encoding.org">get in touch</ref> with us, and we will
                take it down.</p>
-            <div xml:id="about" type="div2">
-               <head>About these Guidelines</head>
                <div xml:id="acknowledgments" type="div3">
                   <head>Acknowledgments</head>
                   <p>Many institutions and individuals assisted in the preparation of these

--- a/source/docs/01-introduction.xml
+++ b/source/docs/01-introduction.xml
@@ -271,7 +271,7 @@
                   <p>This section of the Guidelines defines principles and criteria for designing,
                      developing, and maintaining an XML-based encoding scheme for music notation
                      documents.</p>
-                  <div xml:id="definitionsandparameters" type="div4">
+                  <div xml:id="definitionsAndParameters" type="div3">
                      <head>Definitions and Parameters</head>
                      <p>A music notation document is one that contains music notation; that is, any
                         one of a number of "visual analogues of musical sound, either as a record of
@@ -288,7 +288,7 @@
                         electronic formats. However, conversion of existing documents may require
                         revisions in content or rearrangement of information.</p>
                   </div>
-                  <div xml:id="generalprinciples" type="div4">
+                  <div xml:id="generalPrinciples" type="div3">
                      <head>General Principles</head>
                      <p>MEI may be used to encode both primary sources of music notation, such as an
                         autograph or published score, and secondary sources, such as a scholarly
@@ -322,12 +322,12 @@
                         software environments because they are based on a platform-independent
                         standard.</p>
                   </div>
-                  <div xml:id="structuralfeatures" type="div4">
+                  <div xml:id="structuralFeatures" type="div3">
                      <head>Structural Features</head>
                      <p>The encoding scheme is based on eXtensible Markup Language (XML), a
                         text-based format for representing structured information. It is expressed
                         as a One Document Does-it-all (ODD) document. For more information on ODD,
-                        please refer to <ptr target="#meicustomization"/>, existing notation encoding schemes,
+                        please refer to <ptr target="#meiCustomization"/>, existing notation encoding schemes,
                         etc. have been consulted and employed as appropriate. For example, the data
                         model includes a header that is comparable to the TEI header, and TEI and
                         EAD naming conventions and tag structures have been used whenever feasible.
@@ -350,7 +350,7 @@
                         refinement of element meanings within specific musical, geographic, or
                         temporal contexts.</p>
                   </div>
-                  <div xml:id="controlandmaintenance" type="div4">
+                  <div xml:id="controlAndMaintenance" type="div3">
                      <head>Control and Maintenance</head>
                      <p>The Music Encoding Initiative Community has given itself <ref
                            target="https://music-encoding.org/community/mei-by-laws.html"
@@ -454,7 +454,7 @@
                      attributes carry a suffixed <hi rend="italic">.log</hi> (logical), <hi rend="italic">.ges</hi> (gestural), <hi rend="italic">.vis</hi>
                      (visual), or <hi rend="italic">.anl</hi> (analytical) in their name. In addition, the internal
                      structure of MEI heavily relies on those different domains. When customizing
-                     MEI (see chapter <ptr target="#meicustomization"/>), it is possible to turn off
+                     MEI (see chapter <ptr target="#meiCustomization"/>), it is possible to turn off
                      either visual or gestural domain encoding completely. That way, MEI allows to
                      address the four most eminent musical domains specifically and independent of
                      each other.</p>
@@ -632,7 +632,7 @@
                      correctly, even though they are perfectly valid MEI, and sometimes are
                      necessary to faithfully transcribe a source.</p>
                </div>
-               <div xml:id="meiprofiles" type="div3">
+               <div xml:id="meiProfiles" type="div3">
                   <head>MEI Profiles</head>
                   <p>MEI is an encoding framework, not a data format. This means that MEI provides
                      recommendations for encoding music documents, but it depends on the encoder's
@@ -646,7 +646,7 @@
                      uses of MEI while still maintaining a great level of flexibility. For projects
                      that need even better control over their data, it is highly recommended to
                      create a more specific customized version of MEI (see chapter <ptr
-                        target="#meicustomization"/>). The following customizations are provided
+                        target="#meiCustomization"/>). The following customizations are provided
                      with every release of MEI:</p>
                   <list type="gloss">
                      <label>mei-CMN</label>
@@ -700,14 +700,14 @@
                      project-specific customizations. The latter two profiles target very
                      specific use cases and should not be used by default.</p>
                </div>
-               <div xml:id="meicustomization" type="div3">
+               <div xml:id="meiCustomization" type="div3">
                   <head>Customizing MEI</head>
                   <p>In production, it is best to use a customized version of MEI, restricted to the
                      very needs of a project. Such a custom schema will guide the encoders and will
                      help to ensure consistency and data quality throughout a project’s files. A
                      customization typically provides a subset of MEI’s encoding models (typically
                      starting from one of the official <hi rend="italic">profiles</hi> mentioned in chapter <ptr
-                        target="#meiprofiles"/>), with only one solution for any given situation
+                        target="#meiProfiles"/>), with only one solution for any given situation
                      being allowed. The customization will help to reflect the scope of a project
                      into its data: Only those aspects of music notation a project is interested in
                      will be allowed, so that the absence of a specific information can not be
@@ -727,7 +727,7 @@
                         >Getting Started with P5 ODDs</ref>" document.</p>
                   <p>At this point, there is no specific documentation on how to customize MEI with
                      ODD beyond the generic TEI documentation. However, the provided <ptr
-                        target="#meiprofiles"/> are based on ODD customizations, and may serve as
+                        target="#meiProfiles"/> are based on ODD customizations, and may serve as
                      starting point for further project-specific restrictions. They can be found
                         at <ref
                         target="https://github.com/music-encoding/music-encoding/tree/develop/customizations"

--- a/source/docs/01-introduction.xml
+++ b/source/docs/01-introduction.xml
@@ -224,23 +224,26 @@
                   </div>
                   <div xml:id="modelChanges" type="div4">
                      <head>Model changes in MEI</head>
-                     <p>MEI 5 introduces three new elements: <gi scheme="MEI">plica</gi> and 
+                     <p>MEI 5 introduces five new elements: <gi scheme="MEI">plica</gi> and 
                      <gi scheme="MEI">stem</gi>, for the encoding of documents written in Mensural 
-                     notation, and <gi scheme="MEI">divLine</gi> for Neumes documents. It technically 
-                     removes the &lt;fingerprint&gt; element, which has been deprecated for ten years. 
-                     It also removes the elements &lt;pgHead2&gt; and &lt;pgFoot2&gt;, which are now 
-                     superseded by the <att>func</att> attribute on <gi scheme="MEI">pgHead</gi> and 
-                     <gi scheme="MEI">pgFoot</gi> respectively. Most other changes affect more 
-                     specific aspects in the model of MEI, usually expressed in attributes. These can 
-                     be traced in the detailed Release Notes auto-generated from the Pull Requests on 
-                     GitHub. A larger group of changes affects the internal class structure of MEI only, 
-                     where significant effort went into improved consistency in naming things. While 
-                     this set of changes does not affect end users of MEI during validation of their 
-                     files, they may have consequences for local customizations which reference classes 
-                     not available anymore. If you have advanced local customizations based on MEI v4 or
-                     older releases, please check that the rules provided still work as expected under v5. 
-                     A very helpful addition for this task may be the validation for MEI customizations, 
-                     which is now available and used for all customizations officially provided by MEI.</p>
+                     notation, and <gi scheme="MEI">divLine</gi> for Neumes documents. The new CMN 
+                     element <gi scheme="MEI">repeatMark</gi> can be used to express repetition marks 
+                     as a combination of text and symbols, and the added shared element 
+                     <gi scheme="MEI">extData</gi> provides a container for non-MEI data formats. 
+                     The release technically removes the &lt;fingerprint&gt; element, which has been 
+                     deprecated for ten years. It also removes the elements &lt;pgHead2&gt; and 
+                     &lt;pgFoot2&gt;, which are now superseded by the <att>func</att> attribute on 
+                     <gi scheme="MEI">pgHead</gi> and <gi scheme="MEI">pgFoot</gi> respectively. Most other changes affect more specific aspects in the model of MEI, usually expressed in
+                     attributes. These can be traced in the detailed Release Notes auto-generated from 
+                     the Pull Requests on GitHub. A larger group of changes affects the internal class
+                     structure of MEI only, where significant effort went into improved consistency in
+                     naming things. While this set of changes does not affect end users of MEI during
+                     validation of their files, they may have consequences for local customizations which
+                     reference classes not available anymore. If you have advanced local customizations
+                     based on MEI v4 or older releases, please check that the rules provided still work as
+                     expected under v5. A very helpful addition for this task may be the validation for MEI
+                     customizations, which is now available and used for all customizations officially
+                     provided by MEI.</p>
                   </div>
                   <div xml:id="infrastructuralChanges" type="div4">
                      <head>Infrastructural changes</head>

--- a/source/docs/01-introduction.xml
+++ b/source/docs/01-introduction.xml
@@ -330,9 +330,8 @@
                   <head>Structural Features</head>
                   <p>The encoding scheme is based on eXtensible Markup Language (XML), a
                      text-based format for representing structured information. It is expressed
-                     as a One Document Does-it-all (ODD) document. For more information on ODD,
-                     please refer to <ptr target="#meiCustomization"/>, existing notation encoding schemes,
-                     etc. have been consulted and employed as appropriate. For example, the data
+                     as a One Document Does-it-all (ODD) document. For more information on ODD, please refer to <ptr target="#meiCustomization"/></p>
+                     <p>Related or complementary standards, such as the<ref target="http://www.tei-c.org/Guidelines/P5/">Text Encoding Initiative (TEI) Guidelines for Electronic Text Encoding and Interchange</ref>, <ref target="http://www.loc.gov/ead/">the Encoded Archival Description (EAD)</ref>, <ref target="http://www.loc.gov/marc/bibliographic/ecbdhome.html">MARC 21 Format for Bibliographic Data</ref>, existing notation encoding schemes, etc. have been consulted and employed as appropriate. For example, the data
                      model includes a header that is comparable to the TEI header, and TEI and
                      EAD naming conventions and tag structures have been used whenever feasible.
                      However, while some feature names are similar, or even the same, it is

--- a/source/docs/14-integration.xml
+++ b/source/docs/14-integration.xml
@@ -126,7 +126,7 @@
             <div xml:id="svg" type="div2">
                <head>SVG</head>
                <p>In order to use Scalable Vector Graphics (SVG) in MEI, a new <hi rend="italic">module</hi> needs to be
-                  compiled into ODD (see <ptr target="#meicustomization"/> for an
+                  compiled into ODD (see <ptr target="#meiCustomization"/> for an
                   introduction on how to do that). In order to do that, you need to enter the
                   following <gi scheme="TEI">moduleRef</gi> into the <gi scheme="TEI"
                      >schemaSpec</gi> of your ODD file:</p>
@@ -137,7 +137,7 @@
                   </figure>
                </p>
                <p>With this addition, which can be added to any of the provided customizations of
-                  MEI (see <ptr target="#meiprofiles"/>), the <ref
+                  MEI (see <ptr target="#meiProfiles"/>), the <ref
                      target="https://www.w3.org/TR/SVG11/struct.html#SVGElement">&lt;svg&gt;</ref>
                   element becomes available everywhere `model.graphicLike` (<abbr>i.e.</abbr>, the <gi
                      scheme="MEI">graphic</gi> element) is currently allowed, that is: inside of <gi


### PR DESCRIPTION
This PR adds an "About version 5.0" section to the introduction chapter of the guidelines (as present in the PDF for version 3.0.0). This effectively contains the prosa version of the release notes. The PR also reorganizes the introduction chapter a little bit to improve reading structure. Finally it applies camelCase id's to all div elements.

The structure is now as follows:
![Screenshot 2023-07-27 105445](https://github.com/music-encoding/music-encoding/assets/21059419/dae258cb-f42e-4077-b423-628a2422f97a)
