### PR TITLE
utils: separate contributor list from index generation

### DIFF
--- a/utils/guidelines_xslt/odd2html.xsl
+++ b/utils/guidelines_xslt/odd2html.xsl
@@ -223,6 +223,7 @@
         <xsl:variable name="dataTypeSpecs" select="tools:getDataTypeSpecs()" as="node()"/>
         
         <xsl:variable name="indizes" select="tools:generateIndizes()" as="node()+"/>
+        <xsl:variable name="contributors" select="tools:generateContributorsList()" as="node()+"/>
             
         
         
@@ -239,6 +240,7 @@
             <xsl:sequence select="$dataTypeSpecs"/>
             
             <xsl:sequence select="$indizes"/>
+            <xsl:sequence select="$contributors"/>
         </xsl:variable>
                 
         <!-- generate a single-page HTML version of the Guidelines -->

--- a/utils/guidelines_xslt/odd2html/functions.xsl
+++ b/utils/guidelines_xslt/odd2html/functions.xsl
@@ -378,12 +378,6 @@
         </xd:desc>
         <xd:return></xd:return>
     </xd:doc>
-    <xd:doc>
-        <xd:desc>
-            <xd:p></xd:p>
-        </xd:desc>
-        <xd:return></xd:return>
-    </xd:doc>
     <xsl:function name="tools:generateIndizes" as="node()+">
         <xsl:message select="'Generating indices'"/>
         <section id="elementIndex" class="backIndex">
@@ -426,6 +420,16 @@
                 </div>
             </xsl:for-each>
         </section>
+    </xsl:function>
+
+    <xd:doc>
+        <xd:desc>
+            <xd:p>Generates a list of contributors for the back of the Guidelines PDF</xd:p>
+        </xd:desc>
+        <xd:return></xd:return>
+    </xd:doc>
+    <xsl:function name="tools:generateContributorsList" as="node()+">
+        <xsl:message select="'Generating contributors list'"/>
         <section id="contributorList" class="backIndex">
             <h1>Contributors</h1>
             <p>
@@ -452,7 +456,6 @@
                 bridges between different musical repertoires and styles, historical periods, cultural backgrounds, musical domains, 
                 research interests, and methodical concepts by reasoning about a common encoding framework like MEI. 
             </p>
-            
         </section>
     </xsl:function>
     
@@ -464,6 +467,7 @@
         <xd:return></xd:return>
     </xd:doc>
     <xsl:function name="tools:getContributors" as="node()*">
+        <xsl:message select="'Getting contributors'"/>
         <xsl:variable name="spec.repo.contributors" select="'https://api.github.com/repos/music-encoding/music-encoding/contributors'" as="xs:string"/>
         <xsl:variable name="docs.repo.contributors" select="'https://api.github.com/repos/music-encoding/guidelines/contributors'" as="xs:string"/>
         


### PR DESCRIPTION
This PR is an addition to #1471 and intended to be merged into that PR.

It separates the generation of the contributors list from the generation of indices which prepares an option to not include the full list in the future. A possible use case for that is the reuse of the MEI Utils for project customization specific guidelines (which do not necessarily retrieve any contributors, but would want to include the indices in the back matter) as discussed by @o-sapov in #1452