### PR TITLE
build: fetch stylesheets only for build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "Stylesheets"]
-	path = submodules/Stylesheets
-	url = https://github.com/TEIC/Stylesheets.git
-	branch = released

--- a/BUILD_COMMANDLINE.md
+++ b/BUILD_COMMANDLINE.md
@@ -10,7 +10,8 @@
    |Apache Ant|1.10.14|
    |Verovio Toolkit|4.2.1|
    |Prince XML|15.1|
-   |Saxon HE*| 12.4 |
+   |Saxon HE*|12.4|
+   |TEI Stylesheets*|7.57.0|
    |Xerces*|Synchrosoft patched version 26.1.0.1|
 
    \* automatically pulled during build execution

--- a/BUILD_COMMANDLINE.md
+++ b/BUILD_COMMANDLINE.md
@@ -10,7 +10,7 @@
    |Apache Ant|1.10.14|
    |Verovio Toolkit|4.2.1|
    |Prince XML|15.1|
-   |Saxon HE*|12.4|
+   |Saxon HE*|12.5|
    |TEI Stylesheets*|7.57.0|
    |Xerces*|Synchrosoft patched version 26.1.0.1|
 

--- a/BUILD_COMMANDLINE.md
+++ b/BUILD_COMMANDLINE.md
@@ -150,8 +150,8 @@ The following targets can be called using `ant <target>`:
 | `build-rng -Dcustomization.path="[ABSOLUTE/PATH/TO/YOUR/CUSTOMIZATION]"` | Builds the RNG schema of a specific customization submitted as absolute path with `-Dcustomization.path` input param. |
 | `build-guidelines-html` | Builds the HTML version of the MEI guidelines. |
 | `build-guidelines-pdf` | Builds the PDF version of the MEI guidelines. (Calls `build-guidelines-html` before execution.) |
-| `init` | Initializes the build environment, i.e., checks if saxon and xerces are available, and if not, downloads jar files for Saxon, Xerces and adds them to the `lib` folder. Checks if prince is available. |
+| `init` | Initializes the build environment, i.e., checks if TEI Stylesheets, Saxon and Xerces are available, and if not, it downloads everything into the `lib` folder. Checks if Prince is available. |
 | `init-mei-classpath` | Initializes the mei.classpath, which is essential for the schema generation, by prepending the jar files contained in the lib directory to the java classpath. Will be called automatically if needed. |
 | `compare-versions` | Compares the canonicalized sources of the MEI dev version with the previous stable version and creates an HTML output; custom versions and output folder can be set via `-Dsource`, `-Dold` and `-Doutput` input params. |
 | `clean` | Deletes the following directories: `build`, `dist` and `temp`. |
-| `reset` | Resets the build environment. Same as `clean`, but additionaly deletes the `lib` directory with the Saxon and Xerces jar files. |
+| `reset` | Resets the build environment. Same as `clean`, but additionally deletes the `lib` directory with the TEI Stylesheets and the Saxon and Xerces jar files. |

--- a/BUILD_OXYGEN.md
+++ b/BUILD_OXYGEN.md
@@ -8,7 +8,7 @@ To build the RNG schema of a specific customization, follow these steps:
 
 1. Open the customization file in oXygen.
 
-   To make sure that step 2 works out of the box, make sure that it has the extension `.odd` and not `.xml`. This is necessary for oXygen to recognize the file as TEI ODD customization and offer you the preconfigured transformation scenario for generating RNG schema files from an ODD.
+   To make sure that step 2 works out of the box, make sure that it has the extension `.odd` and not `.xml`. This is necessary for oXygen to recognize the file as TEI ODD customization and offer you the pre-configured transformation scenario for generating RNG schema files from an ODD.
 
 2. Click on the _Configure Transformation Scenario(s)_ button (the red play button with the wrench). This will open a window of the same name.
 

--- a/build.xml
+++ b/build.xml
@@ -74,8 +74,8 @@
     <property name="dir.lib.saxon" value="${dir.lib}/saxon"/>
     <property name="dir.lib.stylesheets" value="${dir.lib}/stylesheets"/>
     <property name="dir.lib.xerces" value="${dir.lib}/xerces"/>
