### PR TITLE
schema: unify customization namespaces

### DIFF
--- a/customizations/mei-CMN.xml
+++ b/customizations/mei-CMN.xml
@@ -20,8 +20,7 @@
 <?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../source/validation/mei-customizations.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0"
-  xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/customizations/mei-CMN.xml
+++ b/customizations/mei-CMN.xml
@@ -55,10 +55,8 @@
         <!-- Declare MEI and XLink namespaces for use in Schematron -->
         <constraintSpec ident="set_ns" scheme="schematron" mode="add">
           <constraint>
-            <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="mei"
-              uri="http://www.music-encoding.org/ns/mei"/>
-            <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="xlink"
-              uri="http://www.w3.org/1999/xlink"/>
+            <sch:ns prefix="mei" uri="http://www.music-encoding.org/ns/mei"/>
+            <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
           </constraint>
         </constraintSpec>
 

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -20,8 +20,7 @@
 <?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../source/validation/mei-customizations.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0"
-  xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -55,10 +55,8 @@
         <!-- Declare MEI and XLink namespaces for use in Schematron -->
         <constraintSpec ident="set_ns" scheme="schematron" mode="add">
           <constraint>
-            <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="mei"
-              uri="http://www.music-encoding.org/ns/mei"/>
-            <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="xlink"
-              uri="http://www.w3.org/1999/xlink"/>
+            <sch:ns prefix="mei" uri="http://www.music-encoding.org/ns/mei"/>
+            <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
           </constraint>
         </constraintSpec>
 

--- a/customizations/mei-Neumes.xml
+++ b/customizations/mei-Neumes.xml
@@ -20,8 +20,7 @@
 <?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../source/validation/mei-customizations.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0"
-  xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/customizations/mei-Neumes.xml
+++ b/customizations/mei-Neumes.xml
@@ -55,10 +55,8 @@
         <!-- Declare MEI and XLink namespaces for use in Schematron -->
         <constraintSpec ident="set_ns" scheme="schematron" mode="add">
           <constraint>
-            <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="mei"
-              uri="http://www.music-encoding.org/ns/mei"/>
-            <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="xlink"
-              uri="http://www.w3.org/1999/xlink"/>
+            <sch:ns prefix="mei" uri="http://www.music-encoding.org/ns/mei"/>
+            <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
           </constraint>
         </constraintSpec>
 

--- a/customizations/mei-all.xml
+++ b/customizations/mei-all.xml
@@ -20,9 +20,7 @@
 <?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../source/validation/mei-customizations.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns:rng="http://relaxng.org/ns/structure/1.0"
-  xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-  xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns="http://www.tei-c.org/ns/1.0">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/customizations/mei-all.xml
+++ b/customizations/mei-all.xml
@@ -59,10 +59,8 @@
         <!-- Declare MEI and XLink namespaces for use in Schematron -->
         <constraintSpec ident="set_ns" scheme="schematron" mode="add">
           <constraint>
-            <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="mei"
-              uri="http://www.music-encoding.org/ns/mei"/>
-            <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="xlink"
-              uri="http://www.w3.org/1999/xlink"/>
+            <sch:ns prefix="mei" uri="http://www.music-encoding.org/ns/mei"/>
+            <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
           </constraint>
         </constraintSpec>
 

--- a/customizations/mei-all_anyStart.xml
+++ b/customizations/mei-all_anyStart.xml
@@ -104,10 +104,8 @@
         <!-- Declare MEI and XLink namespaces for use in Schematron -->
         <constraintSpec ident="set_ns" scheme="schematron" mode="add">
           <constraint>
-            <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="mei"
-              uri="http://www.music-encoding.org/ns/mei"/>
-            <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="xlink"
-              uri="http://www.w3.org/1999/xlink"/>
+            <sch:ns prefix="mei" uri="http://www.music-encoding.org/ns/mei"/>
+            <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
           </constraint>
         </constraintSpec>
 

--- a/customizations/mei-all_anyStart.xml
+++ b/customizations/mei-all_anyStart.xml
@@ -20,10 +20,7 @@
 <?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../source/validation/mei-customizations.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns:rng="http://relaxng.org/ns/structure/1.0"
-  xmlns:sch="http://purl.oclc.org/dsdl/schematron"
-  xmlns:a="http://relaxng.org/ns/compatibility/annotations/1.0" xmlns="http://www.tei-c.org/ns/1.0"
-  xmlns:math="http://exslt.org/math">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
   <teiHeader>
     <fileDesc>
       <titleStmt>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -20,8 +20,7 @@
 <?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <?xml-model href="../source/validation/mei_odds.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="../source/validation/mei-customizations.sch" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0"
-    xmlns:sch="http://purl.oclc.org/dsdl/schematron">
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xmlns:rng="http://relaxng.org/ns/structure/1.0" xmlns:sch="http://purl.oclc.org/dsdl/schematron">
     <teiHeader>
         <fileDesc>
             <titleStmt>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -67,10 +67,8 @@
                 <!-- Declare MEI and XLink namespaces for use in Schematron -->
                 <constraintSpec ident="set_ns" scheme="schematron" mode="add">
                     <constraint>
-                        <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="mei"
-                            uri="http://www.music-encoding.org/ns/mei"/>
-                        <sch:ns xmlns:sch="http://purl.oclc.org/dsdl/schematron" prefix="xlink"
-                            uri="http://www.w3.org/1999/xlink"/>
+                        <sch:ns prefix="mei" uri="http://www.music-encoding.org/ns/mei"/>
+                        <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
                     </constraint>
                 </constraintSpec>
 


### PR DESCRIPTION
This PR unifies the used namespaces in the customization files and removes redundant namespace declarations for schematron. 

NB: Everything has been tested and compared. The only thing changed in the built schemas is in some RNGs removing superfluous namespaces in schematron rules (resulting in slightly smaller RNGs). The build process automatically adds extra namespaces wherever they are needed.