### PR TITLE
schema: restrict content model of `<editor>`

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -5700,10 +5700,11 @@
       <memberOf key="model.respLikePart"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
+     <rng:zeroOrMore>
         <rng:choice>
           <rng:text/>
-          <rng:ref name="model.textPhraseLike.limited"/>
+          <rng:ref name="mei_model.nameLike.agent"/>
+          <rng:ref name="mei_name"/>
         </rng:choice>
       </rng:zeroOrMore>
     </content>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -5704,7 +5704,7 @@
         <rng:choice>
           <rng:text/>
           <rng:ref name="model.nameLike.agent"/>
-          <rng:ref name="mei_name"/>
+          <rng:ref name="name"/>
         </rng:choice>
       </rng:zeroOrMore>
     </content>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -5703,7 +5703,7 @@
      <rng:zeroOrMore>
         <rng:choice>
           <rng:text/>
-          <rng:ref name="mei_model.nameLike.agent"/>
+          <rng:ref name="model.nameLike.agent"/>
           <rng:ref name="mei_name"/>
         </rng:choice>
       </rng:zeroOrMore>


### PR DESCRIPTION
This PR makes the model of `<editor>` more TEI-like.

The "mei_" prefix must be deleted for this PR to work.