### PR TITLE
schema: make all members of att.controlEvent also part of att.color

### DIFF
--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -123,10 +123,10 @@
           <classes>
             <memberOf key="att.common"/>
             <memberOf key="att.facsimile"/>
+            <memberOf key="att.dot.anl"/>
+            <memberOf key="att.dot.ges"/>
             <memberOf key="att.dot.log"/>
             <memberOf key="att.dot.vis"/>
-            <memberOf key="att.dot.ges"/>
-            <memberOf key="att.dot.anl"/>
             <memberOf key="model.noteModifierLike" mode="delete"/>
             <memberOf key="model.eventLike.mensural"/>
           </classes>
@@ -146,10 +146,10 @@
           <classes>
             <memberOf key="att.common"/>
             <memberOf key="att.facsimile"/>
+            <memberOf key="att.rest.anl"/>
+            <memberOf key="att.rest.ges"/>
             <memberOf key="att.rest.log"/>
             <memberOf key="att.rest.vis"/>
-            <memberOf key="att.rest.ges"/>
-            <memberOf key="att.rest.anl"/>
             <memberOf key="model.eventLike"/>
           </classes>
           <content>

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -1255,10 +1255,10 @@
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
       <memberOf key="att.lang"/>
+      <memberOf key="att.attacca.anl"/>
+      <memberOf key="att.attacca.ges"/>
       <memberOf key="att.attacca.log"/>
       <memberOf key="att.attacca.vis"/>
-      <memberOf key="att.attacca.ges"/>
-      <memberOf key="att.attacca.anl"/>
       <memberOf key="model.controlEventLike.cmn"/>
       <!--<memberOf key="model.controlEventLike"/>-->
     </classes>

--- a/source/modules/MEI.cmnOrnaments.xml
+++ b/source/modules/MEI.cmnOrnaments.xml
@@ -158,10 +158,10 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
+      <memberOf key="att.mordent.anl"/>
+      <memberOf key="att.mordent.ges"/>
       <memberOf key="att.mordent.log"/>
       <memberOf key="att.mordent.vis"/>
-      <memberOf key="att.mordent.ges"/>
-      <memberOf key="att.mordent.anl"/>
       <memberOf key="model.ornamentLike.cmn"/>
     </classes>
     <content>
@@ -187,10 +187,10 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
+      <memberOf key="att.trill.anl"/>
+      <memberOf key="att.trill.ges"/>
       <memberOf key="att.trill.log"/>
       <memberOf key="att.trill.vis"/>
-      <memberOf key="att.trill.ges"/>
-      <memberOf key="att.trill.anl"/>
       <memberOf key="model.ornamentLike.cmn"/>
     </classes>
     <content>
@@ -221,10 +221,10 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
+      <memberOf key="att.turn.anl"/>
+      <memberOf key="att.turn.ges"/>
       <memberOf key="att.turn.log"/>
       <memberOf key="att.turn.vis"/>
-      <memberOf key="att.turn.ges"/>
-      <memberOf key="att.turn.anl"/>
       <memberOf key="model.ornamentLike.cmn"/>
     </classes>
     <content>

--- a/source/modules/MEI.harmony.xml
+++ b/source/modules/MEI.harmony.xml
@@ -212,10 +212,10 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
+      <memberOf key="att.harm.anl"/>
+      <memberOf key="att.harm.ges"/>
       <memberOf key="att.harm.log"/>
       <memberOf key="att.harm.vis"/>
-      <memberOf key="att.harm.ges"/>
-      <memberOf key="att.harm.anl"/>
       <memberOf key="model.harmLike"/>
     </classes>
     <content>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -4291,10 +4291,10 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
+      <memberOf key="att.accid.anl"/>
+      <memberOf key="att.accid.ges"/>
       <memberOf key="att.accid.log"/>
       <memberOf key="att.accid.vis"/>
-      <memberOf key="att.accid.ges"/>
-      <memberOf key="att.accid.anl"/>
       <memberOf key="model.noteModifierLike"/>
       <memberOf key="model.syllablePart"/>
     </classes>
@@ -4404,10 +4404,10 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
+      <memberOf key="att.ambNote.anl"/>
+      <memberOf key="att.ambNote.ges"/>
       <memberOf key="att.ambNote.log"/>
       <memberOf key="att.ambNote.vis"/>
