### PR TITLE
schema: remove `@versionDate`

### DIFF
--- a/source/modules/MEI.analytical.xml
+++ b/source/modules/MEI.analytical.xml
@@ -185,7 +185,7 @@
     <desc xml:lang="en">Attributes describing the harmonic function of a single pitch.</desc>
     <attList>
       <attDef ident="deg" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">degree</gloss>
+        <gloss xml:lang="en">degree</gloss>
         <desc xml:lang="en">Captures scale degree information using <ref target="https://www.humdrum.org/rep/deg/">Humdrum **deg syntax</ref> -- an optional indicator
           of melodic approach (^ = ascending approach, v = descending approach), a scale degree
           value (1 = tonic ... 7 = leading tone), and an optional indication of chromatic
@@ -210,7 +210,7 @@
     <desc xml:lang="en">Attributes that describe harmonic intervals.</desc>
     <attList>
       <attDef ident="inth" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">interval harmonic</gloss>
+        <gloss xml:lang="en">interval harmonic</gloss>
         <desc xml:lang="en">Encodes the harmonic interval between pitches occurring at the same time.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.INTERVAL.HARMONIC"/>
@@ -222,7 +222,7 @@
     <desc xml:lang="en">Attributes that provide for description of intervallic content.</desc>
     <attList>
       <attDef ident="intm" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">interval melodic</gloss>
+        <gloss xml:lang="en">interval melodic</gloss>
         <desc xml:lang="en">Encodes the melodic interval from the previous pitch. The value may be a general
           directional indication (u, d, s, etc.), an indication of diatonic interval direction,
           quality, and size, or a precise numeric value in half steps.</desc>
@@ -432,7 +432,7 @@
     <desc xml:lang="en">Attributes that describe pitch class.</desc>
     <attList>
       <attDef ident="pclass" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">pitch class</gloss>
+        <gloss xml:lang="en">pitch class</gloss>
         <desc xml:lang="en">Holds pitch class information.</desc>
         <datatype>
           <rng:ref name="data.PITCHCLASS"/>
@@ -495,7 +495,7 @@
     <desc xml:lang="en">Attributes that specify pitch using sol-fa.</desc>
     <attList>
       <attDef ident="psolfa" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">pitch sol-fa</gloss>
+        <gloss xml:lang="en">pitch sol-fa</gloss>
         <desc xml:lang="en">Contains sol-fa designation, <abbr>e.g.</abbr>, do, re, mi, etc., in either a fixed or movable Do
           system.</desc>
         <datatype>

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -237,21 +237,21 @@
         <desc xml:lang="en">Captures whether a beam is "feathered" and in which direction.</desc>
         <valList type="closed">
           <valItem ident="acc">
-            <gloss versionDate="2022-05-18" xml:lang="en">accelerando</gloss>
+            <gloss xml:lang="en">accelerando</gloss>
             <desc xml:lang="en">means that the secondary beams become progressively more distant
               toward the end of the beam.</desc>
           </valItem>
           <valItem ident="mixed">
-            <gloss versionDate="2022-05-18" xml:lang="en">mixed acc and rit</gloss>
+            <gloss xml:lang="en">mixed acc and rit</gloss>
             <desc xml:lang="en">for beams that are "feathered" in both directions.</desc>
           </valItem>
           <valItem ident="rit">
-            <gloss versionDate="2022-05-18" xml:lang="en">ritardando</gloss>
+            <gloss xml:lang="en">ritardando</gloss>
             <desc xml:lang="en">indicates that the secondary beams get progressively closer together
             toward the end of the beam.</desc>
           </valItem>
           <valItem ident="norm">
-            <gloss versionDate="2022-05-18" xml:lang="en">normal</gloss>
+            <gloss xml:lang="en">normal</gloss>
             <desc xml:lang="en">indicates that the secondary beams are equidistant along the course of
               the beam.</desc>
           </valItem>
@@ -353,7 +353,7 @@
     </classes>
     <attList>
       <attDef ident="func" usage="req">
-        <gloss versionDate="2022-10-18" xml:lang="en">function</gloss>
+        <gloss xml:lang="en">function</gloss>
         <desc xml:lang="en">Describes the function of the bracketed event sequence.</desc>
         <datatype>
           <rng:data type="NMTOKENS"/>
@@ -474,7 +474,7 @@
     <desc xml:lang="en">Attributes that indicate whether an event participates in a glissando.</desc>
     <attList>
       <attDef ident="gliss" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">glissando</gloss>
+        <gloss xml:lang="en">glissando</gloss>
         <desc xml:lang="en">Indicates that this element participates in a glissando. If visual information about
           the glissando needs to be recorded, then a <gi scheme="MEI">gliss</gi> element should be
           employed instead.</desc>
@@ -749,7 +749,7 @@
     <desc xml:lang="en">Logical domain attributes.</desc>
     <attList>
       <attDef ident="func" usage="req">
-        <gloss versionDate="2022-10-18" xml:lang="en">function</gloss>
+        <gloss xml:lang="en">function</gloss>
         <desc xml:lang="en">Function of the meter signature group.</desc>
         <valList type="closed">
           <valItem ident="alternating">
@@ -840,7 +840,7 @@
     <desc xml:lang="en">Attributes that record numbers to be displayed with a feature.</desc>
     <attList>
       <attDef ident="num" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">number</gloss>
+        <gloss xml:lang="en">number</gloss>
         <desc xml:lang="en">Records a number or count accompanying a notational feature.</desc>
         <datatype>
           <rng:data type="positiveInteger"/>
@@ -853,7 +853,7 @@
       tremolo or tuplet.</desc>
     <attList>
       <attDef ident="num.place" usage="opt">
-        <gloss versionDate="2022-10-30" xml:lang="en">number placement</gloss>
+        <gloss xml:lang="en">number placement</gloss>
         <desc xml:lang="en">States where the tuplet number will be placed in relation to the note heads.</desc>
         <datatype>
           <rng:ref name="data.STAFFREL.basic"/>
@@ -902,7 +902,7 @@
     </classes>
     <attList>
       <attDef ident="dir" usage="req">
-        <gloss versionDate="2022-10-30" xml:lang="en">direction</gloss>
+        <gloss xml:lang="en">direction</gloss>
         <desc xml:lang="en">Records the position of the piano damper pedal.</desc>
         <valList type="closed">
           <valItem ident="down">
@@ -920,7 +920,7 @@
         </valList>
       </attDef>
       <attDef ident="func" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">function</gloss>
+        <gloss xml:lang="en">function</gloss>
         <desc xml:lang="en">Indicates the function of the depressed pedal, but not necessarily the text associated
           with its use. Use the <gi scheme="MEI">dir</gi> element for such text.</desc>
         <datatype>
@@ -1220,7 +1220,7 @@
     </classes>
   </classSpec>
   <elementSpec ident="arpeg" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">arpeggiation</gloss>
+    <gloss xml:lang="en">arpeggiation</gloss>
     <desc xml:lang="en">Indicates that the notes of a chord are to be performed successively
       rather than simultaneously, usually from lowest to highest. Sometimes called a "roll".</desc>
     <classes>
@@ -1333,7 +1333,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="beamSpan" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">beam span</gloss>
+    <gloss xml:lang="en">beam span</gloss>
     <desc xml:lang="en">Alternative element for explicitly encoding beams, particularly those which
       extend across bar lines.</desc>
     <classes>
@@ -1367,7 +1367,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="beatRpt" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">beat repeat</gloss>
+    <gloss xml:lang="en">beat repeat</gloss>
     <desc xml:lang="en">An indication that material on a preceding beat should be repeated.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1455,7 +1455,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="breath" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">breath mark</gloss>
+    <gloss xml:lang="en">breath mark</gloss>
     <desc xml:lang="en">An indication of a point at which the performer on an instrument requiring
       breath (including the voice) may breathe.</desc>
     <classes>
@@ -1492,7 +1492,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="bTrem" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">bowed tremolo</gloss>
+    <gloss xml:lang="en">bowed tremolo</gloss>
     <desc xml:lang="en">A rapid alternation on a single pitch or chord.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1545,7 +1545,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="fTrem" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">fingered tremolo</gloss>
+    <gloss xml:lang="en">fingered tremolo</gloss>
     <desc xml:lang="en">A rapid alternation between a pair of notes (or chords or perhaps
       between a note and a chord) that are (usually) farther apart than a major second.</desc>
     <classes>
@@ -1583,7 +1583,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="gliss" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">glissando</gloss>
+    <gloss xml:lang="en">glissando</gloss>
     <desc xml:lang="en">A continuous or sliding movement from one pitch to another, usually
       indicated by a straight or wavy line.</desc>
     <classes>
@@ -1626,7 +1626,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="graceGrp" module="MEI.cmn">
-    <gloss versionDate="2023-06-16" xml:lang="en">grace group</gloss>
+    <gloss xml:lang="en">grace group</gloss>
     <desc xml:lang="en">A container for a sequence of grace notes.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1706,7 +1706,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="halfmRpt" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">half-measure repeat</gloss>
+    <gloss xml:lang="en">half-measure repeat</gloss>
     <desc xml:lang="en">A half-measure repeat in any meter.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1722,7 +1722,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="harpPedal" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">harp pedal</gloss>
+    <gloss xml:lang="en">harp pedal</gloss>
     <desc xml:lang="en">Harp pedal diagram.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1751,7 +1751,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="lv" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">laissez vibrer</gloss>
+    <gloss xml:lang="en">laissez vibrer</gloss>
     <desc xml:lang="en">A "tie-like" indication that a note should ring beyond its written duration.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1835,7 +1835,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="meterSig" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">meter signature</gloss>
+    <gloss xml:lang="en">meter signature</gloss>
     <desc xml:lang="en">Written meter signature.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1851,7 +1851,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="meterSigGrp" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">meter signature group</gloss>
+    <gloss xml:lang="en">meter signature group</gloss>
     <desc xml:lang="en">Used to capture alternating, interchanging, mixed or other non-standard meter signatures.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1877,7 +1877,7 @@
     </constraintSpec>
   </elementSpec>
   <elementSpec ident="mNum" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">measure number</gloss>
+    <gloss xml:lang="en">measure number</gloss>
     <desc xml:lang="en">Designation, name, or label for a measure, often but not always
       consisting of digits. Use this element when the <att>n</att> attribute on <gi scheme="MEI"
       >measure</gi> does not adequately capture the appearance or placement of the measure
