### PR TITLE
schema: allow additive `@dur` on `<halfmRpt>`

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -578,7 +578,7 @@
     <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.event"/>
-      <memberOf key="att.duration.log"/>
+      <memberOf key="att.duration.additive"/>
     </classes>
   </classSpec>
   <classSpec ident="att.harpPedal.log" module="MEI.cmn" type="atts">


### PR DESCRIPTION
I think additive `@dur` makes sense for `<halfmRpt>`, because how would we otherwise encode situations like this:

![grafik](https://github.com/music-encoding/music-encoding/assets/1147152/f583b25b-4de8-4028-b14d-82622c7a4f23)

This example can then be encoded like:
```xml
<measure>
  <staff>
    <layer>
      <beam>
        <note dur="8" pname="a" oct="4"/>
        <note dur="8" pname="b" oct="4"/>
        <note dur="8" pname="a" oct="4"/>
        <note dur="8" pname="g" oct="4"/>
        <note dur="8" pname="a" oct="4"/>
      </beam>
      <halfmRpt dur="2 8"/>
    </layer>
  </staff>
</measure>
<measure>
  <staff>
    <layer>
      <beam>
        <halfmRpt dur="2 8"/>
        <note dur="8" pname="a" oct="4"/>
        <note dur="8" pname="b" oct="4"/>
        <note dur="8" pname="a" oct="4"/>
        <note dur="8" pname="b" oct="4"/>
        <note dur="8" pname="a" oct="4"/>
      </beam>
    </layer>
  </staff>
</measure>
```

