### PR TITLE
utils: fix git head

### DIFF
--- a/utils/guidelines_xslt/odd2html/functions.xsl
+++ b/utils/guidelines_xslt/odd2html/functions.xsl
@@ -107,7 +107,7 @@
         
         <xsl:variable name="overlay.content" as="xs:string?">
             <xsl:choose>
-                <xsl:when test="tokenize($git.head,'/')[last()] = ('stable','main','master')"></xsl:when>
+                <xsl:when test="tokenize($git.head,'/')[last()] = ('stable','main','master, 'v5.0')"></xsl:when>
                 <xsl:when test="tokenize($git.head,'/')[last()] = 'develop'">DEVELOPMENT VERSION</xsl:when>
                 <xsl:otherwise><xsl:value-of select="upper-case(tokenize($git.head,'/')[last()]) || ' BRANCH'"/></xsl:otherwise>
             </xsl:choose>

--- a/utils/guidelines_xslt/odd2html/functions.xsl
+++ b/utils/guidelines_xslt/odd2html/functions.xsl
@@ -107,7 +107,7 @@
         
         <xsl:variable name="overlay.content" as="xs:string?">
             <xsl:choose>
-                <xsl:when test="tokenize($git.head,'/')[last()] = ('stable','main','master, 'v5.0')"></xsl:when>
+                <xsl:when test="tokenize($git.head,'/')[last()] = ('stable','main','master,'v5.0')"></xsl:when>
                 <xsl:when test="tokenize($git.head,'/')[last()] = 'develop'">DEVELOPMENT VERSION</xsl:when>
                 <xsl:otherwise><xsl:value-of select="upper-case(tokenize($git.head,'/')[last()]) || ' BRANCH'"/></xsl:otherwise>
             </xsl:choose>


### PR DESCRIPTION
This PR fixes the allowed git heads for a clean PDF by including the release tag.

This will need to be improved in the future.