### PR TITLE
guidelines: add missing contributors

### DIFF
--- a/source/contributors/curated.contributors.json
+++ b/source/contributors/curated.contributors.json
@@ -1,68 +1,5 @@
 [
     {
-        "login": "BruxDDay",
-        "name": "David A. Day",
-        "github": "https://github.com/BruxDDay",
-        "viaf": "http://viaf.org/viaf/61614909",
-        "orcid": "",
-        "avatar": "https://avatars.githubusercontent.com/u/19493378?v=4",
-        "suppress":false
-    },
-    {
-        "login": "DDMAL-LabManager",
-        "name": "DDMAL LabManager",
-        "github": "https://github.com/DDMAL-LabManager",
-        "viaf": "",
-        "orcid": "",
-        "avatar": "https://avatars.githubusercontent.com/u/31481010?v=4",
-        "suppress":true
-    },
-    {
-        "login": "dinamix1",
-        "name": "dinamix",
-        "github": "https://github.com/dinamix1",
-        "viaf": "",
-        "orcid": "",
-        "avatar": "https://avatars.githubusercontent.com/u/9153739?v=4",
-        "suppress":true
-    },
-    {
-        "login": "doerners",
-        "name": "Sophia Dörner",
-        "github": "https://github.com/doerners",
-        "viaf": "",
-        "orcid": "https://orcid.org/0000-0001-8747-3422",
-        "avatar": "https://avatars.githubusercontent.com/u/38356908?v=4",
-        "suppress":false
-    },
-    {
-        "login": "JRegimbal",
-        "name": "Juliette Regimbal",
-        "github": "https://github.com/JRegimbal",
-        "viaf": "",
-        "orcid": "https://orcid.org/0000-0003-4902-046X",
-        "avatar": "https://avatars.githubusercontent.com/u/6963142?v=4",
-        "suppress":false
-    },
-    {
-        "login": "MajaHartwig",
-        "name": "Maja Hartwig",
-        "github": "https://github.com/MajaHartwig",
-        "viaf": "http://viaf.org/viaf/254615230",
-        "orcid": "",
-        "avatar": "https://avatars.githubusercontent.com/u/2674338?v=4",
-        "suppress":false
-    },
-    {
-        "login": "TristanoTenaglia",
-        "name": "Tristano Tenaglia",
-        "github": "https://github.com/TristanoTenaglia",
-        "viaf": "",
-        "orcid": "",
-        "avatar": "https://avatars.githubusercontent.com/u/9153739?v=4",
-        "suppress":false
-    },
-    {
         "login": "ahankinson",
         "name": "Andrew Hankinson",
         "github": "https://github.com/ahankinson",
@@ -99,6 +36,15 @@
         "suppress":false
     },
     {
+        "login": "BruxDDay",
+        "name": "David A. Day",
+        "github": "https://github.com/BruxDDay",
+        "viaf": "http://viaf.org/viaf/61614909",
+        "orcid": "",
+        "avatar": "https://avatars.githubusercontent.com/u/19493378?v=4",
+        "suppress":false
+    },
+    {
         "login": "bwbohl",
         "name": "Benjamin W. Bohl",
         "github": "https://github.com/bwbohl",
@@ -117,12 +63,12 @@
         "suppress":false
     },
     {
-        "login": "dependabot[bot]",
-        "name": "",
-        "github": "https://github.com/apps/dependabot",
+        "login": "DDMAL-LabManager",
+        "name": "DDMAL LabManager",
+        "github": "https://github.com/DDMAL-LabManager",
         "viaf": "",
         "orcid": "",
-        "avatar": "https://avatars.githubusercontent.com/in/29110?v=4",
+        "avatar": "https://avatars.githubusercontent.com/u/31481010?v=4",
         "suppress":true
     },
     {
@@ -132,6 +78,24 @@
         "viaf": "",
         "orcid": "https://orcid.org/0000-0003-4151-0499",
         "avatar": "https://avatars.githubusercontent.com/u/4179692?v=4",
+        "suppress":false
+    },
+    {
+        "login": "dinamix1",
+        "name": "dinamix",
+        "github": "https://github.com/dinamix1",
+        "viaf": "",
+        "orcid": "",
+        "avatar": "https://avatars.githubusercontent.com/u/9153739?v=4",
+        "suppress":true
+    },
+    {
+        "login": "doerners",
+        "name": "Sophia Dörner",
+        "github": "https://github.com/doerners",
+        "viaf": "",
+        "orcid": "https://orcid.org/0000-0001-8747-3422",
+        "avatar": "https://avatars.githubusercontent.com/u/38356908?v=4",
         "suppress":false
     },
     {
@@ -180,6 +144,15 @@
         "suppress":false
     },
     {
+        "login": "JRegimbal",
+        "name": "Juliette Regimbal",
+        "github": "https://github.com/JRegimbal",
+        "viaf": "",
+        "orcid": "https://orcid.org/0000-0003-4902-046X",
+        "avatar": "https://avatars.githubusercontent.com/u/6963142?v=4",
+        "suppress":false
+    },
+    {
         "login": "karend27",
         "name": "Karen Desmond",
         "github": "https://github.com/karend27",
@@ -213,6 +186,15 @@
         "viaf": "http://viaf.org/viaf/313473048",
         "orcid": "https://orcid.org/0000-0002-9525-4331",
         "avatar": "https://avatars.githubusercontent.com/u/689412?v=4",
+        "suppress":false
+    },
+    {
+        "login": "MajaHartwig",
+        "name": "Maja Hartwig",
+        "github": "https://github.com/MajaHartwig",
+        "viaf": "http://viaf.org/viaf/254615230",
+        "orcid": "",
+        "avatar": "https://avatars.githubusercontent.com/u/2674338?v=4",
         "suppress":false
     },
     {
@@ -312,6 +294,15 @@
         "viaf": "",
         "orcid": "",
         "avatar": "https://avatars.githubusercontent.com/u/1147152?v=4",
+        "suppress":false
+    },
+    {
+        "login": "TristanoTenaglia",
+        "name": "Tristano Tenaglia",
+        "github": "https://github.com/TristanoTenaglia",
+        "viaf": "",
+        "orcid": "",
+        "avatar": "https://avatars.githubusercontent.com/u/9153739?v=4",
         "suppress":false
     },
     {

--- a/source/contributors/curated.contributors.json
+++ b/source/contributors/curated.contributors.json
@@ -9,12 +9,30 @@
         "suppress":false
     },
     {
+        "login": "alastair",
+        "name": "Alastair Porter",
+        "github": "https://github.com/alastair",
+        "viaf": "",
+        "orcid": "",
+        "avatar": "https://avatars.githubusercontent.com/u/19217?v=4",
+        "suppress":false
+    },
+    {
         "login": "annplaksin",
         "name": "Anna Plaksin",
         "github": "https://github.com/annplaksin",
         "viaf": "http://viaf.org/viaf/2799161575661804730001",
         "orcid": "https://orcid.org/0000-0002-9969-0608",
         "avatar": "https://avatars.githubusercontent.com/u/12529090?v=4",
+        "suppress":false
+    },
+    {
+        "login": "apacha",
+        "name": "Alexander Pacha",
+        "github": "https://github.com/apacha",
+        "viaf": "http://viaf.org/viaf/5118166360578907070008",
+        "orcid": "https://orcid.org/0000-0002-6064-7696",
+        "avatar": "https://avatars.githubusercontent.com/u/594497?v=4",
         "suppress":false
     },
     {
@@ -258,6 +276,15 @@
         "viaf": "https://viaf.org/viaf/313473016/",
         "orcid": "",
         "avatar": "https://avatars.githubusercontent.com/u/5712877?v=4",
+        "suppress":false
+    },
+    {
+        "login": "pfefferniels",
+        "name": "Niels Pfeffer",
+        "github": "https://github.com/pfefferniels",
+        "viaf": "http://viaf.org/viaf/748168290783457610003",
+        "orcid": "https://orcid.org/0000-0002-6210-7255",
+        "avatar": "https://avatars.githubusercontent.com/u/47777840?v=4",
         "suppress":false
     },
     {

--- a/source/docs/01-introduction.xml
+++ b/source/docs/01-introduction.xml
@@ -51,6 +51,7 @@
                <name ref="https://api.github.com/users/napulen">Néstor Nápoles López</name>
                <name ref="https://api.github.com/users/MajaHartwig">MajaHartwig</name>
                <name ref="https://api.github.com/users/musicEnfanthen">Stefan Münnich</name>
+               <name ref="https://api.github.com/users/apacha">Alexander Pacha</name>
                <name ref="https://api.github.com/users/pe-ro">pe-ro</name>
                <name ref="https://api.github.com/users/lpugin">Laurent Pugin</name>
                <name ref="https://api.github.com/users/JRegimbal">Juliette Regimbal</name>

--- a/source/docs/04-cmn.xml
+++ b/source/docs/04-cmn.xml
@@ -55,6 +55,7 @@
                <name ref="https://api.github.com/users/MajaHartwig">MajaHartwig</name>
                <name ref="https://api.github.com/users/musicEnfanthen">Stefan Münnich</name>
                <name ref="https://api.github.com/users/pe-ro">pe-ro</name>
+               <name ref="https://api.github.com/users/alastair">Alastair Porter</name>
                <name ref="https://api.github.com/users/lpugin">Laurent Pugin</name>
                <name ref="https://api.github.com/users/JRegimbal">Juliette Regimbal</name>
                <name ref="https://api.github.com/users/rettinghaus">Klaus Rettinghaus</name>

--- a/source/docs/06-neumes.xml
+++ b/source/docs/06-neumes.xml
@@ -55,6 +55,7 @@
                <name ref="https://api.github.com/users/MajaHartwig">MajaHartwig</name>
                <name ref="https://api.github.com/users/musicEnfanthen">Stefan Münnich</name>
                <name ref="https://api.github.com/users/pe-ro">pe-ro</name>
+               <name ref="https://api.github.com/users/pfefferniels">Niels Pfeffer</name>
                <name ref="https://api.github.com/users/lpugin">Laurent Pugin</name>
                <name ref="https://api.github.com/users/JRegimbal">Juliette Regimbal</name>
                <name ref="https://api.github.com/users/rettinghaus">Klaus Rettinghaus</name>


### PR DESCRIPTION
As a follow-up of #1292, this PR adds the missing contributors to the guidelines chapters and the curated json list which is now sorted alphabetically.

In addition, Dependabot is removed from the curated list.