### PR TITLE
schema: make att.course.log member of att.accidental

### DIFF
--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -62,6 +62,7 @@
   <classSpec ident="att.course.log" module="MEI.stringtab" type="atts">
     <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
+      <memberOf key="att.accidental"/>
       <memberOf key="att.pitched"/>
     </classes>
   </classSpec>


### PR DESCRIPTION
This PR makes `att.course.log` member of `att.accidental`, so `@accid` is available for `course` and `string`.

Closes #1542
