### PR TITLE
docs: remove superfluous quotes on values

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -2320,8 +2320,8 @@
     <desc xml:lang="en">Attributes that record placement of notes on a single-line staff.</desc>
     <attList>
       <attDef ident="ontheline" usage="opt">
-        <desc xml:lang="en">Determines the placement of notes on a 1-line staff. A value of '<val>true</val>' places all
-          notes on the line, while a value of '<val>false</val>' places stems-up notes above the line and
+        <desc xml:lang="en">Determines the placement of notes on a 1-line staff. A value of <val>true</val> places all
+          notes on the line, while a value of <val>false</val> places stems-up notes above the line and
           stems-down notes below the line.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>
@@ -2579,7 +2579,7 @@
     <desc xml:lang="en">Attributes capturing placement on a staff.</desc>
     <attList>
        <attDef ident="onstaff" usage="opt">
-          <desc xml:lang="en">Indicates the placement of the item within the staff. A value of '<val>true</val>' means on the staff, and '<val>false</val>' off the staff.</desc>
+          <desc xml:lang="en">Indicates the placement of the item within the staff. A value of <val>true</val> means on the staff, and <val>false</val> off the staff.</desc>
           <datatype>
              <rng:ref name="data.BOOLEAN"/>
           </datatype>


### PR DESCRIPTION
This PR removes quotes around `<val>` elements that lead to doubled ones in the guidelines.

spotted by @musicEnfanthen 