### PR TITLE
gh-actions: update labeler action

### DIFF
--- a/.github/pr-labeler_config.yml
+++ b/.github/pr-labeler_config.yml
@@ -1,29 +1,35 @@
-"Component: Build":
-- build.xml
+'Component: Build':
+  - changed-files:
+    - any-glob-to-any-file: ['build.xml']
 
-"Component: Core Schema":
-- source/modules/**/*
-- source/mei-source.xml
+'Component: Core Schema':
+  - changed-files:
+    - any-glob-to-any-file: ['source/modules/**/*', 'source/mei-source.xml']
 
-"Component: Customizations":
-- customizations/**/*
+'Component: Customizations':
+  - changed-files:
+    - any-glob-to-any-file: ['customizations/**/*']
 
-"Component: Guidelines & Documentation":
-- source/docs/**/*
-- source/examples/**/*
-- source/web/**/*
+'Component: Guidelines & Documentation':
+  - changed-files:
+    - any-glob-to-any-file: ['source/docs/**/*', 'source/examples/**/*']
 
-"Component: Images":
-- source/images/**/*
+'Component: Images':
+  - changed-files:
+    - any-glob-to-any-file: ['source/assets/images/**/*']
 
-"Component: Style":
-- source/assets/css/**/*
+'Component: Style':
+  - changed-files:
+    - any-glob-to-any-file: ['source/assets/css/**/*']
 
-"Component: Utils":
-- utils/**/*
+'Component: Utils':
+  - changed-files:
+    - any-glob-to-any-file: ['utils/**/*']
 
-"Component: Validation":
-- source/validation/**/*
+'Component: Validation':
+  - changed-files:
+    - any-glob-to-any-file: ['source/validation/**/*']
 
-"Component: Workflows":
-- .github/workflows/**/*
+'Component: Workflows':
+  - changed-files:
+    - any-glob-to-any-file: ['.github/**/*']

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'music-encoding'
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # ratchet:actions/labeler@v5.0.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -16,6 +16,9 @@ on:
 
 jobs:
   label:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     if: github.repository_owner == 'music-encoding'
     steps:


### PR DESCRIPTION
This PR updates the labeler github action that was failing recently. After update to labeler v5, there was quite some change in the action syntax that needed adjustment (cf. https://github.com/actions/labeler/tree/v5.0.0#breaking-changes-in-v5).

Some of the glob paths in the config file have been adjusted as well when they referenced non-existing files or folders.