### PR TITLE
schema: change rng:empty to tei:empty

### DIFF
--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -131,7 +131,7 @@
             <memberOf key="model.eventLike.mensural"/>
           </classes>
           <content>
-            <rng:empty/>
+            <empty/>
           </content>
           <remarks>
             <p>This element provides an alternative to the <att>dots</att> attribute on <gi scheme="MEI"

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -897,7 +897,7 @@
                         <memberOf key="att.placement" mode="add"/>
                     </classes>
                     <content autoPrefix="true">
-                        <rng:empty/>
+                        <empty/>
                     </content>
                     <constraintSpec ident="fermata_start-type_attributes_required" scheme="schematron">
                         <constraint>

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -1233,7 +1233,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The modern arpeggiation symbol is a vertical wavy line preceding the chord. When the notes
@@ -1346,7 +1346,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="beamspan_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
@@ -1381,7 +1381,7 @@
       <memberOf key="model.eventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p> <gi scheme="MEI">beatRpt</gi> may also be used in guitar or rhythm parts to indicate where
@@ -1403,7 +1403,7 @@
       <memberOf key="model.controlEventLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="bend_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
@@ -1468,7 +1468,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="breath_start-type_attributes_required" scheme="schematron">
       <constraint>
@@ -1524,7 +1524,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="fermata_start-type_attributes_required" scheme="schematron">
       <constraint>
@@ -1680,7 +1680,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="hairpin_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
@@ -1718,7 +1718,7 @@
       <memberOf key="model.eventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="harpPedal" module="MEI.cmn">
@@ -1734,7 +1734,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="harpPedal_start-type_attributes_required" scheme="schematron">
       <constraint>
@@ -1847,7 +1847,7 @@
       <memberOf key="model.meterSigLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="meterSigGrp" module="MEI.cmn">
@@ -1917,7 +1917,7 @@
       <memberOf key="model.eventLike.measureFilling"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>Automatically-generated numbering of consecutive measures of rest may be controlled via the
@@ -1938,7 +1938,7 @@
       <memberOf key="model.eventLike.measureFilling"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The automated numbering of consecutive measures of rest may be controlled via the
@@ -1960,7 +1960,7 @@
       <memberOf key="model.eventLike.measureFilling"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="mSpace" module="MEI.cmn">
@@ -1976,7 +1976,7 @@
       <memberOf key="model.eventLike.measureFilling"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The automated numbering of consecutive measures of space may be controlled via the
@@ -1998,7 +1998,7 @@
       <memberOf key="model.eventLike.measureFilling"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <!--<remarks xml:lang="en"><p>The num attribute can used to store a number to be rendered along with
         the note. See Read, p. 102-105.</p></remarks>-->
@@ -2016,7 +2016,7 @@
       <memberOf key="model.eventLike.measureFilling"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>In modern publishing practice, repeats of more than two measures should be written out
@@ -2199,7 +2199,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="pedal_start-type_attributes_required" scheme="schematron">
       <constraint>
@@ -2447,7 +2447,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="tupletSpan_start-_and_end-type_attributes_required"
       scheme="schematron">

--- a/source/modules/MEI.cmnOrnaments.xml
+++ b/source/modules/MEI.cmnOrnaments.xml
@@ -165,7 +165,7 @@
       <memberOf key="model.ornamentLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="mordent_start-type_attributes_required" scheme="schematron">
       <constraint>
@@ -194,7 +194,7 @@
       <memberOf key="model.ornamentLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="trill_start-type_attributes_required" scheme="schematron">
       <constraint>
@@ -228,7 +228,7 @@
       <memberOf key="model.ornamentLike.cmn"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="turn_start-type_attributes_required" scheme="schematron">
       <constraint>

--- a/source/modules/MEI.edittrans.xml
+++ b/source/modules/MEI.edittrans.xml
@@ -540,7 +540,7 @@
       <memberOf key="model.transcriptionLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>When material is omitted because it is illegible or inaudible, <gi scheme="MEI"
@@ -574,7 +574,7 @@
       <memberOf key="model.transcriptionLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="character" usage="opt">

--- a/source/modules/MEI.harmony.xml
+++ b/source/modules/MEI.harmony.xml
@@ -137,7 +137,7 @@
       <memberOf key="att.chordMember.vis"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The <att>string</att>, <att>fret</att>, and <att>fing</att> attributes are provided in

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -454,7 +454,7 @@
       <memberOf key="model.staffDefPart.mensural"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The <gi scheme="MEI">mensur</gi> element is provided for the encoding of mensural notation.
@@ -494,7 +494,7 @@
       <memberOf key="model.staffDefPart.mensural"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The proport element is provided for the encoding of mensural notation. It allows the
@@ -514,7 +514,7 @@
       <memberOf key="att.stem.anl"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="Check_stem" scheme="schematron">
       <constraint>

--- a/source/modules/MEI.midi.xml
+++ b/source/modules/MEI.midi.xml
@@ -256,7 +256,7 @@
       <memberOf key="att.midiValue"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The <att>num</att> attribute specifies a MIDI parameter number, while <att>val</att>
