### PR TITLE
schema: replace version 5.0 with dev

### DIFF
--- a/customizations/mei-CMN.xml
+++ b/customizations/mei-CMN.xml
@@ -105,7 +105,7 @@
         <classSpec ident="att.meiVersion" module="MEI.shared" type="atts" mode="change">
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
-              <defaultVal>dev+CMN</defaultVal>
+              <defaultVal>5.1-dev+CMN</defaultVal>
               <valList type="closed" mode="change">
                 <valItem ident="5.1-dev+anyStart" mode="delete"/>
                 <valItem ident="5.1-dev+basic" mode="delete"/>

--- a/customizations/mei-CMN.xml
+++ b/customizations/mei-CMN.xml
@@ -105,12 +105,12 @@
         <classSpec ident="att.meiVersion" module="MEI.shared" type="atts" mode="change">
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
-              <defaultVal>5.0+CMN</defaultVal>
+              <defaultVal>dev+CMN</defaultVal>
               <valList type="closed" mode="change">
-                <valItem ident="5.0+anyStart" mode="delete"/>
-                <valItem ident="5.0+basic" mode="delete"/>
-                <valItem ident="5.0+Mensural" mode="delete"/>
-                <valItem ident="5.0+Neumes" mode="delete"/>
+                <valItem ident="dev+anyStart" mode="delete"/>
+                <valItem ident="dev+basic" mode="delete"/>
+                <valItem ident="dev+Mensural" mode="delete"/>
+                <valItem ident="dev+Neumes" mode="delete"/>
             </valList>
             </attDef>
           </attList>

--- a/customizations/mei-CMN.xml
+++ b/customizations/mei-CMN.xml
@@ -107,10 +107,10 @@
             <attDef ident="meiversion" usage="rec" mode="change">
               <defaultVal>dev+CMN</defaultVal>
               <valList type="closed" mode="change">
-                <valItem ident="dev+anyStart" mode="delete"/>
-                <valItem ident="dev+basic" mode="delete"/>
-                <valItem ident="dev+Mensural" mode="delete"/>
-                <valItem ident="dev+Neumes" mode="delete"/>
+                <valItem ident="5.1-dev+anyStart" mode="delete"/>
+                <valItem ident="5.1-dev+basic" mode="delete"/>
+                <valItem ident="5.1-dev+Mensural" mode="delete"/>
+                <valItem ident="5.1-dev+Neumes" mode="delete"/>
             </valList>
             </attDef>
           </attList>

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -105,7 +105,7 @@
         <classSpec ident="att.meiVersion" module="MEI.shared" type="atts" mode="change">
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
-              <defaultVal>dev+Mensural</defaultVal>
+              <defaultVal>5.1-dev+Mensural</defaultVal>
               <valList type="closed" mode="change">
                 <valItem ident="5.1-dev+anyStart" mode="delete"/>
                 <valItem ident="5.1-dev+basic" mode="delete"/>

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -107,10 +107,10 @@
             <attDef ident="meiversion" usage="rec" mode="change">
               <defaultVal>dev+Mensural</defaultVal>
               <valList type="closed" mode="change">
-                <valItem ident="dev+anyStart" mode="delete"/>
-                <valItem ident="dev+basic" mode="delete"/>
-                <valItem ident="dev+CMN" mode="delete"/>
-                <valItem ident="dev+Neumes" mode="delete"/>
+                <valItem ident="5.1-dev+anyStart" mode="delete"/>
+                <valItem ident="5.1-dev+basic" mode="delete"/>
+                <valItem ident="5.1-dev+CMN" mode="delete"/>
+                <valItem ident="5.1-dev+Neumes" mode="delete"/>
             </valList>
             </attDef>
           </attList>

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -105,12 +105,12 @@
         <classSpec ident="att.meiVersion" module="MEI.shared" type="atts" mode="change">
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
-              <defaultVal>5.0+Mensural</defaultVal>
+              <defaultVal>dev+Mensural</defaultVal>
               <valList type="closed" mode="change">
-                <valItem ident="5.0+anyStart" mode="delete"/>
-                <valItem ident="5.0+basic" mode="delete"/>
-                <valItem ident="5.0+CMN" mode="delete"/>
-                <valItem ident="5.0+Neumes" mode="delete"/>
+                <valItem ident="dev+anyStart" mode="delete"/>
+                <valItem ident="dev+basic" mode="delete"/>
+                <valItem ident="dev+CMN" mode="delete"/>
+                <valItem ident="dev+Neumes" mode="delete"/>
             </valList>
             </attDef>
           </attList>

