### PR TITLE
schema: align dedicatee element with composer and similar

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -5201,9 +5201,10 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
+      <memberOf key="att.evidence"/>
       <memberOf key="att.facsimile"/>
       <memberOf key="att.lang"/>
-      <memberOf key="model.textPhraseLike.limited"/>
+      <memberOf key="model.respLikePart"/>
     </classes>
     <content>
       <rng:zeroOrMore>
@@ -5213,14 +5214,6 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="check_dedicatee" scheme="schematron">
-      <constraint>
-        <sch:rule context="mei:dedicatee">
-          <sch:assert test="not(ancestor::mei:dedicatee)">The dedicatee element may not be
-            recursively nested.</sch:assert>
-        </sch:rule>
-      </constraint>
-    </constraintSpec>
   </elementSpec>
   <elementSpec ident="depth" module="MEI.shared">
     <desc xml:lang="en">Description of a measurement taken through a three-dimensional object.</desc>


### PR DESCRIPTION
In reaction to https://github.com/music-encoding/music-encoding/issues/555#issuecomment-1694513365 this remodels `dedicatee` to be in line with `composer`, `funder` and other similar elements, mainly to make it available as child of `work`.