### PR TITLE
build: update Prince version in build instructions

### DIFF
--- a/BUILD_COMMANDLINE.md
+++ b/BUILD_COMMANDLINE.md
@@ -9,7 +9,7 @@
    |Java| Java Development Kit (JDK) 17 recommended (at least Java 8 at runtime to support Apache Ant™)|
    |Apache Ant|1.10.14|
    |Verovio Toolkit|4.2.1|
-   |Prince XML|15.1|
+   |Prince XML|15.3|
    |Saxon HE*| 12.4 |
    |Xerces*|Synchrosoft patched version 26.1.0.1|
 


### PR DESCRIPTION
This tiny PR updates the recommended Prince version to the latest version.

Needs music-encoding/docker-mei#41