--- a/customizations/mei-Neumes.xml
+++ b/customizations/mei-Neumes.xml
@@ -108,10 +108,10 @@
             <attDef ident="meiversion" usage="rec" mode="change">
               <defaultVal>dev+Neumes</defaultVal>
               <valList type="closed" mode="change">
-                <valItem ident="dev+anyStart" mode="delete"/>
-                <valItem ident="dev+basic" mode="delete"/>
-                <valItem ident="dev+CMN" mode="delete"/>
-                <valItem ident="dev+Mensural" mode="delete"/>
+                <valItem ident="5.1-dev+anyStart" mode="delete"/>
+                <valItem ident="5.1-dev+basic" mode="delete"/>
+                <valItem ident="5.1-dev+CMN" mode="delete"/>
+                <valItem ident="5.1-dev+Mensural" mode="delete"/>
             </valList>
             </attDef>
           </attList>

--- a/customizations/mei-Neumes.xml
+++ b/customizations/mei-Neumes.xml
@@ -106,12 +106,12 @@
         <classSpec ident="att.meiVersion" module="MEI.shared" type="atts" mode="change">
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
-              <defaultVal>5.0+Neumes</defaultVal>
+              <defaultVal>dev+Neumes</defaultVal>
               <valList type="closed" mode="change">
-                <valItem ident="5.0+anyStart" mode="delete"/>
-                <valItem ident="5.0+basic" mode="delete"/>
-                <valItem ident="5.0+CMN" mode="delete"/>
-                <valItem ident="5.0+Mensural" mode="delete"/>
+                <valItem ident="dev+anyStart" mode="delete"/>
+                <valItem ident="dev+basic" mode="delete"/>
+                <valItem ident="dev+CMN" mode="delete"/>
+                <valItem ident="dev+Mensural" mode="delete"/>
             </valList>
             </attDef>
           </attList>

--- a/customizations/mei-Neumes.xml
+++ b/customizations/mei-Neumes.xml
@@ -106,7 +106,7 @@
         <classSpec ident="att.meiVersion" module="MEI.shared" type="atts" mode="change">
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
-              <defaultVal>dev+Neumes</defaultVal>
+              <defaultVal>5.1-dev+Neumes</defaultVal>
               <valList type="closed" mode="change">
                 <valItem ident="5.1-dev+anyStart" mode="delete"/>
                 <valItem ident="5.1-dev+basic" mode="delete"/>

--- a/customizations/mei-all.xml
+++ b/customizations/mei-all.xml
@@ -108,7 +108,7 @@
         <classSpec ident="att.meiVersion" module="MEI.shared" type="atts" mode="change">
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
-              <defaultVal>dev</defaultVal>
+              <defaultVal>5.1-dev</defaultVal>
               <valList type="closed" mode="change">
                 <valItem ident="5.1-dev+anyStart" mode="delete"/>
                 <valItem ident="5.1-dev+basic" mode="delete"/>

--- a/customizations/mei-all.xml
+++ b/customizations/mei-all.xml
@@ -110,11 +110,11 @@
             <attDef ident="meiversion" usage="rec" mode="change">
               <defaultVal>dev</defaultVal>
               <valList type="closed" mode="change">
-                <valItem ident="dev+anyStart" mode="delete"/>
-                <valItem ident="dev+basic" mode="delete"/>
-                <valItem ident="dev+CMN" mode="delete"/>
-                <valItem ident="dev+Mensural" mode="delete"/>
-                <valItem ident="dev+Neumes" mode="delete"/>
+                <valItem ident="5.1-dev+anyStart" mode="delete"/>
+                <valItem ident="5.1-dev+basic" mode="delete"/>
+                <valItem ident="5.1-dev+CMN" mode="delete"/>
+                <valItem ident="5.1-dev+Mensural" mode="delete"/>
+                <valItem ident="5.1-dev+Neumes" mode="delete"/>
             </valList>
             </attDef>
           </attList>

