### PR TITLE
utils: fix element descriptions in guidelines ref

### DIFF
--- a/utils/guidelines_xslt/odd2html/generateWebsite.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsite.xsl
@@ -1007,7 +1007,7 @@
                                 <xsl:apply-templates select=".//span[@class='specList-elementSpec']" mode="#current"/>
                             </div>
                             <div class="tile-subtitle text-gray">
-                                <xsl:apply-templates select="text()"/>
+                                <xsl:apply-templates select="text()|abbr/text()"/>
                             </div>
                         </div>
                     </div>
@@ -1048,7 +1048,7 @@
                                 <xsl:apply-templates select=".//a" mode="#current"/>
                             </div>
                             <div class="tile-subtitle text-gray">
-                                <xsl:apply-templates select="text()"/>
+                                <xsl:apply-templates select="text()|abbr/text()"/>
                             </div>
                         </div>
                     </div>

--- a/utils/guidelines_xslt/odd2html/generateWebsite.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsite.xsl
@@ -1007,7 +1007,7 @@
                                 <xsl:apply-templates select=".//span[@class='specList-elementSpec']" mode="#current"/>
                             </div>
                             <div class="tile-subtitle text-gray">
-                                <xsl:apply-templates select="text()|abbr/text()"/>
+                                <xsl:apply-templates select=".//span[@class='specList-elementSpec-desc']"/>
                             </div>
                         </div>
                     </div>

--- a/utils/guidelines_xslt/odd2html/generateWebsite.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsite.xsl
@@ -1048,7 +1048,7 @@
                                 <xsl:apply-templates select=".//a" mode="#current"/>
                             </div>
                             <div class="tile-subtitle text-gray">
-                                <xsl:apply-templates select="text()|abbr/text()"/>
+                                <xsl:apply-templates select="text()"/>
                             </div>
                         </div>
                     </div>

--- a/utils/guidelines_xslt/odd2html/guidelines.xsl
+++ b/utils/guidelines_xslt/odd2html/guidelines.xsl
@@ -199,7 +199,9 @@
             <xsl:choose>
                 <xsl:when test="not($specDesc/@atts)">
                     <span class="specList-{local-name($spec)}"><a class="{tools:getLinkClasses($key)}" href="#{$key}"><xsl:value-of select="$key"/></a></span>
-                    <xsl:apply-templates select="$spec/tei:desc/node()" mode="#current"/>
+                    <span class="specList-{local-name($spec)}-desc">
+                        <xsl:apply-templates select="$spec/tei:desc/node()" mode="#current"/>
+                    </span>
                 </xsl:when>
                 <xsl:otherwise>
                     <table class="specDesc">


### PR DESCRIPTION
I tried `.//text()` at first to process all elements which occur, but it returned too much content (like attribute names). I guess that the script I edited is dealing with pre-processed data. After analyzing the MEI modules I figured out that adding `abbr` to the script should work (for now).
Thanks for feedback.

Fixes #1343