### PR TITLE
schema: make caesura and breath eventLike

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -1466,6 +1466,7 @@
       <memberOf key="att.breath.ges"/>
       <memberOf key="att.breath.anl"/>
       <memberOf key="model.controlEventLike.cmn"/>
+      <memberOf key="model.eventLike.cmn"/>
     </classes>
     <content>
       <empty/>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -4819,6 +4819,7 @@
       <memberOf key="att.caesura.log"/>
       <memberOf key="att.caesura.vis"/>
       <memberOf key="model.controlEventLike"/>
+      <memberOf key="model.eventLike"/>
     </classes>
     <content>
       <empty/>


### PR DESCRIPTION
This PR makes `caesura` and `breath` member of `model.eventLike` and `model.eventLike.cmn` respectively. 

Closes #1521.