### PR TITLE
guidelines: add missing contributors (2)

### DIFF
--- a/source/contributors/curated.contributors.json
+++ b/source/contributors/curated.contributors.json
@@ -90,6 +90,15 @@
         "suppress":true
     },
     {
+        "login": "dependabot[bot]",
+        "name": "",
+        "github": "https://github.com/apps/dependabot",
+        "viaf": "",
+        "orcid": "",
+        "avatar": "https://avatars.githubusercontent.com/in/29110?v=4",
+        "suppress":true
+    },
+    {
         "login": "DILewis",
         "name": "David Lewis",
         "github": "https://github.com/DILewis",

--- a/source/contributors/curated.contributors.json
+++ b/source/contributors/curated.contributors.json
@@ -105,7 +105,7 @@
         "viaf": "",
         "orcid": "",
         "avatar": "https://avatars.githubusercontent.com/u/9153739?v=4",
-        "suppress":true
+        "suppress":false
     },
     {
         "login": "doerners",
@@ -159,6 +159,15 @@
         "viaf": "http://viaf.org/viaf/69035906",
         "orcid": "https://orcid.org/0000-0001-8897-2880",
         "avatar": "https://avatars.githubusercontent.com/u/10829937?v=4",
+        "suppress":false
+    },
+    {
+        "login": "jcdevaney",
+        "name": "Johanna Devaney",
+        "github": "https://github.com/jcdevaney",
+        "viaf": "http://viaf.org/viaf/313271713",
+        "orcid": "https://orcid.org/0000-0002-7353-5271",
+        "avatar": "https://avatars.githubusercontent.com/u/1108426?v=4",
         "suppress":false
     },
     {
@@ -231,6 +240,15 @@
         "viaf": "",
         "orcid": "https://orcid.org/0000-0002-5042-2266",
         "avatar": "https://avatars.githubusercontent.com/u/13948831?v=4",
+        "suppress":false
+    },
+    {
+        "login": "mss2221",
+        "name": "Mark Saccomano",
+        "github": "https://github.com/mss2221",
+        "viaf": "",
+        "orcid": "https://orcid.org/0000-0002-4635-7684",
+        "avatar": "hhttps://avatars.githubusercontent.com/u/27446953?v=4",
         "suppress":false
     },
     {
@@ -314,6 +332,14 @@
         "avatar": "https://avatars.githubusercontent.com/u/7693447?v=4",
         "suppress":false
     },
+    {
+        "login": "riedde",
+        "name": "Dennis Ried",
+        "github": "https://github.com/riedde",
+        "viaf": "http://viaf.org/viaf/18157038080566862515",
+        "orcid": "https://orcid.org/0000-0001-5545-2088",
+        "avatar": "https://avatars.githubusercontent.com/u/27779797?v=4",
+        "suppress":false
     {
         "login": "th-we",
         "name": "Thomas Weber",

--- a/utils/guidelines_xslt/odd2html/functions.xsl
+++ b/utils/guidelines_xslt/odd2html/functions.xsl
@@ -429,7 +429,7 @@
             <p>
                 The Guidelines and specifications made available in this document wouldn't have been possible without the generous
                 and selfless support of a large number of people. Some of those people, especially from the early days of MEI are 
-                explicitly mentioned in chapter <a href="#acknowledgments">1.1.2 Acknowledgments</a> of these Guidelines. However, we 
+                explicitly mentioned in chapter <a href="#acknowledgments">1.1.1 Acknowledgments</a> of these Guidelines. However, we 
                 believe it is important to give proper recognition to everyone contributing to this community effort. Without 
                 their continued commitment, MEI would not be possible. 
             </p>            


### PR DESCRIPTION
Another follow-up of #1292 and #1294 to include all missing contributors from the main and guidelines repo. It also reincludes dependabot (with suppress flag) that is needed to suppress the output in the PDF guidelines.

It also fixes a wrong chapter reference from the contributors list.