### PR TITLE
customizations: bring back some visual attributes to staffDef in MEI Basic

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -867,7 +867,7 @@
                 </classSpec>
                 
                 
-                <classSpec ident="att.staffDef.vis" module="MEI.visual" type="atts" mode="change">
+                <classSpec ident="att.staffDef.vis" module="MEI.visual" type="atts" mode="replace">
                     <desc xml:lang="en">Visual domain attributes for staffDef.</desc>
                     <classes>
                       <!--<memberOf key="att.barring"/>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -396,7 +396,7 @@
                 <classSpec type="atts" ident="att.rdg.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.score.vis" module="MEI.visual" mode="delete"/>
                 <classSpec type="atts" ident="att.scoreDef.vis" module="MEI.visual" mode="delete"/>
-                <classSpec type="atts" ident="att.staffDef.vis" module="MEI.visual" mode="delete"/>
+                <!--<classSpec type="atts" ident="att.staffDef.vis" module="MEI.visual" mode="delete"/>-->
                 <classSpec type="atts" ident="att.syllable.vis" module="MEI.visual" mode="delete"/>
 
                 <!--<classSpec type="atts" ident="att.arpeg.vis" module="MEI.visual" mode="change">
@@ -867,6 +867,64 @@
                 </classSpec>
                 
                 
+                <classSpec ident="att.staffDef.vis" module="MEI.visual" type="atts" mode="change">
+                    <desc xml:lang="en">Visual domain attributes for staffDef.</desc>
+                    <classes>
+                      <!--<memberOf key="att.barring"/>
+                      <memberOf key="att.cleffing.vis"/>
+                      <memberOf key="att.distances"/>
+                      <memberOf key="att.guitarGrid.vis"/>
+                      <memberOf key="att.keySigDefault.vis"/>
+                      <memberOf key="att.lyricStyle"/>
+                      <memberOf key="att.meterSigDefault.vis"/>
+                      <memberOf key="att.multinumMeasures"/>
+                      <memberOf key="att.notationStyle"/>
+                      <memberOf key="att.oneLineStaff"/>-->
+                      <memberOf key="att.scalable"/>
+                      <!--<memberOf key="att.staffItems"/>
+                      <memberOf key="att.textStyle"/>
+                      <memberOf key="att.visibility"/>
+                      <memberOf key="att.staffDef.vis.cmn"/>
+                      <memberOf key="att.staffDef.vis.mensural"/>-->
+                    </classes>
+                    <attList>
+                      <!--<attDef ident="layerscheme" usage="opt">
+                        <desc xml:lang="en">Indicates the number of layers and their stem directions.</desc>
+                        <datatype>
+                          <rng:ref name="data.LAYERSCHEME"/>
+                        </datatype>
+                      </attDef>-->
+                      <attDef ident="lines.color" usage="opt">
+                        <desc xml:lang="en">Captures the colors of the staff lines.</desc>
+                        <datatype maxOccurs="unbounded">
+                          <rng:ref name="data.COLOR"/>
+                        </datatype>
+                        <remarks xml:lang="en">
+                          <p>The value is structured; that is, it should contain a single color value or have
+                            the same number of space-separated values as the number of lines indicated by the
+                            lines attribute. The first value then applies to the lowest line of the staff.</p>
+                          <p>All values from data.COLOR are allowed.</p>
+                        </remarks>
+                      </attDef>
+                      <attDef ident="lines.visible" usage="opt">
+                        <desc xml:lang="en">Records whether all staff lines are visible.</desc>
+                        <datatype>
+                          <rng:ref name="data.BOOLEAN"/>
+                        </datatype>
+                      </attDef>
+                      <attDef ident="spacing" usage="opt">
+                        <desc xml:lang="en">Records the absolute distance (as opposed to the relative distances recorded in <gi
+                          scheme="MEI">scoreDef</gi> elements) between this staff and the preceding one in the same
+                          system. This value is meaningless for the first staff in a system since the spacing.system
+                          attribute indicates the spacing between systems.</desc>
+                        <datatype>
+                          <rng:ref name="data.MEASUREMENTSIGNED"/>
+                        </datatype>
+                      </attDef>
+                    </attList>
+                  </classSpec>
+
+                  
                 <classSpec ident="att.symbol.vis" module="MEI.visual" type="atts" mode="change">
                     <desc xml:lang="en">Visual domain attributes.</desc>
                     <classes>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -912,15 +912,6 @@
                           <rng:ref name="data.BOOLEAN"/>
                         </datatype>
                       </attDef>
-                      <attDef ident="spacing" usage="opt">
-                        <desc xml:lang="en">Records the absolute distance (as opposed to the relative distances recorded in <gi
-                          scheme="MEI">scoreDef</gi> elements) between this staff and the preceding one in the same
-                          system. This value is meaningless for the first staff in a system since the spacing.system
-                          attribute indicates the spacing between systems.</desc>
-                        <datatype>
-                          <rng:ref name="data.MEASUREMENTSIGNED"/>
-                        </datatype>
-                      </attDef>
                     </attList>
                   </classSpec>
 


### PR DESCRIPTION
This PR brings back some attributes from `att.staffDef.vis`: 

* `@scale`
* ~~`@spacing`~~
* `@lines.color`
* `@lines.visible`

The first one and the last one I see as mandatory, the others are definitely nice to have. 

Closes #1444
