### PR TITLE
schema: make directive-like elements member of att.verticalGrp

### DIFF
--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -304,6 +304,7 @@
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.staffLoc.pitched"/>
       <memberOf key="att.typography"/>
+      <memberOf key="att.verticalGrp"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -273,6 +273,7 @@
       <memberOf key="att.color"/>
       <memberOf key="att.curvature"/>
       <memberOf key="att.lineRend.base"/>
+      <memberOf key="att.verticalGrp"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2"/>
       <memberOf key="att.xy"/>
@@ -323,6 +324,7 @@
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.staffLoc.pitched"/>
       <memberOf key="att.typography"/>
+      <memberOf key="att.verticalGrp"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>
@@ -404,6 +406,7 @@
       <memberOf key="att.extSym"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.typography"/>
+      <memberOf key="att.verticalGrp"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>
@@ -551,6 +554,7 @@
       <memberOf key="att.extSym"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.typography"/>
+      <memberOf key="att.verticalGrp"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>
@@ -590,6 +594,7 @@
       <memberOf key="att.altSym"/>
       <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.verticalGrp"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>
@@ -604,6 +609,7 @@
       <memberOf key="att.altSym"/>
       <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.verticalGrp"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>
@@ -760,6 +766,7 @@
     <classes>
       <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.verticalGrp"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
       <memberOf key="att.visualOffset2.to"/>
@@ -790,6 +797,7 @@
       <memberOf key="att.extSym"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.typography"/>
+      <memberOf key="att.verticalGrp"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>
@@ -1133,6 +1141,7 @@
     <desc xml:lang="en">Visual domain attributes.</desc>
     <classes>
       <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.verticalGrp"/>
     </classes>
   </classSpec>
   <classSpec ident="att.meterSig.vis" module="MEI.visual" type="atts">
@@ -1201,6 +1210,7 @@
       <memberOf key="att.extSym"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.typography"/>
+      <memberOf key="att.verticalGrp"/>
       <memberOf key="att.visualOffset"/>
     </classes>
   </classSpec>
@@ -1343,6 +1353,7 @@
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.extender"/>
+      <memberOf key="att.verticalGrp"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
       <memberOf key="att.visualOffset2.to"/>
@@ -1370,6 +1381,7 @@
       <memberOf key="att.color"/>
       <memberOf key="att.enclosingChars"/>
       <memberOf key="att.placementRelStaff"/>
+      <memberOf key="att.verticalGrp"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
       <memberOf key="att.visualOffset2.to"/>
@@ -1913,6 +1925,7 @@
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.extSym"/>
       <memberOf key="att.typography"/>
+      <memberOf key="att.verticalGrp"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
       <memberOf key="att.visualOffset2.to"/>
@@ -1973,6 +1986,7 @@
       <memberOf key="att.extSym"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.typography"/>
+      <memberOf key="att.verticalGrp"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>


### PR DESCRIPTION
Make bend, caesura, cpMark, metaMark, ornam, harm, fing, fingGrp, fermata, harpPedal, octave, mordent, trill, and turn members of att.vertical.Grp.