### PR TITLE
schema: fix reference to verticalGroup class

### DIFF
--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -274,7 +274,7 @@
       <memberOf key="att.color"/>
       <memberOf key="att.curvature"/>
       <memberOf key="att.lineRend.base"/>
-      <memberOf key="att.verticalGrp"/>
+      <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2"/>
       <memberOf key="att.xy"/>
@@ -305,7 +305,7 @@
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.staffLoc.pitched"/>
       <memberOf key="att.typography"/>
-      <memberOf key="att.verticalGrp"/>
+      <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>
@@ -326,7 +326,7 @@
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.staffLoc.pitched"/>
       <memberOf key="att.typography"/>
-      <memberOf key="att.verticalGrp"/>
+      <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>
@@ -408,7 +408,7 @@
       <memberOf key="att.extSym"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.typography"/>
-      <memberOf key="att.verticalGrp"/>
+      <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>
@@ -559,7 +559,7 @@
       <memberOf key="att.extSym"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.typography"/>
-      <memberOf key="att.verticalGrp"/>
+      <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>
@@ -600,7 +600,7 @@
       <memberOf key="att.color"/>
       <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
-      <memberOf key="att.verticalGrp"/>
+      <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>
@@ -616,7 +616,7 @@
       <memberOf key="att.color"/>
       <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
-      <memberOf key="att.verticalGrp"/>
+      <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>
@@ -774,7 +774,7 @@
       <memberOf key="att.color"/>
       <memberOf key="att.extender"/>
       <memberOf key="att.placementRelStaff"/>
-      <memberOf key="att.verticalGrp"/>
+      <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
       <memberOf key="att.visualOffset2.to"/>
@@ -805,7 +805,7 @@
       <memberOf key="att.extSym"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.typography"/>
-      <memberOf key="att.verticalGrp"/>
+      <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>
@@ -1150,7 +1150,7 @@
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.placementRelStaff"/>
-      <memberOf key="att.verticalGrp"/>
+      <memberOf key="att.verticalGroup"/>
     </classes>
   </classSpec>
   <classSpec ident="att.meterSig.vis" module="MEI.visual" type="atts">
@@ -1219,7 +1219,7 @@
       <memberOf key="att.extSym"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.typography"/>
-      <memberOf key="att.verticalGrp"/>
+      <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
     </classes>
   </classSpec>
@@ -1362,7 +1362,7 @@
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.extender"/>
-      <memberOf key="att.verticalGrp"/>
+      <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
       <memberOf key="att.visualOffset2.to"/>
@@ -1390,7 +1390,7 @@
       <memberOf key="att.color"/>
       <memberOf key="att.enclosingChars"/>
       <memberOf key="att.placementRelStaff"/>
-      <memberOf key="att.verticalGrp"/>
+      <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
       <memberOf key="att.visualOffset2.to"/>
@@ -1936,7 +1936,7 @@
       <memberOf key="att.extSym"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.typography"/>
-      <memberOf key="att.verticalGrp"/>
+      <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.visualOffset2.ho"/>
       <memberOf key="att.visualOffset2.to"/>
@@ -1997,7 +1997,7 @@
       <memberOf key="att.extSym"/>
       <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.typography"/>
-      <memberOf key="att.verticalGrp"/>
+      <memberOf key="att.verticalGroup"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>


### PR DESCRIPTION
This PR adjusts a slight oversight in #1472. The referenced class is named `att.verticalGroup`.