### PR TITLE
utils: improve searchability of attributes in the guidelines

### DIFF
--- a/source/assets/css/print/mei.css
+++ b/source/assets/css/print/mei.css
@@ -737,10 +737,6 @@ div.facet.attributes div.classItem > label {
     display: none;
 }
 
-div.facet div.classItem span.ident.attribute:before, span.att:before {
-    content: '@';
-}
-
 span.val:before {
     content: "'";
 }

--- a/source/assets/css/screen/mei-screen.css
+++ b/source/assets/css/screen/mei-screen.css
@@ -116,10 +116,6 @@
 	font-weight: bold;
 }
 
-.specPage .ident.attribute:before {
-	content: '@';
-}
-
 .specPage .chapterLinksBox {
 	font-size: .75rem;
 	font-weight: 400;
@@ -313,10 +309,6 @@ h2, h3 {
 
 span.att {
     font-weight: bolder;
-}
-
-span.att:before, .link_odd–attClass:before {
-    content: '@';
 }
 
 span.caption {

--- a/source/assets/css/screen/mei-website.css
+++ b/source/assets/css/screen/mei-website.css
@@ -4249,9 +4249,6 @@ a.text-error:hover {
 .specPage .ident {
  font-weight:bold
 }
-.specPage .ident.attribute:before {
- content:'@'
-}
 .specPage .chapterLinksBox {
  font-size:.75rem;
  font-weight:400

--- a/utils/guidelines_xslt/odd2html/generateWebsite.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsite.xsl
@@ -823,7 +823,7 @@
             </span>
             <xsl:for-each select="child::item[@class='attribute']">
                 <div class="attributeRef">
-                    <span class="ident attribute"><xsl:value-of select="child::link/text()"/></span>
+                    <span class="ident attribute">@<xsl:value-of select="child::link/text()"/></span>
                     <span class="desc"><xsl:apply-templates select="child::desc/node()" mode="get.website"/></span>
                 </div>
             </xsl:for-each>
@@ -985,7 +985,7 @@
               <table class="specDesc">
                  <tbody>
                     <tr>
-                       <td class="Attribute"><span class="att"><a class="link_odd link_odd_attClass" href="../attribute-classes/att.evidence.html">cert</a></span></td>
+                       <td class="Attribute"><span class="att">@<a class="link_odd link_odd_attClass" href="../attribute-classes/att.evidence.html">cert</a></span></td>
                        <td>Signifies the degree of certainty or precision associated with a feature.</td>
                     </tr>
                  </tbody>

--- a/utils/guidelines_xslt/odd2html/guidelines.xsl
+++ b/utils/guidelines_xslt/odd2html/guidelines.xsl
@@ -210,7 +210,7 @@
                                 <xsl:variable name="current.att" select="." as="xs:string"/>
                                 <tr>
                                     <td class="Attribute">
-                                        <span class="att"><xsl:value-of select="$current.att"/></span> (<a class="{tools:getLinkClasses($key)}" href="#{$key}"><xsl:value-of select="$key"/></a>)
+                                        <span class="att">@<xsl:value-of select="$current.att"/></span> (<a class="{tools:getLinkClasses($key)}" href="#{$key}"><xsl:value-of select="$key"/></a>)
                                     </td>
                                     <td>
                                         <xsl:choose>
@@ -336,7 +336,7 @@
         </xd:desc>
     </xd:doc>
     <xsl:template match="tei:att" mode="guidelines">
-        <span class="att"><xsl:apply-templates select="node()" mode="#current"/></span>
+        <span class="att">@<xsl:apply-templates select="node()" mode="#current"/></span>
     </xsl:template>
     
     <xd:doc>

--- a/utils/guidelines_xslt/odd2html/preparePDF.xsl
+++ b/utils/guidelines_xslt/odd2html/preparePDF.xsl
@@ -82,7 +82,7 @@
                                     <div class="classItem">
                                         <label>
                                             <a class="link_odd link_odd_elementSpec" href="#{$current.item/@ident}"><xsl:value-of select="$current.item/@ident"/></a> / 
-                                            <span class="ident attribute"><xsl:value-of select="$att.item/link/text()"/></span> 
+                                            <span class="ident attribute">@<xsl:value-of select="$att.item/link/text()"/></span> 
                                         </label>
                                         <div class="desc"><xsl:apply-templates select="$att.item/desc/node()" mode="#current"/></div>
                                     </div>

--- a/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
@@ -625,7 +625,7 @@
         <item class="attribute" ident="{$current.att/@ident}" module="{$module}">
             <link><xsl:value-of select="$current.att/@ident"/></link>
             <desc>
-                <span class="ident attribute" title="{normalize-space(string-join($desc/descendant-or-self::text(),' '))}"><xsl:value-of select="$current.att/@ident"/></span>
+                <span class="ident attribute" title="{normalize-space(string-join($desc/descendant-or-self::text(),' '))}">@<xsl:value-of select="$current.att/@ident"/></span>
                 <xsl:if test="$usage">
                     <span class="attributeUsage">(<xsl:value-of select="$usage"/>)</span>
                 </xsl:if>
@@ -805,7 +805,7 @@
         
         <!--
         <div class="attributeDef def" data-module="{$module}">
-            <span class="ident attribute" title="{normalize-space(string-join($desc/descendant-or-self::text(),' '))}"><xsl:value-of select="$current.att/@ident"/></span>
+            <span class="ident attribute" title="{normalize-space(string-join($desc/descendant-or-self::text(),' '))}">@<xsl:value-of select="$current.att/@ident"/></span>
             <xsl:if test="$usage">
                 <span class="attributeUsage">(<xsl:value-of select="$usage"/>)</span>
             </xsl:if>
@@ -1561,7 +1561,7 @@
         </xd:desc>
     </xd:doc>
     <xsl:template match="tei:att" mode="parse.odd">
-        <span class="att"><xsl:apply-templates select="node()" mode="#current"/></span>
+        <span class="att">@<xsl:apply-templates select="node()" mode="#current"/></span>
     </xsl:template>
     
     <xd:doc>


### PR DESCRIPTION
This PR improves the searchability of attributes in the guidelines by removing the css-driven pseudo-`@` and includes literal `@`-signs in the utils scripts.

Fixes part of #1518 .

(This is for testing purposes. If we decide to go this route, we can also consider enhancements for elements).