### PR TITLE
customizations: clean up of line.form and line.width

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -401,6 +401,7 @@
                         <memberOf key="att.altSym" mode="add"></memberOf>
                         <memberOf key="att.color" mode="add"></memberOf>
                         <memberOf key="att.extSym" mode="add"></memberOf>
+                        <memberOf key="att.lineRend.base" mode="add"></memberOf>
                         <memberOf key="att.typography" mode="add"></memberOf>
                         <memberOf key="att.visualOffset" mode="add"></memberOf>
                         <memberOf key="att.xy" mode="add"></memberOf>
@@ -434,18 +435,6 @@
                             <desc>Captures the fill color of the arrow if different from the line color.</desc>
                             <datatype maxOccurs="1" minOccurs="1">
                                 <rng:ref name="data.COLOR"></rng:ref>
-                            </datatype>
-                        </attDef>
-                        <attDef ident="line.form" mode="add" predeclare="false" usage="opt">
-                            <desc>Visual form of the line.</desc>
-                            <datatype maxOccurs="1" minOccurs="1">
-                                <rng:ref name="data.LINEFORM"></rng:ref>
-                            </datatype>
-                        </attDef>
-                        <attDef ident="line.width" mode="add" predeclare="false" usage="opt">
-                            <desc>Width of the line.</desc>
-                            <datatype maxOccurs="1" minOccurs="1">
-                                <rng:ref name="data.LINEWIDTH"></rng:ref>
                             </datatype>
                         </attDef>-\->
                     </attList>

--- a/source/docs/04-cmn.xml
+++ b/source/docs/04-cmn.xml
@@ -904,7 +904,7 @@
                            <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve" valid="true"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/cmn/cmn-gliss.txt" parse="text"/></egXML>
                         </figure>
                      </p>
-                     <p>The <gi scheme="MEI">gliss</gi> element is a member of the <ident type="class">model.controlEventLike</ident> class and therefore, like other control events, it occurs inside a measure after the staves and uses its <att>staff</att>, <att>layer</att>, <att>tstamp</att>, <att>tstamp2</att>, <att>startid</att> and <att>endid</att> attributes to connect it to the affected notes or chords. It is a semantic error not to specify a starting point attribute. The visual appearance of the indicating line may be recorded in the <att>line.form</att> and <att>line.width</att> attributes.</p>
+                     <p>The <gi scheme="MEI">gliss</gi> element is a member of the <ident type="class">model.controlEventLike</ident> class and therefore, like other control events, it occurs inside a measure after the staves and uses its <att>staff</att>, <att>layer</att>, <att>tstamp</att>, <att>tstamp2</att>, <att>startid</att> and <att>endid</att> attributes to connect it to the affected notes or chords. It is a semantic error not to specify a starting point attribute. The visual appearance of the indicating line may be recorded in the <att>lform</att> and <att>lwidth</att> attributes.</p>
                   </div>
                   <div xml:id="cmnBend" type="div4">
                      <head>Bend</head>


### PR DESCRIPTION
As a follow-up on #1285, this PR fixes the last remnants of `line.form` and `line.width` in the specs. So it syncs the model of `att.arpeg.vis` in MEI Basic with that in MEI all. (It is out commented in Basic, but should be in sync nonetheless.) Additionally, it fixes the long-deprecated line attributes for `gliss` described in the CMN guidelines.