-    <property name="saxon.version" value="SaxonHE12-4"/>
-    <property name="saxon.jar.file" value="saxon-he-12.4.jar"/>
+    <property name="saxon.version" value="SaxonHE12-5"/>
+    <property name="saxon.jar.file" value="saxon-he-12.5.jar"/>
     <property name="stylesheets.version" value="7.57.0"/>
     <property name="xerces.version" value="26.1.0.1"/>
     <property name="xerces.jar.file" value="oxygen-patched-xerces-${xerces.version}.jar"/>

--- a/build.xml
+++ b/build.xml
@@ -168,7 +168,7 @@
         <echo if:set="saxon-available" message="saxon available: ${saxon-available}"/>
         <echo unless:set="saxon-available" message="saxon available: false"/>
         <!-- check if Stylesheets are available -->
-        <fileset id="version.file" dir="${dir.lib.stylesheets}">
+        <fileset id="stylesheets.version.file" dir="${dir.lib.stylesheets}">
             <patternset>
                 <include name="VERSION"/>
             </patternset>

--- a/build.xml
+++ b/build.xml
@@ -168,8 +168,14 @@
         <echo if:set="saxon-available" message="saxon available: ${saxon-available}"/>
         <echo unless:set="saxon-available" message="saxon available: false"/>
         <!-- check if Stylesheets are available -->
+        <fileset id="version.file" dir="${dir.lib.stylesheets}">
+            <patternset>
+                <include name="VERSION"/>
+            </patternset>
+            <contains text="${stylesheets.version}" />
+        </fileset>
         <condition property="stylesheets-available">
-            <available file="${dir.lib.stylesheets}"/>
+            <resourcecount when="equal" count="1" refid="version.file"/>
         </condition>
         <echo if:set="stylesheets-available" message="stylesheets available: ${stylesheets-available}"/>
         <echo unless:set="stylesheets-available" message="stylesheets available: false"/>

--- a/build.xml
+++ b/build.xml
@@ -76,7 +76,7 @@
     <property name="dir.lib.xerces" value="${dir.lib}/xerces"/>
     <property name="saxon.version" value="SaxonHE12-4"/>
     <property name="saxon.jar.file" value="saxon-he-12.4.jar"/>
-    <property name="stylesheets.version" value="7.56.0"/>
+    <property name="stylesheets.version" value="7.57.0"/>
     <property name="xerces.version" value="26.1.0.1"/>
     <property name="xerces.jar.file" value="oxygen-patched-xerces-${xerces.version}.jar"/>
     <property name="oxygen.basic.utilites.jar.file" value="oxygen-basic-utilities-${xerces.version}.jar"/>

--- a/build.xml
+++ b/build.xml
@@ -72,9 +72,11 @@
     <property name="dir.dist.schemata" location="${dir.dist}/schemata/"/>
     <property name="dir.lib" value="lib"/>
     <property name="dir.lib.saxon" value="${dir.lib}/saxon"/>
+    <property name="dir.lib.stylesheets" value="${dir.lib}/stylesheets"/>
     <property name="dir.lib.xerces" value="${dir.lib}/xerces"/>
     <property name="saxon.download.version" value="SaxonHE12-4"/>
     <property name="saxon.jar.file" value="saxon-he-12.4.jar"/>
+    <property name="stylesheets.download.version" value="7.56.0"/>
     <property name="xerces.version" value="26.1.0.1"/>
     <property name="xerces.jar.file" value="oxygen-patched-xerces-${xerces.version}.jar"/>
     <property name="oxygen.basic.utilites.jar.file" value="oxygen-basic-utilities-${xerces.version}.jar"/>
@@ -114,7 +116,7 @@
     </target>
 
     <target name="echo-mei">
-      <loadfile srcfile="source/assets/images/meilogo_ascii_100.txt" property="mei"/>
+        <loadfile srcfile="source/assets/images/meilogo_ascii_100.txt" property="mei" />
         <echo message="${mei}"/>
     </target>
 
@@ -165,6 +167,15 @@
         </condition>
         <echo if:set="saxon-available" message="saxon available: ${saxon-available}"/>
         <echo unless:set="saxon-available" message="saxon available: false"/>
