### PR TITLE
utils: fix wording for datatype list values

### DIFF
--- a/utils/guidelines_xslt/odd2html/specs/dataTypeSpecs.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/dataTypeSpecs.xsl
@@ -24,7 +24,7 @@
                     <!--<xd:li>Chapter references</xd:li>-->
                     <xd:li>Module</xd:li>
                     <xd:li>Used By</xd:li>
-                    <xd:li>Allowed values</xd:li>
+                    <xd:li>Tolerated values</xd:li>
                     <xd:li>Remarks (optional)</xd:li>
                     <xd:li>Constraints (optional)</xd:li>
                     <xd:li>Declaration</xd:li>
@@ -62,7 +62,7 @@
         
         <xsl:variable name="moduleFacet" select="tools:getModuleFacet($data.type)" as="node()"/>
         <xsl:variable name="usedByFacet" select="tools:getDatatypeUsersFacet($data.type)" as="node()"/>
-        <xsl:variable name="allowedValuesFacet" select="tools:getAllowedValuesFacet($data.type)" as="node()?"/>
+        <xsl:variable name="toleratedValuesFacet" select="tools:getToleratedValuesFacet($data.type)" as="node()?"/>
         <xsl:variable name="remarksFacet" select="tools:getRemarksFacet($data.type)" as="node()?"/>
         <xsl:variable name="constraintsFacet" select="tools:getSchematronFacet($data.type)" as="node()?"/>
         <xsl:variable name="declarationFacet" select="tools:getDeclarationFacet($data.type)" as="node()"/>
@@ -75,7 +75,7 @@
                 </div>
                 <xsl:sequence select="$moduleFacet"/>
                 <xsl:sequence select="$usedByFacet"/>
-                <xsl:sequence select="$allowedValuesFacet"/>
+                <xsl:sequence select="$toleratedValuesFacet"/>
                 <xsl:sequence select="$remarksFacet"/>
                 <xsl:sequence select="$constraintsFacet"/>
                 <xsl:sequence select="$declarationFacet"/>

--- a/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
@@ -474,8 +474,10 @@
         <xsl:variable name="values" select="$object//tei:valList/tei:valItem" as="node()*"/>
         
         <xsl:if test="count($values) gt 0">
+            <xsl:variable name="valTolerance" select="if($object//tei:valList/@type = 'semi') then('Suggested') else('Allowed')" as="xs:string?"/>
+            
             <div class="facet allowedValues" id="allowedValues">
-                <div class="label">Allowed Values</div>
+                <div class="label"><xsl:value-of select="$valTolerance || ' Values'"/></div>
                 <div class="statement list">
                     <xsl:for-each select="$values">
                         <div class="dataValueBox" id="{@ident}">
@@ -631,7 +633,8 @@
                 <span class="attributeValues">
                     <xsl:choose>
                         <xsl:when test="$current.att/tei:valList">
-                            Allowed values are:
+                            <xsl:variable name="valTolerance" select="if($current.att/tei:valList/@type = 'semi') then('Suggested') else('Allowed')" as="xs:string?"/>
+                            <xsl:value-of select="' ' || $valTolerance || ' values are:'"/>
                             <xsl:for-each select="$current.att/tei:valList/tei:valItem">
                                 <xsl:if test="position() gt 1">, </xsl:if> "<span style="font-weight: 500;"><xsl:value-of select="@ident"/></span>" <xsl:if test="tei:desc"> <i>(<xsl:value-of select="tei:desc/text()"/>)</i></xsl:if>
                             </xsl:for-each>

--- a/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
@@ -463,7 +463,7 @@
     
     <xd:doc>
         <xd:desc>
-            <xd:p>Retreives the allowed values of an attribute</xd:p>
+            <xd:p>Retrieves the allowed values of an attribute</xd:p>
         </xd:desc>
         <xd:param name="object"></xd:param>
         <xd:return></xd:return>
@@ -609,7 +609,7 @@
     
     <xd:doc>
         <xd:desc>
-            <xd:p>Resolves the defition of an attribute</xd:p>
+            <xd:p>Resolves the definition of an attribute</xd:p>
         </xd:desc>
         <xd:param name="current.att">The current attribute</xd:param>
         <xd:param name="module"></xd:param>

--- a/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
@@ -463,12 +463,12 @@
     
     <xd:doc>
         <xd:desc>
-            <xd:p>Retrieves the allowed values of an attribute</xd:p>
+            <xd:p>Retrieves the tolerated values of an attribute</xd:p>
         </xd:desc>
         <xd:param name="object"></xd:param>
         <xd:return></xd:return>
     </xd:doc>
-    <xsl:function name="tools:getAllowedValuesFacet" as="node()?">
+    <xsl:function name="tools:getToleratedValuesFacet" as="node()?">
         <xsl:param name="object" as="node()"/>
         
         <xsl:variable name="values" select="$object//tei:valList/tei:valItem" as="node()*"/>
@@ -476,7 +476,7 @@
         <xsl:if test="count($values) gt 0">
             <xsl:variable name="valTolerance" select="if($object//tei:valList/@type = 'semi') then('Suggested') else('Allowed')" as="xs:string?"/>
             
-            <div class="facet allowedValues" id="allowedValues">
+            <div class="facet toleratedValues" id="toleratedValues">
                 <div class="label"><xsl:value-of select="$valTolerance || ' Values'"/></div>
                 <div class="statement list">
                     <xsl:for-each select="$values">


### PR DESCRIPTION
This PR adjusts the XSLT function tools:getToleratedValuesFacet that generates a facet for possible datatype values from a given object node. It checks if the valList type is 'semi' or 'closed' and assigns a tolerance level ('Suggested' or 'Allowed') accordingly.
It also renames all instances of "allowed Values" with "tolerated Values" to better reflect the container-like function.

This enhancement provides a more flexible way to handle and display the tolerance level of datatype list values.

Fixes #1382