### PR TITLE
schema: add stem.split to att.stems

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -3258,9 +3258,6 @@
           <valItem ident="right">
             <desc xml:lang="en">The stem branches off to the right.</desc>
           </valItem>
-          <valItem ident="straight">
-            <desc xml:lang="en">The stem is a straight line.</desc>
-          </valItem>
         </valList>
       </attDef>
       <attDef ident="stem.visible" usage="opt">

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -3237,6 +3237,32 @@
           </constraint>
         </constraintSpec>
       </attDef>
+      <attDef ident="stem.split" usage="opt">
+        <desc xml:lang="en">Determines if and how a stem should be split within a chord.</desc>
+        <constraintSpec ident="check_stem.split" scheme="schematron">
+          <constraint>
+            <sch:rule context="@stem.split">
+              <sch:assert role="error" test="not(parent::node()/local-name() = 'chord')">
+                @stem.split must not be used on chords.
+              </sch:assert>
+              <sch:assert role="error" test="self::node()/ancestor::mei:chord">
+                Split stem notes are expected to be chord notes.
+              </sch:assert>
+            </sch:rule>
+          </constraint>
+        </constraintSpec>
+        <valList type="closed">
+          <valItem ident="left">
+            <desc xml:lang="en">The stem branches off to the left.</desc>
+          </valItem>
+          <valItem ident="right">
+            <desc xml:lang="en">The stem branches off to the right.</desc>
+          </valItem>
+          <valItem ident="straight">
+            <desc xml:lang="en">The stem is a straight line.</desc>
+          </valItem>
+        </valList>
+      </attDef>
       <attDef ident="stem.visible" usage="opt">
         <desc xml:lang="en">Determines whether a stem should be displayed.</desc>
         <datatype>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -3243,7 +3243,7 @@
           <constraint>
             <sch:rule context="@stem.split">
               <sch:assert role="error" test="not(parent::node()/local-name() = 'chord')">
-                @stem.split must not be used on chords.
+                @stem.split must not be used directly on chord elements.
               </sch:assert>
               <sch:assert role="error" test="self::node()/ancestor::mei:chord">
                 Split stem notes are expected to be chord notes.


### PR DESCRIPTION
It seems we reached consensus on possible encodings for split stem notation. 
This PR offers an implementation with `@stem.split` as part of `att.stems`. 
Alternatively it could be a direct child of `note` to simplify the schematron rules.

closes #721


- [x] modify schema
- [ ] add example to the guidelines