### PR TITLE
utils: improve logging output for build-guidelines-html step

### DIFF
--- a/utils/guidelines_xslt/odd2html.xsl
+++ b/utils/guidelines_xslt/odd2html.xsl
@@ -201,8 +201,8 @@
         <xsl:message select="'.   data types: ' || count($data.types)"/>
         <xsl:message select="'.   macro groups: ' || count($macro.groups)"/>
         
-        <xsl:variable name="toc" select="tools:generateToc()" as="node()"/>
         <xsl:variable name="preface" select="tools:generatePreface()" as="node()+"/>
+        <xsl:variable name="toc" select="tools:generateToc()" as="node()"/>
         <xsl:variable name="guidelines" as="node()">
             <main>
                 <xsl:apply-templates select="$mei.source//tei:body/child::tei:div" mode="guidelines"/>                

--- a/utils/guidelines_xslt/odd2html/functions.xsl
+++ b/utils/guidelines_xslt/odd2html/functions.xsl
@@ -101,7 +101,7 @@
         <xd:return></xd:return>
     </xd:doc>
     <xsl:function name="tools:generatePreface" as="node()+">
-        
+        <xsl:message select="'Generating preface'"/>
         <xsl:variable name="git.link" select="'https://github.com/music-encoding/music-encoding/commit/' || $retrieved.hash" as="xs:string"/>
         <xsl:variable name="git.short" select="substring($retrieved.hash,1,7)" as="xs:string"/>
         
@@ -180,6 +180,7 @@
         <xd:return></xd:return>
     </xd:doc>
     <xsl:function name="tools:generateToc" as="node()">
+        <xsl:message select="'Generating TOC'"/>
         <nav>
             <header>Table of Contents</header>
             <!-- TODO: Do we have front pages that need to be included? -->
@@ -384,6 +385,7 @@
         <xd:return></xd:return>
     </xd:doc>
     <xsl:function name="tools:generateIndizes" as="node()+">
+        <xsl:message select="'Generating indices'"/>
         <section id="elementIndex" class="backIndex">
             <h1>Index of Elements</h1>
             <xsl:for-each select="$elements.pdf.links">

--- a/utils/guidelines_xslt/odd2html/generateWebsite.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsite.xsl
@@ -31,6 +31,7 @@
     </xd:doc>
     <xsl:template name="generateWebsite">
         <xsl:param name="input" as="node()+"/>
+        <xsl:message select="'Generating HTML document for website'"/>
         
         <xsl:variable name="web.output" select="$dist.folder" as="xs:string"/>
         

--- a/utils/guidelines_xslt/odd2html/prepareLiveExamples.xsl
+++ b/utils/guidelines_xslt/odd2html/prepareLiveExamples.xsl
@@ -43,6 +43,7 @@
     
     <xsl:template name="prepareLiveExamples">
         <xsl:param name="guidelinesSources" as="node()*"/>
+        <xsl:message select="'Preparing live examples'"/>
         
         <xsl:for-each select="$guidelinesSources//egx:egXML['verovio' = tokenize(normalize-space(@rend),' ')]">
             <xsl:variable name="id" select="generate-id(.)" as="xs:string"/>

--- a/utils/guidelines_xslt/odd2html/specs/attClassSpecs.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/attClassSpecs.xsl
@@ -40,6 +40,7 @@
         <xd:return>the section element</xd:return>
     </xd:doc>
     <xsl:function name="tools:getAttClassSpecs" as="node()">
+        <xsl:message select="'Getting attribute class specs'"/>
         <section id="attClassSpecs" class="specSection">
             <h1>Attribute Class Specifications</h1>
             <xsl:for-each select="$att.classes">

--- a/utils/guidelines_xslt/odd2html/specs/dataTypeSpecs.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/dataTypeSpecs.xsl
@@ -40,6 +40,7 @@
         <xd:return>the section element</xd:return>
     </xd:doc>
     <xsl:function name="tools:getDataTypeSpecs" as="node()">
+        <xsl:message select="'Getting data type specs'"/>
         <section id="dataTypeSpecs" class="specSection">
             <h1>Data Type Specifications</h1>
             <xsl:for-each select="$data.types">

--- a/utils/guidelines_xslt/odd2html/specs/elementSpecs.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/elementSpecs.xsl
@@ -42,6 +42,7 @@
         <xd:return>the section element</xd:return>
     </xd:doc>
     <xsl:function name="tools:getElementSpecs" as="node()">
+        <xsl:message select="'Getting element specs'"/>
         <section id="elementSpecs" class="specSection">
             <h1>Element Specifications</h1>
             <xsl:for-each select="$elements">

--- a/utils/guidelines_xslt/odd2html/specs/macroGroupSpecs.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/macroGroupSpecs.xsl
@@ -42,6 +42,7 @@
         <xd:return>the section element</xd:return>
     </xd:doc>
     <xsl:function name="tools:getMacroGroupSpecs" as="node()">
+        <xsl:message select="'Getting macro group specs'"/>
         <section id="macroGroupSpecs" class="specSection">
             <h1>Macro Group Specifications</h1>
             <xsl:for-each select="$macro.groups">

--- a/utils/guidelines_xslt/odd2html/specs/modelClassSpecs.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/modelClassSpecs.xsl
@@ -41,6 +41,7 @@
         <xd:return>the section element</xd:return>
     </xd:doc>
     <xsl:function name="tools:getModelClassSpecs" as="node()">
+        <xsl:message select="'Getting model class specs'"/>
         <section id="modelClassSpecs" class="specSection">
             <h1>Model Class Specifications</h1>
             <xsl:for-each select="$model.classes">


### PR DESCRIPTION
This PR makes the logging output for the ant build-guidelines-html step a little bit more verbose. Previously, one could get the impression that the job got stuck. 