### PR TITLE
schema: fix attribution of `@tab.anchorline` and `@tab.align`

### DIFF
--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -67,6 +67,9 @@
   </classSpec>
   <classSpec ident="att.scoreDef.vis.tablature" module="MEI.stringtab" type="atts">
     <desc xml:lang="en">Visual domain attributes for scoreDef in the tablature repertoire.</desc>
+  </classSpec>
+  <classSpec ident="att.staffDef.vis.tablature" module="MEI.stringtab" type="atts">
+    <desc xml:lang="en">Visual domain attributes for staffDef in the tablature repertoire.</desc>
     <attList>
       <attDef ident="tab.align" usage="opt">
         <desc xml:lang="en">Attribute that describes the vertical alignment of tablature symbols. Only applicable in cases where the symbols' vertical position does not communicate other information, such as courses (<abbr>i.e.</abbr>, only in German lute tablature). Typical values are <val>top</val> and <val>bottom</val>.</desc>

--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -67,9 +67,6 @@
   </classSpec>
   <classSpec ident="att.scoreDef.vis.tablature" module="MEI.stringtab" type="atts">
     <desc xml:lang="en">Visual domain attributes for scoreDef in the tablature repertoire.</desc>
-  </classSpec>
-  <classSpec ident="att.stringtab" module="MEI.stringtab" type="atts">
-    <desc xml:lang="en">String tablature string and fret information.</desc>
     <attList>
       <attDef ident="tab.align" usage="opt">
         <desc xml:lang="en">Attribute that describes the vertical alignment of tablature symbols. Only applicable in cases where the symbols' vertical position does not communicate other information, such as courses (<abbr>i.e.</abbr>, only in German lute tablature). Typical values are <val>top</val> and <val>bottom</val>.</desc>
@@ -84,6 +81,11 @@
           <rng:ref name="data.CLEFLINE"/>
         </datatype>
       </attDef>
+    </attList>
+  </classSpec>
+  <classSpec ident="att.stringtab" module="MEI.stringtab" type="atts">
+    <desc xml:lang="en">String tablature string and fret information.</desc>
+    <attList>
       <attDef ident="tab.fing" usage="opt">
         <desc xml:lang="en">This attribute is deprecated and will be removed in a future version. Indicates which finger, if any, should be used to play an individual string. The index, middle, ring, and little fingers are represented by the values 1-4, while <val>t</val> is for the thumb. The values <val>x</val> and <val>o</val> indicate muffled and open strings, respectively.</desc>
         <datatype>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1731,6 +1731,7 @@
       <memberOf key="att.visibility"/>
       <memberOf key="att.staffDef.vis.cmn"/>
       <memberOf key="att.staffDef.vis.mensural"/>
+      <memberOf key="att.staffDef.vis.tablature"/>
     </classes>
     <attList>
       <attDef ident="layerscheme" usage="opt">


### PR DESCRIPTION
Changing `<attList>` of `att.scoreDef.vis.tablature` and `att.stringtab`

This change is moving attributes `@tab.align` and `@tab.anchorline` from the list of attributes meant for string and fret information to the list of visual domain attributes of the element `<scoreDef>` .

Closes #1540 