-      <memberOf key="att.ambNote.ges"/>
-      <memberOf key="att.ambNote.anl"/>
     </classes>
     <content>
       <empty/>
@@ -4448,10 +4448,6 @@
       assertion.</desc>
     <classes>
       <memberOf key="att.common"/>
-      <memberOf key="att.annot.log"/>
-      <memberOf key="att.annot.vis"/>
-      <memberOf key="att.annot.ges"/>
-      <memberOf key="att.annot.anl"/>
       <memberOf key="att.audience"/>
       <memberOf key="att.bibl"/>
       <memberOf key="att.dataPointing"/>
@@ -4460,6 +4456,10 @@
       <memberOf key="att.plist"/>
       <memberOf key="att.source"/>
       <memberOf key="att.targetEval"/>
+      <memberOf key="att.annot.anl"/>
+      <memberOf key="att.annot.ges"/>
+      <memberOf key="att.annot.log"/>
+      <memberOf key="att.annot.vis"/>
       <memberOf key="model.annotLike"/>
     </classes>
     <content>
@@ -4531,10 +4531,10 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
+      <memberOf key="att.artic.anl"/>
+      <memberOf key="att.artic.ges"/>
       <memberOf key="att.artic.log"/>
       <memberOf key="att.artic.vis"/>
-      <memberOf key="att.artic.ges"/>
-      <memberOf key="att.artic.anl"/>
       <memberOf key="model.chordPart"/>
       <memberOf key="model.noteModifierLike"/>
     </classes>
@@ -4581,10 +4581,10 @@
       <memberOf key="att.facsimile"/>
       <memberOf key="att.pointing"/>
       <memberOf key="att.targetEval"/>
+      <memberOf key="att.barLine.anl"/>
+      <memberOf key="att.barLine.ges"/>
       <memberOf key="att.barLine.log"/>
       <memberOf key="att.barLine.vis"/>
-      <memberOf key="att.barLine.ges"/>
-      <memberOf key="att.barLine.anl"/>
       <memberOf key="model.eventLike"/>
     </classes>
     <content>
@@ -4958,10 +4958,10 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
+      <memberOf key="att.chord.anl"/>
+      <memberOf key="att.chord.ges"/>
       <memberOf key="att.chord.log"/>
       <memberOf key="att.chord.vis"/>
-      <memberOf key="att.chord.ges"/>
-      <memberOf key="att.chord.anl"/>
       <memberOf key="model.eventLike"/>
     </classes>
     <content>
@@ -5032,10 +5032,10 @@
       <memberOf key="att.common"/>
       <memberOf key="att.event"/>
       <memberOf key="att.facsimile"/>
+      <memberOf key="att.clefGrp.anl"/>
+      <memberOf key="att.clefGrp.ges"/>
       <memberOf key="att.clefGrp.log"/>
       <memberOf key="att.clefGrp.vis"/>
-      <memberOf key="att.clefGrp.ges"/>
-      <memberOf key="att.clefGrp.anl"/>
       <memberOf key="model.eventLike"/>
       <memberOf key="model.staffDefPart"/>
     </classes>
@@ -5168,10 +5168,10 @@
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
       <memberOf key="att.source"/>
+      <memberOf key="att.custos.anl"/>
+      <memberOf key="att.custos.ges"/>
       <memberOf key="att.custos.log"/>
       <memberOf key="att.custos.vis"/>
-      <memberOf key="att.custos.ges"/>
-      <memberOf key="att.custos.anl"/>
       <memberOf key="model.eventLike"/>
     </classes>
     <content>
@@ -5400,10 +5400,10 @@
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
       <memberOf key="att.lang"/>
+      <memberOf key="att.dir.anl"/>
+      <memberOf key="att.dir.ges"/>
       <memberOf key="att.dir.log"/>
       <memberOf key="att.dir.vis"/>
-      <memberOf key="att.dir.ges"/>
-      <memberOf key="att.dir.anl"/>
       <memberOf key="model.controlEventLike"/>
     </classes>
     <content>
@@ -5561,10 +5561,10 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
+      <memberOf key="att.dot.anl"/>
+      <memberOf key="att.dot.ges"/>
       <memberOf key="att.dot.log"/>
       <memberOf key="att.dot.vis"/>
-      <memberOf key="att.dot.ges"/>
-      <memberOf key="att.dot.anl"/>
       <memberOf key="model.noteModifierLike"/>
       <memberOf key="model.eventLike.mensural"/>
     </classes>
