### PR TITLE
schema: replace outdated tei:macroSpec[type] syntax

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -24,7 +24,7 @@
   <moduleSpec ident="MEI.cmn">
     <desc xml:lang="en">Common Music Notation (CMN) repertoire component declarations.</desc>
   </moduleSpec>
-  <macroSpec ident="data.DURATION.cmn" module="MEI.cmn" type="dt">
+  <dataSpec ident="data.DURATION.cmn" module="MEI.cmn">
     <desc xml:lang="en">Logical, that is, written, duration attribute values for the CMN repertoire.</desc>
     <content>
       <valList type="closed">
@@ -72,8 +72,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.HARPPEDALPOSITION" module="MEI.cmn" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.HARPPEDALPOSITION" module="MEI.cmn">
     <desc xml:lang="en">Indicates the pedal setting for a harp strings.</desc>
     <content>
       <valList type="closed">
@@ -88,8 +88,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.STAFFITEM.cmn" module="MEI.cmn" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.STAFFITEM.cmn" module="MEI.cmn">
     <desc xml:lang="en">Items in the CMN repertoire that may be printed near a staff.</desc>
     <content>
       <valList type="closed">
@@ -157,7 +157,7 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
+  </dataSpec>
   <classSpec ident="att.arpeg.log" module="MEI.cmn" type="atts">
     <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>

--- a/source/modules/MEI.cmnOrnaments.xml
+++ b/source/modules/MEI.cmnOrnaments.xml
@@ -24,7 +24,7 @@
   <moduleSpec ident="MEI.cmnOrnaments">
     <desc xml:lang="en">CMN ornament component declarations.</desc>
   </moduleSpec>