+        <!-- check if stylesheets are available -->
+        <condition property="stylesheets-available">
+            <or>
+                <available file="${dir.lib.stylesheets}"/>
+            </or>
+        </condition>
+        <echo if:set="stylesheets-available"
+            message="stylesheets available: ${stylesheets-available}"/>
+        <echo unless:set="stylesheets-available" message="stylesheets available: false"/>
         <!-- check if Prince is available -->
         <condition property="prince-available">
             <available file="prince" filepath="${env.PATH}" />
@@ -172,6 +183,7 @@
         <echo if:set="prince-available" message="prince available: ${prince-available}"/>
         <echo unless:set="prince-available" message="prince available: false"/>
 
+        <antcall target="stylesheets-prepare" unless:true="${stylesheets-available}"/>
         <antcall target="saxon-prepare" unless:true="${saxon-available}"/>
         <antcall target="xerces-download" unless:true="${xerces-available}"/>
 
@@ -190,7 +202,9 @@
 
     <target name="saxon-download" unless="${saxon-available}">
         <mkdir dir="temp"/>
-        <get src="https://github.com/Saxonica/Saxon-HE/releases/download/${saxon.download.version}/${saxon.download.version}J.zip" dest="temp/download"/>
+        <get
+            src="https://github.com/Saxonica/Saxon-HE/releases/download/${saxon.download.version}/${saxon.download.version}J.zip"
+            dest="temp/download"/>
     </target>
 
     <target name="saxon-prepare" depends="saxon-unzip" unless="${saxon-available}">
@@ -200,6 +214,30 @@
     <target name="saxon-unzip" depends="saxon-download" unless="${saxon-available}">
         <mkdir dir="${dir.lib.saxon}"/>
         <unzip src="temp/download" overwrite="true" dest="${dir.lib.saxon}"/>
+    </target>
+
+    <target name="stylesheets-download" unless="${stylesheets-available}">
+        <mkdir dir="temp"/>
+        <get
+            src="https://github.com/TEIC/Stylesheets/releases/download/v${stylesheets.download.version}/tei-xsl-${stylesheets.download.version}.zip"
+            dest="temp/download"/>
+    </target>
+
+    <target name="stylesheets-prepare" depends="stylesheets-unzip" unless="${stylesheets-available}">
+        <delete dir="temp/"/>
+    </target>
+
+    <target name="stylesheets-unzip" depends="stylesheets-download"
+        unless="${stylesheets-available}">
+        <mkdir dir="${dir.lib.stylesheets}"/>
+        <unzip src="temp/download" overwrite="true" dest="${dir.lib.stylesheets}">
+            <patternset>
+                <include name="xml/tei/stylesheet/**"/>
+            </patternset>
+            <mapper>
+                <globmapper from="xml/tei/stylesheet/*" to="*"/>
+            </mapper>
+        </unzip>
     </target>
 
     <target name="xerces-download" unless="${xerces-available}">
@@ -222,7 +260,7 @@
 
     <target name="build-compiled-odd" description="Builds the compiled ODD of a specific customization submitted as absolute path with -Dcustomization.path input param." depends="canonicalize-source">
         <basename property="selectedSchema" file="${customization.path}" suffix=".xml"/>
-        <ant dir="submodules/Stylesheets/odd/" antfile="build-to.xml" target="go" inheritall="true">
+        <ant dir="${dir.lib.stylesheets}/odd/" antfile="build-to.xml" target="go" inheritall="true">
             <property name="inputFile" value="${customization.path}"/>
             <property name="outputFile" value="${dir.dist.schemata}/${selectedSchema}_compiled.odd"/>
             <property name="defaultSource" value="${canonicalized.source.path.cross_platform}"/>
@@ -238,7 +276,7 @@
         <antcall target="build-compiled-odd">
             <param name="customization.path" value="${customization.path}"></param>
         </antcall>