@@ -5583,12 +5583,12 @@
     <desc xml:lang="en">Indication of the volume of a note, phrase, or section of music.</desc>
     <classes>
       <memberOf key="att.common"/>
-      <memberOf key="att.dynam.log"/>
-      <memberOf key="att.dynam.vis"/>
-      <memberOf key="att.dynam.ges"/>
-      <memberOf key="att.dynam.anl"/>
       <memberOf key="att.facsimile"/>
       <memberOf key="att.lang"/>
+      <memberOf key="att.dynam.anl"/>
+      <memberOf key="att.dynam.ges"/>
+      <memberOf key="att.dynam.log"/>
+      <memberOf key="att.dynam.vis"/>
       <memberOf key="model.controlEventLike"/>
     </classes>
     <content>
@@ -5686,13 +5686,13 @@
       etc.</desc>
     <classes>
       <memberOf key="att.common"/>
+      <memberOf key="att.facsimile"/>
+      <memberOf key="att.pointing"/>
+      <memberOf key="att.targetEval"/>
       <memberOf key="att.ending.anl"/>
       <memberOf key="att.ending.ges"/>
       <memberOf key="att.ending.log"/>
       <memberOf key="att.ending.vis"/>
-      <memberOf key="att.facsimile"/>
-      <memberOf key="att.pointing"/>
-      <memberOf key="att.targetEval"/>
       <memberOf key="model.endingLike"/>
     </classes>
     <content>
@@ -5968,10 +5968,10 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
+      <memberOf key="att.grpSym.anl"/>
+      <memberOf key="att.grpSym.ges"/>
       <memberOf key="att.grpSym.log"/>
       <memberOf key="att.grpSym.vis"/>
-      <memberOf key="att.grpSym.ges"/>
-      <memberOf key="att.grpSym.anl"/>
     </classes>
     <content>
       <rng:zeroOrMore>
@@ -6299,10 +6299,10 @@
       <memberOf key="att.nInteger"/>
       <memberOf key="att.responsibility"/>
       <memberOf key="att.typed"/>
+      <memberOf key="att.layer.anl"/>
+      <memberOf key="att.layer.ges"/>
       <memberOf key="att.layer.log"/>
       <memberOf key="att.layer.vis"/>
-      <memberOf key="att.layer.ges"/>
-      <memberOf key="att.layer.anl"/>
       <memberOf key="model.layerLike"/>
     </classes>
     <content>
@@ -6341,10 +6341,10 @@
       <memberOf key="att.nInteger"/>
       <memberOf key="att.responsibility"/>
       <memberOf key="att.typed"/>
+      <memberOf key="att.layerDef.anl"/>
+      <memberOf key="att.layerDef.ges"/>
       <memberOf key="att.layerDef.log"/>
       <memberOf key="att.layerDef.vis"/>
-      <memberOf key="att.layerDef.ges"/>
-      <memberOf key="att.layerDef.anl"/>
       <memberOf key="model.layerDefLike"/>
     </classes>
     <content>
@@ -6394,12 +6394,12 @@
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
       <memberOf key="att.lang"/>
+      <memberOf key="att.metadataPointing"/>
+      <memberOf key="att.xy"/>
       <memberOf key="att.lyrics.anl"/>
       <memberOf key="att.lyrics.ges"/>
       <memberOf key="att.lyrics.log"/>
       <memberOf key="att.lyrics.vis"/>
-      <memberOf key="att.metadataPointing"/>
-      <memberOf key="att.xy"/>
       <memberOf key="model.lgLike"/>
     </classes>
     <content>
@@ -6719,10 +6719,10 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
+      <memberOf key="att.note.anl"/>
+      <memberOf key="att.note.ges"/>
       <memberOf key="att.note.log"/>
       <memberOf key="att.note.vis"/>
-      <memberOf key="att.note.ges"/>
-      <memberOf key="att.note.anl"/>
       <memberOf key="model.chordPart"/>
       <memberOf key="model.eventLike"/>
     </classes>
@@ -6793,10 +6793,10 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
+      <memberOf key="att.ornam.anl"/>
+      <memberOf key="att.ornam.ges"/>
       <memberOf key="att.ornam.log"/>
       <memberOf key="att.ornam.vis"/>