--- a/customizations/mei-all.xml
+++ b/customizations/mei-all.xml
@@ -108,13 +108,13 @@
         <classSpec ident="att.meiVersion" module="MEI.shared" type="atts" mode="change">
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
-              <defaultVal>5.0</defaultVal>
+              <defaultVal>dev</defaultVal>
               <valList type="closed" mode="change">
-                <valItem ident="5.0+anyStart" mode="delete"/>
-                <valItem ident="5.0+basic" mode="delete"/>
-                <valItem ident="5.0+CMN" mode="delete"/>
-                <valItem ident="5.0+Mensural" mode="delete"/>
-                <valItem ident="5.0+Neumes" mode="delete"/>
+                <valItem ident="dev+anyStart" mode="delete"/>
+                <valItem ident="dev+basic" mode="delete"/>
+                <valItem ident="dev+CMN" mode="delete"/>
+                <valItem ident="dev+Mensural" mode="delete"/>
+                <valItem ident="dev+Neumes" mode="delete"/>
             </valList>
             </attDef>
           </attList>

--- a/customizations/mei-all_anyStart.xml
+++ b/customizations/mei-all_anyStart.xml
@@ -171,10 +171,10 @@
             <attDef ident="meiversion" usage="rec" mode="change">
               <defaultVal>dev+anyStart</defaultVal>
               <valList type="closed" mode="change">
-                <valItem ident="dev+basic" mode="delete"/>
-                <valItem ident="dev+CMN" mode="delete"/>
-                <valItem ident="dev+Mensural" mode="delete"/>
-                <valItem ident="dev+Neumes" mode="delete"/>
+                <valItem ident="5.1-dev+basic" mode="delete"/>
+                <valItem ident="5.1-dev+CMN" mode="delete"/>
+                <valItem ident="5.1-dev+Mensural" mode="delete"/>
+                <valItem ident="5.1-dev+Neumes" mode="delete"/>
             </valList>
             </attDef>
           </attList>

--- a/customizations/mei-all_anyStart.xml
+++ b/customizations/mei-all_anyStart.xml
@@ -163,13 +163,13 @@
           <constraintSpec ident="meiVersion.warning.anyStart" scheme="schematron" mode="add">
             <constraint>
               <sch:rule context="/mei:*">
-                <sch:report role="error" test="not(local-name(.) = ('mei', 'meiHead', 'meiCorpus', 'music')) and not(@meiversion = 'dev+anyStart')">If the root element is any other than mei, meiHead, meiCorpus, or music the value of @meiversion must be 'dev+anyStart'.</sch:report>
+                <sch:report role="error" test="not(local-name(.) = ('mei', 'meiHead', 'meiCorpus', 'music')) and not(@meiversion = '5.1-dev+anyStart')">If the root element is any other than mei, meiHead, meiCorpus, or music the value of @meiversion must be '5.1-dev+anyStart'.</sch:report>
               </sch:rule>
             </constraint>
           </constraintSpec>
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
-              <defaultVal>dev+anyStart</defaultVal>
+              <defaultVal>5.1-dev+anyStart</defaultVal>
               <valList type="closed" mode="change">
                 <valItem ident="5.1-dev+basic" mode="delete"/>
                 <valItem ident="5.1-dev+CMN" mode="delete"/>

--- a/customizations/mei-all_anyStart.xml
+++ b/customizations/mei-all_anyStart.xml
@@ -169,7 +169,6 @@
           </constraintSpec>
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
-              <defaultVal>5.1-dev+anyStart</defaultVal>
               <valList type="closed" mode="change">
                 <valItem ident="5.1-dev+basic" mode="delete"/>
                 <valItem ident="5.1-dev+CMN" mode="delete"/>

--- a/customizations/mei-all_anyStart.xml
+++ b/customizations/mei-all_anyStart.xml
@@ -163,18 +163,18 @@
           <constraintSpec ident="meiVersion.warning.anyStart" scheme="schematron" mode="add">
             <constraint>
               <sch:rule context="/mei:*">
-                <sch:report role="error" test="not(local-name(.) = ('mei', 'meiHead', 'meiCorpus', 'music')) and not(@meiversion = '5.0+anyStart')">If the root element is any other than mei, meiHead, meiCorpus, or music the value of @meiversion must be '5.0+anyStart'.</sch:report>
+                <sch:report role="error" test="not(local-name(.) = ('mei', 'meiHead', 'meiCorpus', 'music')) and not(@meiversion = 'dev+anyStart')">If the root element is any other than mei, meiHead, meiCorpus, or music the value of @meiversion must be 'dev+anyStart'.</sch:report>
               </sch:rule>
             </constraint>
           </constraintSpec>
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
-              <defaultVal>5.0+anyStart</defaultVal>
+              <defaultVal>dev+anyStart</defaultVal>
               <valList type="closed" mode="change">
