### PR TITLE
guidelines: encode quotes

### DIFF
--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -718,11 +718,11 @@
                <p>The IFLA’s FRBR model distinguishes four levels of abstraction, or entities:</p>
                <list type="gloss">
                   <label>Work</label>
-                  <item>FRBR defines a work as a "distinct intellectual or artistic creation", an abstract entity because there is no single material object one can point to as the work.</item>
+                  <item>FRBR defines a work as a <quote>distinct intellectual or artistic creation</quote>, an abstract entity because there is no single material object one can point to as the work.</item>
                   <label>Expression</label>
-                  <item>An expression is defined as "the intellectual or artistic realization of a work in the form of [...] notation, sound, image, object, movement, etc., or any combination of such forms". Expressions are also abstract entities.</item>
+                  <item>An expression is defined as <quote>the intellectual or artistic realization of a work in the form of [...] notation, sound, image, object, movement, etc., or any combination of such forms</quote>. Expressions are also abstract entities.</item>
                   <label>Manifestation</label>
-                  <item>A manifestation is defined as "the physical embodiment of an expression of a work", including, for instance, manuscripts, books, sound recordings, films, video recordings, CD-ROMs, multimedia kits, etc. The manifestation represents all the physical objects that bear the same characteristics, with respect to both intellectual content and physical form.</item>
+                  <item>A manifestation is defined as <quote>the physical embodiment of an expression of a work</quote>, including, for instance, manuscripts, books, sound recordings, films, video recordings, CD-ROMs, multimedia kits, etc. The manifestation represents all the physical objects that bear the same characteristics, with respect to both intellectual content and physical form.</item>
                   <label>Item</label>
                   <item>A single exemplar of a manifestation is called an item, <abbr>e.g.</abbr>, a specific copy of a printed score. With manuscripts, item and manifestation levels are nearly identical. A manuscript may be regarded as a manifestation having only one item.</item>
                </list>

--- a/source/docs/04-cmn.xml
+++ b/source/docs/04-cmn.xml
@@ -220,7 +220,7 @@
                <div xml:id="cmnDefsSepecial" type="div3">
                   <head>Special cases in staff definitions</head>
                   <p>Usually <gi scheme="MEI">clef</gi>, <gi scheme="MEI">key</gi>, and <gi scheme="MEI">meterSig</gi> apply to a whole staff.</p>
-                  <p>In some rare cases one can find different meters in different layers, as seen in Maurice Ravel’s <hi rend="italic">Oiseaux tristes</hi>.</p>
+                  <p>In some rare cases one can find different meters in different layers, as seen in <name ref="https://en.wikipedia.org/wiki/Maurice_Ravel">Maurice Ravel’s</name> <hi rend="italic">Oiseaux tristes</hi>.</p>
                   <p>
                      <figure>
                         <head>Different meters in different layers on the upper staff</head>

--- a/source/docs/04-cmn.xml
+++ b/source/docs/04-cmn.xml
@@ -1373,7 +1373,7 @@
                      </figure>
                   </p>
                   <p>Some trills may be introduced by a turn or followed by an inverted turn leading to the next note (see Le garzantine, Musica 2003, p. 911). In such cases, the trill is encoded as in previous examples and associated with the principal note. Starting or concluding turns are notated on the staff (in <gi scheme="MEI">layer</gi>) as <ptr target="#cmnNotesGrace"/>.</p>
-                  <p>The following example, from a keyboard sonata by Joseph Haydn, shows a trill with concluding grace notes (called <hi rend="italic">Nachschlag</hi>):</p>
+                  <p>The following example, from a keyboard sonata by Joseph Haydn, shows a trill with concluding grace notes (called <foreign rend="italic" xml:lang="de">Nachschlag</foreign>):</p>
                   <p>
                      <figure>
                         <head>Haydn, Sonata in D major, Hoboken XVI:33 (Wiener Urtex no. 34), mvmt. 1.</head>

--- a/source/docs/08-lyricsperfdir.xml
+++ b/source/docs/08-lyricsperfdir.xml
@@ -163,7 +163,7 @@
                      <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/lyricsDesc/lyricsDesc-sample281.txt" parse="text"/></egXML>
                   </figure>
                </p>
-               <p>As it is common practice in written text, it is assumed that a space separates words. Many vocal texts, however, introduce elisions and connect two syllables into one unit. For example, the vocal text from Mozart’s <hi rend="italic">Don Giovanni</hi> sung by Don Giovanni in Finale II, Ho fermo il core in petto introduces an elision between the word fermo and il and between core and in. An elision can be indicated by placing both syllables within the same <gi scheme="MEI">note</gi> and setting the <gi scheme="MEI">syl</gi> element’s <att>con</att> attribute value to 't':</p>
+               <p>As it is common practice in written text, it is assumed that a space separates words. Many vocal texts, however, introduce elisions and connect two syllables into one unit. For example, the vocal text from Mozart’s <hi rend="italic">Don Giovanni</hi> sung by Don Giovanni in Finale II, <quote>Ho fermo il core in petto</quote> introduces an elision between the word fermo and il and between core and in. An elision can be indicated by placing both syllables within the same <gi scheme="MEI">note</gi> and setting the <gi scheme="MEI">syl</gi> element’s <att>con</att> attribute value to 't':</p>
                <p>
                   <figure>
                      <head/>

--- a/utils/guidelines_xslt/odd2html/guidelines.xsl
+++ b/utils/guidelines_xslt/odd2html/guidelines.xsl
@@ -363,7 +363,6 @@
         </xsl:choose>
     </xsl:template>
     
-    
     <xd:doc>
         <xd:desc>
             <xd:p>soCalled</xd:p>
@@ -463,6 +462,15 @@
         <span class="mentioned"><xsl:apply-templates select="node()" mode="#current"/></span>
     </xsl:template>
     
+    <xd:doc>
+        <xd:desc>
+            <xd:p>Quoted content</xd:p>
+        </xd:desc>
+    </xd:doc>
+    <xsl:template match="tei:q|tei:quote" mode="guidelines">
+        <xsl:value-of select="'&quot;'"/><xsl:apply-templates select="node()" mode="#current"/><xsl:value-of select="'&quot;'"/>
+    </xsl:template>
+
     <xd:doc>
         <xd:desc>
             <xd:p>Emphasized content</xd:p>


### PR DESCRIPTION
This PR adds a rule for quoted content to the `guidelines.xsl` and properly encodes some quotes.
Additionally it adds a link and marks a foreign word as such.