-      <memberOf key="att.ornam.ges"/>
-      <memberOf key="att.ornam.anl"/>
       <memberOf key="model.controlEventLike"/>
     </classes>
     <content>
@@ -6859,10 +6859,10 @@
     <desc xml:lang="en">An indication of extra visual space between notational elements.</desc>
     <classes>
       <memberOf key="att.common"/>
+      <memberOf key="att.pad.anl"/>
+      <memberOf key="att.pad.ges"/>
       <memberOf key="att.pad.log"/>
       <memberOf key="att.pad.vis"/>
-      <memberOf key="att.pad.ges"/>
-      <memberOf key="att.pad.anl"/>
       <memberOf key="model.eventLike"/>
     </classes>
     <content>
@@ -6875,10 +6875,10 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.metadataPointing"/>
+      <memberOf key="att.part.anl"/>
+      <memberOf key="att.part.ges"/>
       <memberOf key="att.part.log"/>
       <memberOf key="att.part.vis"/>
-      <memberOf key="att.part.ges"/>
-      <memberOf key="att.part.anl"/>
       <memberOf key="model.partLike"/>
     </classes>
     <content>
@@ -6914,10 +6914,10 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.metadataPointing"/>
+      <memberOf key="att.parts.anl"/>
+      <memberOf key="att.parts.ges"/>
       <memberOf key="att.parts.log"/>
       <memberOf key="att.parts.vis"/>
-      <memberOf key="att.parts.ges"/>
-      <memberOf key="att.parts.anl"/>
       <memberOf key="model.partsLike"/>
     </classes>
     <content>
@@ -7051,10 +7051,10 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
+      <memberOf key="att.phrase.anl"/>
+      <memberOf key="att.phrase.ges"/>
       <memberOf key="att.phrase.log"/>
       <memberOf key="att.phrase.vis"/>
-      <memberOf key="att.phrase.ges"/>
-      <memberOf key="att.phrase.anl"/>
       <memberOf key="model.controlEventLike"/>
     </classes>
     <content>
@@ -7482,10 +7482,10 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
+      <memberOf key="att.rest.anl"/>
+      <memberOf key="att.rest.ges"/>
       <memberOf key="att.rest.log"/>
       <memberOf key="att.rest.vis"/>
-      <memberOf key="att.rest.ges"/>
-      <memberOf key="att.rest.anl"/>
       <memberOf key="model.eventLike"/>
     </classes>
     <content>
@@ -7580,10 +7580,10 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.metadataPointing"/>
+      <memberOf key="att.score.anl"/>
+      <memberOf key="att.score.ges"/>
       <memberOf key="att.score.log"/>
       <memberOf key="att.score.vis"/>
-      <memberOf key="att.score.ges"/>
-      <memberOf key="att.score.anl"/>
       <memberOf key="model.scoreLike"/>
     </classes>
     <content>
@@ -7614,10 +7614,10 @@
     <desc xml:lang="en">Container for score meta-information.</desc>
     <classes>
       <memberOf key="att.common"/>
+      <memberOf key="att.scoreDef.anl"/>
+      <memberOf key="att.scoreDef.ges"/>
       <memberOf key="att.scoreDef.log"/>
       <memberOf key="att.scoreDef.vis"/>
-      <memberOf key="att.scoreDef.ges"/>
-      <memberOf key="att.scoreDef.anl"/>
       <memberOf key="model.scoreDefLike"/>
     </classes>
     <content>
@@ -7662,11 +7662,11 @@
       <memberOf key="att.facsimile"/>
       <memberOf key="att.metadataPointing"/>
       <memberOf key="att.pointing"/>
+      <memberOf key="att.targetEval"/>
       <memberOf key="att.section.anl"/>
       <memberOf key="att.section.ges"/>
       <memberOf key="att.section.log"/>
       <memberOf key="att.section.vis"/>
-      <memberOf key="att.targetEval"/>
       <memberOf key="model.sectionLike"/>
     </classes>
     <content>
@@ -7917,10 +7917,10 @@
       <memberOf key="att.nInteger"/>
       <memberOf key="att.responsibility"/>
       <memberOf key="att.typed"/>
+      <memberOf key="att.staffDef.anl"/>
+      <memberOf key="att.staffDef.ges"/>
       <memberOf key="att.staffDef.log"/>
       <memberOf key="att.staffDef.vis"/>
