### PR TITLE
schema: relax model of work, expression, manifestation, and item

### DIFF
--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -907,7 +907,7 @@
                      <gi scheme="MEI">title</gi>
                   </item>
                   <item>
-                     <gi scheme="MEI">respStmt</gi> (before MEI 6.0: Responsibility-like elements (e.g.,  composer, lyricist and others)
+                     <gi scheme="MEI">respStmt</gi> [before MEI 6.0: Responsibility-like elements (e.g.,  composer, lyricist and others)]
                   </item>
                   <item>
                      <gi scheme="MEI">incip</gi>

--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -898,7 +898,7 @@
                      <specDesc key="work"/>
                   </specList>
                </p>
-               <p>All the components of <gi scheme="MEI">work</gi> are optional. Before MEI 6.0 they had to occur in the following order:</p>
+               <p>All the components of <gi scheme="MEI">work</gi> are optional. They may occur in any order.</p>
                <list rend="numbered">
                   <item>
                      <gi scheme="MEI">identifier</gi>

--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -899,7 +899,7 @@
                   </specList>
                </p>
                <p>All the components of <gi scheme="MEI">work</gi> are optional. They may occur in any order.</p>
-               <list rend="numbered">
+               <list rend="bulleted">
                   <item>
                      <gi scheme="MEI">identifier</gi>
                   </item>

--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -898,7 +898,7 @@
                      <specDesc key="work"/>
                   </specList>
                </p>
-               <p>All the components of <gi scheme="MEI">work</gi> are optional, but they must occur in the following order:</p>
+               <p>All the components of <gi scheme="MEI">work</gi> are optional. Before MEI 6.0 they had to occur in the following order:</p>
                <list rend="numbered">
                   <item>
                      <gi scheme="MEI">identifier</gi>
@@ -907,7 +907,7 @@
                      <gi scheme="MEI">title</gi>
                   </item>
                   <item>
-                     <gi scheme="MEI">respStmt</gi>
+                     <gi scheme="MEI">respStmt</gi> (before MEI 6.0: Responsibility-like elements (e.g.,  composer, lyricist and others)
                   </item>
                   <item>
                      <gi scheme="MEI">incip</gi>
@@ -1336,7 +1336,9 @@
                   </specList>
                </p>
                <p>Many of these elements are already described in chapter <ptr target="#headerstructure"/>, especially in <ptr target="#headerWorkDescription"/>.</p>
-               <p>The <gi scheme="MEI">manifestationList</gi> is available to create lists of physical sources representing a work, for instance for use in a thematic catalog or a critical edition. The <gi scheme="MEI">manifestation</gi> child element corresponds to the <ptr target="#FRBR"/> level of the same name, that is, it describes embodiments of certain expressions of a work. The list below reflects the order in which the optional components of manifestation must occur. <specList>
+               <p>The <gi scheme="MEI">manifestationList</gi> is available to create lists of physical sources representing a work, for instance for use in a thematic catalog or a critical edition. The <gi scheme="MEI">manifestation</gi> child element corresponds to the <ptr target="#FRBR"/> level of the same name, that is, it describes embodiments of certain expressions of a work. The list below reflects the order in which the optional components of manifestation had to occur before MEI 6.0.
+                  </p>
+               <p><specList>
                      <specDesc key="locus"/>
                   </specList>
                   <specList>

--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -907,8 +907,7 @@
                      <gi scheme="MEI">title</gi>
                   </item>
                   <item>
-                     <gi scheme="MEI">respStmt</gi> [before MEI 6.0: Responsibility-like elements (e.g.,  composer, lyricist and others)]
-                  </item>
+                     <gi scheme="MEI">respStmt</gi></item>
                   <item>
                      <gi scheme="MEI">incip</gi>
                   </item>

--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -1336,7 +1336,7 @@
                   </specList>
                </p>
                <p>Many of these elements are already described in chapter <ptr target="#headerstructure"/>, especially in <ptr target="#headerWorkDescription"/>.</p>
-               <p>The <gi scheme="MEI">manifestationList</gi> is available to create lists of physical sources representing a work, for instance for use in a thematic catalog or a critical edition. The <gi scheme="MEI">manifestation</gi> child element corresponds to the <ptr target="#FRBR"/> level of the same name, that is, it describes embodiments of certain expressions of a work. The list below reflects the order in which the optional components of manifestation had to occur before MEI 6.0.
+               <p>The <gi scheme="MEI">manifestationList</gi> is available to create lists of physical sources representing a work, for instance for use in a thematic catalog or a critical edition. The <gi scheme="MEI">manifestation</gi> child element corresponds to the <ptr target="#FRBR"/> level of the same name, that is, it describes embodiments of certain expressions of a work. The components of manifestation may occur in any order.
                   </p>
                <p><specList>
                      <specDesc key="locus"/>

--- a/source/modules/MEI.frbr.xml
+++ b/source/modules/MEI.frbr.xml
@@ -177,69 +177,71 @@
       <rng:zeroOrMore>
         <rng:ref name="model.headLike"/>
       </rng:zeroOrMore>
-      <rng:zeroOrMore>
-        <rng:ref name="model.identifierLike"/>
-      </rng:zeroOrMore>
-      <rng:oneOrMore>
-        <rng:ref name="model.titleLike"/>
-      </rng:oneOrMore>
-      <rng:optional>
-        <rng:ref name="respStmt"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="dedication"/>
-      </rng:optional>
-      <rng:zeroOrMore>
-        <rng:ref name="model.workIdent"/>
-      </rng:zeroOrMore>
-      <rng:zeroOrMore>
-        <rng:ref name="otherChar"/>
-      </rng:zeroOrMore>
-      <rng:optional>
-        <rng:ref name="creation"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="history"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="langUsage"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="perfMedium"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="perfDuration"/>
-      </rng:optional>
-      <rng:zeroOrMore>
-        <rng:ref name="extent"/>
-      </rng:zeroOrMore>
-      <rng:optional>
-        <rng:ref name="scoreFormat"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="contents"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="context"/>
-      </rng:optional>
-      <rng:zeroOrMore>
-        <rng:ref name="biblList"/>
-      </rng:zeroOrMore>
-      <rng:optional>
-        <rng:ref name="notesStmt"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="classification"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="componentList"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="relationList"/>
-      </rng:optional>
-      <rng:zeroOrMore>
-        <rng:ref name="extMeta"/>
-      </rng:zeroOrMore>
+      <rng:interleave>
+        <rng:zeroOrMore>
+          <rng:ref name="model.identifierLike"/>
+        </rng:zeroOrMore>
+        <rng:oneOrMore>
+          <rng:ref name="model.titleLike"/>
+        </rng:oneOrMore>
+        <rng:optional>
+          <rng:ref name="respStmt"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="dedication"/>
+        </rng:optional>
+        <rng:zeroOrMore>
+          <rng:ref name="model.workIdent"/>
+        </rng:zeroOrMore>
+        <rng:zeroOrMore>
+          <rng:ref name="otherChar"/>
+        </rng:zeroOrMore>
+        <rng:optional>
+          <rng:ref name="creation"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="history"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="langUsage"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="perfMedium"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="perfDuration"/>
+        </rng:optional>
+        <rng:zeroOrMore>
+          <rng:ref name="extent"/>
+        </rng:zeroOrMore>
+        <rng:optional>
+          <rng:ref name="scoreFormat"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="contents"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="context"/>
+        </rng:optional>
+        <rng:zeroOrMore>
+          <rng:ref name="biblList"/>
+        </rng:zeroOrMore>
+        <rng:optional>
+          <rng:ref name="notesStmt"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="classification"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="componentList"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="relationList"/>
+        </rng:optional>
+        <rng:zeroOrMore>
+          <rng:ref name="extMeta"/>
+        </rng:zeroOrMore>
+      </rng:interleave>
     </content>
     <remarks xml:lang="en">
       <p>The <gi scheme="MEI">perfDuration</gi> element captures the <emph>intended duration</emph>
@@ -276,39 +278,41 @@
       <rng:zeroOrMore>
         <rng:ref name="model.headLike"/>
       </rng:zeroOrMore>
-      <rng:zeroOrMore>
-        <rng:ref name="model.identifierLike"/>
-      </rng:zeroOrMore>
-      <rng:optional>
-        <rng:ref name="dedication"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="availability"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="physDesc"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="physLoc"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="history"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="notesStmt"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="classification"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="componentList"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="relationList"/>
-      </rng:optional>
-      <rng:zeroOrMore>
-        <rng:ref name="extMeta"/>
-      </rng:zeroOrMore>
+      <rng:interleave>
+        <rng:zeroOrMore>
+          <rng:ref name="model.identifierLike"/>
+        </rng:zeroOrMore>
+        <rng:optional>
+          <rng:ref name="dedication"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="availability"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="physDesc"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="physLoc"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="history"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="notesStmt"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="classification"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="componentList"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="relationList"/>
+        </rng:optional>
+        <rng:zeroOrMore>
+          <rng:ref name="extMeta"/>
+        </rng:zeroOrMore>
+      </rng:interleave>
     </content>
   </elementSpec>
   <elementSpec ident="itemList" module="MEI.frbr">
@@ -342,55 +346,57 @@
       <rng:zeroOrMore>
         <rng:ref name="model.headLike"/>
       </rng:zeroOrMore>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:ref name="locus"/>
-          <rng:ref name="locusGrp"/>
-        </rng:choice>
-      </rng:zeroOrMore>
-      <rng:zeroOrMore>
-        <rng:ref name="model.identifierLike"/>
-      </rng:zeroOrMore>
-      <rng:optional>
-        <rng:ref name="titleStmt"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="dedication"/>
-      </rng:optional>
-      <rng:ref name="macro.bibldescPart"/>
-      <rng:optional>
-        <rng:ref name="creation"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="history"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="langUsage"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="contents"/>
-      </rng:optional>
-      <rng:zeroOrMore>
-        <rng:ref name="biblList"/>
-      </rng:zeroOrMore>
-      <rng:optional>
-        <rng:ref name="notesStmt"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="classification"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="itemList"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="componentList"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="relationList"/>
-      </rng:optional>
-      <rng:zeroOrMore>
-        <rng:ref name="extMeta"/>
-      </rng:zeroOrMore>
+      <rng:interleave>
+        <rng:zeroOrMore>
+          <rng:choice>
+            <rng:ref name="locus"/>
+            <rng:ref name="locusGrp"/>
+          </rng:choice>
+        </rng:zeroOrMore>
+        <rng:zeroOrMore>
+          <rng:ref name="model.identifierLike"/>
+        </rng:zeroOrMore>
+        <rng:optional>
+          <rng:ref name="titleStmt"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="dedication"/>
+        </rng:optional>
+        <rng:ref name="macro.bibldescPart"/>
+        <rng:optional>
+          <rng:ref name="creation"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="history"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="langUsage"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="contents"/>
+        </rng:optional>
+        <rng:zeroOrMore>
+          <rng:ref name="biblList"/>
+        </rng:zeroOrMore>
+        <rng:optional>
+          <rng:ref name="notesStmt"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="classification"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="itemList"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="componentList"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="relationList"/>
+        </rng:optional>
+        <rng:zeroOrMore>
+          <rng:ref name="extMeta"/>
+        </rng:zeroOrMore>
+      </rng:interleave>
     </content>
     <constraintSpec ident="check_singleton" scheme="schematron">
       <constraint>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -2980,69 +2980,71 @@
       <rng:zeroOrMore>
         <rng:ref name="model.headLike"/>
       </rng:zeroOrMore>
-      <rng:zeroOrMore>
-        <rng:ref name="model.identifierLike"/>
-      </rng:zeroOrMore>
-      <rng:oneOrMore>
-        <rng:ref name="model.titleLike"/>
-      </rng:oneOrMore>
-      <rng:optional>
-        <rng:ref name="respStmt"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="dedication"/>
-      </rng:optional>
-      <rng:zeroOrMore>
-        <rng:ref name="model.workIdent"/>
-      </rng:zeroOrMore>
-      <rng:zeroOrMore>
-        <rng:ref name="otherChar"/>
-      </rng:zeroOrMore>
-      <rng:optional>
-        <rng:ref name="creation"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="history"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="langUsage"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="perfMedium"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="perfDuration"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="audience"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="contents"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="context"/>
-      </rng:optional>
-      <rng:zeroOrMore>
-        <rng:ref name="biblList"/>
-      </rng:zeroOrMore>
-      <rng:optional>
-        <rng:ref name="notesStmt"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="classification"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="expressionList"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="componentList"/>
-      </rng:optional>
-      <rng:optional>
-        <rng:ref name="relationList"/>
-      </rng:optional>
-      <rng:zeroOrMore>
-        <rng:ref name="extMeta"/>
-      </rng:zeroOrMore>
+      <rng:interleave>
+        <rng:zeroOrMore>
+          <rng:ref name="model.identifierLike"/>
+        </rng:zeroOrMore>
+        <rng:oneOrMore>
+          <rng:ref name="model.titleLike"/>
+        </rng:oneOrMore>
+        <rng:optional>
+          <rng:ref name="respStmt"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="dedication"/>
+        </rng:optional>
+        <rng:zeroOrMore>
+          <rng:ref name="model.workIdent"/>
+        </rng:zeroOrMore>
+        <rng:zeroOrMore>
+          <rng:ref name="otherChar"/>
+        </rng:zeroOrMore>
+        <rng:optional>
+          <rng:ref name="creation"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="history"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="langUsage"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="perfMedium"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="perfDuration"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="audience"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="contents"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="context"/>
+        </rng:optional>
+        <rng:zeroOrMore>
+          <rng:ref name="biblList"/>
+        </rng:zeroOrMore>
+        <rng:optional>
+          <rng:ref name="notesStmt"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="classification"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="expressionList"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="componentList"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="relationList"/>
+        </rng:optional>
+        <rng:zeroOrMore>
+          <rng:ref name="extMeta"/>
+        </rng:zeroOrMore>
+      </rng:interleave>
     </content>
     <remarks xml:lang="en">
       <p>The <gi scheme="MEI">perfDuration</gi> element captures the <emph>intended duration</emph>


### PR DESCRIPTION
[@bwbohl EDIT] This PR relaxes the content model of the mentioned FRBR elements by removing the predefined order of their child elements. Doing so it accommodates broader use in different editorial contexts / following different editorial guidelines.