### PR TITLE
validation: make mei-customizations.sch check any customization

### DIFF
--- a/source/validation/mei-customizations.sch
+++ b/source/validation/mei-customizations.sch
@@ -31,8 +31,9 @@
     
     <!-- CHECK IF MEI SOURCE IS IN EXPECTED LOCATION AND AVAILABLE -->
     <sch:pattern id="check_source_available">
-        <sch:rule context="tei:TEI">
-            <sch:assert test="doc-available($mei.source.path)" role="error">The MEI Source file is not available at the expected location of <sch:value-of select="$mei.source.path"/></sch:assert>
+        <sch:rule context="tei:schemaSpec">
+            <sch:extends rule="get.source"/>
+            <sch:assert role="warning" test="doc-available($applicable.source.path)">The applicable MEI Source file is not available at the expected location of <sch:value-of select="$applicable.source.path"/></sch:assert>
         </sch:rule>
     </sch:pattern>
     

--- a/source/validation/mei-customizations.sch
+++ b/source/validation/mei-customizations.sch
@@ -70,14 +70,15 @@
     <!-- CHECK IF ELEMENTS ARE PROPERLY INCLUDED AND EXCEPTED FROM MODULES -->
     <sch:pattern id="check_moduleRef_includesExcepts">
         <sch:rule context="tei:moduleRef[@key and (@include or @except)]">
+            <sch:extends rule="get.source"/>
             <sch:let name="moduleKey" value="@key"/>
-            <sch:let name="all.elements.in.module" value="$mei.source//tei:elementSpec[@module = $moduleKey]/@ident"/>
+            <sch:let name="all.elements.in.module" value="$applicable.source.doc//tei:elementSpec[@module = $moduleKey]/@ident"/>
             <sch:let name="included.elements" value="tokenize(normalize-space(@include),' ')"/>
             <sch:let name="false.inclusions" value="$included.elements[not(. = $all.elements.in.module)]"/>
             <sch:let name="excepted.elements" value="tokenize(normalize-space(@except),' ')"/>
             <sch:let name="false.exceptions" value="$excepted.elements[not(. = $all.elements.in.module)]"/>
-            <sch:assert test="not(@include) or count($false.inclusions) = 0">The following elements are not available in <sch:value-of select="$moduleKey"/>: <sch:value-of select="string-join((for $error in $false.inclusions return ($error || ' (should be: ' || $mei.source//tei:elementSpec[@ident = $error]/@module || ')')), ', ')"/>.</sch:assert>
-            <sch:assert test="not(@except) or count($false.exceptions) = 0">The following elements are not available in <sch:value-of select="$moduleKey"/>: <sch:value-of select="string-join((for $error in $false.exceptions return ($error || ' (should be: ' || $mei.source//tei:elementSpec[@ident = $error]/@module || ')')), ', ')"/>.</sch:assert>
+            <sch:assert test="not(@include) or count($false.inclusions) = 0">The following elements are not available in <sch:value-of select="$moduleKey"/>: <sch:value-of select="string-join((for $error in $false.inclusions return ($error || ' (should be: ' || $applicable.source.doc//tei:elementSpec[@ident = $error]/@module || ')')), ', ')"/>.</sch:assert>
+            <sch:assert test="not(@except) or count($false.exceptions) = 0">The following elements are not available in <sch:value-of select="$moduleKey"/>: <sch:value-of select="string-join((for $error in $false.exceptions return ($error || ' (should be: ' || $applicable.source.doc//tei:elementSpec[@ident = $error]/@module || ')')), ', ')"/>.</sch:assert>
         </sch:rule>
     </sch:pattern>
     

--- a/source/validation/mei-customizations.sch
+++ b/source/validation/mei-customizations.sch
@@ -60,8 +60,10 @@
     <!-- CHECK IF MODULES ARE AVAILABLE -->
     <sch:pattern id="check_moduleRef">
         <sch:rule context="tei:moduleRef[@key]">
+            <sch:extends rule="get.source"/>
             <sch:let name="moduleKey" value="@key"/>