-        <ant dir="submodules/Stylesheets/html5" antfile="build-to.xml" target="odd" inheritall="true">
+        <ant dir="${dir.lib.stylesheets}/html5" antfile="build-to.xml" target="odd" inheritall="true">
             <property name="inputFile" value="${dir.dist.schemata}/${selectedSchema}_compiled.odd"/>
             <property name="outputFile" value="${dir.dist.schemata}/${selectedSchema}_compiled.html"/>
             <property name="verbose" value="${verbose}"/>
@@ -252,7 +290,7 @@
         <echo>building rng ${selectedSchema} from ${customization.path}</echo>
         <echo>    source: ${canonicalized.source.path.cross_platform}</echo>
         <echo>    output: ${dir.dist.schemata}/${selectedSchema}.rng</echo>
-        <ant dir="submodules/Stylesheets/rng/" antfile="build-to.xml" target="dist" inheritall="true" usenativebasedir="true"><!-- check whether nativebasdir is required -->
+        <ant dir="${dir.lib.stylesheets}/rng/" antfile="build-to.xml" target="dist" inheritall="true" usenativebasedir="true"><!-- check whether nativebasdir is required -->
             <property name="inputFile" value="${customization.path}"/>
             <property name="outputFile" value="${dir.dist.schemata}/${selectedSchema}.rng"/>
             <property name="defaultSource" value="${canonicalized.source.path.cross_platform}"/>

--- a/build.xml
+++ b/build.xml
@@ -135,7 +135,7 @@
         <echo>Local github.sha: ${github.sha.local}</echo>
     </target>
 
-    <target name="get-local-git-branch" description="Retrieves the current git branch via command line.">
+    <target name="get-local-git-branch" description="Retrieves the current git branch via command  line.">
         <exec executable="git" outputproperty="github.branch.local">
             <arg value="branch"/>
             <arg value="--show-current"/>
@@ -143,13 +143,13 @@
         <echo>Local github.branch: ${github.branch.local}</echo>
     </target>
 
-    <target name="reset" description="Resets the build environment. Same as `clean`, but additionally deletes the `lib` directory with the Saxon and Xerces jar files.">
+    <target name="reset" description="Resets the build environment. Same as `clean`, but additionally deletes the `lib` directory with the TEI Stylesheets and the Saxon and Xerces jar files.">
         <delete dir="lib"/>
         <antcall target="clean"/>
     </target>
     
-    <target name="init" description="Initializes the build environment, i.e., checks if Saxon and Xerces are available, and if not, downloads jar files for Saxon, Xerces and adds them to the lib folder. Checks if Prince is available.">
-        <!-- check if Xerces is available -->
+    <target name="init" description="Initializes the build environment, i.e., checks if TEI Stylesheets, Saxon and Xerces are available, and if not, it downloads everything into the `lib` folder. Checks if prince is available.">
+        <!-- check if xerces is available -->
         <condition property="xerces-available">
             <or>
                 <available file="${dir.lib.xerces}/${xerces.jar.file}"/>
@@ -301,7 +301,7 @@
     </target>
 
     <target name="build-guidelines-html" description="Builds the HTML version of the MEI guidelines." depends="canonicalize-source" unless="${build-guidelines-html.done}">
-        <!-- TODO check dependency try with mei-source.xml -->
+        <!-- TODO: check dependency try with mei-source.xml -->
         <antcall target="get-local-git-sha" if:blank="${github.sha}"/>
         <antcall target="get-local-git-branch" if:blank="${github.ref}"/>
         <basename property="selectedSchema" file="${customization.path}" suffix=".xml"/>

--- a/build.xml
+++ b/build.xml
@@ -148,7 +148,7 @@
         <antcall target="clean"/>
     </target>
     
-    <target name="init" description="Initializes the build environment, i.e., checks if TEI Stylesheets, Saxon and Xerces are available, and if not, it downloads everything into the `lib` folder. Checks if prince is available.">
+    <target name="init" description="Initializes the build environment, i.e., checks if TEI Stylesheets, Saxon and Xerces are available, and if not, it downloads everything into the `lib` folder. Checks if Prince is available.">
         <!-- check if xerces is available -->
         <condition property="xerces-available">
             <or>

--- a/build.xml
+++ b/build.xml
@@ -175,7 +175,10 @@
             <contains text="${stylesheets.version}" />
         </fileset>
         <condition property="stylesheets-available">
