### PR TITLE
utils: correctly display angle brackets in search queries

### DIFF
--- a/utils/guidelines_xslt/odd2html/generateSearchIndex.xsl
+++ b/utils/guidelines_xslt/odd2html/generateSearchIndex.xsl
@@ -173,7 +173,7 @@
                 
                 searchResultsBox.innerHTML = '';
                 
-                document.querySelector('#searchPattern').innerHTML = pattern;
+                document.querySelector('#searchPattern').innerText = pattern;
                 
                 const pathAdjust = (reducedLevels) ? './' : '../';
                 


### PR DESCRIPTION
When inserting search queries into the title of the search modal, the code previously set `.innerHTML`, which means that any query that could be interpreted as HTML (even if poorly formed!) would be rendered. While this is a markup injection vector, there's no security risk because search queries aren't sharable (i.e. they aren't stored in the URL). Instead, this is merely an annoyance to users attempting to search for XML tags.

For example, if you want to learn more about the `<measure>` element and put it in the search bar, this is what you see:
<img width="602" alt="Screen Shot 2024-08-10 at 3 30 38 PM" src="https://github.com/user-attachments/assets/9c6feea5-88cd-4f0e-89cb-58c61df10cb6">

This change instead uses `.innerText` so anything HTML-like in a query isn't rendered.

The search results aren't great for queries that include angle brackets or "@" signs, but that's a different issue.