@@ -1905,7 +1905,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="mRest" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">measure rest</gloss>
+    <gloss xml:lang="en">measure rest</gloss>
     <desc xml:lang="en">Complete measure rest in any meter. <!-- (Read, p. 97-98). --> </desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1926,7 +1926,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="mRpt" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">measure repeat</gloss>
+    <gloss xml:lang="en">measure repeat</gloss>
     <desc xml:lang="en">An indication that the previous measure should be repeated.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1947,7 +1947,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="mRpt2" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">2-measure repeat</gloss>
+    <gloss xml:lang="en">2-measure repeat</gloss>
     <desc xml:lang="en">An indication that the previous two measures should be
       repeated.</desc>
     <classes>
@@ -1964,7 +1964,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="mSpace" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">measure space</gloss>
+    <gloss xml:lang="en">measure space</gloss>
     <desc xml:lang="en">A measure containing only empty space in any meter.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1985,7 +1985,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="multiRest" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">multiple rest</gloss>
+    <gloss xml:lang="en">multiple rest</gloss>
     <desc xml:lang="en">Multiple measures of rest compressed into a single symbol, frequently
       found in performer parts.</desc>
     <classes>
@@ -2004,7 +2004,7 @@
         the note. See Read, p. 102-105.</p></remarks>-->
   </elementSpec>
   <elementSpec ident="multiRpt" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">multiple repeat</gloss>
+    <gloss xml:lang="en">multiple repeat</gloss>
     <desc xml:lang="en">Multiple repeated measures.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2068,7 +2068,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="oLayer" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">ossia layer</gloss>
+    <gloss xml:lang="en">ossia layer</gloss>
     <desc xml:lang="en">A layer that contains an alternative to material in another layer.</desc>
     <classes>
       <memberOf key="att.basic"/>
@@ -2154,7 +2154,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="oStaff" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">ossia staff</gloss>
+    <gloss xml:lang="en">ossia staff</gloss>
     <desc xml:lang="en">A staff that holds an alternative passage which may be played instead of
       the original material.</desc>
     <classes>
@@ -2216,7 +2216,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="reh" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">rehearsal mark</gloss>
+    <gloss xml:lang="en">rehearsal mark</gloss>
     <desc xml:lang="en">In an orchestral score and its corresponding parts, a mark indicating a
       convenient point from which to resume rehearsal after a break.</desc>
     <classes>
@@ -2245,7 +2245,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="repeatMark" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">repetition mark</gloss>
+    <gloss xml:lang="en">repetition mark</gloss>
     <desc xml:lang="en">
       An instruction expressed as a combination of text and symbols – segno and coda – typically above, 
       below, or between staves, but not on the staff.</desc>
@@ -2434,7 +2434,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="tupletSpan" module="MEI.cmn">
-    <gloss versionDate="2022-05-18" xml:lang="en">tuplet span</gloss>
+    <gloss xml:lang="en">tuplet span</gloss>
     <desc xml:lang="en">Alternative element for encoding tuplets, especially useful for tuplets
       that extend across bar lines.</desc>
     <classes>

--- a/source/modules/MEI.cmnOrnaments.xml
+++ b/source/modules/MEI.cmnOrnaments.xml
@@ -96,7 +96,7 @@
     <desc xml:lang="en">Attributes for marking the presence of an ornament.</desc>
     <attList>
       <attDef ident="ornam" usage="opt">
-        <gloss versionDate="2022-10-30" xml:lang="en">ornament</gloss>
+        <gloss xml:lang="en">ornament</gloss>
         <desc xml:lang="en">Indicates that this element has an attached ornament. If visual information about the
           ornament is needed, then one of the elements that represents an ornament (mordent, trill,
           or turn) should be employed.</desc>

--- a/source/modules/MEI.corpus.xml
+++ b/source/modules/MEI.corpus.xml
@@ -28,7 +28,7 @@
     <desc xml:lang="en">Groups elements that may be document elements when the corpus module is invoked.</desc>
   </classSpec>
   <elementSpec ident="meiCorpus" module="MEI.corpus">
-    <gloss versionDate="2022-05-18" xml:lang="en">MEI corpus</gloss>
+    <gloss xml:lang="en">MEI corpus</gloss>
     <desc xml:lang="en">A group of related MEI documents, consisting of a header for the group, and
       one or more <gi scheme="MEI">mei</gi> elements, each with its own complete header.</desc>
     <classes>

--- a/source/modules/MEI.critapp.xml
+++ b/source/modules/MEI.critapp.xml
@@ -63,7 +63,7 @@
     </classes>
   </classSpec>
   <elementSpec ident="app" module="MEI.critapp">
-    <gloss versionDate="2023-06-16" xml:lang="en">apparatus</gloss>
+    <gloss xml:lang="en">apparatus</gloss>
     <desc xml:lang="en">Contains one or more alternative encodings.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -91,7 +91,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="lem" module="MEI.critapp">
-    <gloss versionDate="2023-06-16" xml:lang="en">lemma</gloss>
+    <gloss xml:lang="en">lemma</gloss>
     <desc xml:lang="en">Contains the lemma, or base text, of a textual variation.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -143,7 +143,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="rdg" module="MEI.critapp">
-    <gloss versionDate="2023-06-16" xml:lang="en">reading</gloss>
+    <gloss xml:lang="en">reading</gloss>
     <desc xml:lang="en">Contains a single reading within a textual variation.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.drama.xml
+++ b/source/modules/MEI.drama.xml
@@ -48,7 +48,7 @@
     </classes>
   </classSpec>
   <elementSpec ident="sp" module="MEI.drama">
-    <gloss versionDate="2022-05-18" xml:lang="en">speech</gloss>
+    <gloss xml:lang="en">speech</gloss>
     <desc xml:lang="en">Contains an individual speech in a performance text.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -130,7 +130,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="stageDir" module="MEI.drama">
-    <gloss versionDate="2022-05-18" xml:lang="en">stage direction</gloss>
+    <gloss xml:lang="en">stage direction</gloss>
     <desc xml:lang="en">Contains any kind of stage direction within a dramatic text or
       fragment.</desc>
     <classes>

--- a/source/modules/MEI.edittrans.xml
+++ b/source/modules/MEI.edittrans.xml
@@ -124,7 +124,7 @@
     </classes>
   </classSpec>
   <elementSpec ident="abbr" module="MEI.edittrans" ns="http://www.music-encoding.org/ns/mei">
-    <gloss versionDate="2022-05-18" xml:lang="en">abbreviation</gloss>
+    <gloss xml:lang="en">abbreviation</gloss>
     <desc xml:lang="en">A generic element for 1) a shortened form of a word, including an acronym
       or 2) a shorthand notation.</desc>
     <classes>
@@ -176,7 +176,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="add" module="MEI.edittrans">
-    <gloss versionDate="2022-05-18" xml:lang="en">addition</gloss>
+    <gloss xml:lang="en">addition</gloss>
     <desc xml:lang="en">Marks an addition to the text.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -256,7 +256,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="corr" module="MEI.edittrans">
-    <gloss versionDate="2022-05-18" xml:lang="en">correction</gloss>
+    <gloss xml:lang="en">correction</gloss>
     <desc xml:lang="en">Contains the correct form of an apparent erroneous passage.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -306,7 +306,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="cpMark" module="MEI.edittrans">
-    <gloss versionDate="2022-05-18" xml:lang="en">copy/colla parte mark</gloss>
+    <gloss xml:lang="en">copy/colla parte mark</gloss>
     <desc xml:lang="en">A verbal or graphical indication to copy musical material
       written elsewhere.</desc>
     <classes>
@@ -425,7 +425,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="del" module="MEI.edittrans">
-    <gloss versionDate="2022-05-18" xml:lang="en">deletion</gloss>
+    <gloss xml:lang="en">deletion</gloss>
     <desc xml:lang="en">Contains information deleted, marked as deleted, or otherwise indicated as
       superfluous or spurious in the copy text by an author, scribe, annotator, or corrector.</desc>
     <classes>
@@ -476,7 +476,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="expan" module="MEI.edittrans">
-    <gloss versionDate="2022-05-18" xml:lang="en">expansion</gloss>
+    <gloss xml:lang="en">expansion</gloss>
     <desc xml:lang="en">Contains the expansion of an abbreviation.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -509,7 +509,7 @@
     </content>
     <attList>
       <attDef ident="abbr" usage="opt">
-        <gloss versionDate="2022-10-30" xml:lang="en">abbreviation</gloss>
+        <gloss xml:lang="en">abbreviation</gloss>
         <desc xml:lang="en">Captures the abbreviated form of the text.</desc>
         <datatype>
           <rng:data type="string"/>
@@ -719,7 +719,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="orig" module="MEI.edittrans">
-    <gloss versionDate="2022-05-18" xml:lang="en">original</gloss>
+    <gloss xml:lang="en">original</gloss>
     <desc xml:lang="en">Contains material which is marked as following the original, rather than
       being normalized or corrected.</desc>
     <classes>
@@ -769,7 +769,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="reg" module="MEI.edittrans">
-    <gloss versionDate="2022-05-18" xml:lang="en">regularization</gloss>
+    <gloss xml:lang="en">regularization</gloss>
     <desc xml:lang="en">Contains material which has been regularized or normalized in some
       sense.</desc>
     <classes>
@@ -853,7 +853,7 @@
     </content>
     <attList>
       <attDef ident="desc" usage="opt">
-        <gloss versionDate="2022-10-30" xml:lang="en">description</gloss>
+        <gloss xml:lang="en">description</gloss>
         <desc xml:lang="en">Provides a description of the means of restoration, <val>stet</val> or <val>strike-down</val>, 
           for example.</desc>
         <datatype>
@@ -917,7 +917,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="subst" module="MEI.edittrans">
-    <gloss versionDate="2022-05-18" xml:lang="en">substitution</gloss>
+    <gloss xml:lang="en">substitution</gloss>
     <desc xml:lang="en">Groups transcriptional elements when the combination is to be regarded as
       a single intervention in the text.</desc>
     <classes>

--- a/source/modules/MEI.facsimile.xml
+++ b/source/modules/MEI.facsimile.xml
@@ -28,8 +28,8 @@
     <desc xml:lang="en">Attributes that associate a feature corresponding with all or part of an image.</desc>
     <attList>
       <attDef ident="facs" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">facsimile</gloss>
