### PR TITLE
guidelines: clarify use of page/system/line beginnings

### DIFF
--- a/source/docs/02-shared.xml
+++ b/source/docs/02-shared.xml
@@ -333,7 +333,7 @@
                         <specDesc key="colLayout"/>
                      </specList>
                   </p>
-                  <p>In order to force a new system in the musical text <gi scheme="MEI">sb</gi> can be used.</p>
+                  <p>In order to force the beginning of a new system in the musical text <gi scheme="MEI">sb</gi> can be used.</p>
                   <p>
                      <specList>
                         <specDesc key="sb"/>

--- a/source/docs/02-shared.xml
+++ b/source/docs/02-shared.xml
@@ -333,7 +333,7 @@
                         <specDesc key="colLayout"/>
                      </specList>
                   </p>
-                  <p>In order to force a system break in the musical text <gi scheme="MEI">sb</gi> can be used.</p>
+                  <p>In order to force a new system in the musical text <gi scheme="MEI">sb</gi> can be used.</p>
                   <p>
                      <specList>
                         <specDesc key="sb"/>

--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -1439,7 +1439,7 @@
                            <specDesc key="lg"/>
                         </specList>
                      </p>
-                     <p>The following example shows the encoding of the title page of <name ref="https://en.wikipedia.org/wiki/Ralph_Vaughan_Williams">Vaughan Williams'</name> <hi rend="italic">On Wenlock Edge</hi>. Note the use of the <gi scheme="MEI">lb</gi> element to mark new lines present in the original.</p>
+                     <p>The following example shows the encoding of the title page of <name ref="https://en.wikipedia.org/wiki/Ralph_Vaughan_Williams">Vaughan Williams'</name> <hi rend="italic">On Wenlock Edge</hi>. Note the use of the <gi scheme="MEI">lb</gi> element to mark the beginning of new lines present in the original.</p>
                      <p>
                         <figure>
                            <head/>

--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -1439,7 +1439,7 @@
                            <specDesc key="lg"/>
                         </specList>
                      </p>
-                     <p>The following example shows the encoding of the title page of Vaughan Williams' <hi rend="italic">On Wenlock Edge</hi>. Note the use of the <gi scheme="MEI">lb</gi> element to mark the line breaks present in the original.</p>
+                     <p>The following example shows the encoding of the title page of Vaughan Williams' <hi rend="italic">On Wenlock Edge</hi>. Note the use of the <gi scheme="MEI">lb</gi> element to mark the line beginnings present in the original.</p>
                      <p>
                         <figure>
                            <head/>

--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -1439,7 +1439,7 @@
                            <specDesc key="lg"/>
                         </specList>
                      </p>
-                     <p>The following example shows the encoding of the title page of Vaughan Williams' <hi rend="italic">On Wenlock Edge</hi>. Note the use of the <gi scheme="MEI">lb</gi> element to mark the line beginnings present in the original.</p>
+                     <p>The following example shows the encoding of the title page of <name ref="https://en.wikipedia.org/wiki/Ralph_Vaughan_Williams">Vaughan Williams'</name> <hi rend="italic">On Wenlock Edge</hi>. Note the use of the <gi scheme="MEI">lb</gi> element to mark new lines present in the original.</p>
                      <p>
                         <figure>
                            <head/>

--- a/source/docs/08-lyricsperfdir.xml
+++ b/source/docs/08-lyricsperfdir.xml
@@ -181,7 +181,7 @@
                      <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve" valid="feasible"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/lyricsDesc/lyricsDesc-sample283.txt" parse="text"/></egXML>
                   </figure>
                </p>
-               <p>Optionally, it is possible to include an <gi scheme="MEI">lb</gi> element within <gi scheme="MEI">verse</gi> to explicitly encode line and line group endings. This is specifically meant to facilitate karaoke applications.</p>
+               <p>Optionally, it is possible to include an <gi scheme="MEI">lb</gi> element within <gi scheme="MEI">verse</gi> to explicitly encode line and line group beginnings. This is specifically meant to facilitate karaoke applications.</p>
                <p>Finally, the <att>rhythm</att> attribute on <gi scheme="MEI">l</gi> can be used to specify a rhythm for the syllable that differs from that of the notes on the staff (see <ptr target="#lyricsAfterEvents"/>).</p>
             </div>
             <div xml:id="lyricsAfterEvents" type="div2">

--- a/source/docs/09-textencoding.xml
+++ b/source/docs/09-textencoding.xml
@@ -179,7 +179,7 @@
                            <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/text/text-sample369.txt" parse="text"/></egXML>
                         </figure>
                      </p>
-                     <p>Alternatively, the pointers in the table of contents might link to the page breaks at which a song begins, assuming that these have been included in the markup:</p>
+                     <p>Alternatively, the pointers in the table of contents might link to the page beginnings at which a song begins, assuming that these have been included in the markup:</p>
                      <p>
                         <figure>
                            <head/>
@@ -212,7 +212,7 @@
                            <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/text/text-sample372.txt" parse="text"/></egXML>
                         </figure>
                      </p>
-                     <p>Note that if the page breaks in the original source have also been explicitly encoded, and given identifiers, the references to them in the above index can more usefully be recorded as links. For example, assuming that the encoding of page 77 of the original source starts like this:</p>
+                     <p>Note that if the page beginnings in the original source have also been explicitly encoded, and given identifiers, the references to them in the above index can more usefully be recorded as links. For example, assuming that the encoding of page 77 of the original source starts like this:</p>
                      <p>
                         <figure>
                            <head/>

--- a/source/docs/13-linkingdata.xml
+++ b/source/docs/13-linkingdata.xml
@@ -182,7 +182,7 @@
                             <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/linkalign/linkalign-example021.txt" parse="text"/></egXML>
                         </figure>
                     </p>
-                    <p>The <att>next</att> and <att>prev</att> attributes may also be useful to clarify a sequence of entities which occurs across some form of interruption, in this case, notes before and after a system or page break where there is no custos or direct in the source:</p>
+                    <p>The <att>next</att> and <att>prev</att> attributes may also be useful to clarify a sequence of entities which occurs across some form of interruption, in this case, notes before and after a new system or page beginning where there is no custos or direct in the source:</p>
                     <p>
                         <figure>
                             <head/>
@@ -206,7 +206,7 @@
                         </specList>
                     </p>
                     <p>
-                        The <gi scheme="MEI">ptr</gi> element is a traversible pointer to another location. It is an empty linking element that uses only attributes to describe its link destination. It cannot contain text or sub-elements to describe the referenced object. The next example shows the use of the <gi scheme="MEI">ptr</gi> element to target a certain identifier (here <abbr>e.g.</abbr>, a page number, or more precisely, page break elements, <gi scheme="MEI">pb</gi>, bearing these identifiers) from within a <gi scheme="MEI">list</gi> of item descriptions:
+                        The <gi scheme="MEI">ptr</gi> element is a traversible pointer to another location. It is an empty linking element that uses only attributes to describe its link destination. It cannot contain text or sub-elements to describe the referenced object. The next example shows the use of the <gi scheme="MEI">ptr</gi> element to target a certain identifier (here <abbr>e.g.</abbr>, a page number, or more precisely, page beginning elements, <gi scheme="MEI">pb</gi>, bearing these identifiers) from within a <gi scheme="MEI">list</gi> of item descriptions:
                     </p>
                     <p>
                         <figure>


### PR DESCRIPTION
This PR changes references to the `lb` element and similar where it could be misleading. 

closes #1489