### PR TITLE
schema: align att.arpeg.vis with other line-like elements

### DIFF
--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -81,6 +81,7 @@
       <memberOf key="att.color"/>
       <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extSym"/>
+      <memberOf key="att.lineRend.base"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
@@ -114,18 +115,6 @@
         <desc xml:lang="en">Captures the fill color of the arrow if different from the line color.</desc>
         <datatype>
           <rng:ref name="data.COLOR"/>
-        </datatype>
-      </attDef>
-      <attDef ident="line.form" usage="opt">
-        <desc xml:lang="en">Visual form of the line.</desc>
-        <datatype>
-          <rng:ref name="data.LINEFORM"/>
-        </datatype>
-      </attDef>
-      <attDef ident="line.width" usage="opt">
-        <desc xml:lang="en">Width of the line.</desc>
-        <datatype>
-          <rng:ref name="data.LINEWIDTH"/>
         </datatype>
       </attDef>
     </attList>


### PR DESCRIPTION
This PR makes `att.arpeg.vis` member of `att.lineRend.base` to replace the solitary `@line.form` and `@line.width` with the common `@lform` and `@lwidth` attributes.