-        <desc versionDate="2022-10-18" xml:lang="en">Points to one or more images, portions of an image, or surfaces which correspond to the current element.</desc>
+        <gloss xml:lang="en">facsimile</gloss>
+        <desc xml:lang="en">Points to one or more images, portions of an image, or surfaces which correspond to the current element.</desc>
         <datatype minOccurs="1" maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
         </datatype>

--- a/source/modules/MEI.figtable.xml
+++ b/source/modules/MEI.figtable.xml
@@ -64,7 +64,7 @@
     </classes>
   </classSpec>
   <elementSpec ident="fig" module="MEI.figtable">
-    <gloss versionDate="2022-05-18" xml:lang="en">figure</gloss>
+    <gloss xml:lang="en">figure</gloss>
     <desc xml:lang="en">Groups elements representing or containing graphic information such as an
       illustration or figure.</desc>
     <classes>
@@ -90,7 +90,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="figDesc" module="MEI.figtable">
-    <gloss versionDate="2022-05-18" xml:lang="en">figure description</gloss>
+    <gloss xml:lang="en">figure description</gloss>
     <desc xml:lang="en">Contains a brief prose description of the appearance or content of
       a graphic figure, for use when documenting an image without displaying it.</desc>
     <classes>
@@ -189,7 +189,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="td" module="MEI.figtable">
-    <gloss versionDate="2022-05-18" xml:lang="en">table data</gloss>
+    <gloss xml:lang="en">table data</gloss>
     <desc xml:lang="en">Designates a table cell that contains data as opposed to a cell that
       contains column or row heading information.</desc>
     <classes>
@@ -219,7 +219,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="th" module="MEI.figtable">
-    <gloss versionDate="2022-05-18" xml:lang="en">table header</gloss>
+    <gloss xml:lang="en">table header</gloss>
     <desc xml:lang="en">Designates a table cell containing column or row heading information as
       opposed to one containing data.</desc>
     <classes>
@@ -249,7 +249,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="tr" module="MEI.figtable">
-    <gloss versionDate="2022-05-18" xml:lang="en">table row</gloss>
+    <gloss xml:lang="en">table row</gloss>
     <desc xml:lang="en">A formatting element that contains one or more cells (intersection of a row
       and a column) in a <gi scheme="MEI">table</gi>.</desc>
     <classes>

--- a/source/modules/MEI.fingering.xml
+++ b/source/modules/MEI.fingering.xml
@@ -65,7 +65,7 @@
     </classes>
   </classSpec>
   <elementSpec ident="fing" module="MEI.fingering">
-    <gloss versionDate="2023-06-16" xml:lang="en">finger</gloss>
+    <gloss xml:lang="en">finger</gloss>
     <desc xml:lang="en">An individual finger in a fingering indication.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -105,7 +105,7 @@
     </constraintSpec>
   </elementSpec>
   <elementSpec ident="fingGrp" module="MEI.fingering">
-    <gloss versionDate="2023-06-16" xml:lang="en">finger group</gloss>
+    <gloss xml:lang="en">finger group</gloss>
     <desc xml:lang="en">A group of individual fingers in a fingering indication.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.genetic.xml
+++ b/source/modules/MEI.genetic.xml
@@ -58,7 +58,7 @@
     </attList>
   </classSpec>
   <elementSpec ident="genDesc" module="MEI.genetic">
-    <gloss versionDate="2023-06-16" xml:lang="en">genetic description</gloss>
+    <gloss xml:lang="en">genetic description</gloss>
     <desc xml:lang="en">Bundles information about the textual development of a
       work.</desc>
     <classes>

--- a/source/modules/MEI.gestural.xml
+++ b/source/modules/MEI.gestural.xml
@@ -611,7 +611,7 @@
         </datatype>
       </attDef>
       <attDef ident="pnum" usage="opt">
-        <gloss versionDate="2022-10-30" xml:lang="en">pitch number</gloss>
+        <gloss xml:lang="en">pitch number</gloss>
         <desc xml:lang="en">Holds a pitch-to-number mapping, a base-40 or MIDI note number, for example.</desc>
         <datatype>
           <rng:ref name="data.PITCHNUMBER"/>

--- a/source/modules/MEI.harmony.xml
+++ b/source/modules/MEI.harmony.xml
@@ -57,7 +57,7 @@
     </classes>
     <attList>
       <attDef ident="chordref" usage="opt">
-        <gloss versionDate="2022-10-30" xml:lang="en">chord reference</gloss>
+        <gloss xml:lang="en">chord reference</gloss>
         <desc xml:lang="en">Contains a reference to a <gi scheme="MEI">chordDef</gi> element elsewhere in the
           document.</desc>
         <datatype>
@@ -101,7 +101,7 @@
     </classes>
   </classSpec>
   <elementSpec ident="chordDef" module="MEI.harmony">
-    <gloss versionDate="2022-05-18" xml:lang="en">chord definition</gloss>
+    <gloss xml:lang="en">chord definition</gloss>
     <desc xml:lang="en">Chord tablature definition.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -164,7 +164,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="f" module="MEI.harmony">
-    <gloss versionDate="2022-05-18" xml:lang="en">figure</gloss>
+    <gloss xml:lang="en">figure</gloss>
     <desc xml:lang="en">Single element of a figured bass indication.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -187,7 +187,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="fb" module="MEI.harmony">
-    <gloss versionDate="2022-05-18" xml:lang="en">figured bass</gloss>
+    <gloss xml:lang="en">figured bass</gloss>
     <desc xml:lang="en">Symbols added to a bass line that indicate harmony. Used to improvise a
       chordal accompaniment. Sometimes called Generalbass, thoroughbass, or basso continuo.</desc>
     <classes>
@@ -206,7 +206,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="harm" module="MEI.harmony">
-    <gloss versionDate="2022-05-18" xml:lang="en">harmony</gloss>
+    <gloss xml:lang="en">harmony</gloss>
     <desc xml:lang="en">An indication of harmony, <abbr>e.g.</abbr>, chord names, tablature grids, harmonic
       analysis, figured bass.</desc>
     <classes>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -364,7 +364,7 @@
     <desc xml:lang="en">Collects work-like elements.</desc>
   </classSpec>
   <elementSpec ident="accessRestrict" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">access restriction</gloss>
+    <gloss xml:lang="en">access restriction</gloss>
     <desc xml:lang="en">Describes the conditions that affect the accessibility of
       material.</desc>
     <classes>
@@ -422,7 +422,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="altId" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">alternative identifier</gloss>
+    <gloss xml:lang="en">alternative identifier</gloss>
     <desc xml:lang="en">May contain a bibliographic identifier that does not fit within
       the meiHead element’s id attribute, for example because the identifier does not fit the
       definition of an XML id or because multiple identifiers are needed.</desc>
@@ -445,7 +445,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="appInfo" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">application information</gloss>
+    <gloss xml:lang="en">application information</gloss>
     <desc xml:lang="en">Groups information about applications which have acted upon
       the MEI file.</desc>
     <classes>
@@ -611,7 +611,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="captureMode" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">capture mode</gloss>
+    <gloss xml:lang="en">capture mode</gloss>
     <desc xml:lang="en">The means used to record notation, sound, or images in the production of
       a source/manifestation (<abbr>e.g.</abbr>, analogue, acoustic, electric, digital, optical etc.).</desc>
     <classes>
@@ -626,7 +626,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="carrierForm" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">carrier form</gloss>
+    <gloss xml:lang="en">carrier form</gloss>
     <desc xml:lang="en">The specific class of material to which the physical carrier of the
       source/manifestation belongs (<abbr>e.g.</abbr>, sound cassette, videodisc, microfilm cartridge,
       transparency, etc.). The carrier for a manifestation comprising multiple physical components
@@ -679,7 +679,7 @@
     </constraintSpec>
   </elementSpec>
   <elementSpec ident="catRel" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">category relationship</gloss>
+    <gloss xml:lang="en">category relationship</gloss>
     <desc xml:lang="en">Contains the name, i.e., label, of a related
         category.</desc>
     <classes>
@@ -764,7 +764,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="changeDesc" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">change description</gloss>
+    <gloss xml:lang="en">change description</gloss>
     <desc xml:lang="en">Description of a revision of the MEI file.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1152,7 +1152,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="domainsDecl" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">domains declaration</gloss>
+    <gloss xml:lang="en">domains declaration</gloss>
     <desc xml:lang="en">Indicates which domains are included in the encoding.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1177,7 +1177,7 @@
     </attList>
   </elementSpec>
   <elementSpec ident="editionStmt" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">edition statement</gloss>
+    <gloss xml:lang="en">edition statement</gloss>
     <desc xml:lang="en">Container for meta-data pertaining to a particular edition of the
       material being described.</desc>
     <classes>
@@ -1205,7 +1205,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="editorialDecl" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">editorial declaration</gloss>
+    <gloss xml:lang="en">editorial declaration</gloss>
     <desc xml:lang="en">Used to provide details of editorial principles and practices
       applied during the encoding of musical text.</desc>
     <classes>
@@ -1238,7 +1238,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="encodingDesc" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">encoding description</gloss>
+    <gloss xml:lang="en">encoding description</gloss>
     <desc xml:lang="en">Documents the relationship between an electronic file and the
       source or sources from which it was derived as well as applications used in the
       encoding/editing process.</desc>
@@ -1278,7 +1278,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="exhibHist" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">exhibition history</gloss>
+    <gloss xml:lang="en">exhibition history</gloss>
     <desc xml:lang="en">A record of public exhibitions, including dates, venues,
       etc.</desc>
     <classes>
@@ -1313,7 +1313,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="extMeta" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">extended metadata</gloss>
+    <gloss xml:lang="en">extended metadata</gloss>
     <desc xml:lang="en">Provides a container element for non-MEI metadata formats.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1332,7 +1332,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="fileChar" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">file characteristics</gloss>
+    <gloss xml:lang="en">file characteristics</gloss>
     <desc xml:lang="en">Standards or schemes used to encode the file (<abbr>e.g.</abbr>, ASCII, SGML,
       etc.), physical characteristics of the file (<abbr>e.g.</abbr>, recording density, parity, blocking, etc.),
       and other characteristics that have a bearing on how the file can be processed.</desc>
