### PR TITLE
schema: revise model of `<respStmt>`

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -7513,7 +7513,7 @@
       <rng:zeroOrMore>
         <rng:ref name="annot"/>
       </rng:zeroOrMore>
-    </rng:content>
+    </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-respStmt.html">respStmt</ref> element of the Text Encoding Initiative (TEI).</p>
     </remarks>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -7482,26 +7482,38 @@
       <rng:zeroOrMore>
         <rng:ref name="model.headLike"/>
       </rng:zeroOrMore>
+      <rng:choice>
+        <rng:group>
+          <rng:oneOrMore>
+            <rng:oneOrMore>
+              <rng:ref name="resp"/>
+            </rng:oneOrMore>
+            <rng:oneOrMore>
+              <rng:choice>
+                <rng:ref name="model.nameLike.agent"/>
+                <rng:ref name="name"/>
+              </rng:choice>
+            </rng:oneOrMore>
+          </rng:oneOrMore>
+        </rng:group>
+        <rng:group>
+          <rng:oneOrMore>
+            <rng:oneOrMore>
+              <rng:choice>
+                <rng:ref name="model.nameLike.agent"/>
+                <rng:ref name="name"/>
+              </rng:choice>
+            </rng:oneOrMore>
+            <rng:oneOrMore>
+              <rng:ref name="resp"/>
+            </rng:oneOrMore>
+          </rng:oneOrMore>
+        </rng:group>
+      </rng:choice>
       <rng:zeroOrMore>
-        <rng:choice>
-          <rng:ref name="name"/>
-          <rng:ref name="resp"/>
-          <rng:ref name="model.nameLike.agent"/>
-        </rng:choice>
+        <rng:ref name="annot"/>
       </rng:zeroOrMore>
-    </content>
-    <constraintSpec ident="check_respStmt" scheme="schematron">
-      <constraint>
-        <sch:rule context="mei:respStmt[not(ancestor::mei:change)]">
-          <sch:assert
-            test="(mei:resp and (mei:name or mei:corpName or mei:persName)) or
-            count(mei:*[@role]) = count(mei:*) and count(mei:*) &gt; 0"
-            role="warning">At least one element pair (a resp element and a name-like element) is
-            recommended. Alternatively, each name-like element may have a @role
-            attribute.</sch:assert>
-        </sch:rule>
-      </constraint>
-    </constraintSpec>
+    </rng:content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-respStmt.html">respStmt</ref> element of the Text Encoding Initiative (TEI).</p>
     </remarks>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -7509,6 +7509,12 @@
             </rng:oneOrMore>
           </rng:oneOrMore>
         </rng:group>
+        <rng:oneOrMore>
+          <rng:choice>
+            <rng:ref name="model.nameLike.agent"/>
+            <rng:ref name="name"/>
+          </rng:choice>
+        </rng:oneOrMore>
       </rng:choice>
       <rng:zeroOrMore>
         <rng:ref name="annot"/>


### PR DESCRIPTION
This PR changes the content model of respStmt to 
- make it more TEI-like ( resp+, nameLike+ or nameLike+, resp+);
- clarify use of respStmt

This is a backward-compatibility breaking change.  However, if the existing model of respStmt has been used to contain only names, each with a role attribute, then that usage can easily be converted via XSLT to the new model; that is, the content of the role attribute can be placed in a new resp element.