### PR TITLE
docs: remove regex from description

### DIFF
--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -498,7 +498,7 @@
         <rng:param name="minInclusive">0</rng:param>
       </rng:data>
     </content>
-    <remarks>
+    <remarks xml:lang="en">
       <p>The value must fall between 0 and the numerator of the time signature + 1,
         where 0 represents the left bar line and the upper boundary represents the right bar line.
         For example, in 12/8 the value must be in the range from 0 to 13.

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -492,15 +492,18 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.BEAT" module="MEI" type="dt">
-    <desc xml:lang="en">A beat location, <abbr>i.e.</abbr>, [0-9]+(\.?[0-9]*)? The value must fall between 0 and the numerator
-      of the time signature + 1, where 0 represents the left bar line and the upper boundary
-      represents the right bar line. For example, in 12/8 the value must be in the range from 0 to
-      13.</desc>
+    <desc xml:lang="en">A beat location, <abbr>i.e.</abbr>, a decimal number.</desc>
     <content>
       <rng:data type="decimal">
         <rng:param name="minInclusive">0</rng:param>
       </rng:data>
     </content>
+    <remarks>
+      <p>The value must fall between 0 and the numerator of the time signature + 1,
+        where 0 represents the left bar line and the upper boundary represents the right bar line.
+        For example, in 12/8 the value must be in the range from 0 to 13.
+      </p>
+    </remarks>
   </macroSpec>
   <macroSpec ident="data.BEATRPT.REND" module="MEI" type="dt">
     <desc xml:lang="en">Visual and performance information for a repeated beat symbol.</desc>


### PR DESCRIPTION
As discussed in #1520 this PR refines `data.BEAT` to remove a remaining regex from a description.