-                <valItem ident="5.0+basic" mode="delete"/>
-                <valItem ident="5.0+CMN" mode="delete"/>
-                <valItem ident="5.0+Mensural" mode="delete"/>
-                <valItem ident="5.0+Neumes" mode="delete"/>
+                <valItem ident="dev+basic" mode="delete"/>
+                <valItem ident="dev+CMN" mode="delete"/>
+                <valItem ident="dev+Mensural" mode="delete"/>
+                <valItem ident="dev+Neumes" mode="delete"/>
             </valList>
             </attDef>
           </attList>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -992,10 +992,10 @@
                     <attList>
                         <attDef ident="meiversion" usage="req" mode="change">
                             <valList type="closed" mode="change">
-                                <valItem ident="dev+anyStart" mode="delete"/>
-                                <valItem ident="dev+CMN" mode="delete"/>
-                                <valItem ident="dev+Mensural" mode="delete"/>
-                                <valItem ident="dev+Neumes" mode="delete"/>
+                                <valItem ident="5.1-dev+anyStart" mode="delete"/>
+                                <valItem ident="5.1-dev+CMN" mode="delete"/>
+                                <valItem ident="5.1-dev+Mensural" mode="delete"/>
+                                <valItem ident="5.1-dev+Neumes" mode="delete"/>
                             </valList>
                         </attDef>
                     </attList>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -992,10 +992,10 @@
                     <attList>
                         <attDef ident="meiversion" usage="req" mode="change">
                             <valList type="closed" mode="change">
-                                <valItem ident="5.0+anyStart" mode="delete"/>
-                                <valItem ident="5.0+CMN" mode="delete"/>
-                                <valItem ident="5.0+Mensural" mode="delete"/>
-                                <valItem ident="5.0+Neumes" mode="delete"/>
+                                <valItem ident="dev+anyStart" mode="delete"/>
+                                <valItem ident="dev+CMN" mode="delete"/>
+                                <valItem ident="dev+Mensural" mode="delete"/>
+                                <valItem ident="dev+Neumes" mode="delete"/>
                             </valList>
                         </attDef>
                     </attList>

--- a/source/docs/01-introduction.xml
+++ b/source/docs/01-introduction.xml
@@ -283,8 +283,8 @@
                      <p>A lot of effort went into updating the infrastructure for generating releases. These
                      changes are designed to help improve the development workflow of MEI, improving consistency
                      and oversight of changes as they are contributed to MEI. Our new setup is explained in 
-                     great detail in <ref target="https://github.com/music-encoding/music-encoding/blob/v5.0/README.md">the project README file</ref>. 
-                     We have also expanded our <ref target="https://github.com/music-encoding/music-encoding/blob/v5.0/CONTRIBUTING.md">Contribution Guidelines</ref> 
+                     great detail in <ref target="https://github.com/music-encoding/music-encoding/blob/dev/README.md">the project README file</ref>. 
+                     We have also expanded our <ref target="https://github.com/music-encoding/music-encoding/blob/dev/CONTRIBUTING.md">Contribution Guidelines</ref> 
                      and other documentation files in the <ref target="https://github.com/music-encoding/music-encoding">music-encoding GitHub repository</ref>.</p>
                      <p>The MEI documentation and guidelines are now expressed in TEI ODD again, 
                      moving away from the MarkDown-based approach used in the preparation of 
@@ -777,8 +777,8 @@
                         target="#meiProfiles"/> are based on ODD customizations, and may serve as
                      starting point for further project-specific restrictions. They can be found
                         at <ref
-                        target="https://github.com/music-encoding/music-encoding/tree/v5.0/customizations"
-                        >https://github.com/music-encoding/music-encoding/tree/v5.0/customizations</ref>.
+                        target="https://github.com/music-encoding/music-encoding/tree/dev/customizations"
+                        >https://github.com/music-encoding/music-encoding/tree/dev/customizations</ref>.
                      In addition, several projects have shared their customizations on GitHub, such
                         as <ref
                         target="https://github.com/Freischuetz-Digital/data-music/tree/master/schemata/odd"

