### PR TITLE
guidelines: fix the end tag of edit section in tempo example file

### DIFF
--- a/source/examples/verovio/tempo-01.mei
+++ b/source/examples/verovio/tempo-01.mei
@@ -57,7 +57,7 @@
               <tempo staff="1" tstamp="1.000000">Andante con moto <rend fontfam="smufl">&#xE1D3;</rend> = 70</tempo>
               <slur startid="#m0_s2_e1" endid="#m0_s2_e2" />
             </measure>
-            <?edit-start?>
+            <?edit-end?>
             <measure n="1">
               <staff n="1">
                 <layer n="1">


### PR DESCRIPTION
This PR fixes a typo in the end tag of the edit section in the tempo mei example. Before this fix, the full file was displayed in the guidelines instead of the marked snippet.