@@ -1347,7 +1347,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="fileDesc" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">file description</gloss>
+    <gloss xml:lang="en">file description</gloss>
     <desc xml:lang="en">Contains a full bibliographic description of the MEI file.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -1679,7 +1679,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="langUsage" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">language usage</gloss>
+    <gloss xml:lang="en">language usage</gloss>
     <desc xml:lang="en">Groups elements describing the languages, sub-languages, dialects,
       etc., represented within the encoded resource.</desc>
     <classes>
@@ -1700,7 +1700,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="meiHead" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">MEI header</gloss>
+    <gloss xml:lang="en">MEI header</gloss>
     <desc xml:lang="en">Supplies the descriptive and declarative metadata prefixed to every
       MEI-conformant text.</desc>
     <classes>
@@ -1876,7 +1876,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="notesStmt" module="MEI.header">
-    <gloss versionDate="2023-06-16" xml:lang="en">notes statement</gloss>
+    <gloss xml:lang="en">notes statement</gloss>
     <desc xml:lang="en">Collects any notes providing information about a text additional to
       that recorded in other parts of the bibliographic description.</desc>
     <classes>
@@ -1896,7 +1896,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="otherChar" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">other distinguishing characteristic</gloss>
+    <gloss xml:lang="en">other distinguishing characteristic</gloss>
     <desc xml:lang="en">Any characteristic that serves to differentiate a
       work or expression from another.</desc>
     <classes>
@@ -1998,7 +1998,7 @@
           </remarks>-->
   </elementSpec>
   <elementSpec ident="perfDuration" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">performance duration</gloss>
+    <gloss xml:lang="en">performance duration</gloss>
     <desc xml:lang="en">Used to express the duration of performance of printed or
       manuscript music or the playing time for a sound recording, videorecording, etc.</desc>
     <classes>
@@ -2026,7 +2026,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="perfMedium" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">performance medium</gloss>
+    <gloss xml:lang="en">performance medium</gloss>
     <desc xml:lang="en">Indicates the number and character of the performing forces used in
       a musical composition.</desc>
     <classes>
@@ -2055,7 +2055,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="perfRes" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">performance resource</gloss>
+    <gloss xml:lang="en">performance resource</gloss>
     <desc xml:lang="en">Name of an instrument on which a performer plays, a performer's
       voice range, or a standard performing ensemble designation.</desc>
     <classes>
@@ -2083,7 +2083,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="perfResList" module="MEI.header">
-    <gloss versionDate="2023-06-16" xml:lang="en">performance resources list</gloss>
+    <gloss xml:lang="en">performance resources list</gloss>
     <desc xml:lang="en">Several instrumental or vocal resources treated as a group.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2112,7 +2112,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="physDesc" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">physical description</gloss>
+    <gloss xml:lang="en">physical description</gloss>
     <desc xml:lang="en">Container for information about the appearance, construction, or
       handling of physical materials, such as their dimension, quantity, color, style, and technique
       of creation.</desc>
@@ -2141,7 +2141,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="physMedium" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">physical medium</gloss>
+    <gloss xml:lang="en">physical medium</gloss>
     <desc xml:lang="en">Records the physical materials used in the source, such as ink and
       paper.</desc>
     <classes>
@@ -2164,7 +2164,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="plateNum" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">plate number</gloss>
+    <gloss xml:lang="en">plate number</gloss>
     <desc xml:lang="en">Designation assigned to a resource by a music publisher, usually printed
       at the bottom of each page, and sometimes appearing also on the title page.</desc>
     <classes>
@@ -2239,7 +2239,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="projectDesc" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">project description</gloss>
+    <gloss xml:lang="en">project description</gloss>
     <desc xml:lang="en">Project-level meta-data describing the aim or purpose for which
       the electronic file was encoded, funding agencies, etc. together with any other relevant
       information concerning the process by which it was assembled or collected.</desc>
@@ -2297,7 +2297,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pubStmt" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">publication statement</gloss>
+    <gloss xml:lang="en">publication statement</gloss>
     <desc xml:lang="en">Container for information regarding the publication or
       distribution of a bibliographic item, including the publisher’s name and address, the date of
       publication, and other relevant details.</desc>
@@ -2326,7 +2326,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="revisionDesc" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">revision description</gloss>
+    <gloss xml:lang="en">revision description</gloss>
     <desc xml:lang="en">Container for information about alterations that have been made
       to an MEI file.</desc>
     <classes>
@@ -2350,7 +2350,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="samplingDecl" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">sampling declaration</gloss>
+    <gloss xml:lang="en">sampling declaration</gloss>
     <desc xml:lang="en">Contains a prose description of the rationale and methods used in
       sampling texts in the creation of a corpus or collection.</desc>
     <classes>
@@ -2409,7 +2409,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="seriesStmt" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">series statement</gloss>
+    <gloss xml:lang="en">series statement</gloss>
     <desc xml:lang="en">Groups information about the series, if any, to which a publication
       belongs.</desc>
     <classes>
@@ -2451,7 +2451,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="soundChan" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">sound channels</gloss>
+    <gloss xml:lang="en">sound channels</gloss>
     <desc xml:lang="en">Reflects the number of apparent sound channels in the playback of a
       recording (monaural, stereophonic, quadraphonic, etc.).</desc>
     <classes>
@@ -2541,7 +2541,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="sourceDesc" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">source description</gloss>
+    <gloss xml:lang="en">source description</gloss>
     <desc xml:lang="en">A container for the descriptions of the source(s) used in the
       creation of the electronic file.</desc>
     <classes>
@@ -2561,7 +2561,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="specRepro" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">special reproduction characteristic</gloss>
+    <gloss xml:lang="en">special reproduction characteristic</gloss>
     <desc xml:lang="en">The equalization system, noise reduction system,
       etc. used in making the recording (<abbr>e.g.</abbr>, NAB, DBX, Dolby, etc.).</desc>
     <classes>
@@ -2576,7 +2576,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="stdVals" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">standard values</gloss>
+    <gloss xml:lang="en">standard values</gloss>
     <desc xml:lang="en">Specifies the format used when standardized date or number values are
       supplied.</desc>
     <classes>
@@ -2599,7 +2599,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="sysReq" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">system requirements</gloss>
+    <gloss xml:lang="en">system requirements</gloss>
     <desc xml:lang="en">System requirements for using the electronic item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2612,7 +2612,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="tagsDecl" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">tagging declaration</gloss>
+    <gloss xml:lang="en">tagging declaration</gloss>
     <desc xml:lang="en">Provides detailed information about the tagging applied to a
       document.</desc>
     <classes>
@@ -2744,7 +2744,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="titleStmt" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">title statement</gloss>
+    <gloss xml:lang="en">title statement</gloss>
     <desc xml:lang="en">Container for title and responsibility meta-data.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -2768,7 +2768,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="trackConfig" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">track configuration</gloss>
+    <gloss xml:lang="en">track configuration</gloss>
     <desc xml:lang="en">Number of physical/input tracks on a sound medium (<abbr>e.g.</abbr>, eight
       track, twelve track).</desc>
     <classes>
@@ -2799,7 +2799,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="treatHist" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">treatment history</gloss>
+    <gloss xml:lang="en">treatment history</gloss>
     <desc xml:lang="en">A record of the treatment the item has undergone (<abbr>e.g.</abbr>,
       de-acidification, restoration, etc.).</desc>
     <classes>
@@ -2838,7 +2838,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="treatSched" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">treatment scheduled</gloss>
+    <gloss xml:lang="en">treatment scheduled</gloss>
     <desc xml:lang="en">Scheduled treatment, <abbr>e.g.</abbr>, de-acidification, restoration, etc., for
       an item.</desc>
     <classes>
@@ -2873,7 +2873,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="unpub" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">unpublished</gloss>
+    <gloss xml:lang="en">unpublished</gloss>
     <desc xml:lang="en">Used to explicitly indicate that a bibliographic resource is
       unpublished.</desc>
     <classes>
@@ -2891,7 +2891,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="useRestrict" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">usage restrictions</gloss>
+    <gloss xml:lang="en">usage restrictions</gloss>
     <desc xml:lang="en">Container for information about the conditions that affect use of a
       bibliographic item after access has been granted.</desc>
     <classes>
@@ -3021,7 +3021,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="workList" module="MEI.header">
-    <gloss versionDate="2022-05-18" xml:lang="en">work list</gloss>
+    <gloss xml:lang="en">work list</gloss>
     <desc xml:lang="en">Grouping mechanism for information describing non-bibliographic aspects of a
       text.</desc>
     <classes>

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -440,7 +440,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="mensur" module="MEI.mensural">
-    <gloss versionDate="2022-05-18" xml:lang="en">mensuration</gloss>
+    <gloss xml:lang="en">mensuration</gloss>
     <desc xml:lang="en">Collects information about the metrical relationship between a note value
       and the next smaller value; that is, either triple or duple.</desc>
     <classes>
@@ -481,7 +481,7 @@
     </constraintSpec>
   </elementSpec>
   <elementSpec ident="proport" module="MEI.mensural">
-    <gloss versionDate="2022-05-18" xml:lang="en">proportion</gloss>
+    <gloss xml:lang="en">proportion</gloss>
     <desc xml:lang="en">Description of note duration as arithmetic ratio.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.midi.xml
+++ b/source/modules/MEI.midi.xml
@@ -161,7 +161,7 @@
     <desc xml:lang="en">Attributes that record MIDI numbers.</desc>
     <attList>
       <attDef ident="num" usage="req">
-        <gloss versionDate="2022-10-30" xml:lang="en">number</gloss>
+        <gloss xml:lang="en">number</gloss>
         <desc xml:lang="en">MIDI number in the range set by data.MIDIVALUE.</desc>
         <datatype>
           <rng:ref name="data.MIDIVALUE"/>
@@ -246,7 +246,7 @@
     </classes>
   </classSpec>
   <elementSpec ident="cc" module="MEI.midi">
-    <gloss versionDate="2022-05-18" xml:lang="en">control change</gloss>
+    <gloss xml:lang="en">control change</gloss>
     <desc xml:lang="en">MIDI parameter/control change.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -263,7 +263,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="chan" module="MEI.midi">
-    <gloss versionDate="2022-05-18" xml:lang="en">channel</gloss>
+    <gloss xml:lang="en">channel</gloss>
     <desc xml:lang="en">MIDI channel assignment.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -282,7 +282,7 @@
     </attList>
   </elementSpec>
   <elementSpec ident="chanPr" module="MEI.midi">
