### PR TITLE
schema: align method attribute with TEI

### DIFF
--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -305,7 +305,8 @@
     </remarks>
   </classSpec>
   <classSpec ident="att.regularMethod" module="MEI.header" type="atts">
-    <desc xml:lang="en">Attributes that describe correction and normalization methods.</desc>
+    <gloss xml:lang="en" versionDate="2024-07-22">regularization method</gloss>
+    <desc xml:lang="en" versionDate="2024-07-22">Attributes that describe correction and normalization methods.</desc>
     <attList>
       <attDef ident="method" usage="opt">
         <desc xml:lang="en">Indicates the method employed to mark corrections and normalizations.</desc>
@@ -313,8 +314,8 @@
           <valItem ident="silent">
             <desc xml:lang="en">Corrections and normalizations made silently.</desc>
           </valItem>
-          <valItem ident="tags">
-            <desc xml:lang="en">Corrections and normalizations indicated using elements.</desc>
+          <valItem ident="markup">
+            <desc xml:lang="en">Corrections and normalizations represented using markup.</desc>
           </valItem>
         </valList>
       </attDef>


### PR DESCRIPTION
This PR aligns the values in `att.regularMethod` with those in TEI's [correction](https://github.com/TEIC/TEI/blob/dev/P5/Source/Specs/correction.xml) and [normalization](https://github.com/TEIC/TEI/blob/dev/P5/Source/Specs/normalization.xml). In addition it adds a `gloss`.

Closes #1512.