### PR TITLE
schema: fix missing scheme attributes in gi elements

### DIFF
--- a/source/docs/13-linkingdata.xml
+++ b/source/docs/13-linkingdata.xml
@@ -121,7 +121,7 @@
                             <specDesc key="att.dataPointing" atts="data"/>
                         </specList>
                     </p>
-                    <p>To reference images, the <ident type="class">att.facsimile</ident> class provides an attribute for pointing to <gi>surface</gi> and <gi>zone</gi> elements:</p>
+                    <p>To reference images, the <ident type="class">att.facsimile</ident> class provides an attribute for pointing to <gi scheme="MEI">surface</gi> and <gi scheme="MEI">zone</gi> elements:</p>
                     <p>
                         <specList>
                             <specDesc key="att.facsimile" atts="facs"/>

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -922,7 +922,7 @@
       <attDef ident="func" usage="opt">
         <gloss versionDate="2022-10-18" xml:lang="en">function</gloss>
         <desc xml:lang="en">Indicates the function of the depressed pedal, but not necessarily the text associated
-          with its use. Use the <gi>dir</gi> element for such text.</desc>
+          with its use. Use the <gi scheme="MEI">dir</gi> element for such text.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>
         </datatype>


### PR DESCRIPTION
This PR adds missing `scheme` attributes to `gi` elements. According to validation script `mei-source.sch` these attributes are needed.