### PR TITLE
customizations: fix start elements in anystart

### DIFF
--- a/customizations/mei-all_anyStart.xml
+++ b/customizations/mei-all_anyStart.xml
@@ -81,7 +81,7 @@
         editor editorialDecl encodingDesc ending epigraph episema event eventList exhibHist expan
         expansion explicit expression expressionList extData extent extMeta f facsimile famName fb fermata fig
         figDesc fileChar fileDesc fing fingGrp foliaDesc foliation folium foreName front
-        fTrem funder gap genDesc genName genre genState geogFeat geogName gliss graceGrp graphic group grpSym 
+        fTrem funder gap genDesc genName genre genState geogFeat geogName gliss graceGrp graphic group grpSym
         hairpin halfmRpt hand handList handShift harm harpPedal head height heraldry hex hispanTick
         history identifier imprimatur imprint incip incipCode incipText inscription instrDef
         instrGrp interpretation item itemList key keyAccid keySig l label labelAbbr language langUsage

--- a/customizations/mei-all_anyStart.xml
+++ b/customizations/mei-all_anyStart.xml
@@ -69,36 +69,36 @@
         meiHead, meiCorpus, and music. -->
       <schemaSpec ident="mei" ns="http://www.music-encoding.org/ns/mei" prefix="mei_" start="abbr
         accessRestrict accid accMat acquisition actor add addDesc addName address addrLine altId
-        ambitus ambNote anchoredText annot app appInfo application argument arpeg arranger artic
+        ambitus ambNote analytic anchoredText annot app appInfo application argument arpeg arranger artic
         attacca attUsage audience author availability avFile back barLine barre beam beamSpan beatRpt
-        bend bibl biblList biblScope bifolium binding bindingDesc bloc body bracketSpan breath bTrem
+        bend bibl biblList biblScope biblStruct bifolium binding bindingDesc bloc body bracketSpan breath bTrem
         byline caesura caption captureMode carrierForm castGrp castItem castList catchwords category
         catRel cb cc chan change changeDesc chanPr choice chord chordDef chordMember chordTable
         classDecls classification clef clefGrp clip collation colLayout colophon componentList composer
         condition contentItem contents context contributor corpName corr correction country cpMark
         creation cue curve custos cutout damage date decoDesc decoNote dedicatee dedication del depth
-        desc dim dimensions dir distributor district div domainsDecl dot dynam edition editionStmt
+        desc dim dimensions dir distributor district div divLine domainsDecl dot dynam edition editionStmt
         editor editorialDecl encodingDesc ending epigraph episema event eventList exhibHist expan
-        expansion explicit expression expressionList extent extMeta f facsimile famName fb fermata fig
-        figDesc fileChar fileDesc fing fingerprint fingGrp foliaDesc foliation folium foreName front
-        fTrem funder gap genDesc genName genre geogFeat geogName gliss graceGrp graphic group grpSym
+        expansion explicit expression expressionList extData extent extMeta f facsimile famName fb fermata fig
+        figDesc fileChar fileDesc fing fingGrp foliaDesc foliation folium foreName front
+        fTrem funder gap genDesc genName genre genState geogFeat geogName gliss graceGrp graphic group grpSym 
         hairpin halfmRpt hand handList handShift harm harpPedal head height heraldry hex hispanTick
-        history identifier imprimatur imprint incip incipCode incipit incipText inscription instrDef
+        history identifier imprimatur imprint incip incipCode incipText inscription instrDef
         instrGrp interpretation item itemList key keyAccid keySig l label labelAbbr language langUsage
         layer layerDef layout layoutDesc lb lem lg li librettist ligature line liquescent list locus
-        locusGrp lv lyricist mapping marker material mdiv measure mei meiCorpus meiHead mensur
-        mensuration metaMark metaText meter meterSig meterSigGrp midi mNum mordent mRest mRpt mRpt2
+        locusGrp lv lyricist manifestation manifestationList mapping marker mdiv measure mei meiCorpus meiHead mensur
+        mensuration metaMark metaText meter meterSig meterSigGrp midi mNum monogr mordent mRest mRpt mRpt2
         mSpace multiRest multiRpt music name nameLink namespace nc ncGrp neume normalization note
-        noteOff noteOn notesStmt num octave oLayer orig ornam oriscus ossia oStaff otherChar p pad part
+        noteOff noteOn notesStmt num octave oLayer orig oriscus ornam ossia oStaff otherChar p pad part
         parts patch pb pedal perfDuration perfMedium performance perfRes perfResList periodName
-        persName pgDesc pgFoot pgFoot2 pgHead pgHead2 phrase physDesc physLoc physMedium plateNum
-        playingSpeed port postBox postCode price prog projectDesc propName proport propValue provenance
+        persName pgDesc pgFoot pgHead phrase physDesc physLoc physMedium plateNum
+        playingSpeed plica port postBox postCode price prog projectDesc propName proport propValue provenance
         ptr publisher pubPlace pubStmt q quilisma quote rdg recipient recording ref refrain reg region
-        reh relatedItem relation relationList rend repository resp respStmt rest restore revisionDesc
+        reh relatedItem relation relationList rend repeatMark repository resp respStmt rest restore revisionDesc
         role roleDesc roleName rubric samplingDecl sb score scoreDef scoreFormat scriptDesc scriptNote
         seal sealDesc secFolio section seg segmentation seqNum series seriesStmt settlement sic
-        signatures signifLet slur soundChan source sourceDesc sp space speaker strophicus specRepro
-        sponsor stack staff staffDef staffGrp stageDir stamp state stdVals street styleName subst
+        signatures signifLet slur soundChan source sourceDesc sp space speaker specRepro
+        sponsor stack staff staffDef staffGrp stageDir stamp stdVals stem street strophicus styleName subst
         supplied support supportDesc surface syl syllable symbol symbolDef symbolTable symName symProp
         sysReq table tagsDecl tagUsage taxonomy td tempo term termList textLang th tie title titlePage
         titlePart titleStmt tr trackConfig treatHist treatSched trill trkName tuplet tupletSpan turn


### PR DESCRIPTION
This PR fixes the start elements in `mei-all_anyStart.xml`.

For MEI 5, `fingerprint`, `pgHead2` and `pgFoot2` have been removed and `divLine`, `extData`, `plica`, `repeatMark` and `stem` have been added.

Other additions and deletions are for elements in MEI 4 (or older?) that were still missing or not removed.

The list is now in sync with the current elements overview in the dev guidelines: https://music-encoding.org/guidelines/dev/elements.html

Fixes #1302