### PR TITLE
schema: reduce version number

### DIFF
--- a/customizations/mei-all_anyStart.xml
+++ b/customizations/mei-all_anyStart.xml
@@ -161,8 +161,8 @@
             <attDef ident="meiversion" usage="rec" mode="change">
               <desc>Specifies a generic MEI version label.</desc>
               <valList type="closed">
-                <valItem ident="5.0.0-dev">
-                  <desc>Development version of MEI 5.0.0</desc>
+                <valItem ident="5.0-dev">
+                  <desc>Development version of MEI 5.0</desc>
                 </valItem>
               </valList>
             </attDef>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -966,7 +966,7 @@
                         <attDef ident="meiversion" usage="req">
                             <desc>Specifies a generic MEI version label.</desc>
                             <valList type="closed">
-                                <valItem ident="5.0.0-dev+basic">
+                                <valItem ident="5.0-dev+basic">
                                     <desc>This version of MEI.</desc>
                                 </valItem>
                             </valList>

--- a/source/examples/neumes/neumes-sample169.txt
+++ b/source/examples/neumes/neumes-sample169.txt
@@ -1,4 +1,4 @@
-<music xmlns="http://www.music-encoding.org/ns/mei" meiversion="4.0.0">
+<music xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0-dev">
    <body>
       <mdiv>
          <score>

--- a/source/examples/verovio/04-score-redefinition.mei
+++ b/source/examples/verovio/04-score-redefinition.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/accid-03.mei
+++ b/source/examples/verovio/accid-03.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/alteration.mei
+++ b/source/examples/verovio/alteration.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/ars_antiqua.mei
+++ b/source/examples/verovio/ars_antiqua.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/augmentation.mei
+++ b/source/examples/verovio/augmentation.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/imperfection.mei
+++ b/source/examples/verovio/imperfection.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/implicit-mensuration.mei
+++ b/source/examples/verovio/implicit-mensuration.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/mensuration_changes.mei
+++ b/source/examples/verovio/mensuration_changes.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/motet_fauvel_fol22r_triplum.mei
+++ b/source/examples/verovio/motet_fauvel_fol22r_triplum.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/notes_rests.mei
+++ b/source/examples/verovio/notes_rests.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/octave-shift-01.mei
+++ b/source/examples/verovio/octave-shift-01.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/partial-imp-01-propinquam.mei
+++ b/source/examples/verovio/partial-imp-01-propinquam.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/partial-imp-02-bilateral.mei
+++ b/source/examples/verovio/partial-imp-02-bilateral.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/partial-imp-03-remotam.mei
+++ b/source/examples/verovio/partial-imp-03-remotam.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/partial-imp-04-remotam.mei
+++ b/source/examples/verovio/partial-imp-04-remotam.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/tempo-01.mei
+++ b/source/examples/verovio/tempo-01.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0-dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/mei-source.xml
+++ b/source/mei-source.xml
@@ -80,7 +80,7 @@
             </respStmt>
          </titleStmt>
          <editionStmt>
-            <edition>Version 5.0.0</edition>
+            <edition>Version 5.0</edition>
          </editionStmt>
          <publicationStmt>
             <distributor>Music Encoding Initiative (MEI) Council</distributor>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1891,10 +1891,10 @@
     <attList>
       <attDef ident="meiversion" usage="opt">
         <desc xml:lang="en">Specifies a generic MEI version label.</desc>
-        <defaultVal>5.0.0-dev</defaultVal>
+        <defaultVal>5.0-dev</defaultVal>
         <valList type="closed">
-          <valItem ident="5.0.0-dev">
-            <desc xml:lang="en">Development version of MEI 5.0.0</desc>
+          <valItem ident="5.0-dev">
+            <desc xml:lang="en">Development version of MEI 5.0</desc>
           </valItem>
         </valList>
       </attDef>


### PR DESCRIPTION
This PR is a first step towards v5.0 as it reduces the current version number to two levels (`5.0-dev`).

Fixes #1174