### PR TITLE
schema: for consistency, allow `<clef>` within `<scoreDef>`

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -7892,6 +7892,9 @@
         <rng:ref name="model.symbolTableLike"/>
       </rng:zeroOrMore>
       <rng:optional>
+        <rng:ref name="clef"/>
+      </rng:optional>
+      <rng:optional>
         <rng:ref name="model.keySigLike"/>
       </rng:optional>
       <rng:optional>


### PR DESCRIPTION
For consistency, allow `<clef>` within `<scoreDef>` since `@clef.*` are allowed

* Fixes to #1439