--- a/source/examples/neumes/neumes-sample169.txt
+++ b/source/examples/neumes/neumes-sample169.txt
@@ -1,4 +1,4 @@
-<music xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<music xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
    <body>
       <mdiv>
          <score>

--- a/source/examples/neumes/neumes-sample169.txt
+++ b/source/examples/neumes/neumes-sample169.txt
@@ -1,4 +1,4 @@
-<music xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<music xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
    <body>
       <mdiv>
          <score>

--- a/source/examples/shared/shared-sample0000.txt
+++ b/source/examples/shared/shared-sample0000.txt
@@ -1,4 +1,4 @@
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
    <meiHead>
       <!-- metadata goes here -->
    </meiHead>

--- a/source/examples/shared/shared-sample0000.txt
+++ b/source/examples/shared/shared-sample0000.txt
@@ -1,4 +1,4 @@
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
    <meiHead>
       <!-- metadata goes here -->
    </meiHead>

--- a/source/examples/shared/shared-sample0001.txt
+++ b/source/examples/shared/shared-sample0001.txt
@@ -1,4 +1,4 @@
-<meiCorpus xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<meiCorpus xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
    <meiHead>
       <!-- metadata on the corpus goes here -->
    </meiHead>

--- a/source/examples/shared/shared-sample0001.txt
+++ b/source/examples/shared/shared-sample0001.txt
@@ -1,4 +1,4 @@
-<meiCorpus xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<meiCorpus xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
    <meiHead>
       <!-- metadata on the corpus goes here -->
    </meiHead>

--- a/source/examples/shared/shared-sample0002.txt
+++ b/source/examples/shared/shared-sample0002.txt
@@ -1,3 +1,3 @@
-<meiHead xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<meiHead xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
    <!-- metadata goes here -->
 </meiHead>

--- a/source/examples/shared/shared-sample0002.txt
+++ b/source/examples/shared/shared-sample0002.txt
@@ -1,3 +1,3 @@
-<meiHead xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<meiHead xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
    <!-- metadata goes here -->
 </meiHead>

--- a/source/examples/shared/shared-sample0003.txt
+++ b/source/examples/shared/shared-sample0003.txt
@@ -1,3 +1,3 @@
-<music xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<music xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
    <!-- description of musical text goes here -->
 </music>

--- a/source/examples/shared/shared-sample0003.txt
+++ b/source/examples/shared/shared-sample0003.txt
@@ -1,3 +1,3 @@
-<music xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<music xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
    <!-- description of musical text goes here -->
 </music>

--- a/source/examples/svg/svg-example.xml
+++ b/source/examples/svg/svg-example.xml
@@ -1,6 +1,6 @@
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<music xmlns="http://www.music-encoding.org/ns/mei">
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<music xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
   <facsimile>
     <?edit-start?>
     <surface lrx="3000" lry="2000" ulx="0" uly="0">

--- a/source/examples/svg/svg-example.xml
+++ b/source/examples/svg/svg-example.xml
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<music xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<music xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
   <facsimile>
     <?edit-start?>
     <surface lrx="3000" lry="2000" ulx="0" uly="0">

--- a/source/examples/verovio/04-score-redefinition.mei
+++ b/source/examples/verovio/04-score-redefinition.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/04-score-redefinition.mei
+++ b/source/examples/verovio/04-score-redefinition.mei
@@ -1,6 +1,6 @@
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/accid-03.mei
+++ b/source/examples/verovio/accid-03.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/accid-03.mei
+++ b/source/examples/verovio/accid-03.mei
@@ -1,6 +1,6 @@
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/alteration.mei
+++ b/source/examples/verovio/alteration.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/alteration.mei
+++ b/source/examples/verovio/alteration.mei
@@ -1,6 +1,6 @@
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/ars_antiqua.mei
+++ b/source/examples/verovio/ars_antiqua.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/ars_antiqua.mei
+++ b/source/examples/verovio/ars_antiqua.mei
@@ -1,6 +1,6 @@
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/augmentation.mei
+++ b/source/examples/verovio/augmentation.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/augmentation.mei
+++ b/source/examples/verovio/augmentation.mei
@@ -1,6 +1,6 @@
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/editorial_example.mei
+++ b/source/examples/verovio/editorial_example.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/source/examples/verovio/editorial_example.mei
+++ b/source/examples/verovio/editorial_example.mei
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0.0">
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
    <meiHead>
       <fileDesc>
          <titleStmt>