-  <macroSpec ident="data.ORNAM.cmn" module="MEI.cmnOrnaments" type="dt">
+  <dataSpec ident="data.ORNAM.cmn" module="MEI.cmnOrnaments">
     <desc xml:lang="en">CMN ornam attribute values: A = appogiatura (upper neighbor); a = acciaccatura (lower
       neighbor); b = bebung; I = ascending slide; i = descending slide; k = delayed turn; K = 5-note
       turn; m = mordent (alternation with lower neighbor); M = inverted mordent (alternation with
@@ -37,7 +37,7 @@
           >[A|a|b|I|i|K|k|M|m|N|n|S|s|T|t|O]|(A|a|S|s|K|k)?(T|t|M|m)(I|i|S|s)?</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
+  </dataSpec>
   <classSpec ident="att.mordent.log" module="MEI.cmnOrnaments" type="atts">
     <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>

--- a/source/modules/MEI.frbr.xml
+++ b/source/modules/MEI.frbr.xml
@@ -24,7 +24,7 @@
   <moduleSpec ident="MEI.frbr">
     <desc xml:lang="en">FRBR (Functional Requirements for Bibliographic Records) declarations.</desc>
   </moduleSpec>
-  <macroSpec ident="data.FRBRRELATIONSHIP" module="MEI.frbr" type="dt">
+  <dataSpec ident="data.FRBRRELATIONSHIP" module="MEI.frbr">
     <desc xml:lang="en">Relationships between FRBR entities.</desc>
     <content>
       <valList type="closed">
@@ -154,7 +154,7 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
+  </dataSpec>
   <classSpec ident="model.expressionLike" type="model" module="MEI.frbr">
     <desc xml:lang="en">Collects FRBR expression-like elements.</desc>
   </classSpec>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -24,7 +24,7 @@
   <moduleSpec ident="MEI.header">
     <desc xml:lang="en">Metadata header component declarations.</desc>
   </moduleSpec>
-  <macroSpec ident="macro.availabilityPart" module="MEI.header" type="pe">
+  <macroSpec ident="macro.availabilityPart" module="MEI.header">
     <desc xml:lang="en">Groups elements that may appear as part of a description of the availability of and access
       to a bibliographic item.</desc>
     <content>
@@ -50,7 +50,7 @@
       </rng:choice>
     </content>
   </macroSpec>
-  <macroSpec ident="macro.bibldescPart" module="MEI.header" type="pe">
+  <macroSpec ident="macro.bibldescPart" module="MEI.header">
     <desc xml:lang="en">Groups manifestation- and item-specific elements that may appear as part of a
       bibliographic description.</desc>
     <content>

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -24,7 +24,7 @@
   <moduleSpec ident="MEI.mensural">
     <desc xml:lang="en">Mensural repertoire component declarations.</desc>
   </moduleSpec>
-  <macroSpec ident="data.DURATION.mensural" module="MEI.mensural" type="dt">
+  <dataSpec ident="data.DURATION.mensural" module="MEI.mensural">
     <desc xml:lang="en">Logical, that is, written, note-shape (or note symbol) attribute values for the mensural repertoire.</desc>
     <content>
       <valList type="closed">
@@ -54,8 +54,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MULTIBREVERESTS.mensural" module="MEI.mensural" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MULTIBREVERESTS.mensural" module="MEI.mensural">
     <desc xml:lang="en">Logical, that is, written, duration attribute values for multi-breve rests in the mensural repertoire.</desc>
     <content>
       <valList type="closed">
@@ -67,8 +67,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.DURATIONRESTS.mensural" module="MEI.mensural" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.DURATIONRESTS.mensural" module="MEI.mensural">
     <desc xml:lang="en">Logical, that is, written, duration attribute values for mensural rests.</desc>
     <content>
       <rng:choice>
@@ -76,8 +76,8 @@
         <rng:ref name="data.DURATION.mensural"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.DURQUALITY.mensural" module="MEI.mensural" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.DURQUALITY.mensural" module="MEI.mensural">
     <desc xml:lang="en">Duration attribute values of a given note symbol for the mensural repertoire.</desc>
     <content>
       <valList type="closed">
@@ -101,8 +101,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.FLAGFORM.mensural" module="MEI.mensural" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.FLAGFORM.mensural" module="MEI.mensural">
     <desc xml:lang="en">Form of the flag.</desc>
     <content>
       <valList type="closed">
@@ -132,8 +132,8 @@
             <!--<graphic url="ExampleImages/accid-20100510.png" height="50%" width="50%"/>-->
         </p>
     </remarks>
-  </macroSpec>
-  <macroSpec ident="data.FLAGPOS.mensural" module="MEI.mensural" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.FLAGPOS.mensural" module="MEI.mensural">
     <desc xml:lang="en">Position of the flag relative to the stem.</desc>
     <content>
       <valList type="closed">
@@ -148,8 +148,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.STAFFITEM.mensural" module="MEI.mensural" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.STAFFITEM.mensural" module="MEI.mensural">
     <desc xml:lang="en">Items in the Mensural repertoire that may be printed near a staff.</desc>
     <content>
       <valList type="closed">
@@ -158,8 +158,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.STEMFORM.mensural" module="MEI.mensural" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.STEMFORM.mensural" module="MEI.mensural">
     <desc xml:lang="en">Form of the stem attached to the note.</desc>
     <content>
       <valList type="closed">
@@ -177,7 +177,7 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
+  </dataSpec>
   <classSpec ident="att.duration.quality" module="MEI.mensural" type="atts">
     <desc xml:lang="en">Attribute that expresses duration for a given mensural note symbol.</desc>
     <constraintSpec ident="check_duplex_quality" scheme="schematron">

--- a/source/modules/MEI.neumes.xml
+++ b/source/modules/MEI.neumes.xml
@@ -24,9 +24,9 @@
   <moduleSpec ident="MEI.neumes">
     <desc xml:lang="en">Neume repertoire component declarations.</desc>
   </moduleSpec>
-  <macroSpec ident="data.STAFFITEM.neumes" module="MEI.neumes" type="dt">
+  <dataSpec ident="data.STAFFITEM.neumes" module="MEI.neumes">
     <desc xml:lang="en">Items in the Neume repertoire that may be printed near a staff.</desc>
-  </macroSpec>
+  </dataSpec>
   <classSpec ident="att.divLine.log" module="MEI.neumes" type="atts">
     <desc xml:lang="en">Logical domain attributes.</desc>
     <attList>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -24,7 +24,7 @@
   <moduleSpec ident="MEI.shared">
     <desc xml:lang="en">Component declarations that are shared between two or more modules.</desc>
   </moduleSpec>
-  <macroSpec ident="macro.anyXML" module="MEI.shared" type="pe">
+  <macroSpec ident="macro.anyXML" module="MEI.shared">
     <desc xml:lang="en">Permits any XML elements except those from the MEI or SVG namespace.</desc>
     <content>
       <rng:element>
@@ -48,7 +48,7 @@
       </rng:element>
     </content>
   </macroSpec>
-  <macroSpec ident="macro.metaLike.page" module="MEI.shared" type="pe">
+  <macroSpec ident="macro.metaLike.page" module="MEI.shared">
     <desc xml:lang="en">Groups elements that contain meta-data about a single page.</desc>
     <content>
       <rng:optional>
@@ -62,7 +62,7 @@
       </rng:optional>
     </content>
   </macroSpec>
-  <macroSpec ident="macro.musicPart" module="MEI.shared" type="pe">
+  <macroSpec ident="macro.musicPart" module="MEI.shared">
     <desc xml:lang="en">Groups elements that may appear as part of the music element.</desc>
     <content>
       <rng:optional>
@@ -79,7 +79,7 @@
       </rng:optional>
     </content>
   </macroSpec>
-  <macroSpec ident="macro.struc-unstrucContent" module="MEI.shared" type="pe">
+  <macroSpec ident="macro.struc-unstrucContent" module="MEI.shared">
     <desc xml:lang="en">Provides a choice between structured and unstructured/mixed content.</desc>
     <content>
       <rng:choice>
@@ -100,7 +100,7 @@
       </rng:choice>
     </content>
   </macroSpec>
-  <macroSpec ident="macro.titlePart" module="MEI.shared" type="pe">
+  <macroSpec ident="macro.titlePart" module="MEI.shared">
     <desc xml:lang="en">Groups elements that may appear as part of a bibliographic title.</desc>
     <content>
       <rng:zeroOrMore>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -125,7 +125,7 @@
       </rng:zeroOrMore>
     </content>
   </macroSpec>
-  <macroSpec ident="data.BETYPE" module="MEI.shared" type="dt">
+  <dataSpec ident="data.BETYPE" module="MEI.shared">
     <desc xml:lang="en">Datatypes for values in begin, end, abstype and inttype attributes.</desc>
     <content>
       <valList type="closed">
@@ -170,7 +170,7 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
+  </dataSpec>
   <classSpec ident="att.accid.log" module="MEI.shared" type="atts">
     <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>

--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -24,13 +24,13 @@
   <moduleSpec ident="MEI.stringtab">
     <desc xml:lang="en">Tablature component declarations.</desc>
   </moduleSpec>
-  <macroSpec ident="data.COURSENUMBER" module="MEI.stringtab" type="dt">
+  <dataSpec ident="data.COURSENUMBER" module="MEI.stringtab">
     <desc xml:lang="en">In string tablature, the number of the course to be played.</desc>
     <content>
       <rng:data type="positiveInteger"/>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.COURSETUNING" module="MEI.stringtab" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.COURSETUNING" module="MEI.stringtab">
     <desc xml:lang="en">Standard course tunings.</desc>
     <content>
       <valList type="semi">
@@ -60,7 +60,7 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
+  </dataSpec>
   <classSpec ident="att.course.log" module="MEI.stringtab" type="atts">
     <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -1666,8 +1666,8 @@
         <valItem ident="pressusmaior"/>
       </valList>
     </content>
-  </macroSpec>-->
-  <macroSpec ident="data.INTERVAL.HARMONIC" module="MEI" type="dt">
+  </dataSpec>-->
+  <dataSpec ident="data.INTERVAL.HARMONIC" module="MEI">
     <desc xml:lang="en">A token indicating diatonic interval quality and size in shorthand notation.</desc>
     <content>
       <rng:choice>
@@ -1688,7 +1688,7 @@
         </list>
       </p>
     </remarks>
-  </macroSpec>
+  </dataSpec>
   <dataSpec ident="data.INTERVAL.MELODIC" module="MEI">
     <desc xml:lang="en">A token indicating direction of the interval but not its precise value, a diatonic
       interval (with optional direction and quality), or a decimal value in half steps. Decimal

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -24,7 +24,7 @@
   <moduleSpec ident="MEI">
     <desc xml:lang="en">Data type definitions.</desc>
   </moduleSpec>
-  <macroSpec ident="data.ACCIDENTAL.WRITTEN" module="MEI" type="dt">
+  <dataSpec ident="data.ACCIDENTAL.WRITTEN" module="MEI">
     <desc xml:lang="en">Written accidental values.</desc>
     <content>
       <alternate>
@@ -39,8 +39,8 @@
         <graphic url="../images/ExampleImages/accid-20100510.png" height="50%" width="50%"/>
       </p>
     </remarks>
-  </macroSpec>
-  <macroSpec ident="data.ACCIDENTAL.WRITTEN.basic" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.ACCIDENTAL.WRITTEN.basic" module="MEI">
     <desc xml:lang="en">Written standard accidental values.</desc>
     <content>
       <valList type="closed">
@@ -82,8 +82,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.ACCIDENTAL.WRITTEN.extended" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.ACCIDENTAL.WRITTEN.extended" module="MEI">
     <desc xml:lang="en">Written quarter-tone accidental values.</desc>
     <content>
       <valList type="closed">
@@ -133,8 +133,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.ACCIDENTAL.aeu" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.ACCIDENTAL.aeu" module="MEI">
     <desc xml:lang="en">Arel-Ezgi-Uzdilek (AEU) accidental values (written and gestural/performed).</desc>
     <content>
       <valList type="closed">
@@ -169,8 +169,8 @@
         <graphic url="../images/ExampleImages/accidAEU-overview.png" height="50%" width="50%"/>
       </p>
     </remarks>
-  </macroSpec>
-  <macroSpec ident="data.ACCIDENTAL.persian" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.ACCIDENTAL.persian" module="MEI">
     <desc xml:lang="en">Persian accidental values (written and gestural/performed).</desc>
     <content>
       <valList type="closed">
@@ -182,8 +182,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.ACCIDENTAL.GESTURAL" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.ACCIDENTAL.GESTURAL" module="MEI">
     <desc xml:lang="en">Gestural/performed standard accidental values.</desc>
     <content>
       <alternate>
@@ -193,8 +193,8 @@
         <macroRef key="data.ACCIDENTAL.persian"/>
       </alternate>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.ACCIDENTAL.GESTURAL.basic" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.ACCIDENTAL.GESTURAL.basic" module="MEI">
     <desc xml:lang="en">Gestural/performed accidental values.</desc>
     <content>
       <valList type="closed">
@@ -221,8 +221,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.ACCIDENTAL.GESTURAL.extended" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.ACCIDENTAL.GESTURAL.extended" module="MEI">
     <desc xml:lang="en">Gestural/performed quarter-tone accidental values.</desc>
     <content>
       <valList type="closed">
@@ -246,8 +246,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.ARTICULATION" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.ARTICULATION" module="MEI">
     <desc xml:lang="en">The following list of articulations mostly corresponds to symbols from the Western Musical
       Symbols portion of the Unicode Standard. The dot and stroke values may be used in cases where
       interpretation is difficult or undesirable.</desc>
@@ -388,16 +388,16 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-  </macroSpec>
-  <macroSpec ident="data.AUGMENTDOT" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.AUGMENTDOT" module="MEI">
     <desc xml:lang="en">Dots attribute values (number of augmentation dots) (Read, 113-119, ex. 8-21).</desc>
     <content>
       <rng:data type="nonNegativeInteger">
         <rng:param name="maxInclusive">4</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.BARMETHOD" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.BARMETHOD" module="MEI">
     <desc xml:lang="en">Records where bar lines are drawn. The value 'staff' describes the traditional placement
       of bar lines.</desc>
     <content>
@@ -413,8 +413,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.BARRENDITION" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.BARRENDITION" module="MEI">
     <desc xml:lang="en">Renderings of bar lines. Some values correspond to the Western Musical Symbols portion of
       the Unicode Standard.</desc>
     <content>
@@ -466,16 +466,16 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.BEAM" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.BEAM" module="MEI">
     <desc xml:lang="en">Beam attribute values: initial, medial, terminal. Nested beaming is permitted.</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">[i|m|t][1-6]</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.BEAMPLACE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.BEAMPLACE" module="MEI">
     <desc xml:lang="en">Location of a beam relative to the events it affects.</desc>
     <content>
       <valList type="closed">
@@ -490,8 +490,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.BEAT" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.BEAT" module="MEI">
     <desc xml:lang="en">A beat location, <abbr>i.e.</abbr>, a decimal number.</desc>
     <content>
       <rng:data type="decimal">
@@ -504,8 +504,8 @@
         For example, in 12/8 the value must be in the range from 0 to 13.
       </p>
     </remarks>
-  </macroSpec>
-  <macroSpec ident="data.BEATRPT.REND" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.BEATRPT.REND" module="MEI">
     <desc xml:lang="en">Visual and performance information for a repeated beat symbol.</desc>
     <content>
       <rng:choice>
@@ -517,8 +517,8 @@
         </rng:data>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.BEND.AMOUNT" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.BEND.AMOUNT" module="MEI">
     <desc xml:lang="en">Either an integer value, a decimal value, or a token. Fractional values are limited to
       .25, .5, .75, while the token value is restricted to 'full'.</desc>
     <content>
@@ -534,8 +534,8 @@
         </rng:data>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.BOOLEAN" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.BOOLEAN" module="MEI">
     <desc xml:lang="en">Boolean attribute values.</desc>
     <content>
       <valList type="closed">
@@ -547,8 +547,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.CANCELACCID" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.CANCELACCID" module="MEI">
     <desc xml:lang="en">Indicates where cancellation accidentals are shown in a key signature.</desc>
     <content>
       <valList type="closed">
@@ -566,8 +566,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.CERTAINTY" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.CERTAINTY" module="MEI">
     <desc xml:lang="en">Values for certainty attribute. Certainty may be expressed by one of the predefined symbolic values <val>high</val>, 
       <val>medium</val>, or <val>low</val>. The value <val>unknown</val> should be used in cases where the encoder 
       does not wish to assert an opinion about the matter.</desc>
@@ -587,15 +587,15 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.CLEFLINE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.CLEFLINE" module="MEI">
     <desc xml:lang="en">Clef line attribute values. The value must be in the range between 1 and the number of
       lines on the staff. The numbering of lines starts with the lowest line of the staff.</desc>
     <content>
       <rng:data type="positiveInteger"/>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.CLEFSHAPE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.CLEFSHAPE" module="MEI">
     <desc xml:lang="en">Clef shape attribute values (Read, p.53-56). Some values correspond to the Unicode
       Standard.</desc>
     <content>
@@ -628,8 +628,8 @@
         used to clarify the sounding octave of the instruments for the clef.
       </p>
     </remarks>
-  </macroSpec>
-  <macroSpec ident="data.CLUSTER" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.CLUSTER" module="MEI">
     <desc xml:lang="en">Tone-cluster rendition.</desc>
     <content>
       <valList type="closed">
@@ -644,8 +644,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.CONFIDENCE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.CONFIDENCE" module="MEI">
     <desc xml:lang="en">Confidence is expressed as a real number between 0 and 1; 0 representing certainly false
       and 1 representing certainly true.</desc>
     <content>
@@ -654,8 +654,8 @@
         <rng:param name="maxInclusive">1</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.COLORNAMES" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.COLORNAMES" module="MEI">
     <desc xml:lang="en">List of named colors from CSS Color Module Level 4.</desc>
     <content>
       <valList type="closed">
@@ -1111,8 +1111,8 @@
         >https://www.w3.org/TR/css-color-4/</ref>. </p>
       <p>All of these keywords are case-insensitive.</p>
     </remarks>
-  </macroSpec>
-  <macroSpec ident="data.COLORVALUES" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.COLORVALUES" module="MEI">
     <desc xml:lang="en">Parameterized color values</desc>
     <content>
       <rng:choice>
@@ -1146,8 +1146,8 @@
         </rng:data>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.COLOR" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.COLOR" module="MEI">
     <desc xml:lang="en">A value in one of the following forms is expected: 1) hexadecimal RRGGBB, 2) hexadecimal
       RRGGBBAA, 3) CSS RGB, 4) CSS RGBA, 5) HSL, 6) HSLA, or 7) CSS color name.</desc>
     <content>