-    <gloss versionDate="2022-05-18" xml:lang="en">channel pressure</gloss>
+    <gloss xml:lang="en">channel pressure</gloss>
     <desc xml:lang="en">MIDI channel pressure/after touch.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -321,7 +321,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="instrDef" module="MEI.midi">
-    <gloss versionDate="2022-05-18" xml:lang="en">instrument definition</gloss>
+    <gloss xml:lang="en">instrument definition</gloss>
     <desc xml:lang="en">MIDI instrument declaration.</desc>
     <classes>
       <memberOf key="att.basic"/>
@@ -347,7 +347,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="instrGrp" module="MEI.midi">
-    <gloss versionDate="2022-05-18" xml:lang="en">instrument group</gloss>
+    <gloss xml:lang="en">instrument group</gloss>
     <desc xml:lang="en">Collects MIDI instrument definitions.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -448,7 +448,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="prog" module="MEI.midi">
-    <gloss versionDate="2022-05-18" xml:lang="en">program</gloss>
+    <gloss xml:lang="en">program</gloss>
     <desc xml:lang="en">MIDI program change.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -460,7 +460,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="seqNum" module="MEI.midi">
-    <gloss versionDate="2022-05-18" xml:lang="en">sequence number</gloss>
+    <gloss xml:lang="en">sequence number</gloss>
     <desc xml:lang="en">MIDI sequence number.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -481,7 +481,7 @@
     </attList>
   </elementSpec>
   <elementSpec ident="trkName" module="MEI.midi">
-    <gloss versionDate="2022-05-18" xml:lang="en">track name</gloss>
+    <gloss xml:lang="en">track name</gloss>
     <desc xml:lang="en">MIDI track/sequence name.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -493,7 +493,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="vel" module="MEI.midi">
-    <gloss versionDate="2022-05-18" xml:lang="en">velocity</gloss>
+    <gloss xml:lang="en">velocity</gloss>
     <desc xml:lang="en">MIDI Note-on/off velocity.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.msDesc.xml
+++ b/source/modules/MEI.msDesc.xml
@@ -89,7 +89,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="addDesc" module="MEI.msDesc">
-    <gloss versionDate="2022-05-18" xml:lang="en">addition description</gloss>
+    <gloss xml:lang="en">addition description</gloss>
     <desc xml:lang="en">Provides a description of significant additions found within an
       item, such as marginalia or other annotations.</desc>
     <classes>
@@ -106,7 +106,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="binding" module="MEI.msDesc">
-    <gloss versionDate="2022-05-18" xml:lang="en">binding</gloss>
+    <gloss xml:lang="en">binding</gloss>
     <desc xml:lang="en">Contains a description of one binding, <abbr>i.e.</abbr>, type of covering, boards, etc.
       applied to an item.</desc>
     <classes>
@@ -134,7 +134,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="bindingDesc" module="MEI.msDesc">
-    <gloss versionDate="2022-05-18" xml:lang="en">binding description</gloss>
+    <gloss xml:lang="en">binding description</gloss>
     <desc xml:lang="en">Describes the present and former bindings of an item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -230,7 +230,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="decoDesc" module="MEI.msDesc">
-    <gloss versionDate="2022-05-18" xml:lang="en">decoration description</gloss>
+    <gloss xml:lang="en">decoration description</gloss>
     <desc xml:lang="en">Contains a description of the decoration of an item.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -265,7 +265,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="decoNote" module="MEI.msDesc">
-    <gloss versionDate="2022-05-18" xml:lang="en">decoration note</gloss>
+    <gloss xml:lang="en">decoration note</gloss>
     <desc xml:lang="en">Contains a description of one or more decorative features of an
       item.</desc>
     <classes>
@@ -421,7 +421,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="layoutDesc" module="MEI.msDesc">
-    <gloss versionDate="2022-05-18" xml:lang="en">layout description</gloss>
+    <gloss xml:lang="en">layout description</gloss>
     <desc xml:lang="en">Collects layout descriptions.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -493,7 +493,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="locusGrp" module="MEI.msDesc">
-    <gloss versionDate="2022-05-18" xml:lang="en">locus group</gloss>
+    <gloss xml:lang="en">locus group</gloss>
     <desc xml:lang="en">Groups locations which together form a distinct but discontinuous item
       within a manuscript or manuscript part, according to a specific foliation.</desc>
     <classes>
@@ -557,7 +557,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="scriptDesc" module="MEI.msDesc">
-    <gloss versionDate="2022-05-18" xml:lang="en">script description</gloss>
+    <gloss xml:lang="en">script description</gloss>
     <desc xml:lang="en">Contains a description of the letters or characters used in an
       autographic item.</desc>
     <classes>
@@ -592,7 +592,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="scriptNote" module="MEI.msDesc">
-    <gloss versionDate="2022-05-18" xml:lang="en">script note</gloss>
+    <gloss xml:lang="en">script note</gloss>
     <desc xml:lang="en">Describes a particular script distinguished within the description of an
       autographic item.</desc>
     <classes>
@@ -643,7 +643,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="sealDesc" module="MEI.msDesc">
-    <gloss versionDate="2022-05-18" xml:lang="en">seal description</gloss>
+    <gloss xml:lang="en">seal description</gloss>
     <desc xml:lang="en">Describes the seals or similar external attachments applied to an
       item.</desc>
     <classes>
@@ -684,7 +684,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="secFolio" module="MEI.msDesc">
-    <gloss versionDate="2022-05-18" xml:lang="en">second folio</gloss>
+    <gloss xml:lang="en">second folio</gloss>
     <desc xml:lang="en">Marks the word or words taken from a fixed point in a codex (typically
       the beginning of the second leaf) in order to provide a unique identifier for the item.</desc>
     <classes>
@@ -780,7 +780,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="supportDesc" module="MEI.msDesc">
-    <gloss versionDate="2022-05-18" xml:lang="en">support description</gloss>
+    <gloss xml:lang="en">support description</gloss>
     <desc xml:lang="en">Groups elements describing the physical support material of an
       item.</desc>
     <classes>
@@ -848,7 +848,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="typeDesc" module="MEI.msDesc">
-    <gloss versionDate="2022-05-18" xml:lang="en">type description</gloss>
+    <gloss xml:lang="en">type description</gloss>
     <desc xml:lang="en">Contains a description of the typefaces or other aspects of the
       printing of a printed source.</desc>
     <classes>
@@ -883,7 +883,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="typeNote" module="MEI.msDesc">
-    <gloss versionDate="2022-05-18" xml:lang="en">type note</gloss>
+    <gloss xml:lang="en">type note</gloss>
     <desc xml:lang="en">Describes a particular font or other significant typographic feature of a
       printed resource.</desc>
     <classes>

--- a/source/modules/MEI.namesdates.xml
+++ b/source/modules/MEI.namesdates.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
   NOTICE: Copyright (c) 2017-2023 by the Music Encoding Initiative (MEI) Board (formerly known as "MEI Council").
 
   Licensed under the Educational Community License, Version 2.0 (the "License"); you may
@@ -66,7 +65,7 @@
     <desc xml:lang="en">Groups elements which form part of a personal name.</desc>
   </classSpec>
   <elementSpec ident="addName" module="MEI.namesdates">
-    <gloss versionDate="2022-05-18" xml:lang="en">additional name</gloss>
+    <gloss xml:lang="en">additional name</gloss>
     <desc xml:lang="en">Contains an additional name component, such as a nickname, epithet, or
       alias, or any other descriptive phrase used within a personal name.</desc>
     <classes>
@@ -119,7 +118,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="corpName" module="MEI.namesdates">
-    <gloss versionDate="2022-05-18" xml:lang="en">corporate name</gloss>
+    <gloss xml:lang="en">corporate name</gloss>
     <desc xml:lang="en">Identifies an organization or group of people that acts as a single
       entity.</desc>
     <classes>
@@ -207,7 +206,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="famName" module="MEI.namesdates">
-    <gloss versionDate="2022-05-18" xml:lang="en">family name</gloss>
+    <gloss xml:lang="en">family name</gloss>
     <desc xml:lang="en">Contains a family (inherited) name, as opposed to a given, baptismal, or
       nick name.</desc>
     <classes>
@@ -257,7 +256,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="genName" module="MEI.namesdates">
-    <gloss versionDate="2022-05-18" xml:lang="en">generational name component</gloss>
+    <gloss xml:lang="en">generational name component</gloss>
     <desc xml:lang="en">Contains a name component used to distinguish otherwise
       similar names on the basis of the relative ages or generations of the persons named.</desc>
     <classes>
@@ -284,7 +283,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="geogFeat" module="MEI.namesdates">
-    <gloss versionDate="2022-05-18" xml:lang="en">geographical feature name</gloss>
+    <gloss xml:lang="en">geographical feature name</gloss>
     <desc xml:lang="en">Contains a common noun identifying a geographical
       feature.</desc>
     <classes>
@@ -311,7 +310,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="geogName" module="MEI.namesdates">
-    <gloss versionDate="2022-05-18" xml:lang="en">geographic name</gloss>
+    <gloss xml:lang="en">geographic name</gloss>
     <desc xml:lang="en">The proper noun designation for a place, natural feature, or political
       jurisdiction.</desc>
     <classes>
@@ -347,7 +346,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="nameLink" module="MEI.namesdates">
-    <gloss versionDate="2022-05-18" xml:lang="en">name link</gloss>
+    <gloss xml:lang="en">name link</gloss>
     <desc xml:lang="en">Contains a connecting phrase or link used within a name but not regarded as
       part of it, such as "van der" or "of", "from", etc.</desc>
     <classes>
@@ -374,7 +373,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="periodName" module="MEI.namesdates">
-    <gloss versionDate="2022-05-18" xml:lang="en">period name</gloss>
+    <gloss xml:lang="en">period name</gloss>
     <desc xml:lang="en">A label that describes a period of time, such as 'Baroque' or '3rd Style
       period'.</desc>
     <classes>
@@ -402,7 +401,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="persName" module="MEI.namesdates">
-    <gloss versionDate="2022-05-18" xml:lang="en">personal name</gloss>
+    <gloss xml:lang="en">personal name</gloss>
     <desc xml:lang="en">Designation for an individual, including any or all of that individual's
       forenames, surnames, honorific titles, and added names.</desc>
     <classes>