--- a/source/examples/verovio/imperfection.mei
+++ b/source/examples/verovio/imperfection.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/imperfection.mei
+++ b/source/examples/verovio/imperfection.mei
@@ -1,6 +1,6 @@
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/implicit-mensuration.mei
+++ b/source/examples/verovio/implicit-mensuration.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/implicit-mensuration.mei
+++ b/source/examples/verovio/implicit-mensuration.mei
@@ -1,6 +1,6 @@
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/mensuration_changes.mei
+++ b/source/examples/verovio/mensuration_changes.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/mensuration_changes.mei
+++ b/source/examples/verovio/mensuration_changes.mei
@@ -1,6 +1,6 @@
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/motet_fauvel_fol22r_triplum.mei
+++ b/source/examples/verovio/motet_fauvel_fol22r_triplum.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/motet_fauvel_fol22r_triplum.mei
+++ b/source/examples/verovio/motet_fauvel_fol22r_triplum.mei
@@ -1,6 +1,6 @@
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/notes_rests.mei
+++ b/source/examples/verovio/notes_rests.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/notes_rests.mei
+++ b/source/examples/verovio/notes_rests.mei
@@ -1,6 +1,6 @@
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/octave-shift-01.mei
+++ b/source/examples/verovio/octave-shift-01.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/octave-shift-01.mei
+++ b/source/examples/verovio/octave-shift-01.mei
@@ -1,6 +1,6 @@
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/partial-imp-01-propinquam.mei
+++ b/source/examples/verovio/partial-imp-01-propinquam.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/partial-imp-01-propinquam.mei
+++ b/source/examples/verovio/partial-imp-01-propinquam.mei
@@ -1,6 +1,6 @@
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/partial-imp-02-bilateral.mei
+++ b/source/examples/verovio/partial-imp-02-bilateral.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/partial-imp-02-bilateral.mei
+++ b/source/examples/verovio/partial-imp-02-bilateral.mei
@@ -1,6 +1,6 @@
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/partial-imp-03-remotam.mei
+++ b/source/examples/verovio/partial-imp-03-remotam.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/partial-imp-03-remotam.mei
+++ b/source/examples/verovio/partial-imp-03-remotam.mei
@@ -1,6 +1,6 @@
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/partial-imp-04-remotam.mei
+++ b/source/examples/verovio/partial-imp-04-remotam.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/partial-imp-04-remotam.mei
+++ b/source/examples/verovio/partial-imp-04-remotam.mei
@@ -1,6 +1,6 @@
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/tempo-01.mei
+++ b/source/examples/verovio/tempo-01.mei
@@ -1,6 +1,6 @@
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
 <?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1-dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/examples/verovio/tempo-01.mei
+++ b/source/examples/verovio/tempo-01.mei
@@ -1,6 +1,6 @@
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
-<?xml-model href="https://music-encoding.org/schema/5.0/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.0">
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://music-encoding.org/schema/dev/mei-all.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<mei xmlns="http://www.music-encoding.org/ns/mei" meiversion="dev">
   <meiHead>
     <fileDesc>
       <titleStmt>

--- a/source/mei-source.xml
+++ b/source/mei-source.xml
@@ -80,7 +80,7 @@
             </respStmt>
          </titleStmt>
          <editionStmt>
-            <edition>Version 5.0</edition>
+            <edition>Development Version</edition>
          </editionStmt>
          <publicationStmt>
             <distributor>Music Encoding Initiative (MEI) Council</distributor>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1894,22 +1894,22 @@
         <defaultVal>5.1-dev</defaultVal>
         <valList type="closed">
           <valItem ident="5.1-dev">
-            <desc xml:lang="en">Development version of MEI 6.0</desc>
+            <desc xml:lang="en">Development version</desc>
           </valItem>
           <valItem ident="5.1-dev+anyStart">
-            <desc>Development version of MEI 6.0+anyStart</desc>
+            <desc>Development version</desc>
           </valItem>
           <valItem ident="5.1-dev+basic">
-              <desc>Development version of MEI 6.0+basic</desc>
+              <desc>Development version</desc>
           </valItem>
           <valItem ident="5.1-dev+CMN">
