### PR TITLE
docs: remove misleading regex

### DIFF
--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -25,7 +25,7 @@
     <desc xml:lang="en">Tablature component declarations.</desc>
   </moduleSpec>
   <macroSpec ident="data.COURSENUMBER" module="MEI.stringtab" type="dt">
-    <desc xml:lang="en" versionDate="2024-08-12">In string tablature, the number of the course to be played.</desc>
+    <desc xml:lang="en">In string tablature, the number of the course to be played.</desc>
     <content>
       <rng:data type="positiveInteger"/>
     </content>
@@ -97,7 +97,7 @@
         </datatype>
       </attDef>
       <attDef ident="tab.string" usage="opt">
-        <desc xml:lang="en">This attribute is deprecated in favour of <att>tab.course</att> and will be removed in a future version. Records which string is to be played.</desc>
+        <desc xml:lang="en">This attribute is deprecated in favor of <att>tab.course</att> and will be removed in a future version. Records which string is to be played.</desc>
         <datatype>
           <rng:ref name="data.STRINGNUMBER"/>
         </datatype>
@@ -122,10 +122,10 @@
     </attList>
   </classSpec>
   <classSpec ident="att.stringtab.tuning" module="MEI.stringtab" type="atts">
-    <desc xml:lang="en">This collection of attributes is deprecated in favour of the new <gi scheme="MEI">tuning</gi> element and will be removed in a future version. String tablature tuning information.</desc>
+    <desc xml:lang="en">This collection of attributes is deprecated in favor of the new <gi scheme="MEI">tuning</gi> element and will be removed in a future version. String tablature tuning information.</desc>
     <attList>
       <attDef ident="tab.strings" usage="opt">
-        <desc xml:lang="en">This attribute is deprecated in favour of the new <gi scheme="MEI">tuning</gi> element and will be removed in a future version. Provides a *written* pitch and octave for each open string or course of
+        <desc xml:lang="en">This attribute is deprecated in favor of the new <gi scheme="MEI">tuning</gi> element and will be removed in a future version. Provides a *written* pitch and octave for each open string or course of
           strings.</desc>
         <datatype>
           <rng:list>
@@ -139,7 +139,7 @@
         </datatype>
       </attDef>
       <attDef ident="tab.courses" usage="opt">
-        <desc xml:lang="en">This attribute is deprecated in favour of the new <gi scheme="MEI">tuning</gi> element and will be removed in a future version. Provides a *written* pitch and octave for each open string or course of strings.</desc>
+        <desc xml:lang="en">This attribute is deprecated in favor of the new <gi scheme="MEI">tuning</gi> element and will be removed in a future version. Provides a *written* pitch and octave for each open string or course of strings.</desc>
         <datatype>
           <rng:list>
             <rng:oneOrMore>
@@ -180,7 +180,7 @@
     </content>
     <attList>
       <attDef ident="fret" usage="opt">
-        <desc xml:lang="en">This attribute is deprecated in favour of <att>tab.fret</att>, and will be removed in a future version. Records the location at which the strings should be stopped against a fret in a fretboard diagram. This may or may not be the same as the actual location on the fretboard of the instrument in performance.</desc>
+        <desc xml:lang="en">This attribute is deprecated in favor of <att>tab.fret</att>, and will be removed in a future version. Records the location at which the strings should be stopped against a fret in a fretboard diagram. This may or may not be the same as the actual location on the fretboard of the instrument in performance.</desc>
         <datatype>
           <rng:data type="positiveInteger">
             <rng:param name="minInclusive">1</rng:param>

--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -25,7 +25,7 @@
     <desc xml:lang="en">Tablature component declarations.</desc>
   </moduleSpec>
   <macroSpec ident="data.COURSENUMBER" module="MEI.stringtab" type="dt">
-    <desc xml:lang="en">In string tablature, the number of the course to be played, <abbr>i.e.</abbr>, [1-9]+.</desc>
+    <desc xml:lang="en" versionDate="2024-08-12">In string tablature, the number of the course to be played.</desc>
     <content>
       <rng:data type="positiveInteger"/>
     </content>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3584,7 +3584,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.STRINGNUMBER" module="MEI" type="dt">
-    <desc xml:lang="en">This datatype is deprecated in favour of data.COURSENUMBER and will be removed in a future version. In string tablature, the number of the string to be played.</desc>
+    <desc xml:lang="en">This datatype is deprecated in favor of data.COURSENUMBER and will be removed in a future version. In string tablature, the number of the string to be played.</desc>
     <content>
       <rng:data type="positiveInteger"/>
     </content>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3584,7 +3584,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.STRINGNUMBER" module="MEI" type="dt">
-    <desc xml:lang="en">This attribute is deprecated in favour of data.COURSENUMBER and will be removed in a future version. In string tablature, the number of the string to be played, <abbr>i.e.</abbr>, [1-9]+.</desc>
+    <desc xml:lang="en">This datatype is deprecated in favour of data.COURSENUMBER and will be removed in a future version. In string tablature, the number of the string to be played.</desc>
     <content>
       <rng:data type="positiveInteger"/>
     </content>


### PR DESCRIPTION
This PR removes the misleading regex in the datatype description for `data.COURSENUMBER` and `data.STRINGNUMBER`, which left the impression, there is no tenth course. Also it fixes wrong naming.