@@ -436,7 +435,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="postBox" module="MEI.namesdates">
-    <gloss versionDate="2023-06-16" xml:lang="en">postal box or post office box</gloss>
+    <gloss xml:lang="en">postal box or post office box</gloss>
     <desc xml:lang="en">Contains a number or other identifier for some postal
       delivery point other than a street address.</desc>
     <classes>
@@ -459,7 +458,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="postCode" module="MEI.namesdates">
-    <gloss versionDate="2023-06-16" xml:lang="en">postal code</gloss>
+    <gloss xml:lang="en">postal code</gloss>
     <desc xml:lang="en">Contains a numerical or alphanumeric code used as part of a postal address
       to simplify sorting or delivery of mail.</desc>
     <classes>
@@ -508,7 +507,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="roleName" module="MEI.namesdates">
-    <gloss versionDate="2022-05-18" xml:lang="en">role name</gloss>
+    <gloss xml:lang="en">role name</gloss>
     <desc xml:lang="en">Contains a name component which indicates that the referent has a particular
       role or position in society, such as an official title or rank.</desc>
     <classes>
@@ -584,7 +583,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="styleName" module="MEI.namesdates">
-    <gloss versionDate="2022-05-18" xml:lang="en">style name</gloss>
+    <gloss xml:lang="en">style name</gloss>
     <desc xml:lang="en">A label for a characteristic style of writing or performance, such as
       'bebop' or 'rock-n-roll'.</desc>
     <classes>

--- a/source/modules/MEI.neumes.xml
+++ b/source/modules/MEI.neumes.xml
@@ -97,7 +97,7 @@
         </datatype>
       </attDef>
       <attDef ident="pname" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">pitch name</gloss>
+        <gloss xml:lang="en">pitch name</gloss>
         <desc xml:lang="en">Contains a written pitch name.</desc>
         <datatype>
           <rng:data type="token">
@@ -370,7 +370,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="ncGrp" module="MEI.neumes">
-    <gloss versionDate="2023-06-16" xml:lang="en">neume component group</gloss>
+    <gloss xml:lang="en">neume component group</gloss>
     <desc xml:lang="en">Collection of one or more neume components.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.performance.xml
+++ b/source/modules/MEI.performance.xml
@@ -49,7 +49,7 @@
     </attList>
   </classSpec>
   <elementSpec ident="avFile" module="MEI.performance">
-    <gloss versionDate="2022-05-18" xml:lang="en">audio/video file</gloss>
+    <gloss xml:lang="en">audio/video file</gloss>
     <desc xml:lang="en">References an external digital audio or video file.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.ptrref.xml
+++ b/source/modules/MEI.ptrref.xml
@@ -31,7 +31,7 @@
     </classes>
   </classSpec>
   <elementSpec ident="ptr" module="MEI.ptrref">
-    <gloss versionDate="2022-05-18" xml:lang="en">pointer</gloss>
+    <gloss xml:lang="en">pointer</gloss>
     <desc xml:lang="en">Defines a traversible pointer to another location, using only attributes to
       describe the destination.</desc>
     <classes>
@@ -55,7 +55,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="ref" module="MEI.ptrref">
-    <gloss versionDate="2022-05-18" xml:lang="en">reference</gloss>
+    <gloss xml:lang="en">reference</gloss>
     <desc xml:lang="en">Defines a traversible reference to another location. May contain text and
       sub-elements that describe the destination.</desc>
     <classes>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -982,7 +982,7 @@
     <desc xml:lang="en">Attributes that permit total duration to be represented by multiple values.</desc>
     <attList>
       <attDef ident="dur" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">duration</gloss>
+        <gloss xml:lang="en">duration</gloss>
         <desc xml:lang="en">When a duration cannot be represented as a single power-of-two value, multiple
           space-separated values that add up to the total duration may be used.</desc>
         <datatype maxOccurs="unbounded">
@@ -1021,7 +1021,7 @@
     <desc xml:lang="en">Attributes that express duration in musical terms.</desc>
     <attList>
       <attDef ident="dur" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">duration</gloss>
+        <gloss xml:lang="en">duration</gloss>
         <desc xml:lang="en">Records the duration of a feature using the relative durational values provided by the
           data.DURATION datatype.</desc>
         <datatype>
@@ -1034,7 +1034,7 @@
     <desc xml:lang="en">Attributes that describe duration as a ratio.</desc>
     <attList>
       <attDef ident="num" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">number</gloss>
+        <gloss xml:lang="en">number</gloss>
         <desc xml:lang="en">Along with numbase, describes duration as a ratio. num is the first value in the
           ratio, while numbase is the second.</desc>
         <datatype>
@@ -1504,7 +1504,7 @@
     <attList>
       <!-- additional visual characteristics of the line -->
       <attDef ident="lendsym" usage="opt">
-        <gloss versionDate="2022-11-11" xml:lang="en">line end symbol</gloss>
+        <gloss xml:lang="en">line end symbol</gloss>
         <desc xml:lang="en">Symbol rendered at end of line.</desc>
         <datatype>
           <rng:ref name="data.LINESTARTENDSYMBOL"/>
@@ -1517,7 +1517,7 @@
         </datatype>
       </attDef>
       <attDef ident="lstartsym" usage="opt">
-        <gloss versionDate="2022-11-11" xml:lang="en">line start symbol</gloss>
+        <gloss xml:lang="en">line start symbol</gloss>
         <desc xml:lang="en">Symbol rendered at start of line.</desc>
         <datatype>
           <rng:ref name="data.LINESTARTENDSYMBOL"/>
@@ -1945,7 +1945,7 @@
       meter.</desc>
     <attList>
       <attDef ident="metcon" usage="opt">
-        <gloss versionDate="2022-11-11" xml:lang="en">meter conformance</gloss>
+        <gloss xml:lang="en">meter conformance</gloss>
         <desc xml:lang="en">Indicates the relationship between the content of a staff or layer and the prevailing
           meter.</desc>
         <valList type="closed">
@@ -1967,7 +1967,7 @@
       meter.</desc>
     <attList>
       <attDef ident="metcon" usage="opt">
-        <gloss versionDate="2022-11-11" xml:lang="en">meter conformance</gloss>
+        <gloss xml:lang="en">meter conformance</gloss>
         <desc xml:lang="en">Indicates the relationship between the content of a measure and the prevailing
           meter.</desc>
         <datatype>
@@ -2000,7 +2000,7 @@
         </datatype>
       </attDef>
       <attDef ident="sym" usage="opt">
-        <gloss versionDate="2022-11-11" xml:lang="en">symbol</gloss>
+        <gloss xml:lang="en">symbol</gloss>
         <desc xml:lang="en">Indicates the use of a meter symbol instead of a numeric meter signature, that is, 'C'
           for common time or 'C' with a slash for cut time.</desc>
         <datatype>
@@ -2289,7 +2289,7 @@
     <desc xml:lang="en">Attributes that record written octave.</desc>
     <attList>
       <attDef ident="oct" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">octave</gloss>
+        <gloss xml:lang="en">octave</gloss>
         <desc xml:lang="en">Captures written octave information.</desc>
         <datatype>
           <rng:ref name="data.OCTAVE"/>
@@ -2463,28 +2463,28 @@
         </datatype>
       </attDef>
       <attDef ident="page.topmar" usage="opt">
-        <gloss versionDate="2022-11-11" xml:lang="en">page top margin</gloss>
+        <gloss xml:lang="en">page top margin</gloss>
         <desc xml:lang="en">Indicates the amount of whitespace at the top of a page.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTUNSIGNED"/>
         </datatype>
       </attDef>
       <attDef ident="page.botmar" usage="opt">
-        <gloss versionDate="2022-11-11" xml:lang="en">page bottom margin</gloss>
+        <gloss xml:lang="en">page bottom margin</gloss>
         <desc xml:lang="en">Indicates the amount of whitespace at the bottom of a page.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTUNSIGNED"/>
         </datatype>
       </attDef>
       <attDef ident="page.leftmar" usage="opt">
-        <gloss versionDate="2022-11-11" xml:lang="en">page left margin</gloss>
+        <gloss xml:lang="en">page left margin</gloss>
         <desc xml:lang="en">Indicates the amount of whitespace at the left side of a page.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTUNSIGNED"/>
         </datatype>
       </attDef>
       <attDef ident="page.rightmar" usage="opt">
-        <gloss versionDate="2022-11-11" xml:lang="en">page right margin</gloss>
+        <gloss xml:lang="en">page right margin</gloss>
         <desc xml:lang="en">Indicates the amount of whitespace at the right side of a page.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTUNSIGNED"/>
@@ -2570,7 +2570,7 @@
     <desc xml:lang="en">Attributes that record written pitch name.</desc>
     <attList>
       <attDef ident="pname" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">pitch name</gloss>
+        <gloss xml:lang="en">pitch name</gloss>
         <desc xml:lang="en">Contains a written pitch name.</desc>
         <datatype>
           <rng:ref name="data.PITCHNAME"/>
@@ -3456,7 +3456,7 @@
         </datatype>
       </attDef>
       <attDef ident="rend" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">rendition</gloss>
+        <gloss xml:lang="en">rendition</gloss>
         <desc xml:lang="en">Captures the appearance of the element’s contents using MEI-defined
           descriptors.</desc>
         <datatype maxOccurs="unbounded">
@@ -3522,7 +3522,7 @@
       part].</desc>
     <attList>
       <attDef ident="tstamp" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">time stamp</gloss>
+        <gloss xml:lang="en">time stamp</gloss>
         <desc xml:lang="en">Encodes the onset time in terms of musical time, <abbr>i.e.</abbr>, beats[.fractional beat part],
           as expressed in the written time signature.</desc>
         <datatype>
@@ -3548,7 +3548,7 @@
     <desc xml:lang="en">Attributes that describe transposition.</desc>
     <attList>
       <attDef ident="trans.diat" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">transposition (diatonic)</gloss>
+        <gloss xml:lang="en">transposition (diatonic)</gloss>
         <desc xml:lang="en">Records the amount of diatonic pitch shift, <abbr>e.g.</abbr>, C to C♯ = 0, C to D♭ = 1, necessary
           to calculate the sounded pitch from the written one.</desc>
         <datatype>
@@ -3556,7 +3556,7 @@
         </datatype>
       </attDef>
       <attDef ident="trans.semi" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">transposition (semitones)</gloss>