-      <memberOf key="att.staffDef.ges"/>
-      <memberOf key="att.staffDef.anl"/>
       <memberOf key="model.staffDefLike"/>
     </classes>
     <content>
@@ -8062,10 +8062,10 @@
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
       <memberOf key="att.metadataPointing"/>
+      <memberOf key="att.staffGrp.anl"/>
+      <memberOf key="att.staffGrp.ges"/>
       <memberOf key="att.staffGrp.log"/>
       <memberOf key="att.staffGrp.vis"/>
-      <memberOf key="att.staffGrp.ges"/>
-      <memberOf key="att.staffGrp.anl"/>
       <memberOf key="model.staffGrpLike"/>
     </classes>
     <content>
@@ -8112,10 +8112,10 @@
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
       <memberOf key="att.lang"/>
+      <memberOf key="att.syl.anl"/>
+      <memberOf key="att.syl.ges"/>
       <memberOf key="att.syl.log"/>
       <memberOf key="att.syl.vis"/>
-      <memberOf key="att.syl.ges"/>
-      <memberOf key="att.syl.anl"/>
       <memberOf key="model.sylLike"/>
     </classes>
     <content>
@@ -8177,10 +8177,10 @@
       <memberOf key="att.bibl"/>
       <memberOf key="att.facsimile"/>
       <memberOf key="att.lang"/>
+      <memberOf key="att.tempo.anl"/>
+      <memberOf key="att.tempo.ges"/>
       <memberOf key="att.tempo.log"/>
       <memberOf key="att.tempo.vis"/>
-      <memberOf key="att.tempo.ges"/>
-      <memberOf key="att.tempo.anl"/>
       <memberOf key="model.controlEventLike"/>
       <memberOf key="model.workIdent"/>
     </classes>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -137,6 +137,7 @@
   <classSpec ident="att.attacca.vis" module="MEI.visual" type="atts">
     <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
+      <memberOf key="att.color"/>
       <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.verticalGroup"/>
@@ -1919,8 +1920,8 @@
       <memberOf key="att.color"/>
       <memberOf key="att.enclosingChars"/>
       <memberOf key="att.extender"/>
-      <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.extSym"/>
+      <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.typography"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -453,6 +453,7 @@
   <classSpec ident="att.dir.vis" module="MEI.visual" type="atts">
     <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
+      <memberOf key="att.color"/>
       <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.verticalGroup"/>
@@ -480,6 +481,7 @@
     <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.extender"/>
+      <memberOf key="att.color"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
@@ -532,6 +534,7 @@
     <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
+      <memberOf key="att.color"/>
       <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.visualOffset"/>
@@ -588,6 +591,7 @@
     <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
+      <memberOf key="att.color"/>
       <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.visualOffset"/>
@@ -602,6 +606,7 @@
     <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.altSym"/>
+      <memberOf key="att.color"/>
       <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.visualOffset"/>
@@ -758,6 +763,7 @@
   <classSpec ident="att.harm.vis" module="MEI.visual" type="atts">
     <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
+      <memberOf key="att.color"/>
       <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.visualOffset"/>
@@ -1132,6 +1138,7 @@
   <classSpec ident="att.metaMark.vis" module="MEI.visual" type="atts">
     <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
+      <memberOf key="att.color"/>
       <memberOf key="att.placementRelStaff"/>
     </classes>
   </classSpec>
@@ -1877,6 +1884,7 @@
   <classSpec ident="att.tempo.vis" module="MEI.visual" type="atts">
     <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
+      <memberOf key="att.color"/>
       <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.verticalGroup"/>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1530,6 +1530,7 @@
   <classSpec ident="att.repeatMark.vis" module="MEI.visual" type="atts">
     <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
+      <memberOf key="att.color"/>
       <memberOf key="att.extender"/>
       <memberOf key="att.extSym"/>
       <memberOf key="att.placementRelStaff"/>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -480,8 +480,8 @@
   <classSpec ident="att.dynam.vis" module="MEI.visual" type="atts">
     <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
-      <memberOf key="att.extender"/>
       <memberOf key="att.color"/>
+      <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>


### PR DESCRIPTION
As discussed in #1086, all control elements should have `@color` available.

This affects 

- `attacca`
- `dir`
- `dynam`
- `f`
- `fing`
- `fingGrp`
- `harm`
- `metaMark`
- `repeatMark`

Closes #1086.
Closes #1454.