-            <sch:assert test="$moduleKey = $mei.source//tei:moduleSpec/@ident">There is no module "<sch:value-of select="$moduleKey"/>" in MEI.</sch:assert>
+            <sch:let name="exists" value="$moduleKey = $applicable.source.doc//tei:moduleSpec/@ident"/>
+            <sch:assert test="$exists">There is no module "<sch:value-of select="$moduleKey"/>".</sch:assert>
         </sch:rule>
     </sch:pattern>
     

--- a/source/validation/mei-customizations.sch
+++ b/source/validation/mei-customizations.sch
@@ -61,8 +61,11 @@
     
     <!-- CHECK IF A CLASS REFERENCED BY classes/memberOf IS AVAILABLE -->
     <sch:pattern id="check_memberOf_key_available">
+        <sch:let name="classenames.source" value="$mei.source//tei:classSpec/@ident"/>
+        <sch:let name="classnames.customization" value="//tei:classSpec/@ident[@mode = 'add']"/>
         <sch:let name="classnames.deleted" value="//tei:classSpec[@mode = 'delete']/@ident"/>
         <sch:rule context="tei:classes/tei:memberOf">
+            <sch:assert test="@key = ($classenames.source, $classnames.customization)">The referenced class "<sch:value-of select="@key"/>" does neither exist in your source, nor in your customization.</sch:assert>
             <sch:report role="warning" test="@key = $classnames.deleted">The referenced class "<sch:value-of select="@key"/>" has been deleted from you customization.</sch:report>
         </sch:rule>
     </sch:pattern>

--- a/source/validation/mei-customizations.sch
+++ b/source/validation/mei-customizations.sch
@@ -28,7 +28,7 @@
     
     <!-- CHECK IF MODEL CLASSES ARE AVAILABLE AND IN CORRECT MODULE -->
     <sch:pattern id="check_model_classSpecs">
-        <sch:rule context="tei:classSpec[@type = 'model']">
+        <sch:rule context="tei:classSpec[@type = 'model'][not(@mode = 'add')]">
             <sch:let name="ident" value="@ident"/>
             <sch:let name="module" value="@module"/>
             <sch:let name="exists" value="$ident = $mei.source//tei:classSpec[@type = 'model']/@ident"/>

--- a/source/validation/mei-customizations.sch
+++ b/source/validation/mei-customizations.sch
@@ -3,8 +3,8 @@
     <sch:ns prefix="tei" uri="http://www.tei-c.org/ns/1.0"/>
     <sch:ns prefix="rng" uri="http://relaxng.org/ns/structure/1.0"/>
     
-    <sch:let name="schematron.path" value="string(document-uri(.))"/>
-    <sch:let name="mei.source.folder" value="substring-before($schematron.path,'/customizations/') || '/source/'"/>
+    <sch:let name="customization.path" value="string(document-uri(.))"/>
+    <sch:let name="mei.source.folder" value="substring-before($customization.path,'/customizations/') || '/source/'"/>
     <sch:let name="mei.source.path" value="$mei.source.folder || 'mei-source.xml'"/>
     <sch:let name="mei.source" value="document($mei.source.path)"/>
     

--- a/source/validation/mei-customizations.sch
+++ b/source/validation/mei-customizations.sch
@@ -17,7 +17,7 @@
     
     <!-- CHECK IF ATTRIBUTE CLASSES ARE AVAILABLE AND IN CORRECT MODULE -->
     <sch:pattern id="check_att_classSpecs">
-        <sch:rule context="tei:classSpec[@type = 'atts']">
+        <sch:rule context="tei:classSpec[@type = 'atts'][not(@mode = 'add')]">
             <sch:let name="ident" value="@ident"/>
             <sch:let name="module" value="@module"/>
             <sch:let name="exists" value="$ident = $mei.source//tei:classSpec[@type = 'atts']/@ident"/>

