### PR TITLE
schema: add support to encode the level where a proportion is applied

### DIFF
--- a/source/docs/05-mensural.xml
+++ b/source/docs/05-mensural.xml
@@ -270,7 +270,7 @@
                         <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="verovio code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/verovio/mensuration_changes.mei" parse="text"/></egXML>
                      </figure>
                   </p>
-                  <p><hi rend="bold">Sesquialtera</hi> is frequently used to change the mensuration. The effect of the sesquialtera on the mensuration can be encoded by using the <att>tempus</att> and <att>prolatio</att> attributes of <gi scheme="MEI">mensur</gi> (for example, when changing the tempus to perfect, the effect can be encoded in <att>tempus="3"</att>). The actual sesquialtera can be encoded using <att>num="3"</att>, <att>numbase="2"</att>, and <att>level</att> to define the note level the sesquialtera is applied to (e.g. <att>level="semibrevis"</att>).</p>
+                  <p><hi rend="bold">Sesquialtera</hi> is frequently used to change the mensuration. The effect of the sesquialtera on the mensuration can be encoded by using the <att>tempus</att> and <att>prolatio</att> attributes of <gi scheme="MEI">mensur</gi> (for example, when changing the tempus to perfect, the effect can be encoded in <att>tempus="3"</att>). The actual sesquialtera can be encoded using <att>num="3"</att>, <att>numbase="2"</att>, and <att>level</att> to define the note level the sesquialtera is applied to (<abbr>e.g.</abbr>, <att>level="semibrevis"</att>).</p>
                </div>
                <div xml:id="implicitmensuration" type="div3">
                   <head>Implicit mensuration</head>

--- a/source/docs/05-mensural.xml
+++ b/source/docs/05-mensural.xml
@@ -270,6 +270,7 @@
                         <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="verovio code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/verovio/mensuration_changes.mei" parse="text"/></egXML>
                      </figure>
                   </p>
+                  <p><hi rend="bold">Sesquialtera</hi> is frequently used to change the mensuration. The effect of the sesquialtera on the mensuration can be encoded by using the <att>tempus</att> and <att>prolatio</att> attributes of <gi scheme="MEI">mensur</gi> (for example, when changing the tempus to perfect, the effect can be encoded in <att>tempus="3"</att>). The actual sesquialtera can be encoded using <att>num="3"</att>, <att>numbase="2"</att>, and <att>level</att> to define the note level the sesquialtera is applied to (e.g. <att>level="semibrevis"</att>).</p>
                </div>
                <div xml:id="implicitmensuration" type="div3">
                   <head>Implicit mensuration</head>
@@ -418,7 +419,7 @@
                      <label>div</label>
                      <item>Value of the form attribute for a dot of division (this is a dot that modifies the perfect groupings of the notes, thus, changing some notes' duration in the process)</item>
                   </list>
-                  The actual effect of these dots (<hi rend="italic">augmenting</hi> a note and making it perfect, or dividing a sequence of notes in different groupings by <hi rend="italic">imperfecting</hi> some notes or <hi rend="italic">altering</hi> others) is encoded with the <att>dur.quality</att> attribute of the correspoding <gi scheme="MEI">note</gi> elements. Examples of the use of dots of division and augmentation can be found in the <ptr target="#mensuralRules"/> section.
+                  <p>The actual effect of these dots (<hi rend="italic">augmenting</hi> a note and making it perfect, or dividing a sequence of notes in different groupings by <hi rend="italic">imperfecting</hi> some notes or <hi rend="italic">altering</hi> others) is encoded with the <att>dur.quality</att> attribute of the correspoding <gi scheme="MEI">note</gi> elements. Examples of the use of dots of division and augmentation can be found in the <ptr target="#mensuralRules"/> section.</p>
                </div>
                <div xml:id="accidentals" type="div3">
                  <head>Accidentals</head>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1908,7 +1908,7 @@
     </classes>
     <attList>
       <attDef ident="level" usage="opt">
-        <desc>Level of duration at which the proportion given by the @num and @numbase ratio applies to.</desc>
+        <desc>Level of duration at which the proportion given by the @num and @numbase ratio applies.</desc>
         <datatype>
           <rng:ref name="data.DURATION.mensural"/>
         </datatype>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1906,6 +1906,14 @@
       <memberOf key="att.duration.ratio"/>
       <memberOf key="att.mensural.shared"/>
     </classes>
+    <attList>
+      <attDef ident="level" usage="opt">
+        <desc>Level at which the proportion given by the @num and @numbase ratio applies to.</desc>
+        <datatype>
+          <rng:ref name="data.DURATION.mensural"/>
+        </datatype>
+      </attDef>
+    </attList>
   </classSpec>
   <classSpec ident="att.meterConformance" module="MEI.shared" type="atts">
     <desc xml:lang="en">Attributes that provide information about a structure’s conformance to the prevailing

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1908,7 +1908,7 @@
     </classes>
     <attList>
       <attDef ident="level" usage="opt">
-        <desc>Level at which the proportion given by the @num and @numbase ratio applies to.</desc>
+        <desc>Level of duration at which the proportion given by the @num and @numbase ratio applies to.</desc>
         <datatype>
           <rng:ref name="data.DURATION.mensural"/>
         </datatype>


### PR DESCRIPTION
In this pull request we are:
1. Adding a new attribute to the schema: `@level` which indicates the level at which a proportion is applied. 
2. Adding the appropriate documentation for it in the guidelines (showing how it is meant to be used within `<mensur>` in sesquialtera proportion, where the mensuration is also changed as an effect of the use of this proportion).

The pull request generates valid schemas for Mei-all and Mei-mensural: 
[schemas to test.zip](https://github.com/music-encoding/music-encoding/files/12194732/schemas.to.test.zip)

And the use of the `@level` attribute is valid when using these both schemas, as can be tested when using the following file (provided by @annplaksin) and substituting the online schema by any of the two attached above.
[sesquialtera_level.mei.zip](https://github.com/music-encoding/music-encoding/files/12194747/sesquialtera_level.mei.zip)

The discussion about this attribute can be seen here: https://github.com/music-encoding/mensural-ig/discussions/16

