### PR TITLE
customizations: fix basic customization

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -695,7 +695,7 @@
                         <!--<memberOf key="att.typography"/>-->
                         <!--<memberOf key="att.visibility"/>-->
                         <memberOf key="att.visualOffset.ho"/>
-                        <memberOf key="att.visualOffset.to"/>
+                        <!--<memberOf key="att.visualOffset.to"/>-->
                         <!--<memberOf key="att.xy"/>-->
                         <memberOf key="att.chord.vis.cmn"/>
                     </classes>
@@ -861,7 +861,7 @@
                         <memberOf key="att.placementRelStaff"/>
                         <memberOf key="att.visualOffset"/>
                         <memberOf key="att.visualOffset2.ho"/>
-                        <memberOf key="att.visualOffset2.to"/>
+                        <!--<memberOf key="att.visualOffset2.to"/>-->
                         <!--<memberOf key="att.xy"/>-->
                     </classes>
                 </classSpec>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -319,7 +319,7 @@
                 <classSpec type="atts" ident="att.coloration" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.distances" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.duration.default" module="MEI.shared" mode="delete"/>
-                <classSpec type="atts" ident="att.enclosingChars" module="MEI.shared" mode="delete"/>
+                <!--<classSpec type="atts" ident="att.enclosingChars" module="MEI.shared" mode="delete"/>-->
                 <classSpec type="atts" ident="att.endings" module="MEI.shared" mode="delete"/>
                 <classSpec type="atts" ident="att.evidence" module="MEI.shared" mode="delete"/>
                 <!--<classSpec type="atts" ident="att.extender" module="MEI.shared" mode="delete"/>-->

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -927,12 +927,12 @@
                         <memberOf key="att.common"/>
                         <memberOf key="att.facsimile"/>
                         <!--<memberOf key="att.metadataPointing"/>-->
-                        <memberOf key="att.pointing"/>
-                        <memberOf key="att.measure.anl"/>
+                        <!--<memberOf key="att.pointing"/>-->
+                        <!--<memberOf key="att.measure.anl"/>-->
                         <memberOf key="att.measure.ges"/>
                         <memberOf key="att.measure.log"/>
                         <!--<memberOf key="att.measure.vis"/>-->
-                        <memberOf key="att.targetEval"/>
+                        <!--<memberOf key="att.targetEval"/>-->
                         <memberOf key="model.measureLike"/>
                         <memberOf key="att.nNumberLike" mode="add"/>
                     </classes>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -894,7 +894,6 @@
                         <!--<memberOf key="att.fermata.ges"/>-->
                         <!--<memberOf key="att.fermata.anl"/>-->
                         <memberOf key="model.controlEventLike.cmn"/>
-                        <memberOf key="att.placement" mode="add"/>
                     </classes>
                     <content autoPrefix="true">
                         <rng:empty/>


### PR DESCRIPTION
This PR fixes the problems in MEI-Basic revealed by @bwbohl's fantastic `mei-customizations.sch`: 

* brings back the missing `@enclose` attribute used in multiple places
* removes the non-existing `att.placement`
* comments out left attribute classes not used anywhere else