### PR TITLE
schema: remove att.phrase.vis.cmn

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -955,13 +955,6 @@
       </attDef>
     </attList>
   </classSpec>
-  <classSpec ident="att.phrase.vis.cmn" module="MEI.cmn" type="atts">
-    <desc xml:lang="en">Visual domain attributes.</desc>
-    <classes>
-      <memberOf key="att.curvature"/>
-      <memberOf key="att.lineRend.base"/>
-    </classes>
-  </classSpec>
   <classSpec ident="att.pianoPedals" module="MEI.cmn" type="atts">
     <desc xml:lang="en">Used by scoreDef and staffDef to provide default description of piano pedal
       rendition.</desc>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1446,11 +1446,12 @@
     <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.color"/>
+      <memberOf key="att.curvature"/>
+      <memberOf key="att.lineRend.base"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2"/>
       <memberOf key="att.xy"/>
       <memberOf key="att.xy2"/>
-      <memberOf key="att.phrase.vis.cmn"/>
     </classes>
   </classSpec>
   <classSpec ident="att.plica.vis" module="MEI.visual" type="atts">


### PR DESCRIPTION
This is (hopefully) the last PR connected to the clean-up around `lineRend` attributes. It removes `att.phrase.vis.cmn` and aligns `att.phrase.vis` with `att.slur.vis` and `att.tie.vis`.

As a follow up it should be discussed if the `elementSpec` for `phrase` should be moved from the `shared` to the `cmn` module like `slur` and `tie`.
