### PR TITLE
docs: remove contradictory remarks on `<hand>`

### DIFF
--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -1454,7 +1454,7 @@
       </attDef>
     </attList>
     <remarks xml:lang="en">
-      <p>The <att>initial</att> attribute indicates whether this is the first or main hand of the
+      <p>The <att>initial</att> attribute indicates whether this is the first hand of the
         document. The <att>medium</att> attribute describes the writing medium, <abbr>e.g.</abbr>, 
         <val>pencil</val>, or the tint or type of ink, <abbr>e.g.</abbr>, <val>brown</val>. 
         The <att>resp</att> attribute contains an ID reference to an element containing the name of 


### PR DESCRIPTION
This PR removes a statement from the remarks of `<hand>` that contradicts the usage statement on the `@initial` attribute.

Fixes #1524
Refs #1525