-            <desc>Development version of MEI 6.0+CMN</desc>
+            <desc>Development version</desc>
           </valItem>
           <valItem ident="5.1-dev+Mensural">
-            <desc>Development version of MEI 6.0+Mensural</desc>
+            <desc>Development version</desc>
           </valItem>
           <valItem ident="5.1-dev+Neumes">
-            <desc>Development version of MEI 6.0+Neumes</desc>
+            <desc>Development version</desc>
           </valItem>
         </valList>
       </attDef>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1891,25 +1891,25 @@
     <attList>
       <attDef ident="meiversion" usage="opt">
         <desc xml:lang="en">Specifies a generic MEI version label.</desc>
-        <defaultVal>5.0</defaultVal>
+        <defaultVal>dev</defaultVal>
         <valList type="closed">
-          <valItem ident="5.0">
-            <desc xml:lang="en">MEI 5.0</desc>
+          <valItem ident="dev">
+            <desc xml:lang="en">Development version of MEI 6.0</desc>
           </valItem>
-          <valItem ident="5.0+anyStart">
-            <desc>MEI 5.0+anyStart</desc>
+          <valItem ident="dev+anyStart">
+            <desc>Development version of MEI 6.0+anyStart</desc>
           </valItem>
-          <valItem ident="5.0+basic">
-              <desc>MEI 5.0+basic</desc>
+          <valItem ident="dev+basic">
+              <desc>Development version of MEI 6.0+basic</desc>
           </valItem>
-          <valItem ident="5.0+CMN">
-            <desc>MEI 5.0+CMN</desc>
+          <valItem ident="dev+CMN">
+            <desc>Development version of MEI 6.0+CMN</desc>
           </valItem>
-          <valItem ident="5.0+Mensural">
-            <desc>MEI 5.0+Mensural</desc>
+          <valItem ident="dev+Mensural">
+            <desc>Development version of MEI 6.0+Mensural</desc>
           </valItem>
-          <valItem ident="5.0+Neumes">
-            <desc>MEI 5.0+Neumes</desc>
+          <valItem ident="dev+Neumes">
+            <desc>Development version of MEI 6.0+Neumes</desc>
           </valItem>
         </valList>
       </attDef>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1891,7 +1891,7 @@
     <attList>
       <attDef ident="meiversion" usage="opt">
         <desc xml:lang="en">Specifies a generic MEI version label.</desc>
-        <defaultVal>dev</defaultVal>
+        <defaultVal>5.1-dev</defaultVal>
         <valList type="closed">
           <valItem ident="5.1-dev">
             <desc xml:lang="en">Development version of MEI 6.0</desc>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1893,22 +1893,22 @@
         <desc xml:lang="en">Specifies a generic MEI version label.</desc>
         <defaultVal>dev</defaultVal>
         <valList type="closed">
-          <valItem ident="dev">
+          <valItem ident="5.1-dev">
             <desc xml:lang="en">Development version of MEI 6.0</desc>
           </valItem>
-          <valItem ident="dev+anyStart">
+          <valItem ident="5.1-dev+anyStart">
             <desc>Development version of MEI 6.0+anyStart</desc>
           </valItem>
-          <valItem ident="dev+basic">
+          <valItem ident="5.1-dev+basic">
               <desc>Development version of MEI 6.0+basic</desc>
           </valItem>
-          <valItem ident="dev+CMN">
+          <valItem ident="5.1-dev+CMN">
             <desc>Development version of MEI 6.0+CMN</desc>
           </valItem>
-          <valItem ident="dev+Mensural">
+          <valItem ident="5.1-dev+Mensural">
             <desc>Development version of MEI 6.0+Mensural</desc>
           </valItem>
-          <valItem ident="dev+Neumes">
+          <valItem ident="5.1-dev+Neumes">
             <desc>Development version of MEI 6.0+Neumes</desc>
           </valItem>
         </valList>


### PR DESCRIPTION
Following the 5.0 release, the content of the develop branch was identical to that of the stable branch. This pull request restores the dev version for the develop branch.

The proposed solution involves using `dev+...` as the version name/number, eliminating the need to definitely determine the next version number.

However, it is still up for discussion whether to use `6.0-dev+...`, `5.1-dev+...`, or another naming convention.