--- a/source/validation/mei-customizations.sch
+++ b/source/validation/mei-customizations.sch
@@ -4,8 +4,7 @@
     <sch:ns prefix="rng" uri="http://relaxng.org/ns/structure/1.0"/>
     
     <sch:let name="customization.path" value="string(document-uri(.))"/>
-    <sch:let name="mei.source.folder" value="substring-before($customization.path,'/customizations/') || '/source/'"/>
-    <sch:let name="mei.source.path" value="$mei.source.folder || 'mei-source.xml'"/>
+    <sch:let name="mei.source.path" value=" resolve-uri('../mei-source.xml')"/>
     <sch:let name="mei.source" value="document($mei.source.path)"/>
     
     <!-- CHECK IF MEI SOURCE IS IN EXPECTED LOCATION AND AVAILABLE -->

--- a/source/validation/mei-customizations.sch
+++ b/source/validation/mei-customizations.sch
@@ -77,8 +77,16 @@
             <sch:let name="false.inclusions" value="$included.elements[not(. = $all.elements.in.module)]"/>
             <sch:let name="excepted.elements" value="tokenize(normalize-space(@except),' ')"/>
             <sch:let name="false.exceptions" value="$excepted.elements[not(. = $all.elements.in.module)]"/>
-            <sch:assert test="not(@include) or count($false.inclusions) = 0">The following elements are not available in <sch:value-of select="$moduleKey"/>: <sch:value-of select="string-join((for $error in $false.inclusions return ($error || ' (should be: ' || $applicable.source.doc//tei:elementSpec[@ident = $error]/@module || ')')), ', ')"/>.</sch:assert>
-            <sch:assert test="not(@except) or count($false.exceptions) = 0">The following elements are not available in <sch:value-of select="$moduleKey"/>: <sch:value-of select="string-join((for $error in $false.exceptions return ($error || ' (should be: ' || $applicable.source.doc//tei:elementSpec[@ident = $error]/@module || ')')), ', ')"/>.</sch:assert>
+            <sch:assert test="not(@include) or count($false.inclusions) = 0">The following elements are not available in <sch:value-of select="$moduleKey"/>: <sch:value-of select="string-join((
+                for $error in $false.inclusions return
+                    concat($error, if($applicable.source.doc//tei:elementSpec[@ident = $error]/@module) then
+                        ' (should be included in: ' || $applicable.source.doc//tei:elementSpec[@ident = $error]/@module || ')'
+                        else ' (cannot be found in any module)')), ', ')"/>.</sch:assert>
+            <sch:assert test="not(@except) or count($false.exceptions) = 0">The following elements are not available in <sch:value-of select="$moduleKey"/>: <sch:value-of select="string-join((
+                for $error in $false.exceptions return
+                    concat($error, if($applicable.source.doc//tei:elementSpec[@ident = $error]/@module) then
+                        ' (should be excepted in: ' || $applicable.source.doc//tei:elementSpec[@ident = $error]/@module || ')'
+                        else ' (cannot be found in any module)')), ', ')"/>.</sch:assert>
         </sch:rule>
     </sch:pattern>
     

--- a/source/validation/mei-customizations.sch
+++ b/source/validation/mei-customizations.sch
@@ -50,11 +50,10 @@
     <!-- CHECK IF MODEL CLASSES ARE AVAILABLE AND IN CORRECT MODULE -->
     <sch:pattern id="check_model_classSpecs">
         <sch:rule context="tei:classSpec[@type = 'model']">
-            <sch:let name="ident" value="@ident"/>
-            <sch:let name="module" value="@module"/>
-            <sch:let name="exists" value="$ident = $mei.source//tei:classSpec[@type = 'model']/@ident"/>
+            <sch:extends rule="get.source"/>
+            <sch:let name="exists" value="$ident = $applicable.source.doc//tei:classSpec[@type = 'model']/@ident"/>
             <sch:assert test="$exists">There is no model class with name "<sch:value-of select="$ident"/>".</sch:assert>