@@ -1156,8 +1156,8 @@
         <rng:ref name="data.COLORVALUES"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.COMPASSDIRECTION" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.COMPASSDIRECTION" module="MEI">
     <desc xml:lang="en">Description of direction with respect to an imaginary compass.</desc>
     <content>
       <alternate>
@@ -1165,8 +1165,8 @@
         <macroRef key="data.COMPASSDIRECTION.extended"/>
       </alternate>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.COMPASSDIRECTION.basic" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.COMPASSDIRECTION.basic" module="MEI">
     <desc xml:lang="en">Basic compass directions.</desc>
     <content>
       <valList type="closed">
@@ -1184,8 +1184,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.COMPASSDIRECTION.extended" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.COMPASSDIRECTION.extended" module="MEI">
     <desc xml:lang="en">Additional compass directions.</desc>
     <content>
       <valList type="closed">
@@ -1203,8 +1203,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.DEGREES" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.DEGREES" module="MEI">
     <desc xml:lang="en">360th-unit measure of a circle’s circumference; optionally signed decimal number between
       -360 and 360.</desc>
     <content>
@@ -1213,8 +1213,8 @@
         <rng:param name="minInclusive">-360.0</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.DIVISIO" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.DIVISIO" module="MEI">
     <desc xml:lang="en">Divisio values.</desc>
     <content>
       <valList type="closed">
@@ -1241,8 +1241,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.DURATION" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.DURATION" module="MEI">
     <desc xml:lang="en">Logical, that is, written, duration attribute values.</desc>
     <content>
       <rng:choice>
@@ -1250,8 +1250,8 @@
         <rng:ref name="data.DURATION.mensural"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.DURATIONRESTS" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.DURATIONRESTS" module="MEI">
     <desc xml:lang="en">Logical, that is, written, duration attribute values for rests.</desc>
     <content>
       <rng:choice>
@@ -1259,8 +1259,8 @@
         <rng:ref name="data.DURATIONRESTS.mensural"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.DURATION.GESTURAL" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.DURATION.GESTURAL" module="MEI">
     <desc xml:lang="en">Performed duration attribute values.</desc>
     <content>
       <rng:choice>
@@ -1268,8 +1268,8 @@
         <rng:ref name="data.DURATION.mensural"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.ENCLOSURE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.ENCLOSURE" module="MEI">
     <desc xml:lang="en">Enclosures for editorial notes, accidentals, articulations, etc.</desc>
     <content>
       <valList type="closed">
@@ -1287,8 +1287,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.EVENTREL" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.EVENTREL" module="MEI">
     <desc xml:lang="en">Location of musical material relative to a symbol on a staff instead of the staff.</desc>
     <content>
       <alternate>
@@ -1296,8 +1296,8 @@
         <macroRef key="data.EVENTREL.extended"/>
       </alternate>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.EVENTREL.basic" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.EVENTREL.basic" module="MEI">
     <desc xml:lang="en">Location of musical material relative to a symbol other than a staff.</desc>
     <content>
       <valList type="closed">
@@ -1315,8 +1315,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.EVENTREL.extended" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.EVENTREL.extended" module="MEI">
     <desc xml:lang="en">Location of musical material relative to a symbol other than a staff.</desc>
     <content>
       <valList type="closed">
@@ -1334,8 +1334,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.FILL" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.FILL" module="MEI">
     <desc xml:lang="en">Describes how a graphical object, such as a note head, should be filled. The relative
       values — top, bottom, left, and right — indicate these locations *after* rotation is
       applied.</desc>
@@ -1361,8 +1361,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.FINGER.FRET" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.FINGER.FRET" module="MEI">
     <desc xml:lang="en">In a guitar chord diagram, a label indicating which finger, if any, should be used to play
       an individual string. The index, middle, ring, and little fingers are represented by the
       values 1-4, while 't' is for the thumb. The values 'x' and 'o' indicate stopped and open
@@ -1378,20 +1378,20 @@
         </rng:data>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.FONTFAMILY" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.FONTFAMILY" module="MEI">
     <desc xml:lang="en">Font family (for text) attribute values.</desc>
     <content>
       <rng:data type="token"/>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.FONTNAME" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.FONTNAME" module="MEI">
     <desc xml:lang="en">Font name (for text) attribute values.</desc>
     <content>
       <rng:data type="token"/>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.FONTSIZE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.FONTSIZE" module="MEI">
     <desc xml:lang="en">Font size expressions.</desc>
     <content>
       <rng:choice>
@@ -1400,8 +1400,8 @@
         <rng:ref name="data.PERCENT"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.FONTSIZENUMERIC" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.FONTSIZENUMERIC" module="MEI">
     <desc xml:lang="en">Font size expressed as numbers; <abbr>i.e.</abbr>, points or virtual units.</desc>
     <content>
       <rng:data type="token">
@@ -1425,8 +1425,8 @@
         </rng:except>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.FONTSIZESCALE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.FONTSIZESCALE" module="MEI">
     <desc xml:lang="en">Relative size of symbol that may begin/end a line.</desc>
     <content>
       <rng:data type="integer">
@@ -1434,8 +1434,8 @@
         <rng:param name="maxInclusive">9</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.FONTSIZETERM" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.FONTSIZETERM" module="MEI">
     <desc xml:lang="en">Font size expressed as relative term.</desc>
     <content>
       <valList type="closed">
@@ -1468,8 +1468,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.FONTSTYLE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.FONTSTYLE" module="MEI">
     <desc xml:lang="en">Font style (for text) attribute values.</desc>
     <content>
       <valList type="closed">
@@ -1484,8 +1484,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.FONTWEIGHT" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.FONTWEIGHT" module="MEI">
     <desc xml:lang="en">Font weight (for text) attribute values.</desc>
     <content>
       <valList type="closed">
@@ -1497,15 +1497,15 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.FRETNUMBER" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.FRETNUMBER" module="MEI">
     <desc xml:lang="en">In string tablature, the fret number. The value <val>0</val> (zero) indicates the open
       string.</desc>
     <content>
       <rng:data type="nonNegativeInteger"/>
     </content>
-  </macroSpec>
-  <!--<macroSpec ident="data.FRETNUMBER.limited" module="MEI" type="dt">
+  </dataSpec>
+  <!--<dataSpec ident="data.FRETNUMBER.limited" module="MEI">
     <desc xml:lang="en">In a guitar chord diagram, the fret where the finger should be placed. Since guitar chord
       diagrams are limited to the range of frets that fall under the hand, the values here are a
       subset of those available in data.FRETNUMBER. The pos (position) attribute on the chordDef
@@ -1516,8 +1516,8 @@
         <rng:param name="maxInclusive">5</rng:param>
       </rng:data>
     </content>
-  </macroSpec>-->
-  <macroSpec ident="data.GLISSANDO" module="MEI" type="dt">
+  </dataSpec>-->
+  <dataSpec ident="data.GLISSANDO" module="MEI">
     <desc xml:lang="en">Analytical glissando attribute values.</desc>
     <content>
       <valList type="closed">
@@ -1532,8 +1532,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.GRACE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.GRACE" module="MEI">
     <desc xml:lang="en">Do grace notes get time from the current (acc) or previous (unacc) one?</desc>
     <content>
       <valList type="closed">
@@ -1548,8 +1548,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.HEADSHAPE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.HEADSHAPE" module="MEI">
     <desc xml:lang="en">Note head shapes.</desc>
     <content>
       <rng:choice>
