### PR TITLE
guidelines: add attribute changes to "about version" section

### DIFF
--- a/source/docs/01-introduction.xml
+++ b/source/docs/01-introduction.xml
@@ -236,15 +236,15 @@
                      <gi scheme="MEI">pgHead</gi> and <gi scheme="MEI">pgFoot</gi> respectively. 
                      Most other changes affect more specific aspects in the model of MEI, usually 
                      expressed in attributes. These include the refinement of the encoding of key 
-                     signatures, with @key.sig moved to <att>keysig</att>, @keysig.show moved to 
-                     <att>keysig.visible</att>, and @keysig.showchange and @sig.showchange moved to 
-                     <att>keysig.cancelaccid</att> and <att>cancelaccid</att> respectively. The @instr 
+                     signatures, with <att>key.sig</att> moved to <att>keysig</att>, <att>keysig.show</att> moved to 
+                     <att>keysig.visible</att>, and <att>keysig.showchange</att> and <att>sig.showchange</att> moved to 
+                     <att>keysig.cancelaccid</att> and <att>cancelaccid</att> respectively. The <att>instr</att> 
                      attribute is removed from quiet events like <gi scheme="MEI">rest</gi>, 
                      <gi scheme="MEI">mRest</gi>, <gi scheme="MEI">mSpace</gi> and <gi scheme="MEI">multiRest</gi>, 
-                     and the @visible attribute is also removed from <gi scheme="MEI">mRest</gi>. 
-                     Moreover, attributes @line.form and @line.width on the <gi scheme="MEI">arpeg</gi> 
+                     and the <att>visible</att> attribute is also removed from <gi scheme="MEI">mRest</gi>. 
+                     Moreover, attributes <att>line.form</att> and <att>line.width</att> on the <gi scheme="MEI">arpeg</gi> 
                      element are aligned with other line-like elements as <att>lform</att> and 
-                     <att>lwidth</att>. @text.dist on <gi scheme="MEI">scoreDef</gi> and 
+                     <att>lwidth</att>. <att>text.dist</att> on <gi scheme="MEI">scoreDef</gi> and 
                      <gi scheme="MEI">staffDef</gi> is removed in favor of the newly added attributes 
                      <att>dir.dist</att>, <att>reh.dist</att> or <att>tempo.dist</att>. 
                      <att>meter.form</att>="invis" is updated to <att>meter.visible</att>="false", 

--- a/source/docs/01-introduction.xml
+++ b/source/docs/01-introduction.xml
@@ -233,17 +233,38 @@
                      The release technically removes the &lt;fingerprint&gt; element, which has been 
                      deprecated for ten years. It also removes the elements &lt;pgHead2&gt; and 
                      &lt;pgFoot2&gt;, which are now superseded by the <att>func</att> attribute on 
-                     <gi scheme="MEI">pgHead</gi> and <gi scheme="MEI">pgFoot</gi> respectively. Most other changes affect more specific aspects in the model of MEI, usually expressed in
-                     attributes. These can be traced in the detailed Release Notes auto-generated from 
-                     the Pull Requests on GitHub. A larger group of changes affects the internal class
-                     structure of MEI only, where significant effort went into improved consistency in
-                     naming things. While this set of changes does not affect end users of MEI during
-                     validation of their files, they may have consequences for local customizations which
-                     reference classes not available anymore. If you have advanced local customizations
-                     based on MEI v4 or older releases, please check that the rules provided still work as
-                     expected under v5. A very helpful addition for this task may be the validation for MEI
-                     customizations, which is now available and used for all customizations officially
-                     provided by MEI.</p>
+                     <gi scheme="MEI">pgHead</gi> and <gi scheme="MEI">pgFoot</gi> respectively. 
+                     Most other changes affect more specific aspects in the model of MEI, usually 
+                     expressed in attributes. These include the refinement of the encoding of key 
+                     signatures, with @key.sig moved to <att>keysig</att>, @keysig.show moved to 
+                     <att>keysig.visible</att>, and @keysig.showchange and @sig.showchange moved to 
+                     <att>keysig.cancelaccid</att> and <att>cancelaccid</att> respectively. The @instr 
+                     attribute is removed from quiet events like <gi scheme="MEI">rest</gi>, 
+                     <gi scheme="MEI">mRest</gi>, <gi scheme="MEI">mSpace</gi> and <gi scheme="MEI">multiRest</gi>, 
+                     and the @visible attribute is also removed from <gi scheme="MEI">mRest</gi>. 
+                     Moreover, attributes @line.form and @line.width on the <gi scheme="MEI">arpeg</gi> 
+                     element are aligned with other line-like elements as <att>lform</att> and 
+                     <att>lwidth</att>. @text.dist on <gi scheme="MEI">scoreDef</gi> and 
+                     <gi scheme="MEI">staffDef</gi> is removed in favor of the newly added attributes 
+                     <att>dir.dist</att>, <att>reh.dist</att> or <att>tempo.dist</att>. 
+                     <att>meter.form</att>="invis" is updated to <att>meter.visible</att>="false", 
+                     and the same change applies to <att>form</att>="invis" on meterSig, now replaced 
+                     with <att>visible</att>="false". The text-rendition values of <val>letter-spacing</val> 
+                     and <val>line-height</val> on <att>rend</att> are moved to separate attributes, that is, 
+                     <att>rend</att>="letter-spacing(0.25) line-height(120%)" will be now 
+                     <att>letterspacing</att>="0.25" <att>lineheight</att>="120%". Additionally, corrections 
+                     are applied to specific attribute values, such as changing <val>Bagpipe</val> on
+                     <att>midi.instrname</att> to <val>Bag_pipe</val> and replacing <val>dblwhole</val> 
+                     on <att>head.mod</att> with <val>fences</val>. These changes can be traced in the 
+                     detailed Release Notes auto-generated from the Pull Requests on GitHub. A larger 
+                     group of changes affects the internal class structure of MEI only, where significant
+                     effort went into improved consistency in naming things. While this set of changes 
+                     does not affect end users of MEI during validation of files, they may have 
+                     consequences for local customizations which reference classes not available anymore. 
+                     If you have advanced local customizations based on MEI v4 or older releases, 
+                     please check that the rules provided still work as expected under v5. A very helpful 
+                     addition for this task may be the validation for MEI customizations, which is now 
+                     available and used for all customizations officially provided by MEI.</p>
                   </div>
                   <div xml:id="infrastructuralChanges" type="div4">
                      <head>Infrastructural changes</head>

--- a/source/docs/01-introduction.xml
+++ b/source/docs/01-introduction.xml
@@ -255,7 +255,7 @@
                      <att>letterspacing</att>="0.25" <att>lineheight</att>="120%". Additionally, corrections 
                      are applied to specific attribute values, such as changing <val>Bagpipe</val> on
                      <att>midi.instrname</att> to <val>Bag_pipe</val> and replacing <val>dblwhole</val> 
-                     on <att>head.mod</att> with <val>fences</val>. These changes can be traced in the 
+                     on <att>head.mod</att> with <val>fences</val>. All changes can be traced in the 
                      detailed Release Notes auto-generated from the Pull Requests on GitHub. A larger 
                      group of changes affects the internal class structure of MEI only, where significant
                      effort went into improved consistency in naming things. While this set of changes 


### PR DESCRIPTION
This PR includes some more statements on major attribute changes for MEI 5 in the "about version" section of chapter 1 of the guidelines.