### PR TITLE
schema: add att.dataSelecting and add it to symbolDef

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -867,7 +867,7 @@
       <attDef ident="select" usage="opt">
         <desc xml:lang="en">XPath used to select data to which an element or a property applies.</desc>
         <datatype maxOccurs="1">
-          <rng:ref name="data.URI"/>
+          <rng:data type="token"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -861,6 +861,17 @@
       </attDef>
     </attList>
   </classSpec>
+  <classSpec ident="att.dataSelecting" module="MEI.shared" type="atts">
+    <desc xml:lang="en">Attributes for selecting data.</desc>
+    <attList>
+      <attDef ident="select" usage="opt">
+        <desc xml:lang="en">XPath used to select data to which an element or a property applies.</desc>
+        <datatype maxOccurs="1">
+          <rng:ref name="data.URI"/>
+        </datatype>
+      </attDef>
+    </attList>
+  </classSpec>
   <classSpec ident="att.mdiv.log" module="MEI.shared" type="atts">
     <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>

--- a/source/modules/MEI.usersymbols.xml
+++ b/source/modules/MEI.usersymbols.xml
@@ -309,6 +309,7 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.coordinated"/>
+      <memberOf key="att.dataSelecting"/>
     </classes>
     <content>
       <rng:optional>


### PR DESCRIPTION
This PR implements the result of the discussion in https://github.com/music-encoding/music-encoding/issues/1374

I am marking it a draft PR because I am not sure if the `datatype` for `@select` is right. I am actually pretty sure it is not. Any ideas what it should be?