+        <gloss xml:lang="en">transposition (semitones)</gloss>
         <desc xml:lang="en">Records the amount of pitch shift in semitones, <abbr>e.g.</abbr>, C to C♯ = 1, C to D♭ = 1,
           necessary to calculate the sounded pitch from the written one.</desc>
         <datatype>
@@ -4311,7 +4311,7 @@
     <desc xml:lang="en">Groups elements that may appear inside the <gi scheme="MEI">tuning</gi> element.</desc>
   </classSpec>
   <elementSpec ident="accid" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">accidental</gloss>
+    <gloss xml:lang="en">accidental</gloss>
     <desc xml:lang="en">Records a temporary alteration to the pitch of a note.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4382,7 +4382,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="addrLine" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">address line</gloss>
+    <gloss xml:lang="en">address line</gloss>
     <desc xml:lang="en">Single line of a postal address.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4439,7 +4439,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="analytic" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">analytic level</gloss>
+    <gloss xml:lang="en">analytic level</gloss>
     <desc xml:lang="en">Contains bibliographic elements describing an item (<abbr>e.g.</abbr>, an article or
       poem) published within a monograph or journal and not as an independent publication.</desc>
     <classes>
@@ -4468,7 +4468,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="annot" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">annotation</gloss>
+    <gloss xml:lang="en">annotation</gloss>
     <desc xml:lang="en">Provides a statement explaining the text or indicating the basis for an
       assertion.</desc>
     <classes>
@@ -4551,7 +4551,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="artic" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">articulation</gloss>
+    <gloss xml:lang="en">articulation</gloss>
     <desc xml:lang="en">An indication of how to play a note or chord.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4624,7 +4624,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="bibl" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">bibliographic reference</gloss>
+    <gloss xml:lang="en">bibliographic reference</gloss>
     <desc xml:lang="en">Provides a loosely-structured bibliographic citation in which
       the sub-components may or may not be explicitly marked.</desc>
     <classes>
@@ -4710,7 +4710,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="biblScope" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">scope of citation</gloss>
+    <gloss xml:lang="en">scope of citation</gloss>
     <desc xml:lang="en">Defines the scope of a bibliographic reference, for example as a
       list of page numbers, or a named subdivision of a larger work.</desc>
     <classes>
@@ -4748,7 +4748,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="biblStruct" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">structured bibliographic citation</gloss>
+    <gloss xml:lang="en">structured bibliographic citation</gloss>
     <desc xml:lang="en">Contains a bibliographic citation in which
       bibliographic sub-elements must appear in a specified order.</desc>
     <classes>
@@ -4867,7 +4867,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="castGrp" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">cast group</gloss>
+    <gloss xml:lang="en">cast group</gloss>
     <desc xml:lang="en">Groups one or more individual castItem elements within a cast list.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -4936,7 +4936,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="cb" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">column beginning</gloss>
+    <gloss xml:lang="en">column beginning</gloss>
     <desc xml:lang="en">An empty formatting element that forces text to begin in a new
       column.</desc>
     <classes>
@@ -5051,7 +5051,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="clefGrp" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">clef group</gloss>
+    <gloss xml:lang="en">clef group</gloss>
     <desc xml:lang="en">A set of simultaneously-occurring clefs.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -5071,7 +5071,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="colLayout" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">column layout</gloss>
+    <gloss xml:lang="en">column layout</gloss>
     <desc xml:lang="en">An empty formatting element that signals the start of columnar
       layout.</desc>
     <classes>
@@ -5280,7 +5280,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="desc" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">description</gloss>
+    <gloss xml:lang="en">description</gloss>
     <desc xml:lang="en">Container for text that briefly describes the feature to which it is
       attached, including its intended usage, purpose, or application as appropriate.</desc>
     <classes>
@@ -5306,7 +5306,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="dim" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">dimension</gloss>
+    <gloss xml:lang="en">dimension</gloss>
     <desc xml:lang="en">Any single dimensional specification.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -5417,7 +5417,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="dir" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">directive</gloss>
+    <gloss xml:lang="en">directive</gloss>
     <desc xml:lang="en">An instruction expressed as a combination of text and symbols, typically above,
       below, or between staves, but not on the staff — that is not encoded elsewhere in more specific
       elements, like <gi scheme="MEI">tempo</gi>, <gi scheme="MEI">dynam</gi>  or <gi scheme="MEI">repeatMark</gi>.</desc>
@@ -5484,7 +5484,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="div" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">division</gloss>
+    <gloss xml:lang="en">division</gloss>
     <desc xml:lang="en">Major structural division of text, such as a preface, chapter or
       section.</desc>
     <classes>
@@ -5604,7 +5604,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="dynam" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">dynamic</gloss>
+    <gloss xml:lang="en">dynamic</gloss>
     <desc xml:lang="en">Indication of the volume of a note, phrase, or section of music.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -5655,7 +5655,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="edition" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">edition designation</gloss>
+    <gloss xml:lang="en">edition designation</gloss>
     <desc xml:lang="en">A word or text phrase that indicates a difference in either
       content or form between the item being described and a related item previously issued by the
       same publisher/distributor (<abbr>e.g.</abbr>, 2nd edition, version 2.0, etc.), or simultaneously issued by
@@ -5888,7 +5888,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="extData" module="MEI.shared">
-    <gloss versionDate="2023-05-23" xml:lang="en">extended data</gloss>
+    <gloss xml:lang="en">extended data</gloss>
     <desc xml:lang="en">Provides a container element for non-MEI data formats.</desc>
     <classes>
       <memberOf key="att.basic" />
@@ -5987,7 +5987,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="grpSym" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">group symbol</gloss>
+    <gloss xml:lang="en">group symbol</gloss>
     <desc xml:lang="en">A brace or bracket used to group two or more staves of a score or
       part.</desc>
     <classes>
@@ -6026,7 +6026,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="head" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">heading</gloss>
+    <gloss xml:lang="en">heading</gloss>
     <desc xml:lang="en">Contains any heading, for example, the title of a section of text, or the
       heading of a list.</desc>
     <classes>
@@ -6124,7 +6124,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="incip" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">incipit</gloss>
+    <gloss xml:lang="en">incipit</gloss>
     <desc xml:lang="en">The opening music and/or words of a musical or textual work.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6184,7 +6184,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="keyAccid" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">key accidental</gloss>
+    <gloss xml:lang="en">key accidental</gloss>
     <desc xml:lang="en">Accidental in a key signature.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6227,7 +6227,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="keySig" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">key signature</gloss>
+    <gloss xml:lang="en">key signature</gloss>
     <desc xml:lang="en">Written key signature.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6356,7 +6356,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="layerDef" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">layer definition</gloss>
+    <gloss xml:lang="en">layer definition</gloss>
     <desc xml:lang="en">Container for layer meta-information.</desc>
     <classes>
       <memberOf key="att.basic"/>
@@ -6388,7 +6388,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="lb" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">line beginning</gloss>
+    <gloss xml:lang="en">line beginning</gloss>
     <desc xml:lang="en">An empty formatting element that forces text to begin on a new
       line.</desc>
     <classes>
@@ -6411,7 +6411,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="lg" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">line group</gloss>
+    <gloss xml:lang="en">line group</gloss>
     <desc xml:lang="en">May be used for any section of text that is organized as a group of lines;
       however, it is most often used for a group of verse lines functioning as a formal unit, <abbr>e.g.</abbr>, a
       stanza, refrain, verse paragraph, etc.</desc>
@@ -6485,7 +6485,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="mdiv" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">musical division</gloss>
+    <gloss xml:lang="en">musical division</gloss>
     <desc xml:lang="en">Contains a subdivision of the body of a musical text.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6556,7 +6556,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="monogr" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">monograph level</gloss>
+    <gloss xml:lang="en">monograph level</gloss>
     <desc xml:lang="en">Contains bibliographic elements describing an item, for example, a
       published book or journal, score, recording, or an unpublished manuscript.</desc>
     <classes>
@@ -6779,7 +6779,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="num" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">number</gloss>
+    <gloss xml:lang="en">number</gloss>
     <desc xml:lang="en">Numeric information in any form.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6852,7 +6852,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="p" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">paragraph</gloss>
+    <gloss xml:lang="en">paragraph</gloss>
     <desc xml:lang="en">One or more text phrases that form a logical prose passage.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6880,7 +6880,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pad" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">padding</gloss>
+    <gloss xml:lang="en">padding</gloss>
     <desc xml:lang="en">An indication of extra visual space between notational elements.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -6952,7 +6952,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="pb" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">page beginning</gloss>
+    <gloss xml:lang="en">page beginning</gloss>
     <desc xml:lang="en">An empty formatting element that forces text to begin on a new
       page.</desc>
     <classes>
@@ -6980,7 +6980,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pgDesc" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">page description</gloss>
+    <gloss xml:lang="en">page description</gloss>
     <desc xml:lang="en">Contains a brief prose description of the appearance or description
       of the content of a physical page.</desc>
     <classes>
@@ -7006,7 +7006,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pgFoot" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">page footer</gloss>
+    <gloss xml:lang="en">page footer</gloss>
     <desc xml:lang="en">A running footer.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -7039,7 +7039,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pgHead" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">page header</gloss>
+    <gloss xml:lang="en">page header</gloss>
     <desc xml:lang="en">A running header.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -7130,7 +7130,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="physLoc" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">physical location</gloss>
+    <gloss xml:lang="en">physical location</gloss>
     <desc xml:lang="en">Groups information about the current physical location of a
       bibliographic item, such as the repository in which it is located and its shelf mark(s), and
       its previous locations.</desc>
@@ -7183,7 +7183,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="pubPlace" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">publication place</gloss>
+    <gloss xml:lang="en">publication place</gloss>
     <desc xml:lang="en">Name of the place where a bibliographic item was published.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -7225,7 +7225,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="relatedItem" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">related item</gloss>
+    <gloss xml:lang="en">related item</gloss>
     <desc xml:lang="en">Contains or references another bibliographic item which is related to the
       present one.</desc>
     <classes>
@@ -7367,7 +7367,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="rend" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">render</gloss>
+    <gloss xml:lang="en">render</gloss>
     <desc xml:lang="en">A formatting element indicating special visual rendering, <abbr>e.g.</abbr>, bold or
       italicized, of a text word or phrase.</desc>
     <classes>
