### PR TITLE
Fix MEI Basic

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -637,7 +637,7 @@
                         <memberOf key="att.cue"/>
                         <memberOf key="att.duration.log"/><!-- changed from att.restduration.log -->
                         <memberOf key="att.event"/>
-                        <memberOf key="att.rest.log.cmn"/>
+                        <!--<memberOf key="att.rest.log.cmn"/>-->
                     </classes>
                 </classSpec>
 
@@ -696,7 +696,7 @@
                         <memberOf key="att.extSym"/>
                         <memberOf key="att.stems"/>
                         <!--<memberOf key="att.typography"/>-->
-                        <memberOf key="att.visibility"/>
+                        <!--<memberOf key="att.visibility"/>-->
                         <memberOf key="att.visualOffset.ho"/>
                         <memberOf key="att.visualOffset.to"/>
                         <!--<memberOf key="att.xy"/>-->
@@ -895,7 +895,7 @@
                         <memberOf key="att.fermata.log"/>
                         <memberOf key="att.fermata.vis"/>
                         <!--<memberOf key="att.fermata.ges"/>-->
-                        <memberOf key="att.fermata.anl"/>
+                        <!--<memberOf key="att.fermata.anl"/>-->
                         <memberOf key="model.controlEventLike.cmn"/>
                         <memberOf key="att.placement" mode="add"/>
                     </classes>
@@ -1181,7 +1181,7 @@
                         <!--<memberOf key="att.scoreDef.log"/>-->
                         <!--<memberOf key="att.scoreDef.vis"/>-->
                         <!--<memberOf key="att.scoreDef.ges"/>-->
-                        <memberOf key="att.scoreDef.anl"/>
+                        <!--<memberOf key="att.scoreDef.anl"/>-->
                         <memberOf key="model.scoreDefLike"/>
                         
                         <memberOf key="att.keySigDefault.log" mode="add"/>
@@ -1230,10 +1230,10 @@
                         <memberOf key="att.common"/>
                         <memberOf key="att.facsimile"/>
                         <!--<memberOf key="att.metadataPointing"/>-->
-                        <memberOf key="att.staffGrp.log"/>
+                        <!--<memberOf key="att.staffGrp.log"/>-->
                         <memberOf key="att.staffGrp.vis"/>
                         <memberOf key="att.staffGrp.ges"/>
-                        <memberOf key="att.staffGrp.anl"/>
+                        <!--<memberOf key="att.staffGrp.anl"/>-->
                         <memberOf key="model.staffGrpLike"/>
                     </classes>
                     <content>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -35,6 +35,10 @@
                     <name xml:id="LP">Laurent Pugin</name>
                 </respStmt>
                 <respStmt>
+                    <resp>Revisions</resp>
+                    <name xml:id="KR">Klaus Rettinghaus</name>
+                </respStmt>
+                <respStmt>
                     <resp>In collaboration with</resp>
                     <name>The MEI Community</name>
                 </respStmt>
@@ -58,6 +62,9 @@
             </change>
             <change n="3" from="2023-05-24" to="2023-06-12" who="#LP">
                 <desc>Revisions at the MEI Developers Conference, Charlottesville.</desc>
+            </change>
+            <change n="4" when="2023-08-23" who="#KR">
+                <desc>Minor fixes.</desc>
             </change>
         </revisionDesc>
     </teiHeader>
@@ -311,11 +318,11 @@
                 <classSpec type="atts" ident="att.bibl" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.classed" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.clefGrp.log" module="MEI.shared" mode="delete"/>
-                <classSpec type="atts" ident="att.color" module="MEI.shared" mode="delete"/>
+                <!--<classSpec type="atts" ident="att.color" module="MEI.shared" mode="delete"/>-->
                 <classSpec type="atts" ident="att.coloration" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.distances" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.duration.default" module="MEI.shared" mode="delete"/>
-                <classSpec type="atts" ident="att.enclosingChars" module="MEI.shared" mode="delete"/>
+                <!--<classSpec type="atts" ident="att.enclosingChars" module="MEI.shared" mode="delete"/>-->
                 <classSpec type="atts" ident="att.endings" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.evidence" module="MEI.shared" mode="delete"/>
                 <!--<classSpec type="atts" ident="att.extender" module="MEI.shared" mode="delete"/>-->

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -322,7 +322,7 @@
                 <classSpec type="atts" ident="att.coloration" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.distances" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.duration.default" module="MEI.shared" mode="delete"/>
-                <!--<classSpec type="atts" ident="att.enclosingChars" module="MEI.shared" mode="delete"/>-->
+                <classSpec type="atts" ident="att.enclosingChars" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.endings" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.evidence" module="MEI.shared" mode="delete"/>
                 <!--<classSpec type="atts" ident="att.extender" module="MEI.shared" mode="delete"/>-->

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -64,7 +64,7 @@
                 <desc>Revisions at the MEI Developers Conference, Charlottesville.</desc>
             </change>
             <change n="4" when="2023-08-23" who="#KR">
-                <desc>Minor fixes.</desc>
+                <desc>Fixing color attribute and cleanup attribute class references.</desc>
             </change>
         </revisionDesc>
     </teiHeader>


### PR DESCRIPTION
This PR brings some fixes to the Basic customization:

* fix availability of `@color`
* fix availability of `@enclose`
* fix availability of `@loc`, `@oloc`, and `@ploc` for `<rest>`
* comment out previously deleted attribute classes (clean-up including leftovers from #595)
