### PR TITLE
docs: fix link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository contains all the source code of the MEI Schema and Guidelines:
 
 **!ATTENTION!**
 
-For the sake of the continuous integration (CI) workflow, the build artifacts of the schemata and guidelines are no longer included in this repository, but are generated on every commit to the develop branch and automatically pushed to their dedicated repositories. For more information please see the section [Additional Resources](#additional-resources) below.
+Nevertheless, it is possible to [build](#building-mei) any customization locally in your working copy of this repository.
 
 Nevertheless, it is possible to (build)[#building-mei] any customization locally in your working copy of this repository.
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,10 @@ This repository contains all the source code of the MEI Schema and Guidelines:
  * [tests](tests): Unit tests for the MEI Schemata.
  * [utils](utils): Helper scripts e.g. for compiling schemata and guidelines from this repository.
 
-**!ATTENTION!**
-
-Nevertheless, it is possible to [build](#building-mei) any customization locally in your working copy of this repository.
-
-Nevertheless, it is possible to (build)[#building-mei] any customization locally in your working copy of this repository.
+>[!IMPORTANT]
+>For the sake of the continuous integration (CI) workflow, the build artifacts of the schemata and guidelines are no longer included in this repository, but are generated on every commit to the develop branch and automatically pushed to their dedicated repositories. For more information please see the section [Additional Resources](#additional-resources) below.
+>
+>Nevertheless, it is possible to [build](#building-mei) any customization locally in your working copy of this repository.
 
 ## Validating MEI files against an MEI Schema
 

--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@ In this document, you will learn how to contribute to the development of MEI by 
 
 This repository contains all the source code of the MEI Schema and Guidelines:
 
- * [.github](.github): Configuration files for GitHub Actions workflows.
- * [customizations](customizations): TEI ODD files that allow you to build customized MEI schemata.
- * [source](source): Contains the source code, as expressed in TEI ODD. This includes the source code for the MEI Guidelines and the MEI schema modules.
- * [submodules](submodules): A container for Git Submodules: third-party developments that are needed, e.g., for building this repository's contents, but which are not part of our codebase.
- * [tests](tests): Unit tests for the MEI Schemata.
- * [utils](utils): Helper scripts e.g. for compiling schemata and guidelines from this repository.
+* [.github](.github): Configuration files for GitHub Actions workflows.
+* [customizations](customizations): TEI ODD files that allow you to build customized MEI schemata.
+* [source](source): Contains the source code, as expressed in TEI ODD. This includes the source code for the MEI Guidelines and the MEI schema modules.
+* [submodules](submodules): A container for Git Submodules: third-party developments that are needed, e.g., for building this repository's contents, but which are not part of our codebase.
+* [tests](tests): Unit tests for the MEI Schemata.
+* [utils](utils): Helper scripts e.g. for compiling schemata and guidelines from this repository.
 
->[!IMPORTANT]
->For the sake of the continuous integration (CI) workflow, the build artifacts of the schemata and guidelines are no longer included in this repository, but are generated on every commit to the develop branch and automatically pushed to their dedicated repositories. For more information please see the section [Additional Resources](#additional-resources) below.
+> [!IMPORTANT]
+> For the sake of the continuous integration (CI) workflow, the build artifacts of the schemata and guidelines are no longer included in this repository, but are generated on every commit to the develop branch and automatically pushed to their dedicated repositories. For more information please see the section [Additional Resources](#additional-resources) below.
 >
->Nevertheless, it is possible to [build](#building-mei) any customization locally in your working copy of this repository.
+> Nevertheless, it is possible to [build](#building-mei) any customization locally in your working copy of this repository.
 
 ## Validating MEI files against an MEI Schema
 


### PR DESCRIPTION
This PR fixes a broken (wrong formatted) link in the README and introduces a styled block quote instead of the ATTENTION section.

![image](https://github.com/music-encoding/music-encoding/assets/7693447/28859ff5-e778-4401-b777-39af82b5aa4d)
