### PR TITLE
customizations: fix missing `@n` in verse in MEI Basic

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -958,6 +958,30 @@
                             attribute may be used to capture the width of the measure for interchange with music
                             printing systems that utilize this information for printing.</p>
                     </remarks>
+                </elementSpec>                
+                
+                <elementSpec ident="verse" module="MEI.lyrics" mode="change">
+                    <desc xml:lang="en">Division of a poem or song lyrics, sometimes having a fixed length, meter or rhyme scheme; a stanza.</desc>
+                    <classes>
+                        <memberOf key="att.common"/>
+                        <memberOf key="att.verse.vis"/>
+                        <memberOf key="model.verseLike"/>
+                        <memberOf key="att.nNumberLike" mode="add"/>
+                    </classes>
+                    <content>
+                        <rng:zeroOrMore>
+                            <rng:ref name="label"/>
+                        </rng:zeroOrMore>
+                        <rng:zeroOrMore>
+                            <rng:ref name="labelAbbr"/>
+                        </rng:zeroOrMore>
+                        <rng:oneOrMore>
+                            <rng:choice>
+                                <rng:ref name="volta"/>
+                                <rng:ref name="model.sylLike"/>
+                            </rng:choice>
+                        </rng:oneOrMore>
+                    </content>
                 </elementSpec>
                 
                 <classSpec ident="att.meiVersion" module="MEI.shared" type="atts" mode="replace">


### PR DESCRIPTION
One or more `verse` is allowed, but no `@n`. It is semantically problematic and since this is a critical bug in MEI Basic I am making a PR to the release candidate.

