### PR TITLE
docs: refine multiRest description

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -1985,9 +1985,9 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="multiRest" module="MEI.cmn">
-    <gloss xml:lang="en">multiple rest</gloss>
-    <desc xml:lang="en">Multiple measures of rest compressed into a single symbol, frequently
-      found in performer parts.</desc>
+    <gloss xml:lang="en">multimeasure rest</gloss>
+    <desc xml:lang="en">Multiple full measure rests compressed into a single bar, 
+      frequently found in performer parts.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>


### PR DESCRIPTION
A little refinement to clarify that this element combines multiple measures between two bar lines. Furthermore it is not necessarily a single symbol.