### PR TITLE
schema: fix double entries in att.neumeTypes

### DIFF
--- a/source/modules/MEI.neumes.xml
+++ b/source/modules/MEI.neumes.xml
@@ -215,8 +215,6 @@
           <valItem ident="porrectus"/>
           <valItem ident="porrectusflexus"/>
           <valItem ident="pressusmaior"/>
-          <valItem ident="pressusmaior"/>
-          <valItem ident="pressusminor"/>
           <valItem ident="pressusminor"/>
           <valItem ident="punctum"/>
           <valItem ident="quilisma"/>


### PR DESCRIPTION
This PR removes doubled entries from `att.neumeType`.
