### PR TITLE
utils: make attribute and element symbols (`@`, `<`, `>`) searchable & selectable

### DIFF
--- a/source/assets/css/print/mei.css
+++ b/source/assets/css/print/mei.css
@@ -745,22 +745,6 @@ span.val:after {
     content: "'";
 }
 
-.specSection a.link_odd_elementSpec:before, p > a.link_odd_elementSpec:before, .specDesc a.link_odd_elementSpec:before {
-    content: '<';
-}
-
-code .attributevalue a.link_odd_elementSpec:before {
-    content: '';
-}
-
-.specSection a.link_odd_elementSpec:after, p > a.link_odd_elementSpec:after, .specDesc a.link_odd_elementSpec:after {
-    content: '>';
-}
-
-code .attributevalue a.link_odd_elementSpec:after {
-    content: '';
-}
-
 p, body {
     widows: 3;
     orphans: 3;

--- a/source/assets/css/print/mei.css
+++ b/source/assets/css/print/mei.css
@@ -737,10 +737,6 @@ div.facet.attributes div.classItem > label {
     display: none;
 }
 
-div.facet div.classItem span.ident.attribute:before, span.att:before {
-    content: '@';
-}
-
 span.val:before {
     content: "'";
 }

--- a/source/assets/css/print/tei.css
+++ b/source/assets/css/print/tei.css
@@ -1047,14 +1047,6 @@ span.specList-macroSpec {
 span.specList-elementSpec {
     font-weight: bold;
 }
-span.specList-elementSpec:before {
-    /*content: "<";*/
-     
-}
-span.specList-elementSpec:after {
-    /*content: ">";*/
-     
-}
 span.specList-classSpec {
     font-weight: bold;
 }

--- a/source/assets/css/screen/mei-screen.css
+++ b/source/assets/css/screen/mei-screen.css
@@ -100,14 +100,6 @@
 	padding: 0 .2rem;
 }
 
-.specPage .facet.letter a.overviewLink.element:before {
-	content: '<';
-}
-
-.specPage .facet.letter a.overviewLink.element:after {
-	content: '>';
-}
-
 .specPage .facet.letter a.overviewLink.attribute {
 	padding: 0 .3rem;
 }
@@ -341,14 +333,6 @@ span.val:after {
 
 img.graphic {
     max-width: 100%;
-}
-
-.searchHit a.element:before {
-    content: '<';
-}
-
-.searchHit a.element:after {
-    content: '>';
 }
 
 .searchPreview {

--- a/source/assets/css/screen/mei-screen.css
+++ b/source/assets/css/screen/mei-screen.css
@@ -116,10 +116,6 @@
 	font-weight: bold;
 }
 
-.specPage .ident.attribute:before {
-	content: '@';
-}
-
 .specPage .chapterLinksBox {
 	font-size: .75rem;
 	font-weight: 400;
@@ -313,10 +309,6 @@ h2, h3 {
 
 span.att {
     font-weight: bolder;
-}
-
-span.att:before, .link_odd–attClass:before {
-    content: '@';
 }
 
 span.caption {

--- a/source/assets/css/screen/mei-website.css
+++ b/source/assets/css/screen/mei-website.css
@@ -4249,9 +4249,6 @@ a.text-error:hover {
 .specPage .ident {
  font-weight:bold
 }
-.specPage .ident.attribute:before {
- content:'@'
-}
 .specPage .chapterLinksBox {
  font-size:.75rem;
  font-weight:400

--- a/source/assets/css/screen/mei-website.css
+++ b/source/assets/css/screen/mei-website.css
@@ -4237,12 +4237,6 @@ a.text-error:hover {
  display:inline-block;
  padding:0 .2rem
 }
-.specPage .facet.letter a.overviewLink.element:before {
- content:'<'
-}
-.specPage .facet.letter a.overviewLink.element:after {
- content:'>'
-}
 .specPage .facet.letter a.overviewLink.attribute {
  padding:0 .3rem
 }
@@ -4631,12 +4625,6 @@ p.sectionToc a.level-4 {
 p.mainToc {
  margin:0 0 0.2rem
 }
-a.link_odd_elementSpec:before {
- content:'<'
-}
-a.link_odd_elementSpec:after {
- content:'>'
-}
 a.guidelines-edit {
  margin-left:10px;
  float:right;
@@ -5004,9 +4992,6 @@ table.wovenodd>tbody>tr>td table thead {
 }
 .oldGuidelines .textwidget .pre {
  margin-bottom:1.2rem
-}
-.oldGuidelines .textwidget .att:before {
- content:"@"
 }
 .oldGuidelines .textwidget ul.specList {
  list-style-type:none;

--- a/utils/compare_versions/comparison.xsl
+++ b/utils/compare_versions/comparison.xsl
@@ -269,7 +269,7 @@
                     or count($changed.atts) gt 0">
                     <tr class="c" id="{$current.element}">
                         <td class="element ident">
-                            <xsl:value-of select="$current.element"/>
+                            %lt;<xsl:value-of select="$current.element"/>%gt;
                         </td>
                         <td class="module">
                             <xsl:value-of select="$new.element/@module"/>
@@ -418,7 +418,7 @@
                 <tr class="a" id="{$current.element}">
                     <td class="element ident">
                         <a href="{$new.guidelines}/elements/{$current.element}.html" target="_blank">
-                            <xsl:value-of select="$current.element"/>
+                            &lt;<xsl:value-of select="$current.element"/>&gt;
                         </a>
                     </td>
                     <td class="module">
@@ -440,7 +440,7 @@
                 <xsl:variable name="elementSpec" select="$old.file//tei:elementSpec[@ident = $current.element]" as="node()"/>
                 <tr class="r" id="{$current.element}">
                     <td class="element ident">
-                        <xsl:value-of select="$current.element"/>
+                        &lt;<xsl:value-of select="$current.element"/>&gt;
                     </td>
                     <td class="module">
                         <xsl:value-of select="$elementSpec/@module"/>
@@ -465,7 +465,7 @@
                 <xsl:variable name="elementSpec" select="$new.file//tei:elementSpec[@ident = $current.element]" as="node()"/>
                 <tr class="u">
                     <td class="element ident">
-                        <xsl:value-of select="$current.element"/>
+                        &lt;<xsl:value-of select="$current.element"/>&gt;
                     </td>
                     <td class="module unchanged">
                         <xsl:value-of select="$elementSpec/@module"/>

--- a/utils/compare_versions/resources/css/main.css
+++ b/utils/compare_versions/resources/css/main.css
@@ -18,18 +18,6 @@
     fill: #999999;
 }
 
-.attribute:before {
-    content: '@';
-}
-
-.element:before {
-    content: '<';
-}
-
-.element:after {
-    content: '>';
-}
-
 .block {
     display: block;
 }

--- a/utils/guidelines_xslt/odd2html/generateSearchIndex.xsl
+++ b/utils/guidelines_xslt/odd2html/generateSearchIndex.xsl
@@ -184,7 +184,7 @@
                     let a = document.createElement('a')
                     a.setAttribute('href', pathAdjust + hit.item.url)
                     a.classList.add(hit.item.type)
-                    a.innerHTML = hit.item.ident
+                    a.innerHTML = "&amp;lt;" + hit.item.ident + "&amp;gt;"
                     div.append(a)
                     
                     if(hit.item.type === 'chapter') {

--- a/utils/guidelines_xslt/odd2html/generateSearchIndex.xsl
+++ b/utils/guidelines_xslt/odd2html/generateSearchIndex.xsl
@@ -184,9 +184,12 @@
                     let a = document.createElement('a')
                     a.setAttribute('href', pathAdjust + hit.item.url)
                     a.classList.add(hit.item.type)
-                    a.innerHTML = "&amp;lt;" + hit.item.ident + "&amp;gt;"
+                    a.innerHTML = hit.item.ident
+                    if (hit.item.type === "element") {
+                        a.innerHTML = "&amp;lt;" + a.innerHTML + "&amp;gt;"
+                    }
                     div.append(a)
-                    
+
                     if(hit.item.type === 'chapter') {
                         
                         let remarksHits = hit.matches.filter(m => m.key === 'remarks')

--- a/utils/guidelines_xslt/odd2html/generateWebsite.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsite.xsl
@@ -823,7 +823,7 @@
             </span>
             <xsl:for-each select="child::item[@class='attribute']">
                 <div class="attributeRef">
-                    <span class="ident attribute"><xsl:value-of select="child::link/text()"/></span>
+                    <span class="ident attribute">@<xsl:value-of select="child::link/text()"/></span>
                     <span class="desc"><xsl:apply-templates select="child::desc/node()" mode="get.website"/></span>
                 </div>
             </xsl:for-each>
@@ -985,7 +985,7 @@
               <table class="specDesc">
                  <tbody>
                     <tr>
-                       <td class="Attribute"><span class="att"><a class="link_odd link_odd_attClass" href="../attribute-classes/att.evidence.html">cert</a></span></td>
+                       <td class="Attribute"><span class="att">@<a class="link_odd link_odd_attClass" href="../attribute-classes/att.evidence.html">cert</a></span></td>
                        <td>Signifies the degree of certainty or precision associated with a feature.</td>
                     </tr>
                  </tbody>

--- a/utils/guidelines_xslt/odd2html/generateWebsite.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsite.xsl
@@ -198,7 +198,7 @@
                             <div class="statement compact list">
                                 <xsl:for-each select="$elementSpecs[starts-with(@id, $current.letter)]">
                                     <xsl:sort select="@id"/>
-                                    <a class="overviewLink element" title="{normalize-space(string-join(parent::section/div[@class='specs']/div[@class='desc']/text(),' '))}" data-initial="{$current.letter}" data-ident="{@id}" href="./elements/{@id}.html"><xsl:value-of select="@id"/></a>
+                                    <a class="overviewLink element" title="{normalize-space(string-join(parent::section/div[@class='specs']/div[@class='desc']/text(),' '))}" data-initial="{$current.letter}" data-ident="{@id}" href="./elements/{@id}.html">&lt;<xsl:value-of select="@id"/>&gt;</a>
                                 </xsl:for-each>
                             </div>
                         </div>
@@ -977,7 +977,7 @@
         <!-- 
             <li class="specDesc">
                 <span class="specList-elementSpec">
-                    <a class="link_odd link_odd_elementSpec" href="../elements/app.html">app</a>
+                    <a class="link_odd link_odd_elementSpec" href="../elements/app.html">&lt;app&gt;</a>
                 </span>(apparatus) – Contains one or more alternative encodings.
             </li> -->
         <!-- 

--- a/utils/guidelines_xslt/odd2html/guidelines.xsl
+++ b/utils/guidelines_xslt/odd2html/guidelines.xsl
@@ -210,7 +210,7 @@
                                 <xsl:variable name="current.att" select="." as="xs:string"/>
                                 <tr>
                                     <td class="Attribute">
-                                        <span class="att"><xsl:value-of select="$current.att"/></span> (<a class="{tools:getLinkClasses($key)}" href="#{$key}"><xsl:value-of select="$key"/></a>)
+                                        <span class="att">@<xsl:value-of select="$current.att"/></span> (<a class="{tools:getLinkClasses($key)}" href="#{$key}"><xsl:value-of select="$key"/></a>)
                                     </td>
                                     <td>
                                         <xsl:choose>
@@ -336,7 +336,7 @@
         </xd:desc>
     </xd:doc>
     <xsl:template match="tei:att" mode="guidelines">
-        <span class="att"><xsl:apply-templates select="node()" mode="#current"/></span>
+        <span class="att">@<xsl:apply-templates select="node()" mode="#current"/></span>
     </xsl:template>
     
     <xd:doc>

--- a/utils/guidelines_xslt/odd2html/guidelines.xsl
+++ b/utils/guidelines_xslt/odd2html/guidelines.xsl
@@ -198,7 +198,7 @@
             <xsl:attribute name="class" select="'specDesc'"/>
             <xsl:choose>
                 <xsl:when test="not($specDesc/@atts)">
-                    <span class="specList-{local-name($spec)}"><a class="{tools:getLinkClasses($key)}" href="#{$key}"><xsl:value-of select="$key"/></a></span>
+                    <span class="specList-{local-name($spec)}"><a class="{tools:getLinkClasses($key)}" href="#{$key}">&lt;<xsl:value-of select="$key"/>&gt;</a></span>
                     <span class="specList-{local-name($spec)}-desc">
                         <xsl:apply-templates select="$spec/tei:desc/node()" mode="#current"/>
                     </span>

--- a/utils/guidelines_xslt/odd2html/guidelines.xsl
+++ b/utils/guidelines_xslt/odd2html/guidelines.xsl
@@ -130,7 +130,7 @@
         <xsl:variable name="text" select="string(text())" as="xs:string"/>
         <xsl:choose>
             <xsl:when test="@scheme = 'TEI' and unparsed-text-available('https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-' || $text || '.html')">
-                <a class="link_odd_elementSpec" href="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-{$text}.html">tei:<xsl:value-of select="$text"/></a>
+                <a class="link_odd_elementSpec" href="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-{$text}.html">&lt;tei:<xsl:value-of select="$text"/>&gt;</a>
             </xsl:when>
             <xsl:when test="$text = $elements/@ident">
                 <a class="{tools:getLinkClasses($text)}" href="#{$text}"><xsl:value-of select="$text"/></a>

--- a/utils/guidelines_xslt/odd2html/guidelines.xsl
+++ b/utils/guidelines_xslt/odd2html/guidelines.xsl
@@ -133,7 +133,7 @@
                 <a class="link_odd_elementSpec" href="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-{$text}.html">&lt;tei:<xsl:value-of select="$text"/>&gt;</a>
             </xsl:when>
             <xsl:when test="$text = $elements/@ident">
-                <a class="{tools:getLinkClasses($text)}" href="#{$text}"><xsl:value-of select="$text"/></a>
+                <a class="{tools:getLinkClasses($text)}" href="#{$text}">&lt;<xsl:value-of select="$text"/>&gt;</a>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:message terminate="no" select="'WARNING: Unable to retrieve definition of element ' || $text || '. No link created. Please check spelling…'"/>                

--- a/utils/guidelines_xslt/odd2html/preparePDF.xsl
+++ b/utils/guidelines_xslt/odd2html/preparePDF.xsl
@@ -63,7 +63,7 @@
                 <xsl:choose>
                     <xsl:when test="$classType = 'Available at'">
                         <div class="classItem">
-                            <label><a class="link_odd link_odd_elementSpec" href="#{$current.item/@ident}"><xsl:value-of select="$current.item/@ident"/></a></label>
+                            <label><a class="link_odd link_odd_elementSpec" href="#{$current.item/@ident}">&lt;<xsl:value-of select="$current.item/@ident"/>&gt;</a></label>
                             <div class="desc"><xsl:apply-templates select="$current.item/desc/node()" mode="#current"/></div>
                             <div class="breadcrumb">
                                 <span class="step start"><xsl:value-of select="$start"/></span>
@@ -81,7 +81,7 @@
                                     <xsl:variable name="att.item" select="." as="node()"/>
                                     <div class="classItem">
                                         <label>
-                                            <a class="link_odd link_odd_elementSpec" href="#{$current.item/@ident}"><xsl:value-of select="$current.item/@ident"/></a> / 
+                                            <a class="link_odd link_odd_elementSpec" href="#{$current.item/@ident}">&lt;<xsl:value-of select="$current.item/@ident"/>&gt;</a> / 
                                             <span class="ident attribute">@<xsl:value-of select="$att.item/link/text()"/></span> 
                                         </label>
                                         <div class="desc"><xsl:apply-templates select="$att.item/desc/node()" mode="#current"/></div>

--- a/utils/guidelines_xslt/odd2html/preparePDF.xsl
+++ b/utils/guidelines_xslt/odd2html/preparePDF.xsl
@@ -82,7 +82,7 @@
                                     <div class="classItem">
                                         <label>
                                             <a class="link_odd link_odd_elementSpec" href="#{$current.item/@ident}"><xsl:value-of select="$current.item/@ident"/></a> / 
-                                            <span class="ident attribute"><xsl:value-of select="$att.item/link/text()"/></span> 
+                                            <span class="ident attribute">@<xsl:value-of select="$att.item/link/text()"/></span> 
                                         </label>
                                         <div class="desc"><xsl:apply-templates select="$att.item/desc/node()" mode="#current"/></div>
                                     </div>

--- a/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
@@ -181,7 +181,7 @@
                             <xsl:value-of select="', '"/>
                         </xsl:if>
                         <span class="ident element" title="{$desc}">
-                            <a class="link_odd_elementSpec" href="{tools:linkToElement($current.elem)}"><xsl:value-of select="$current.elem"/></a>
+                            <a class="link_odd_elementSpec" href="{tools:linkToElement($current.elem)}">&lt;<xsl:value-of select="$current.elem"/>&gt;</a>
                         </span>
                     </xsl:for-each>
                 </xsl:variable>-->
@@ -212,7 +212,7 @@
                                 <xsl:sort select="." data-type="text"/>
                                 <xsl:variable name="current.elem" select="." as="xs:string"/>
                                 <item class="element" ident="{$current.elem}" module="{$elements/self::tei:elementSpec[@ident = $current.elem]/@module}">
-                                    <link><a class="{tools:getLinkClasses($current.elem)}" href="#{$current.elem}"><xsl:value-of select="$current.elem"/></a></link>
+                                    <link><a class="{tools:getLinkClasses($current.elem)}" href="#{$current.elem}">&lt;<xsl:value-of select="$current.elem"/>&gt;</a></link>
                                     <desc><xsl:apply-templates select="$elements/self::tei:elementSpec[@ident = $current.elem]/tei:desc" mode="guidelines"/></desc>
                                 </item>
                             </xsl:for-each>
@@ -290,7 +290,7 @@
                     <xsl:value-of select="', '"/>
                 </xsl:if>
                 <span class="ident element" title="{$desc}">
-                    <a class="link_odd_elementSpec" href="{tools:linkToElement($current.elem)}"><xsl:value-of select="$current.elem"/></a>
+                    <a class="link_odd_elementSpec" href="{tools:linkToElement($current.elem)}">&lt;<xsl:value-of select="$current.elem"/><&gt;/a>
                 </span>
             </xsl:for-each>
             
@@ -339,7 +339,7 @@
                     </span>
                 </div>-->
                 <item class="element" ident="{$ident}" module="{$elements/self::tei:elementSpec[@ident = $ident]/@module}">
-                    <link><a class="{tools:getLinkClasses($ident)}" href="#{$ident}"><xsl:value-of select="$ident"/></a></link>
+                    <link><a class="{tools:getLinkClasses($ident)}" href="#{$ident}">&lt;<xsl:value-of select="$ident"/>&gt;</a></link>
                     <desc><xsl:apply-templates select="$elements/self::tei:elementSpec[@ident = $ident]/tei:desc" mode="guidelines"/></desc>
                 </item>
             </xsl:for-each>
@@ -417,7 +417,7 @@
                 <xsl:variable name="desc" select="normalize-space(string-join(tei:desc//text(),' '))" as="xs:string?"/>
                 
                 <item class="element" ident="{$current.element/@ident}" module="{$current.element/@module}">
-                    <link><a class="{tools:getLinkClasses($current.element/@ident)}" href="#{$current.element/@ident}"><xsl:value-of select="$current.element/@ident"/></a></link>
+                    <link><a class="{tools:getLinkClasses($current.element/@ident)}" href="#{$current.element/@ident}">&lt;<xsl:value-of select="$current.element/@ident"/>&gt;</a></link>
                     <desc><xsl:apply-templates select="tei:desc" mode="guidelines"/></desc>
 
                     <xsl:variable name="attributes" select="$current.element//tei:attDef[.//rng:ref[@name = $object/@ident]]" as="node()+"/>
@@ -433,7 +433,7 @@
                 </item>
                 
                 <!--<span class="ident element" data-ident="{$current.element/@ident}" data-module="{$current.element/@module}" title="{$desc}">
-                    <a class="{tools:getLinkClasses($current.element/@ident)}" href="#{$current.element/@ident}"><xsl:value-of select="$current.element/@ident"/></a>
+                    <a class="{tools:getLinkClasses($current.element/@ident)}" href="#{$current.element/@ident}">&lt;<xsl:value-of select="$current.element/@ident"/>&gt;</a>
                 </span>-->
             </xsl:for-each>
         </xsl:variable>
@@ -1065,7 +1065,7 @@
                     <xsl:value-of select="', '"/>
                 </xsl:if>
                 <span class="ident element" title="{$desc}">
-                    <a class="{tools:getLinkClasses($current.elem)}" href="#{$current.elem}"><xsl:value-of select="$current.elem"/></a>
+                    <a class="{tools:getLinkClasses($current.elem)}" href="#{$current.elem}">&lt;<xsl:value-of select="$current.elem"/>&gt;</a>
                 </span>
             </xsl:for-each>
             
@@ -1139,14 +1139,14 @@
                 <xsl:variable name="desc" select="normalize-space(string-join(./tei:desc//text(),' '))" as="xs:string"/>
                 <!--<div class="elementDef def">
                     <span class="ident element" title="{$desc}">
-                        <a class="{tools:getLinkClasses($current.elem)}" href="#{$current.elem}"><xsl:value-of select="$current.elem"/></a>
+                        <a class="{tools:getLinkClasses($current.elem)}" href="#{$current.elem}">&lt;<xsl:value-of select="$current.elem"/>&gt;</a>
                     </span>
                     <span class="elementDesc desc">
                         <xsl:apply-templates select="./tei:desc/node()" mode="guidelines"/>
                     </span>
                 </div>-->
                 <item class="element" ident="{$current.elem}" module="{$elements/self::tei:elementSpec[@ident = $current.elem]/@module}">
-                    <link><a class="{tools:getLinkClasses($current.elem)}" href="#{$current.elem}"><xsl:value-of select="$current.elem"/></a></link>
+                    <link><a class="{tools:getLinkClasses($current.elem)}" href="#{$current.elem}">&lt;<xsl:value-of select="$current.elem"/>&gt;</a></link>
                     <desc><xsl:apply-templates select="tei:desc/node()" mode="guidelines"/></desc>
                 </item>
             </xsl:for-each>
@@ -1275,7 +1275,7 @@
                             <xsl:value-of select="', '"/>
                         </xsl:if>
                         <span class="ident element" title="{$desc}">
-                            <a class="{tools:getLinkClasses($current.elem)}" href="#{$current.elem}"><xsl:value-of select="$current.elem"/></a>
+                            <a class="{tools:getLinkClasses($current.elem)}" href="#{$current.elem}">&lt;<xsl:value-of select="$current.elem"/>&gt;</a>
                         </span>
                     </xsl:for-each>
                 </xsl:variable>-->
@@ -1405,12 +1405,12 @@
                     <xsl:variable name="current.elem" select="@ident" as="xs:string"/>
                     <xsl:variable name="desc" select="normalize-space(string-join(./tei:desc//text(),' '))" as="xs:string"/>
                     <item class="element" ident="{$current.elem}" module="{$elements/self::tei:elementSpec[@ident = $current.elem]/@module}">
-                        <link><a class="{tools:getLinkClasses($current.elem)}" href="#{$current.elem}"><xsl:value-of select="$current.elem"/></a></link>
+                        <link>&lt;<a class="{tools:getLinkClasses($current.elem)}" href="#{$current.elem}"><xsl:value-of select="$current.elem"/>&gt;</a></link>
                         <desc><xsl:apply-templates select="tei:desc" mode="guidelines"/></desc>
                     </item>
                     <!--<div class="elementDef def">
                         <span class="ident element" title="{$desc}">
-                            <a class="{tools:getLinkClasses($current.elem)}" href="#{$current.elem}"><xsl:value-of select="$current.elem"/></a>
+                            <a class="{tools:getLinkClasses($current.elem)}" href="#{$current.elem}">&lt;<xsl:value-of select="$current.elem"/>&gt;</a>
                         </span>
                         <span class="elementDesc desc">
                             <xsl:apply-templates select="./tei:desc/node()" mode="guidelines"/>

--- a/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
@@ -625,7 +625,7 @@
         <item class="attribute" ident="{$current.att/@ident}" module="{$module}">
             <link><xsl:value-of select="$current.att/@ident"/></link>
             <desc>
-                <span class="ident attribute" title="{normalize-space(string-join($desc/descendant-or-self::text(),' '))}"><xsl:value-of select="$current.att/@ident"/></span>
+                <span class="ident attribute" title="{normalize-space(string-join($desc/descendant-or-self::text(),' '))}">@<xsl:value-of select="$current.att/@ident"/></span>
                 <xsl:if test="$usage">
                     <span class="attributeUsage">(<xsl:value-of select="$usage"/>)</span>
                 </xsl:if>
@@ -805,7 +805,7 @@
         
         <!--
         <div class="attributeDef def" data-module="{$module}">
-            <span class="ident attribute" title="{normalize-space(string-join($desc/descendant-or-self::text(),' '))}"><xsl:value-of select="$current.att/@ident"/></span>
+            <span class="ident attribute" title="{normalize-space(string-join($desc/descendant-or-self::text(),' '))}">@<xsl:value-of select="$current.att/@ident"/></span>
             <xsl:if test="$usage">
                 <span class="attributeUsage">(<xsl:value-of select="$usage"/>)</span>
             </xsl:if>
@@ -1561,7 +1561,7 @@
         </xd:desc>
     </xd:doc>
     <xsl:template match="tei:att" mode="parse.odd">
-        <span class="att"><xsl:apply-templates select="node()" mode="#current"/></span>
+        <span class="att">@<xsl:apply-templates select="node()" mode="#current"/></span>
     </xsl:template>
     
     <xd:doc>

--- a/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
@@ -290,7 +290,7 @@
                     <xsl:value-of select="', '"/>
                 </xsl:if>
                 <span class="ident element" title="{$desc}">
-                    <a class="link_odd_elementSpec" href="{tools:linkToElement($current.elem)}">&lt;<xsl:value-of select="$current.elem"/><&gt;/a>
+                    <a class="link_odd_elementSpec" href="{tools:linkToElement($current.elem)}">&lt;<xsl:value-of select="$current.elem"/>&gt;</a>
                 </span>
             </xsl:for-each>
             
@@ -1405,7 +1405,7 @@
                     <xsl:variable name="current.elem" select="@ident" as="xs:string"/>
                     <xsl:variable name="desc" select="normalize-space(string-join(./tei:desc//text(),' '))" as="xs:string"/>
                     <item class="element" ident="{$current.elem}" module="{$elements/self::tei:elementSpec[@ident = $current.elem]/@module}">
-                        <link>&lt;<a class="{tools:getLinkClasses($current.elem)}" href="#{$current.elem}"><xsl:value-of select="$current.elem"/>&gt;</a></link>
+                        <link><a class="{tools:getLinkClasses($current.elem)}" href="#{$current.elem}">&lt;<xsl:value-of select="$current.elem"/>&gt;</a></link>
                         <desc><xsl:apply-templates select="tei:desc" mode="guidelines"/></desc>
                     </item>
                     <!--<div class="elementDef def">

--- a/utils/guidelines_xslt/odd2html/specs/moduleSpecs.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/moduleSpecs.xsl
@@ -70,7 +70,7 @@
                     <div class="contents">
                         <xsl:variable name="items" select="$module.content//tei:elementSpec" as="node()*"/>
                         <xsl:for-each select="$items">
-                            <a class="{tools:getLinkClasses(@ident)}" href="#{@ident}" title="{normalize-space(string-join(child::tei:desc//text(),' '))}"><xsl:value-of select="@ident"/></a><xsl:if test="position() lt count($items)">, </xsl:if>        
+                            <a class="{tools:getLinkClasses(@ident)}" href="#{@ident}" title="{normalize-space(string-join(child::tei:desc//text(),' '))}">&lt;<xsl:value-of select="@ident"/>&gt;</a><xsl:if test="position() lt count($items)">, </xsl:if>
                         </xsl:for-each>
                         <xsl:if test="count($items) = 0">
                             <span class="placeholder">– no elements defined in <xsl:value-of select="$module/@ident"/> – </span>


### PR DESCRIPTION
Fixes #1518

Previously these symbols were added in css via pseudo-elements, which are not searchable or selectable on the page (see linked issue for details on how this results in poor UX). This change generates these symbols instead through xslt.