-            <sch:assert test="not($exists) or $module = $mei.source//tei:classSpec[@ident = $ident]/@module">Model class "<sch:value-of select="$ident"/>" is not in module "<sch:value-of select="$module"/>", but in module "<sch:value-of select="$mei.source//tei:classSpec[@ident = $ident]/@module"/>".</sch:assert>
+            <sch:assert test="not($exists) or $module = $applicable.source.doc//tei:classSpec[@ident = $ident]/@module">Model class "<sch:value-of select="$ident"/>" is not in module "<sch:value-of select="$module"/>", but in module "<sch:value-of select="$applicable.source.doc//tei:classSpec[@ident = $ident]/@module"/>".</sch:assert>
         </sch:rule>
     </sch:pattern>
     

--- a/source/validation/mei-customizations.sch
+++ b/source/validation/mei-customizations.sch
@@ -40,11 +40,10 @@
     <!-- CHECK IF ATTRIBUTE CLASSES ARE AVAILABLE AND IN CORRECT MODULE -->
     <sch:pattern id="check_att_classSpecs">
         <sch:rule context="tei:classSpec[@type = 'atts']">
-            <sch:let name="ident" value="@ident"/>
-            <sch:let name="module" value="@module"/>
-            <sch:let name="exists" value="$ident = $mei.source//tei:classSpec[@type = 'atts']/@ident"/>
+            <sch:extends rule="get.source"/>
+            <sch:let name="exists" value="$ident = $applicable.source.doc//tei:classSpec[@type = 'atts']/@ident"/>
             <sch:assert test="$exists">There is no attribute class with name "<sch:value-of select="$ident"/>".</sch:assert>
-            <sch:assert test="not($exists) or $module = $mei.source//tei:classSpec[@ident = $ident]/@module">Attribute class "<sch:value-of select="$ident"/>" is not in module "<sch:value-of select="$module"/>", but in module "<sch:value-of select="$mei.source//tei:classSpec[@ident = $ident]/@module"/>".</sch:assert>
+            <sch:assert test="not($exists) or $module = $applicable.source.doc//tei:classSpec[@ident = $ident]/@module">Attribute class "<sch:value-of select="$ident"/>" is not in module "<sch:value-of select="$module"/>", but in module "<sch:value-of select="$applicable.source.doc//tei:classSpec[@ident = $ident]/@module"/>".</sch:assert>
         </sch:rule>
     </sch:pattern>
     

--- a/source/validation/mei-customizations.sch
+++ b/source/validation/mei-customizations.sch
@@ -15,17 +15,18 @@
             <sch:let name="module.spec" value="ancestor-or-self::tei:schemaSpec//*[@ident = $module] | ancestor-or-self::tei:schemaSpec//*[@key = $module]"/>
             <sch:let name="module.source.path" value="resolve-uri($module.spec/@source, document-uri(/root()))"/>
             <sch:let name="this.source.path" value="resolve-uri(@source, document-uri(/root()))"/>
-            <sch:let name="applicable.source.path" value="if (@source) then
-                                                              if (doc-available($this.source.path)) then
+            <sch:let name="applicable.source.path" value="if ($this.source.path != '') then
                                                                   $this.source.path
-                                                              else 'error'
-                                                          else if (doc-available($module.source.path)) then
+                                                          else if ($module.source.path != '') then
                                                             $module.source.path
-                                                          else if (doc-available($schemaSpec.source.path)) then
+                                                          else if ($schemaSpec.source.path != '') then
                                                             $schemaSpec.source.path
                                                           else $mei.source.path"/>
-            <sch:let name="applicable.source.doc" value="doc($applicable.source.path)"/>
-            <sch:report role="info" test="true()">applicable source: <sch:value-of select="$applicable.source.path"/></sch:report>
+            <sch:let name="applicable.source.doc" value="if (doc-available($applicable.source.path)) then
+                                                            doc($applicable.source.path)
+                                                         else doc($customization.path)"/>
+            <sch:report role="info" test="true()">applicable source path: <sch:value-of select="$applicable.source.path"/></sch:report>
+            <sch:report role="error" test="document-uri($applicable.source.doc) = $customization.path">The applicable source doc is not available at: <sch:value-of select="$applicable.source.path"/></sch:report>
         </sch:rule>
     </sch:pattern>
     

