### PR TITLE
Relax content order of `mei:work`

### DIFF
--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -2954,66 +2954,68 @@
       <rng:zeroOrMore>
         <rng:ref name="model.headLike"/>
       </rng:zeroOrMore>
-      <rng:zeroOrMore>
-        <rng:ref name="model.identifierLike"/>
-      </rng:zeroOrMore>
-      <rng:oneOrMore>
-        <rng:ref name="model.titleLike"/>
-      </rng:oneOrMore>
-      <rng:zeroOrMore>
-        <rng:ref name="model.respLikePart"/>
-      </rng:zeroOrMore>
-      <rng:zeroOrMore>
-        <rng:ref name="model.workIdent"/>
-      </rng:zeroOrMore>
-      <rng:zeroOrMore>
-        <rng:ref name="otherChar"/>
-      </rng:zeroOrMore>
-      <rng:optional>
-        <rng:ref name="creation"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="history"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="langUsage"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="perfMedium"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="perfDuration"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="audience"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="contents"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="context"/>
-      </rng:optional>
-      <rng:zeroOrMore>
-        <rng:ref name="biblList"/>
-      </rng:zeroOrMore>
-      <rng:optional>
-        <rng:ref name="notesStmt"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="classification"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="expressionList"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="componentList"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="relationList"/>
-      </rng:optional>
-      <rng:zeroOrMore>
-        <rng:ref name="extMeta"/>
-      </rng:zeroOrMore>
+      <rng:interleave>
+        <rng:zeroOrMore>
+          <rng:ref name="model.identifierLike"/>
+        </rng:zeroOrMore>
+        <rng:oneOrMore>
+          <rng:ref name="model.titleLike"/>
+        </rng:oneOrMore>
+        <rng:zeroOrMore>
+          <rng:ref name="model.respLikePart"/>
+        </rng:zeroOrMore>
+        <rng:zeroOrMore>
+          <rng:ref name="model.workIdent"/>
+        </rng:zeroOrMore>
+        <rng:zeroOrMore>
+          <rng:ref name="otherChar"/>
+        </rng:zeroOrMore>
+        <rng:optional>
+          <rng:ref name="creation"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="history"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="langUsage"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="perfMedium"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="perfDuration"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="audience"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="contents"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="context"/>
+        </rng:optional>
+        <rng:zeroOrMore>
+          <rng:ref name="biblList"/>
+        </rng:zeroOrMore>
+        <rng:optional>
+          <rng:ref name="notesStmt"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="classification"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="expressionList"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="componentList"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="relationList"/>
+        </rng:optional>
+        <rng:zeroOrMore>
+          <rng:ref name="extMeta"/>
+        </rng:zeroOrMore>
+      </rng:interleave>
     </content>
     <remarks xml:lang="en">
       <p>The <gi scheme="MEI">perfDuration</gi> element captures the <emph>intended duration</emph>


### PR DESCRIPTION
[@bwbohl EDIT] This PR removes the predefined order of the contents in `mei:work`.