@@ -7436,7 +7436,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="resp" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">responsibility</gloss>
+    <gloss xml:lang="en">responsibility</gloss>
     <desc xml:lang="en">A phrase describing the nature of intellectual responsibility.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -7463,7 +7463,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="respStmt" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">responsibility statement</gloss>
+    <gloss xml:lang="en">responsibility statement</gloss>
     <desc xml:lang="en">Transcription of text that names one or more individuals,
       groups, or in rare cases, mechanical processes, responsible for creation, realization,
       production, funding, or distribution of the intellectual or artistic content.</desc>
@@ -7559,7 +7559,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="roleDesc" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">role description</gloss>
+    <gloss xml:lang="en">role description</gloss>
     <desc xml:lang="en">Describes a character’s role in a drama.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -7579,7 +7579,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="sb" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">system beginning</gloss>
+    <gloss xml:lang="en">system beginning</gloss>
     <desc xml:lang="en">An empty formatting element that forces musical notation to begin on
       a new line.</desc>
     <classes>
@@ -7635,7 +7635,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="scoreDef" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">score definition</gloss>
+    <gloss xml:lang="en">score definition</gloss>
     <desc xml:lang="en">Container for score meta-information.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -7822,7 +7822,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="stack" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">stacked text</gloss>
+    <gloss xml:lang="en">stacked text</gloss>
     <desc xml:lang="en">An inline table with a single column.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -7932,7 +7932,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="staffDef" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">staff definition</gloss>
+    <gloss xml:lang="en">staff definition</gloss>
     <desc xml:lang="en">Container for staff meta-information.</desc>
     <classes>
       <memberOf key="att.basic"/>
@@ -8081,7 +8081,7 @@
     </constraintSpec>
   </elementSpec>
   <elementSpec ident="staffGrp" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">staff group</gloss>
+    <gloss xml:lang="en">staff group</gloss>
     <desc xml:lang="en">A group of bracketed or braced staves.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -8131,7 +8131,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="syl" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">syllable</gloss>
+    <gloss xml:lang="en">syllable</gloss>
     <desc xml:lang="en">Individual lyric syllable.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -8281,7 +8281,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="textLang" module="MEI.shared">
-    <gloss versionDate="2022-05-18" xml:lang="en">text language</gloss>
+    <gloss xml:lang="en">text language</gloss>
     <desc xml:lang="en">Identifies the languages and writing systems within the work described
       by a bibliographic description, not the language of the description.</desc>
     <classes>

--- a/source/modules/MEI.text.xml
+++ b/source/modules/MEI.text.xml
@@ -101,7 +101,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="back" module="MEI.text">
-    <gloss versionDate="2022-05-18" xml:lang="en">back matter</gloss>
+    <gloss xml:lang="en">back matter</gloss>
     <desc xml:lang="en">Contains any appendixes, advertisements, indexes, etc. following the main
       body of a musical text.</desc>
     <classes>
@@ -148,7 +148,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="front" module="MEI.text">
-    <gloss versionDate="2022-05-18" xml:lang="en">front matter</gloss>
+    <gloss xml:lang="en">front matter</gloss>
     <desc xml:lang="en">Bundles prefatory text found before the start of the musical text.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -202,7 +202,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="l" module="MEI.text">
-    <gloss versionDate="2022-05-18" xml:lang="en">line of text</gloss>
+    <gloss xml:lang="en">line of text</gloss>
     <desc xml:lang="en">Contains a single line of text within a line group.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -241,7 +241,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="li" module="MEI.text">
-    <gloss versionDate="2022-05-18" xml:lang="en">list item</gloss>
+    <gloss xml:lang="en">list item</gloss>
     <desc xml:lang="en">Single item in a <gi scheme="MEI">list</gi>.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -357,7 +357,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="q" module="MEI.text">
-    <gloss versionDate="2022-05-18" xml:lang="en">quoted</gloss>
+    <gloss xml:lang="en">quoted</gloss>
     <desc xml:lang="en">Contains material which is distinguished from the surrounding phrase-level text
       using quotation marks or a similar method. Use <gi scheme="MEI">quote</gi> for block-level
       quotations.</desc>
@@ -427,7 +427,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="quote" module="MEI.text">
-    <gloss versionDate="2022-05-18" xml:lang="en">quoted material</gloss>
+    <gloss xml:lang="en">quoted material</gloss>
     <desc xml:lang="en">Contains a paragraph-like block of text attributed to an external
       source, normally set off from the surrounding text by spacing or other typographic
       distinction.</desc>
@@ -458,7 +458,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="seg" module="MEI.text">
-    <gloss versionDate="2023-06-16" xml:lang="en">arbitrary segment</gloss>
+    <gloss xml:lang="en">arbitrary segment</gloss>
     <desc xml:lang="en">represents any segmentation of text below the "text component" level.</desc>
     <classes>
       <memberOf key="att.common"/>

--- a/source/modules/MEI.usersymbols.xml
+++ b/source/modules/MEI.usersymbols.xml
@@ -266,7 +266,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="propName" module="MEI.usersymbols">
-    <gloss versionDate="2022-05-18" xml:lang="en">property name</gloss>
+    <gloss xml:lang="en">property name</gloss>
     <desc xml:lang="en">Name of a property of the symbol.</desc>
     <classes>
       <memberOf key="att.basic"/>
@@ -293,7 +293,7 @@
     </attList>
   </elementSpec>
   <elementSpec ident="propValue" module="MEI.usersymbols">
-    <gloss versionDate="2022-05-18" xml:lang="en">property value</gloss>
+    <gloss xml:lang="en">property value</gloss>
     <desc xml:lang="en">A single property value.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -303,7 +303,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="symbolDef" module="MEI.usersymbols">
-    <gloss versionDate="2022-05-18" xml:lang="en">symbol definition</gloss>
+    <gloss xml:lang="en">symbol definition</gloss>
     <desc xml:lang="en">Declaration of an individual symbol in a symbolTable.</desc>
     <classes>
       <memberOf key="att.common"/>
@@ -343,7 +343,7 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="symName" module="MEI.usersymbols">
-    <gloss versionDate="2022-05-18" xml:lang="en">symbol name</gloss>
+    <gloss xml:lang="en">symbol name</gloss>
     <desc xml:lang="en">Contains the name of a symbol, expressed following Unicode
       conventions.</desc>
     <classes>
@@ -354,7 +354,7 @@
     </content>
   </elementSpec>
   <elementSpec ident="symProp" module="MEI.usersymbols">
-    <gloss versionDate="2022-05-18" xml:lang="en">symbol property</gloss>
+    <gloss xml:lang="en">symbol property</gloss>
     <desc xml:lang="en">Provides a name and value for some property of the parent
       symbol.</desc>
     <classes>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -158,7 +158,7 @@
     </classes>
     <attList>
       <attDef ident="len" usage="opt">
-        <gloss versionDate="2022-10-30" xml:lang="en">length</gloss>
+        <gloss xml:lang="en">length</gloss>
         <desc xml:lang="en">States the length of bar lines in virtual units. The value must be greater than 0 and
           is typically equal to 2 times (the number of staff lines - 1); <abbr>e.g.</abbr>, a value of <val>8</val> for a
           5-line staff.</desc>
@@ -625,7 +625,7 @@
     </classes>
     <attList>
       <attDef ident="orient" usage="opt">
-        <gloss versionDate="2022-10-30" xml:lang="en">orientation</gloss>
+        <gloss xml:lang="en">orientation</gloss>
         <valList type="closed">
           <valItem ident="horiz">
             <desc xml:lang="en">Combination expressed horizontally, as for brass instruments.</desc>
@@ -1469,14 +1469,14 @@
     <desc xml:lang="en">Visual domain attributes that describe the properties of a plica stem in the mensural repertoire.</desc>
     <attList>
       <attDef ident="dir" usage="opt">
-        <gloss versionDate="2022-10-30" xml:lang="en">direction</gloss>
+        <gloss xml:lang="en">direction</gloss>
         <desc xml:lang="en">Describes the direction of a stem.</desc>
         <datatype>
           <rng:ref name="data.STEMDIRECTION.basic"/>
         </datatype>
       </attDef>
       <attDef ident="len" usage="opt">
-        <gloss versionDate="2022-10-30" xml:lang="en">length</gloss>
+        <gloss xml:lang="en">length</gloss>
         <desc xml:lang="en">Encodes the stem length.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTUNSIGNED"/>
@@ -1777,7 +1777,7 @@
     </classes>
     <attList>
       <attDef ident="bar.thru" usage="opt">
-        <gloss versionDate="2022-10-18" xml:lang="en">bar lines through</gloss>
+        <gloss xml:lang="en">bar lines through</gloss>
         <desc xml:lang="en">Indicates whether bar lines go across the space between staves (true) or are only
           drawn across the lines of each staff (false).</desc>
         <datatype>
@@ -1810,14 +1810,14 @@
     </classes>
     <attList>
       <attDef ident="pos" usage="opt">
-        <gloss versionDate="2022-10-30" xml:lang="en">position</gloss>
+        <gloss xml:lang="en">position</gloss>
         <desc xml:lang="en">Records the position of the stem in relation to the note head(s).</desc>
         <datatype>
           <rng:ref name="data.STEMPOSITION"/>
         </datatype>
       </attDef>
       <attDef ident="len" usage="opt">
-        <gloss versionDate="2022-10-30" xml:lang="en">length</gloss>
+        <gloss xml:lang="en">length</gloss>
         <desc xml:lang="en">Encodes the stem length.</desc>
         <datatype>
           <rng:ref name="data.MEASUREMENTUNSIGNED"/>
@@ -1830,7 +1830,7 @@
         </datatype>
       </attDef>
       <attDef ident="dir" usage="opt">
-        <gloss versionDate="2022-10-30" xml:lang="en">direction</gloss>
+        <gloss xml:lang="en">direction</gloss>
         <desc xml:lang="en">Describes the direction of a stem.</desc>
         <datatype>
           <rng:ref name="data.STEMDIRECTION"/>


### PR DESCRIPTION
There is a consensus that MEI Guidelines are not going to be translated - at least at this stage. For this reason, having `@versionDate` is not really useful. Also, the addition date of an element is preserved by Git. Furthermore, it is not clear whereas the attribute value should be updated or not when the content of the element is update. For these reasons, it is simpler not to have it and this PR just removes it.