@@ -1558,8 +1558,8 @@
         <rng:ref name="data.NMTOKEN"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.HEADSHAPE.list" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.HEADSHAPE.list" module="MEI">
     <desc xml:lang="en">Enumerated note head shapes.</desc>
     <content>
       <valList type="closed">
@@ -1613,16 +1613,16 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.HEXNUM" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.HEXNUM" module="MEI">
     <desc xml:lang="en">Hexadecimal number.</desc>
     <content>
       <rng:data type="string">
         <rng:param name="pattern">(#x|U\+)[A-F0-9]+</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.HORIZONTALALIGNMENT" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.HORIZONTALALIGNMENT" module="MEI">
     <desc xml:lang="en">Data values for attributes that capture horizontal alignment.</desc>
     <content>
       <valList type="closed">
@@ -1640,8 +1640,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <!--<macroSpec ident="data.INEUMEFORM" module="MEI" type="dt">
+  </dataSpec>
+  <!--<dataSpec ident="data.INEUMEFORM" module="MEI">
     <desc xml:lang="en">Interrupted neume forms.</desc>
     <content>
       <valList type="closed">
@@ -1652,8 +1652,8 @@
         <valItem ident="tiedliquescent2"/>
       </valList>
     </content>
-  </macroSpec>-->
-  <!--<macroSpec ident="data.INEUMENAME" module="MEI" type="dt">
+  </dataSpec>-->
+  <!--<dataSpec ident="data.INEUMENAME" module="MEI">
     <desc xml:lang="en">Interrupted neume, <abbr>i.e.</abbr>, neume written as 2 or more sub-neumes.</desc>
     <content>
       <valList type="closed">
@@ -1689,7 +1689,7 @@
       </p>
     </remarks>
   </macroSpec>
-  <macroSpec ident="data.INTERVAL.MELODIC" module="MEI" type="dt">
+  <dataSpec ident="data.INTERVAL.MELODIC" module="MEI">
     <desc xml:lang="en">A token indicating direction of the interval but not its precise value, a diatonic
       interval (with optional direction and quality), or a decimal value in half steps. Decimal
       values are permitted to accommodate micro-tuning.</desc>
@@ -1744,8 +1744,8 @@
         </list>
       </p>
     </remarks>
-  </macroSpec>
-  <macroSpec ident="data.ISODATE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.ISODATE" module="MEI">
     <desc xml:lang="en">ISO date formats.</desc>
     <content>
       <rng:choice>
@@ -1762,23 +1762,23 @@
         </rng:data>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.ISOTIME" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.ISOTIME" module="MEI">
     <desc xml:lang="en">ISO 24-hour time format: HH:MM:SS.ss, <abbr>i.e.</abbr>,
       [0-9][0-9]:[0-9][0-9]:[0-9][0-9](\.?[0-9]*)?.</desc>
     <content>
       <rng:data type="time"/>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.KEYFIFTHS" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.KEYFIFTHS" module="MEI">
     <desc xml:lang="en">Indicates the location of the tonic in the circle of fifths.</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">mixed|0|([1-9]|1[0-2])[f|s]</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.LAYERSCHEME" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.LAYERSCHEME" module="MEI">
     <desc xml:lang="en">Indicates how stems should be drawn when more than one layer is present and stem
       directions are not indicated on the notes/chords themselves. '1' indicates that there is only
       a single layer on a staff. '2o' means there are two layers with opposing stems. '2f' indicates
@@ -1804,8 +1804,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.LIGATUREFORM" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.LIGATUREFORM" module="MEI">
     <desc xml:lang="en">Ligature forms.</desc>
     <content>
       <valList type="closed">
@@ -1817,8 +1817,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.LINEFORM" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.LINEFORM" module="MEI">
     <desc xml:lang="en">Visual form of a line.</desc>
     <content>
       <valList type="closed">
@@ -1836,8 +1836,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.LINESTARTENDSYMBOL" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.LINESTARTENDSYMBOL" module="MEI">
     <desc xml:lang="en">Symbol that may begin/end a line.</desc>
     <content>
       <valList type="closed">
@@ -1907,8 +1907,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.LINEWIDTH" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.LINEWIDTH" module="MEI">
     <desc xml:lang="en">Datatype of line width measurements.</desc>
     <content>
       <rng:choice>
@@ -1916,8 +1916,8 @@
         <rng:ref name="data.MEASUREMENTUNSIGNED"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.LINEWIDTHTERM" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.LINEWIDTHTERM" module="MEI">
     <desc xml:lang="en">Relative width of a line.</desc>
     <content>
       <valList type="closed">
@@ -1932,8 +1932,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MEASUREBEAT" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MEASUREBEAT" module="MEI">
     <desc xml:lang="en">A count of measures plus a beat location, <abbr>i.e.</abbr>, [0-9]+m *\+ *[0-9]+(\.?[0-9]*)?. The
       measure count is the number of bar lines crossed by the event, while the beat location is a
       timestamp expressed as a beat with an optional fractional part. For example, "1m+3.5"
@@ -1948,8 +1948,8 @@
         <rng:param name="pattern">([0-9]+m\s*\+\s*)?[0-9]+(\.?[0-9]*)?</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MEASUREBEATOFFSET" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MEASUREBEATOFFSET" module="MEI">
     <desc xml:lang="en">A count of measures plus a beat location, <abbr>i.e.</abbr>, (\+|-)?[0-9]+m\+[0-9]+(\.?[0-9]*)?. The
       measure count is the number of bar lines crossed by the event, while the beat location is a
       timestamp expressed as a beat with an optional fractional part. The measure number must be in
@@ -1965,8 +1965,8 @@
         <rng:param name="pattern">(\+|-)?[0-9]+m\+[0-9]+(\.[0-9]*)?</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MEASUREMENTUNSIGNED" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MEASUREMENTUNSIGNED" module="MEI">
     <desc xml:lang="en">Measurement expressed in real-world (<abbr>e.g.</abbr>, centimeters, millimeters, inches, points,
       picas, or pixels) or virtual units (vu). 'vu' is the default value. Unlike
       data.MEASUREMENTSIGNED, only positive values are allowed.</desc>
@@ -1975,8 +1975,8 @@
         <rng:param name="pattern">(\+)?\d+(\.\d+)?(cm|mm|in|pt|pc|px|vu)?</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MEASUREMENTSIGNED" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MEASUREMENTSIGNED" module="MEI">
     <desc xml:lang="en">Measurement expressed in real-world (<abbr>e.g.</abbr>, centimeters, millimeters, inches, points,
       picas, or pixels) or virtual units (vu). 'vu' is the default value. Unlike
       data.MEASUREMENTUNSIGNED, in which only positive values are allowed, both positive and negative
@@ -1986,8 +1986,8 @@
         <rng:param name="pattern">(\+|-)?\d+(\.\d+)?(cm|mm|in|pt|pc|px|vu)?</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MEASUREMENTFONTUNSIGNED" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MEASUREMENTFONTUNSIGNED" module="MEI">
     <desc xml:lang="en">Measurement expressed relative to properties of the current font, in analogy to the
       respective CSS length units. Unlike data.MEASUREMENTFONTUNSIGNED, only positive values are
       allowed.</desc>
@@ -1996,8 +1996,8 @@
         <rng:param name="pattern">\d+(\.\d+)?(ch|em|ex)?</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MEASUREMENTFONTSIGNED" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MEASUREMENTFONTSIGNED" module="MEI">
     <desc xml:lang="en">Measurement expressed relative to properties of the current font, in analogy to the
       respective CSS length units. Unlike data.MEASUREMENTFONTUNSIGNED, both positive and negative values
       are allowed.</desc>
@@ -2006,8 +2006,8 @@
         <rng:param name="pattern">(\+|-)?\d+(\.\d+)?(ch|em|ex)?</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MEASUREMENTTYPOGRAPHYUNSIGNED" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MEASUREMENTTYPOGRAPHYUNSIGNED" module="MEI">
     <desc xml:lang="en">Measurements used for typographical features. Unlike data.MEASUREMENTTYPOGRAPHYSIGNED, only
       positive values are allowed.</desc>
     <content>
@@ -2016,8 +2016,8 @@
         <rng:ref name="data.MEASUREMENTUNSIGNED"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MEASUREMENTTYPOGRAPHYSIGNED" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MEASUREMENTTYPOGRAPHYSIGNED" module="MEI">
     <desc xml:lang="en">Measurements used for typographical features. Unlike data.MEASUREMENTTYPOGRAPHYSIGNED, both
       positive and negative values are allowed.</desc>
     <content>
@@ -2026,8 +2026,8 @@
         <rng:ref name="data.MEASUREMENTSIGNED"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MELODICFUNCTION" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MELODICFUNCTION" module="MEI">
     <desc xml:lang="en">Indication of melodic function, <abbr>i.e.</abbr>, anticipation, lower neighbor, escape tone,
       etc.</desc>
     <content>
@@ -2118,8 +2118,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MENSURATIONSIGN" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MENSURATIONSIGN" module="MEI">
     <desc xml:lang="en">Mensuration signs attribute values.</desc>
     <content>
       <valList type="closed">
@@ -2170,8 +2170,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.METERFORM" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.METERFORM" module="MEI">
     <desc xml:lang="en">Contains an indication of how a meter signature should be rendered.</desc>
     <content>
       <valList type="closed">
@@ -2189,8 +2189,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.METERSIGN" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.METERSIGN" module="MEI">
     <desc xml:lang="en">Meter.sym attribute values for CMN.</desc>
     <content>
       <valList type="closed">
@@ -2205,16 +2205,16 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MIDICHANNEL" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MIDICHANNEL" module="MEI">
     <desc xml:lang="en">MIDI channel number. One-based values must be followed by a lower-case letter "o".</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">0|([1-9]|1[0-5])o?|16o</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MIDIBPM" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MIDIBPM" module="MEI">
     <desc xml:lang="en">Tempo expressed as "beats" per minute, where "beat" is always defined as a quarter note,
       *not the numerator of the time signature or the metronomic indication*.</desc>
     <content>
@@ -2222,15 +2222,15 @@
         <rng:param name="minExclusive">0</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MIDIMSPB" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MIDIMSPB" module="MEI">
     <desc xml:lang="en">Tempo expressed as microseconds per "beat", where "beat" is always defined as a quarter
       note, *not the numerator of the time signature or the metronomic indication*.</desc>
     <content>
       <rng:data type="positiveInteger"/>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MIDINAMES" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MIDINAMES" module="MEI">
     <desc xml:lang="en">General MIDI instrument names.</desc>
     <content>
       <valList type="closed">
@@ -2768,16 +2768,16 @@
       <p>MEI uses 0-based program numbers.</p>
       <p>Percussion sounds are available when the MIDI channel is set to "10".</p>
     </remarks>
-  </macroSpec>
-  <macroSpec ident="data.MIDIVALUE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MIDIVALUE" module="MEI">
     <desc xml:lang="en">Generic MIDI value. One-based values must be followed by a lower-case letter "o".</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">0|([1-9]|[1-9][0-9]|1([0-1][0-9]|2[0-7]))o?|128o</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MIDIVALUE_NAME" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MIDIVALUE_NAME" module="MEI">
     <desc xml:lang="en">data.MIDIVALUE or data.NCName values.</desc>
     <content>
       <rng:choice>
@@ -2785,8 +2785,8 @@
         <rng:ref name="data.NCNAME"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MIDIVALUE_PAN" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MIDIVALUE_PAN" module="MEI">
     <desc xml:lang="en">data.MIDIVALUE or data.PERCENT.LIMITED.SIGNED values.</desc>
     <content>
       <rng:choice>
@@ -2794,8 +2794,8 @@
         <rng:ref name="data.PERCENT.LIMITED.SIGNED"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MIDIVALUE_PERCENT" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MIDIVALUE_PERCENT" module="MEI">
     <desc xml:lang="en">data.MIDIVALUE or data.PERCENT.LIMITED values.</desc>
     <content>
       <rng:choice>
@@ -2803,8 +2803,8 @@
         <rng:ref name="data.PERCENT.LIMITED"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MODE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MODE" module="MEI">
     <desc xml:lang="en">Modes.</desc>
     <content>
       <rng:choice>
@@ -2813,8 +2813,8 @@
         <rng:ref name="data.MODE.extended"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MODE.cmn" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MODE.cmn" module="MEI">
     <desc xml:lang="en">Common modes.</desc>
     <content>
       <valList type="closed">
@@ -2826,8 +2826,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MODE.gregorian" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MODE.gregorian" module="MEI">
     <desc xml:lang="en">Gregorian modes.</desc>
     <content>
       <valList type="closed">
@@ -2860,8 +2860,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MODE.extended" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MODE.extended" module="MEI">
     <desc xml:lang="en">Modern modes.</desc>
     <content>
       <valList type="semi">
@@ -2885,8 +2885,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MODSRELATIONSHIP" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MODSRELATIONSHIP" module="MEI">
     <desc xml:lang="en">Bibliographic relationship values based on MODS version 3.4.</desc>
     <content>
       <valList type="closed">
@@ -2921,8 +2921,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MODUSMAIOR" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MODUSMAIOR" module="MEI">
     <desc xml:lang="en">Maxima-long relationship values.</desc>
     <content>
       <rng:data type="positiveInteger">
@@ -2930,8 +2930,8 @@
         <rng:param name="maxInclusive">3</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MODUSMINOR" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MODUSMINOR" module="MEI">
     <desc xml:lang="en">Long-breve relationship values.</desc>
     <content>
       <rng:data type="positiveInteger">
@@ -2939,28 +2939,28 @@
         <rng:param name="maxInclusive">3</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.MUSICFONT" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.MUSICFONT" module="MEI">
     <desc xml:lang="en">Music font family.</desc>
     <content>
       <rng:data type="token"/>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.NCNAME" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.NCNAME" module="MEI">
     <desc xml:lang="en">"Convenience" datatype that permits combining enumerated values with a user-supplied
       name.</desc>
     <content>
       <rng:data type="NCName"/>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.NMTOKEN" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.NMTOKEN" module="MEI">
     <desc xml:lang="en">"Convenience" datatype that permits combining enumerated values with user-supplied
       values.</desc>
     <content>
       <rng:data type="NMTOKEN"/>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.NONSTAFFPLACE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.NONSTAFFPLACE" module="MEI">
     <desc xml:lang="en">Non-staff location.</desc>
     <content>
       <valList type="closed">
@@ -3008,8 +3008,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.NOTATIONTYPE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.NOTATIONTYPE" module="MEI">
     <desc xml:lang="en">Notation type and subtype</desc>
     <content>
       <valList type="closed">
@@ -3053,8 +3053,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.NOTEHEADMODIFIER" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.NOTEHEADMODIFIER" module="MEI">
     <desc xml:lang="en">Captures any notehead "modifiers"; that is, symbols added to the notehead, such as
       slashes, lines, text, and enclosures, etc.</desc>
     <content>
@@ -3063,8 +3063,8 @@
         <rng:ref name="data.NOTEHEADMODIFIER.pat"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.NOTEHEADMODIFIER.list" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.NOTEHEADMODIFIER.list" module="MEI">
     <desc xml:lang="en">Enumerated note head modifier values.</desc>
     <content>
       <valList type="closed">
@@ -3100,8 +3100,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.NOTEHEADMODIFIER.pat" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.NOTEHEADMODIFIER.pat" module="MEI">
     <desc xml:lang="en">Captures text rendered in the center of the notehead.</desc>
     <content>
       <rng:choice>
@@ -3113,16 +3113,16 @@
         </rng:data>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.OCTAVE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.OCTAVE" module="MEI">
     <desc xml:lang="en">Octave number. The default values conform to the Scientific Pitch Notation (SPN).</desc>
     <content>
       <rng:data type="nonNegativeInteger">
         <rng:param name="maxInclusive">9</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.OCTAVE.DIS" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.OCTAVE.DIS" module="MEI">
     <desc xml:lang="en">The amount of octave displacement; that is, '8' (as in '8va' for 1 octave), '15' (for 2
       octaves), or rarely '22' (for 3 octaves).</desc>
     <content>
@@ -3130,16 +3130,16 @@
         <rng:param name="pattern">8|15|22</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.ORIENTATION" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.ORIENTATION" module="MEI">
     <desc xml:lang="en">Rotation or reflection of base symbol values.</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">reversed|90CW|90CCW</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.NEIGHBORINGLAYER" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.NEIGHBORINGLAYER" module="MEI">
     <desc xml:lang="en">For musical material designated to appear on an adjacent layer or staff, the location of the layer
       relative to the current one; <abbr>i.e.</abbr>, the layer above or the layer below.</desc>
     <content>
@@ -3152,8 +3152,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.PAGE.PANELS" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.PAGE.PANELS" module="MEI">
     <desc xml:lang="en">The number of panels per page.</desc>
     <content>
       <rng:data type="positiveInteger">
@@ -3161,8 +3161,8 @@
         <rng:param name="maxInclusive">2</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.PEDALSTYLE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.PEDALSTYLE" module="MEI">
     <desc xml:lang="en">Styling of piano pedal marks.</desc>
     <content>
       <valList type="closed">
@@ -3184,32 +3184,32 @@
         </valItem>
       </valList>
     </content>
-</macroSpec>
-  <macroSpec ident="data.PERCENT" module="MEI" type="dt">
+</dataSpec>
+  <dataSpec ident="data.PERCENT" module="MEI">
     <desc xml:lang="en">Positive decimal number plus '%', <abbr>i.e.</abbr>, [0-9]+(\.[0-9]*)?%.</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">[0-9]+(\.[0-9]*)?%</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.PERCENT.LIMITED" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.PERCENT.LIMITED" module="MEI">
     <desc xml:lang="en">Decimal number between 0 and 100, followed by a percent sign "%".</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">(([0-9]|[1-9][0-9])(\.[0-9]*)?|100(\.0*)?)%</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.PERCENT.LIMITED.SIGNED" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.PERCENT.LIMITED.SIGNED" module="MEI">
     <desc xml:lang="en">Decimal number between -100 and 100, followed by a percent sign "%".</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">(\+|-)?(([0-9]|[1-9][0-9])(\.[0-9]*)?|100(\.0*)?)%</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.PGFUNC" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.PGFUNC" module="MEI">
     <desc xml:lang="en">Page header and footer function; a value that defines the function (i.e., the placement) of the header or the footer.</desc>
     <content>
       <valList type="closed">
@@ -3233,24 +3233,24 @@
     <remarks xml:lang="en">
       <p>An alternating pattern with "alt1" and "alt2" starts from the first page. However, if header or footer with a func="first" is also defined, it will shift the pattern by one page. A header or footer with func="last" will interupt the pattern.</p>
     </remarks>
-  </macroSpec>
-  <macroSpec ident="data.PGSCALE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.PGSCALE" module="MEI">
     <desc xml:lang="en">Page scale factor; a percentage of the values in page.height and page.width.</desc>
     <content>
       <rng:choice>
         <rng:ref name="data.PERCENT"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.PITCHCLASS" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.PITCHCLASS" module="MEI">
     <desc xml:lang="en">Pclass (pitch class) attribute values.</desc>
     <content>
       <rng:data type="nonNegativeInteger">
         <rng:param name="maxInclusive">11</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.PITCHNAME" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.PITCHNAME" module="MEI">
     <desc xml:lang="en">The pitch names (gamut) used within a single octave. The default values conform to
       Acoustical Society of America representation.</desc>
     <content>
@@ -3258,8 +3258,8 @@
         <rng:param name="pattern">[a-g]</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.PITCHNAME.GESTURAL" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.PITCHNAME.GESTURAL" module="MEI">
     <desc xml:lang="en">Gestural pitch names need an additional value for when the notated pitch is not to be
       sounded.</desc>
     <content>
@@ -3267,14 +3267,14 @@
         <rng:param name="pattern">[a-g]|none</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.PITCHNUMBER" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.PITCHNUMBER" module="MEI">
     <desc xml:lang="en">Pnum (pitch number, <abbr>e.g.</abbr>, MIDI) attribute values.</desc>
     <content>
       <rng:data type="nonNegativeInteger"/>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.PLACEMENT" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.PLACEMENT" module="MEI">
     <desc xml:lang="en">Location information.</desc>
     <content>
       <rng:choice>
@@ -3294,8 +3294,8 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-  </macroSpec>
-  <macroSpec ident="data.PROLATIO" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.PROLATIO" module="MEI">
     <desc xml:lang="en">Semibreve-minim relationship values.</desc>
     <content>
       <rng:data type="positiveInteger">
@@ -3303,16 +3303,16 @@
         <rng:param name="maxInclusive">3</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <!--<macroSpec ident="data.RATIO" module="MEI" type="dt">
+  </dataSpec>
+  <!--<dataSpec ident="data.RATIO" module="MEI">
     <desc xml:lang="en">A ratio, <abbr>i.e.</abbr>, [0-9]+(\.?[0-9]*)?:[0-9]+(\.?[0-9]*)? For example, "40:7.2319".</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">[0-9]+(\.?[0-9]*)?:[0-9]+(\.?[0-9]*)?</rng:param>
       </rng:data>
     </content>
-  </macroSpec>-->
-  <macroSpec ident="data.RELATIONSHIP" module="MEI" type="dt">
+  </dataSpec>-->
+  <dataSpec ident="data.RELATIONSHIP" module="MEI">
     <desc xml:lang="en">General-purpose relationships</desc>
     <content>
       <rng:choice>
@@ -3321,8 +3321,8 @@
         <rng:ref name="data.NMTOKEN"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.ROTATION" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.ROTATION" module="MEI">
     <desc xml:lang="en">Rotation.</desc>
     <content>
       <rng:choice>
@@ -3330,8 +3330,8 @@
         <rng:ref name="data.ROTATIONDIRECTION"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.ROTATIONDIRECTION" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.ROTATIONDIRECTION" module="MEI">
     <desc xml:lang="en">Rotation term.</desc>
     <content>
       <valList type="closed">
@@ -3358,16 +3358,16 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.SCALEDEGREE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.SCALEDEGREE" module="MEI">
     <desc xml:lang="en">Scale degree values.</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">(\^|v)?[1-7](\+|\-)?</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.SLASH" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.SLASH" module="MEI">
     <desc xml:lang="en">The number of slashes to be rendered for tremolandi.</desc>
     <content>
       <rng:data type="positiveInteger">
@@ -3375,8 +3375,8 @@
         <rng:param name="maxInclusive">6</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.SLUR" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.SLUR" module="MEI">
     <desc xml:lang="en">i=initial, m=medial, t=terminal. Number is used to match endpoints of the slur when slurs
       are nested or overlap.</desc>
     <content>
@@ -3391,8 +3391,8 @@
 <note slur="t2"/>
         </egXML>
     </exemplum>
-  </macroSpec>
-  <macroSpec ident="data.STAFFITEM" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.STAFFITEM" module="MEI">
     <desc xml:lang="en">Items that may be printed above, below, or between staves.</desc>
     <content>
       <rng:choice>
@@ -3402,8 +3402,8 @@
         <rng:ref name="data.STAFFITEM.neumes"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.STAFFITEM.basic" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.STAFFITEM.basic" module="MEI">
     <desc xml:lang="en">Items in all repertoires that may be printed near a staff.</desc>
     <content>
       <valList type="closed">
@@ -3441,8 +3441,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.STAFFLOC" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.STAFFLOC" module="MEI">
     <desc xml:lang="en">Staff location. The value <val>0</val> indicates the bottom line of the current staff; positive
       values are used for positions above the bottom line and negative values for the positions
       below. For example, in treble clef, 1 = F4, 2 = G4, 3 = A4, etc. and -1 = D4, -2 = C4, and so
@@ -3450,8 +3450,8 @@
     <content>
       <rng:data type="integer"/>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.STAFFREL" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.STAFFREL" module="MEI">
     <desc xml:lang="en">Location of musical material relative to a staff.</desc>
     <content>
       <rng:choice>
@@ -3474,8 +3474,8 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-  </macroSpec>
-  <macroSpec ident="data.STAFFREL.basic" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.STAFFREL.basic" module="MEI">
     <desc xml:lang="en">Location of symbol relative to a staff.</desc>
     <content>
       <valList type="closed">
@@ -3487,8 +3487,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.STAFFREL.extended" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.STAFFREL.extended" module="MEI">
     <desc xml:lang="en">Location of symbol relative to a staff.</desc>
     <content>
       <valList type="closed">
@@ -3500,8 +3500,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.STEMDIRECTION" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.STEMDIRECTION" module="MEI">
     <desc xml:lang="en">Stem direction.</desc>
     <content>
       <rng:choice>
@@ -3509,8 +3509,8 @@
         <rng:ref name="data.STEMDIRECTION.extended"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.STEMDIRECTION.basic" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.STEMDIRECTION.basic" module="MEI">
     <desc xml:lang="en">Common stem directions.</desc>
     <content>
       <valList type="closed">
@@ -3522,8 +3522,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.STEMDIRECTION.extended" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.STEMDIRECTION.extended" module="MEI">
     <desc xml:lang="en">Additional stem directions.</desc>
     <content>
       <valList type="closed">
@@ -3547,8 +3547,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.STEMMODIFIER" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.STEMMODIFIER" module="MEI">
     <desc xml:lang="en">Stem modification.</desc>
     <content>
       <valList type="closed">
@@ -3581,8 +3581,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.STEMPOSITION" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.STEMPOSITION" module="MEI">
     <desc xml:lang="en">Position of a note’s stem relative to the head of the note.</desc>
     <content>
       <valList type="closed">
@@ -3597,14 +3597,14 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.STRINGNUMBER" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.STRINGNUMBER" module="MEI">
     <desc xml:lang="en">This datatype is deprecated in favor of data.COURSENUMBER and will be removed in a future version. In string tablature, the number of the string to be played.</desc>
     <content>
       <rng:data type="positiveInteger"/>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.TEMPERAMENT" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.TEMPERAMENT" module="MEI">
     <desc xml:lang="en">Temperament or tuning system.</desc>
     <content>
       <valList type="closed">
@@ -3622,14 +3622,14 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.TEMPOVALUE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.TEMPOVALUE" module="MEI">
     <desc xml:lang="en">Beats (meter signature denominator) per minute, <abbr>e.g.</abbr>, 120.</desc>
     <content>
       <rng:data type="decimal"/>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.TEMPUS" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.TEMPUS" module="MEI">
     <desc xml:lang="en">Breve-semibreve relationship values.</desc>
     <content>
       <rng:data type="positiveInteger">
@@ -3637,8 +3637,8 @@
         <rng:param name="maxInclusive">3</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.TEXTRENDITIONLIST" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.TEXTRENDITIONLIST" module="MEI">
     <desc xml:lang="en">Closed list of text rendition values.</desc>
     <content>
       <valList type="closed">
@@ -3735,8 +3735,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.TEXTRENDITIONPAR" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.TEXTRENDITIONPAR" module="MEI">
     <desc xml:lang="en">Parameterized text rendition values.</desc>
     <content>
       <rng:data type="string">
@@ -3744,8 +3744,8 @@
           >(underline|overline|line-through|strike|x-through)\(\d+\)</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.TEXTRENDITION" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.TEXTRENDITION" module="MEI">
     <desc xml:lang="en">Text rendition values.</desc>
     <content>
       <rng:choice>
@@ -3753,31 +3753,31 @@
         <rng:ref name="data.TEXTRENDITIONPAR"/>
       </rng:choice>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.TIE" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.TIE" module="MEI">
     <desc xml:lang="en">Tie attribute values: initial, medial, terminal.</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">[i|m|t]</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.TSTAMPOFFSET" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.TSTAMPOFFSET" module="MEI">
     <desc xml:lang="en">A positive or negative offset from the value given in the tstamp attribute in terms of
       musical time, <abbr>i.e.</abbr>, beats[.fractional beat part].</desc>
     <content>
       <rng:data type="decimal"/>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.TUPLET" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.TUPLET" module="MEI">
     <desc xml:lang="en">Tuplet attribute values: initial, medial, terminal.</desc>
     <content>
       <rng:data type="token">
         <rng:param name="pattern">[i|m|t][1-6]</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
-  <!--<macroSpec ident="data.UNEUMEFORM" module="MEI" type="dt">
+  </dataSpec>
+  <!--<dataSpec ident="data.UNEUMEFORM" module="MEI">
     <desc xml:lang="en">Basic, <abbr>i.e.</abbr>, single, uninterrupted, neume forms.</desc>
     <content>
       <valList type="closed">
@@ -3790,8 +3790,8 @@
         <valItem ident="tied"/>
       </valList>
     </content>
-  </macroSpec>-->
-  <!--<macroSpec ident="data.UNEUMENAME" module="MEI" type="dt">
+  </dataSpec>-->
+  <!--<dataSpec ident="data.UNEUMENAME" module="MEI">
     <desc xml:lang="en">Basic, <abbr>i.e.</abbr>, single, uninterrupted, neume names.</desc>
     <content>
       <valList type="closed">
@@ -3810,14 +3810,14 @@
         <valItem ident="virgastrata"/>
       </valList>
     </content>
-  </macroSpec>-->
-  <macroSpec ident="data.URI" module="MEI" type="dt">
+  </dataSpec>-->
+  <dataSpec ident="data.URI" module="MEI">
     <desc xml:lang="en">A Uniform Resource Identifier, see [RFC2396].</desc>
     <content>
       <rng:data type="anyURI"/>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.VERTICALALIGNMENT" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.VERTICALALIGNMENT" module="MEI">
     <desc xml:lang="en">Data values for attributes that capture vertical alignment.</desc>
     <content>
       <valList type="closed">
@@ -3835,8 +3835,8 @@
         </valItem>
       </valList>
     </content>
-  </macroSpec>
-  <macroSpec ident="data.WORD" module="MEI" type="dt">
+  </dataSpec>
+  <dataSpec ident="data.WORD" module="MEI">
     <desc xml:lang="en">A single "word" that contains only letters, digits, punctuation characters, or symbols. It
       cannot contain whitespace.</desc>
     <content>
@@ -3844,7 +3844,7 @@
         <rng:param name="pattern">(\p{L}|\p{N}|\p{P}|\p{S})*</rng:param>
       </rng:data>
     </content>
-  </macroSpec>
+  </dataSpec>
   <classSpec ident="att.notationType" module="MEI" type="atts">
     <desc xml:lang="en">Attributes that provide for classification of notation.</desc>
     <attList>

--- a/source/validation/mei-source.sch
+++ b/source/validation/mei-source.sch
@@ -82,7 +82,7 @@
             <sch:let name="name" value="string(@name)"/>
             <sch:let name="elements" value="//tei:elementSpec/@ident/string()"/>
             <sch:let name="models" value="//tei:classSpec[@type = 'model']/@ident/string()"/>
-            <sch:let name="macros" value="//tei:macroSpec[@type ='pe']/@ident/string()"/>
+            <sch:let name="macros" value="//tei:macroSpec/@ident/string()"/>
             <sch:let name="datatypes" value="//tei:dataSpec/@ident/string()"/>
             <sch:assert role="error"
                 test="$name = $elements or $name = $models or $name = $macros or $name = $datatypes or $name = ('svg', 'svg_svg')">

--- a/source/validation/mei-source.sch
+++ b/source/validation/mei-source.sch
@@ -52,7 +52,7 @@
             <sch:let name="elements" value="//tei:elementSpec/@ident/string()"/>
             <sch:let name="atts" value="//tei:classSpec[@type ='atts']/@ident/string()"/>
             <sch:let name="models" value="//tei:classSpec[@type ='model']/@ident/string()"/>
-            <sch:let name="macros" value="//tei:macroSpec[@type ='pe']/@ident/string()"/>
+            <sch:let name="macros" value="//tei:macroSpec/@ident/string()"/>
             <sch:assert role="error"
                 test="$key = $elements or $key = $atts or $key = $models or $key = $macros">
                 The &lt;specDesc&gt; referencing "<sch:value-of select="$key"/>" is broken: There is no such thing in the specs.</sch:assert>
@@ -67,7 +67,7 @@
             <sch:let name="key" value="string(@key)"/>
             <sch:let name="atts" value="//tei:classSpec[@type ='atts']/@ident/string()"/>
             <sch:let name="models" value="//tei:classSpec[@type ='model']/@ident/string()"/>
-            <sch:let name="macros" value="//tei:macroSpec[@type ='pe']/@ident/string()"/>
+            <sch:let name="macros" value="//tei:macroSpec/@ident/string()"/>
             <sch:assert role="error"
                 test="$key = $atts or $key = $models or $key = $macros">
                 The &lt;memberOf&gt; referencing "<sch:value-of select="$key"/>" is broken: There is no such thing in the specs.</sch:assert>
@@ -177,7 +177,7 @@
                 <sch:value-of select="$ident"/> is not used by any &lt;memberOf key="<sch:value-of select="$ident"/>"/&gt; or &lt;rng:ref name="<sch:value-of select="$ident"/>"/&gt;element. Is it really necessary?
             </sch:assert>
         </sch:rule>
-        <sch:rule context="tei:macroSpec[@type = 'pe']">
+        <sch:rule context="tei:macroSpec">
             <sch:let name="all.refs" value="//rng:ref/string(@name)"/>
             <sch:let name="ident" value="@ident"/>
             <sch:assert test="$ident = $all.refs" role="warning">

--- a/source/validation/mei-source.sch
+++ b/source/validation/mei-source.sch
@@ -83,7 +83,7 @@
             <sch:let name="elements" value="//tei:elementSpec/@ident/string()"/>
             <sch:let name="models" value="//tei:classSpec[@type = 'model']/@ident/string()"/>
             <sch:let name="macros" value="//tei:macroSpec[@type ='pe']/@ident/string()"/>
-            <sch:let name="datatypes" value="//tei:macroSpec[@type ='dt']/@ident/string()"/>
+            <sch:let name="datatypes" value="//tei:dataSpec/@ident/string()"/>
             <sch:assert role="error"
                 test="$name = $elements or $name = $models or $name = $macros or $name = $datatypes or $name = ('svg', 'svg_svg')">
                 The &lt;rng:ref&gt; to "<sch:value-of select="$name"/>" is broken: There is no such thing in the specs.</sch:assert>
@@ -192,7 +192,7 @@
                 Element &lt;<sch:value-of select="$ident"/>&gt; seems not to be used by either a &lt;rng:ref name="<sch:value-of select="$ident"/>"/&gt; and isn't member of any model class. Is it really necessary?
             </sch:assert>
         </sch:rule>
-        <sch:rule context="tei:macroSpec[@type = 'dt']">
+        <sch:rule context="tei:dataSpec">
             <sch:let name="all.refs" value="//rng:ref/string(@name)"/>
             <sch:let name="all.macroRefs" value="//tei:macroRef/string(@key)"/>
             <sch:let name="ident" value="@ident"/>

--- a/utils/compare_versions/comparison.xsl
+++ b/utils/compare_versions/comparison.xsl
@@ -1052,7 +1052,7 @@
                     or count($added.values) gt 0
                     or count($removed.values) gt 0">
                     <tr class="c" id="{$current.macro}">
-                        <td class="macroSpec datatype ident">
+                        <td class="dataSpec datatype ident">
                             <xsl:value-of select="$current.macro"/>
                         </td>
                         <td class="module">
@@ -1132,7 +1132,7 @@
 
             </xsl:for-each>
         </xsl:variable>
-        <xsl:variable name="unchanged.models" select="$kept.models[not(. = $modified.models//td[@class='macroSpec datatype ident']/text())]" as="xs:string*"/>
+        <xsl:variable name="unchanged.models" select="$kept.models[not(. = $modified.models//td[@class='dataSpec datatype ident']/text())]" as="xs:string*"/>
 
         <h2>DataSpec Comparison (datatypes)</h2>
         <h3 id="dataSpecAdded"><xsl:value-of select="count($added.models)"/> new dataSpecs:</h3>

--- a/utils/guidelines_xslt/odd2html/generateSearchIndex.xsl
+++ b/utils/guidelines_xslt/odd2html/generateSearchIndex.xsl
@@ -32,7 +32,7 @@
         </xsl:variable>
         
         <xsl:variable name="macros" as="element(json:map)*">
-            <xsl:for-each select="$mei.source//tei:macroSpec[@type = 'pe']">
+            <xsl:for-each select="$mei.source//tei:macroSpec">
                 <xsl:variable name="current.macro.group" select="." as="element(tei:macroSpec)"/>
                 <map xmlns="http://www.w3.org/2005/xpath-functions">
                     <string key="ident"><xsl:value-of select="$current.macro.group/@ident"/></string>

--- a/utils/guidelines_xslt/odd2html/generateSearchIndex.xsl
+++ b/utils/guidelines_xslt/odd2html/generateSearchIndex.xsl
@@ -71,8 +71,8 @@
         </xsl:variable>
         
         <xsl:variable name="datatypes" as="element(json:map)*">
-            <xsl:for-each select="$mei.source//tei:macroSpec[@type = 'dt']">
-                <xsl:variable name="current.data.type" select="." as="element(tei:macroSpec)"/>
+            <xsl:for-each select="$mei.source//tei:macroSpec[@type = 'dt']|$mei.source//tei:dataSpec">
+                <xsl:variable name="current.data.type" select="." as="element(tei:dataSpec)"/>
                 <map xmlns="http://www.w3.org/2005/xpath-functions">
                     <string key="ident"><xsl:value-of select="$current.data.type/@ident"/></string>
                     <string key="desc"><xsl:value-of select="normalize-space(string-join($current.data.type/tei:desc//text(),' '))"/></string>

--- a/utils/guidelines_xslt/odd2html/generateSearchIndex.xsl
+++ b/utils/guidelines_xslt/odd2html/generateSearchIndex.xsl
@@ -71,7 +71,7 @@
         </xsl:variable>
         
         <xsl:variable name="datatypes" as="element(json:map)*">
-            <xsl:for-each select="$mei.source//tei:macroSpec[@type = 'dt']|$mei.source//tei:dataSpec">
+            <xsl:for-each select="$mei.source//tei:dataSpec">
                 <xsl:variable name="current.data.type" select="." as="element(tei:dataSpec)"/>
                 <map xmlns="http://www.w3.org/2005/xpath-functions">
                     <string key="ident"><xsl:value-of select="$current.data.type/@ident"/></string>

--- a/utils/guidelines_xslt/odd2html/globalVariables.xsl
+++ b/utils/guidelines_xslt/odd2html/globalVariables.xsl
@@ -229,7 +229,7 @@
         </xd:desc>
     </xd:doc>
     <xsl:variable name="macro.groups" as="node()*">
-        <xsl:for-each select="$mei.source//tei:macroSpec[@type = 'pe']">
+        <xsl:for-each select="$mei.source//tei:macroSpec">
             <xsl:sort select="@ident" data-type="text"/>
             <xsl:sequence select="."/>
         </xsl:for-each>

--- a/utils/guidelines_xslt/odd2html/globalVariables.xsl
+++ b/utils/guidelines_xslt/odd2html/globalVariables.xsl
@@ -193,7 +193,7 @@
         </xd:desc>
     </xd:doc>
     <xsl:variable name="data.types" as="node()*">
-        <xsl:for-each select="$mei.source//tei:macroSpec[@type = 'dt']|$mei.source//tei:dataSpec">
+        <xsl:for-each select="$mei.source//tei:dataSpec">
             <xsl:sort select="@ident" data-type="text"/>
             <xsl:sequence select="."/>
         </xsl:for-each>

--- a/utils/guidelines_xslt/odd2html/globalVariables.xsl
+++ b/utils/guidelines_xslt/odd2html/globalVariables.xsl
@@ -193,7 +193,7 @@
         </xd:desc>
     </xd:doc>
     <xsl:variable name="data.types" as="node()*">
-        <xsl:for-each select="$mei.source//tei:macroSpec[@type = 'dt']">
+        <xsl:for-each select="$mei.source//tei:macroSpec[@type = 'dt']|$mei.source//tei:dataSpec">
             <xsl:sort select="@ident" data-type="text"/>
             <xsl:sequence select="."/>
         </xsl:for-each>

--- a/utils/guidelines_xslt/odd2html/specs/dataTypeSpecs.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/dataTypeSpecs.xsl
@@ -15,7 +15,7 @@
         <xd:desc>
             <xd:p><xd:b>Created on:</xd:b> Nov 12, 2020</xd:p>
             <xd:p><xd:b>Author:</xd:b> Johannes Kepper</xd:p>
-            <xd:p>This file holds rules on how to generate spec pages for macroSpec[@type = 'dt']</xd:p>
+            <xd:p>This file holds rules on how to generate spec pages for dataSpec</xd:p>
             <xd:p>
                 A single data type page has the following facets:
                 <xd:ul>

--- a/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
@@ -1126,7 +1126,7 @@
     <xsl:function name="tools:getParentsByModel" as="node()*">
         <xsl:param name="object" as="node()"/>
         <xsl:variable name="is.element" select="local-name($object) = 'elementSpec'" as="xs:boolean"/>
-        <xsl:variable name="is.macroGroup" select="local-name($object) = 'macroSpec' and $object/@type = 'pe'" as="xs:boolean"/>
+        <xsl:variable name="is.macroGroup" select="local-name($object) = 'macroSpec'" as="xs:boolean"/>
         
         <xsl:variable name="direct.parents" select="$elements/self::tei:elementSpec[.//tei:content//rng:ref[@name = $object/@ident]]" as="node()*"/>
         
@@ -1373,7 +1373,7 @@
         
         <xsl:variable name="is.element" select="local-name($object) = 'elementSpec'" as="xs:boolean"/>
         <xsl:variable name="is.model" select="local-name($object) = 'classSpec' and $object/@type = 'model'" as="xs:boolean"/>
-        <xsl:variable name="is.macro" select="local-name($object) = 'macroSpec' and $object/@type = 'pe'" as="xs:boolean"/>
+        <xsl:variable name="is.macro" select="local-name($object) = 'macroSpec'" as="xs:boolean"/>
         <xsl:variable name="ident" select="if($is.element) then('direct children') else($object/@ident)" as="xs:string"/>
         <xsl:variable name="desc" select="if($is.element) then('') else('(' || $object/@module || ') ' || normalize-space(string-join($object/tei:desc/text(),' ')))" as="xs:string"/>
         

--- a/utils/guidelines_xslt/odd2html/specs/macroGroupSpecs.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/macroGroupSpecs.xsl
@@ -54,7 +54,7 @@
     
     <xd:doc>
         <xd:desc>
-            <xd:p>Creates a section for a single macroSpec</xd:p>
+            <xd:p>Creates a section for a all macroSpecs</xd:p>
         </xd:desc>
         <xd:param name="macro.group">the macro group</xd:param>
         <xd:return>the section element</xd:return>

--- a/utils/guidelines_xslt/odd2html/specs/macroGroupSpecs.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/macroGroupSpecs.xsl
@@ -54,7 +54,7 @@
     
     <xd:doc>
         <xd:desc>
-            <xd:p>Creates a section for a single macroSpec[@type='pe']</xd:p>
+            <xd:p>Creates a section for a single macroSpec</xd:p>
         </xd:desc>
         <xd:param name="macro.group">the macro group</xd:param>
         <xd:return>the section element</xd:return>

--- a/utils/guidelines_xslt/odd2html/specs/moduleSpecs.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/moduleSpecs.xsl
@@ -116,7 +116,7 @@
                 <div class="contentListBox">
                     <h3>Data Types in <xsl:value-of select="$module/@ident"/></h3>
                     <div class="contents">
-                        <xsl:variable name="items" select="$module.content//tei:macroSpec[@type = 'dt']|$module.content//tei:dataSpec" as="node()*"/>
+                        <xsl:variable name="items" select="$module.content//tei:dataSpec" as="node()*"/>
                         <xsl:for-each select="$items">
                             <a class="{tools:getLinkClasses(@ident)}" href="#{@ident}" title="{normalize-space(string-join(child::tei:desc//text(),' '))}"><xsl:value-of select="@ident"/></a><xsl:if test="position() lt count($items)">, </xsl:if>        
                         </xsl:for-each>

--- a/utils/guidelines_xslt/odd2html/specs/moduleSpecs.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/moduleSpecs.xsl
@@ -116,7 +116,7 @@
                 <div class="contentListBox">
                     <h3>Data Types in <xsl:value-of select="$module/@ident"/></h3>
                     <div class="contents">
-                        <xsl:variable name="items" select="$module.content//tei:macroSpec[@type = 'dt']" as="node()*"/>
+                        <xsl:variable name="items" select="$module.content//tei:macroSpec[@type = 'dt']|$module.content//tei:dataSpec" as="node()*"/>
                         <xsl:for-each select="$items">
                             <a class="{tools:getLinkClasses(@ident)}" href="#{@ident}" title="{normalize-space(string-join(child::tei:desc//text(),' '))}"><xsl:value-of select="@ident"/></a><xsl:if test="position() lt count($items)">, </xsl:if>        
                         </xsl:for-each>

--- a/utils/guidelines_xslt/odd2html/specs/moduleSpecs.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/moduleSpecs.xsl
@@ -92,7 +92,7 @@
                 <div class="contentListBox">
                     <h3>Macro Groups in <xsl:value-of select="$module/@ident"/></h3>
                     <div class="contents">
-                        <xsl:variable name="items" select="$module.content//tei:macroSpec[@type = 'pe']" as="node()*"/>
+                        <xsl:variable name="items" select="$module.content//tei:macroSpec" as="node()*"/>
                         <xsl:for-each select="$items">
                             <a class="{tools:getLinkClasses(@ident)}" href="#{@ident}" title="{normalize-space(string-join(child::tei:desc//text(),' '))}"><xsl:value-of select="@ident"/></a><xsl:if test="position() lt count($items)">, </xsl:if>        
                         </xsl:for-each>


### PR DESCRIPTION
This PR updates our ODDs to be valid TEI again. 

Background: the `macroSpec` element lost it's `@type` attribute long ago, and introduced the `dataSpec` element instead. These changes adopt the current TEI schema and adjust our XSLTs for generating the Guidelines accordingly. No changes in schema or Guidelines are expected.