### PR TITLE
docs: update remarks for score element

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -7605,10 +7605,9 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>Since the <gi scheme="MEI">measure</gi> element is optional, a score may consist entirely
-        of page beginnings, each of which points to a page image. <gi scheme="MEI">div</gi> elements
-        are allowed preceding and following sections of music data in order to accommodate blocks of
-        explanatory text.</p>
+      <p>A score may consist entirely of page beginnings, each of which points to a page
+      image. <gi scheme="MEI">div</gi> elements are allowed preceding and following sections
+      of music data in order to accommodate blocks of explanatory text.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="scoreDef" module="MEI.shared">


### PR DESCRIPTION
The current remarks for score are misleading. Removing the initial dependent clause will help fix the problem.