### PR TITLE
utils: fix url creation for processing instructions in canonicalized file

### DIFF
--- a/utils/canonicalization/copy.xsl
+++ b/utils/canonicalization/copy.xsl
@@ -32,7 +32,7 @@
     
     <xsl:template match="/processing-instruction('xml-model')" mode="cleanup">
         <xsl:variable name="pi-value.tokens" select="tokenize(., ' ')"/>
-        <xsl:variable name="pi-href" select="replace($pi-value.tokens[1], '&quot;validation/', '../../../source/&quot;validation/' )"/>
+        <xsl:variable name="pi-href" select="replace($pi-value.tokens[1], '&quot;validation/', '&quot;../source/validation/')"/>
         <xsl:text>&#xa;</xsl:text>
         <xsl:processing-instruction name="xml-model">
             <xsl:value-of select="$pi-href, $pi-value.tokens[position() > 1]" separator=" "/>


### PR DESCRIPTION
This PR fixes a problem in the canonicalization process ending up with an invalid attribute value in the processing instructions:

`<?xml-model href=../../../source/"validation/mei_odds.rng"`
