### PR TITLE
style: add css rule for span.val in PDF guidelines

### DIFF
--- a/source/assets/css/print/mei.css
+++ b/source/assets/css/print/mei.css
@@ -741,6 +741,14 @@ div.facet div.classItem span.ident.attribute:before, span.att:before {
     content: '@';
 }
 
+span.val:before {
+    content: "'";
+}
+
+span.val:after {
+    content: "'";
+}
+
 .specSection a.link_odd_elementSpec:before, p > a.link_odd_elementSpec:before, .specDesc a.link_odd_elementSpec:before {
     content: '<';
 }


### PR DESCRIPTION
This PR adds a missing CSS rule for the PDF guidelines where `<val>` elements were not processed at all. Adds the same css rules applied in the online version.