-            <resourcecount when="equal" count="1" refid="version.file"/>
+            <and>
+                <available file="${dir.lib.stylesheets}"/>
+                <resourcecount when="equal" count="1" refid="stylesheets.version.file"/>
+            </and>
         </condition>
         <echo if:set="stylesheets-available" message="stylesheets available: ${stylesheets-available}"/>
         <echo unless:set="stylesheets-available" message="stylesheets available: false"/>

--- a/build.xml
+++ b/build.xml
@@ -74,9 +74,9 @@
     <property name="dir.lib.saxon" value="${dir.lib}/saxon"/>
     <property name="dir.lib.stylesheets" value="${dir.lib}/stylesheets"/>
     <property name="dir.lib.xerces" value="${dir.lib}/xerces"/>
-    <property name="saxon.download.version" value="SaxonHE12-4"/>
+    <property name="saxon.version" value="SaxonHE12-4"/>
     <property name="saxon.jar.file" value="saxon-he-12.4.jar"/>
-    <property name="stylesheets.download.version" value="7.56.0"/>
+    <property name="stylesheets.version" value="7.56.0"/>
     <property name="xerces.version" value="26.1.0.1"/>
     <property name="xerces.jar.file" value="oxygen-patched-xerces-${xerces.version}.jar"/>
     <property name="oxygen.basic.utilites.jar.file" value="oxygen-basic-utilities-${xerces.version}.jar"/>
@@ -167,14 +167,11 @@
         </condition>
         <echo if:set="saxon-available" message="saxon available: ${saxon-available}"/>
         <echo unless:set="saxon-available" message="saxon available: false"/>
-        <!-- check if stylesheets are available -->
+        <!-- check if Stylesheets are available -->
         <condition property="stylesheets-available">
-            <or>
-                <available file="${dir.lib.stylesheets}"/>
-            </or>
+            <available file="${dir.lib.stylesheets}"/>
         </condition>
-        <echo if:set="stylesheets-available"
-            message="stylesheets available: ${stylesheets-available}"/>
+        <echo if:set="stylesheets-available" message="stylesheets available: ${stylesheets-available}"/>
         <echo unless:set="stylesheets-available" message="stylesheets available: false"/>
         <!-- check if Prince is available -->
         <condition property="prince-available">
@@ -202,9 +199,7 @@
 
     <target name="saxon-download" unless="${saxon-available}">
         <mkdir dir="temp"/>
-        <get
-            src="https://github.com/Saxonica/Saxon-HE/releases/download/${saxon.download.version}/${saxon.download.version}J.zip"
-            dest="temp/download"/>
+        <get src="https://github.com/Saxonica/Saxon-HE/releases/download/${saxon.version}/${saxon.version}J.zip" dest="temp/download"/>
     </target>
 
     <target name="saxon-prepare" depends="saxon-unzip" unless="${saxon-available}">
@@ -218,17 +213,14 @@
 
     <target name="stylesheets-download" unless="${stylesheets-available}">
         <mkdir dir="temp"/>
-        <get
-            src="https://github.com/TEIC/Stylesheets/releases/download/v${stylesheets.download.version}/tei-xsl-${stylesheets.download.version}.zip"
-            dest="temp/download"/>
+        <get src="https://github.com/TEIC/Stylesheets/releases/download/v${stylesheets.version}/tei-xsl-${stylesheets.version}.zip" dest="temp/download"/>
     </target>
 
     <target name="stylesheets-prepare" depends="stylesheets-unzip" unless="${stylesheets-available}">
         <delete dir="temp/"/>
     </target>
 
-    <target name="stylesheets-unzip" depends="stylesheets-download"
-        unless="${stylesheets-available}">
+    <target name="stylesheets-unzip" depends="stylesheets-download" unless="${stylesheets-available}">
         <mkdir dir="${dir.lib.stylesheets}"/>
         <unzip src="temp/download" overwrite="true" dest="${dir.lib.stylesheets}">
             <patternset>


### PR DESCRIPTION
This PR removes the Stylesheets submodule and integrates fetching an official release from GitHub into the ant init process. 
There are also some updates and corrections to the messages.

Closes #1459