@@ -271,7 +271,7 @@
       <memberOf key="att.midi.event"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="num" usage="req">
@@ -291,7 +291,7 @@
       <memberOf key="att.midiNumber"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The value of the <att>num</att> attribute must be in the range 0-127.</p>
@@ -339,7 +339,7 @@
       <memberOf key="model.instrDefLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>This element provides a starting or default instrument declaration for a staff, a group of
@@ -423,7 +423,7 @@
       <memberOf key="att.midiNumber"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="noteOn" module="MEI.midi">
@@ -434,7 +434,7 @@
       <memberOf key="att.midiNumber"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="port" module="MEI.midi">
@@ -445,7 +445,7 @@
       <memberOf key="att.midiNumber"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="prog" module="MEI.midi">
@@ -457,7 +457,7 @@
       <memberOf key="att.midiNumber"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="seqNum" module="MEI.midi">
@@ -468,7 +468,7 @@
       <memberOf key="att.midi.event"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="num" usage="req">
@@ -502,7 +502,7 @@
       <memberOf key="att.midiNumber"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="form" usage="req">

--- a/source/modules/MEI.neumes.xml
+++ b/source/modules/MEI.neumes.xml
@@ -325,7 +325,7 @@
       <memberOf key="model.neumeModifierLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="liquescent" module="MEI.neumes">

--- a/source/modules/MEI.ptrref.xml
+++ b/source/modules/MEI.ptrref.xml
@@ -43,7 +43,7 @@
       <memberOf key="model.locrefLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>Unlike the <gi scheme="MEI">ref</gi> element, <gi scheme="MEI">ptr</gi> cannot contain text

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -4299,7 +4299,7 @@
       <memberOf key="model.syllablePart"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>An accidental may raise a pitch by one or two semitones or it may cancel a previous
@@ -4410,7 +4410,7 @@
       <memberOf key="att.ambNote.anl"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="analytic" module="MEI.shared">
@@ -4539,7 +4539,7 @@
       <memberOf key="model.noteModifierLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>Articulations typically affect duration, such as staccato marks, or the force of attack,
@@ -4588,7 +4588,7 @@
       <memberOf key="model.eventLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>This element is provided for repertoires, such as mensural notation, that lack measures.
@@ -4796,7 +4796,7 @@
       <memberOf key="model.controlEventLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="caesura_start-type_attributes_required" scheme="schematron">
       <constraint>
@@ -4926,7 +4926,7 @@
       <memberOf key="model.milestoneLike.text"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="n" usage="req">
@@ -4993,7 +4993,7 @@
       <memberOf key="model.syllablePart"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="Clef_position_lines" scheme="schematron">
       <constraint>
@@ -5056,7 +5056,7 @@
       <memberOf key="model.milestoneLike.text"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="cols" usage="req">
@@ -5569,7 +5569,7 @@
       <memberOf key="model.eventLike.mensural"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>This element provides an alternative to the <att>dots</att> attribute on <gi scheme="MEI"
@@ -5823,7 +5823,7 @@
       <memberOf key="att.targetEval"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The <att>plist</att> attribute contains an ordered list of identifiers of descendant <gi
@@ -6171,7 +6171,7 @@
       <memberOf key="model.keyAccidLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="Check_keyAccidPlacement" scheme="schematron">
       <constraint>
@@ -6373,7 +6373,7 @@
       <memberOf key="model.lbLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>The <att>n</att> attribute should be used to record a number associated with this textual
@@ -6866,7 +6866,7 @@
       <memberOf key="model.eventLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="part" module="MEI.shared">
@@ -7246,7 +7246,7 @@
       <memberOf key="model.relationLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="FRBR_relation" scheme="schematron">
       <constraint>
@@ -7568,7 +7568,7 @@
       <memberOf key="model.milestoneLike.music"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <remarks xml:lang="en">
       <p>Do not confuse this element with the <gi scheme="MEI">lb</gi> element, which performs a
@@ -7746,7 +7746,7 @@
       <memberOf key="model.eventLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
   </elementSpec>
   <elementSpec ident="speaker" module="MEI.shared">
@@ -8146,7 +8146,7 @@
       <memberOf key="model.textPhraseLike.limited"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="symbolDef_symbol_attributes_required" scheme="schematron">
       <constraint>

--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -87,7 +87,7 @@
       <memberOf key="att.startEndId"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <attList>
       <attDef ident="fret" usage="opt">

--- a/source/modules/MEI.usersymbols.xml
+++ b/source/modules/MEI.usersymbols.xml
@@ -172,7 +172,7 @@
       <memberOf key="model.graphicPrimitiveLike"/>
     </classes>
     <content>
-      <rng:empty/>
+      <empty/>
     </content>
     <constraintSpec ident="symbolDef_curve_attributes_required" scheme="schematron">
       <constraint>


### PR DESCRIPTION
Another try to make a small step towards pureODD. 

Doesn't affect anything, just a small namespace clean-up in our ODDs.
See #1050 and #1164