--- a/source/validation/mei-customizations.sch
+++ b/source/validation/mei-customizations.sch
@@ -59,4 +59,11 @@
         </sch:rule>
     </sch:pattern>
     
+    <!-- CHECK IF A CLASS REFERENCED BY classes/memberOf IS AVAILABLE -->
+    <sch:pattern id="check_memberOf_key_available">
+        <sch:let name="classnames.deleted" value="//tei:classSpec[@mode = 'delete']/@ident"/>
+        <sch:rule context="tei:classes/tei:memberOf">
+            <sch:report role="warning" test="@key = $classnames.deleted">The referenced class "<sch:value-of select="@key"/>" has been deleted from you customization.</sch:report>
+        </sch:rule>
+    </sch:pattern>
 </sch:schema>

--- a/source/validation/mei-customizations.sch
+++ b/source/validation/mei-customizations.sch
@@ -66,7 +66,7 @@
         <sch:let name="classnames.deleted" value="//tei:classSpec[@mode = 'delete']/@ident"/>
         <sch:rule context="tei:classes/tei:memberOf">
             <sch:assert test="@key = ($classenames.source, $classnames.customization)">The referenced class "<sch:value-of select="@key"/>" does neither exist in your source, nor in your customization.</sch:assert>
-            <sch:report role="warning" test="@key = $classnames.deleted">The referenced class "<sch:value-of select="@key"/>" has been deleted from you customization.</sch:report>
+            <sch:report role="warning" test="@key = $classnames.deleted">The referenced class "<sch:value-of select="@key"/>" has been deleted from your customization.</sch:report>
         </sch:rule>
     </sch:pattern>
 </sch:schema>

--- a/source/validation/mei-customizations.sch
+++ b/source/validation/mei-customizations.sch
@@ -7,6 +7,28 @@
     <sch:let name="mei.source.path" value=" resolve-uri('../mei-source.xml')"/>
     <sch:let name="mei.source" value="document($mei.source.path)"/>
     
+    <sch:pattern id="abstract-rules">
+        <sch:rule abstract="true" id="get.source">
+            <sch:let name="schemaSpec.source.path" value="resolve-uri(ancestor-or-self::tei:schemaSpec/@source, document-uri(/root()))"/>
+            <sch:let name="ident" value="@ident"/>
+            <sch:let name="module" value="@module"/>
+            <sch:let name="module.spec" value="ancestor-or-self::tei:schemaSpec//*[@ident = $module] | ancestor-or-self::tei:schemaSpec//*[@key = $module]"/>
+            <sch:let name="module.source.path" value="resolve-uri($module.spec/@source, document-uri(/root()))"/>
+            <sch:let name="this.source.path" value="resolve-uri(@source, document-uri(/root()))"/>
+            <sch:let name="applicable.source.path" value="if (@source) then
+                                                              if (doc-available($this.source.path)) then
+                                                                  $this.source.path
+                                                              else 'error'
+                                                          else if (doc-available($module.source.path)) then
+                                                            $module.source.path
+                                                          else if (doc-available($schemaSpec.source.path)) then
+                                                            $schemaSpec.source.path
+                                                          else $mei.source.path"/>
+            <sch:let name="applicable.source.doc" value="doc($applicable.source.path)"/>
+            <sch:report role="info" test="true()">applicable source: <sch:value-of select="$applicable.source.path"/></sch:report>
+        </sch:rule>
+    </sch:pattern>
+    
     <!-- CHECK IF MEI SOURCE IS IN EXPECTED LOCATION AND AVAILABLE -->
     <sch:pattern id="check_source_available">
         <sch:rule context="tei:TEI">


### PR DESCRIPTION
Currently the mei-customizations.sch Schematron is setup to check the cannon customizations only. Moreover it only supports customizations of mei-source.xml and does not check `classes/memberOf` statements.

This PR fixes these limitations.

Fixes #1392 