### PR TITLE
guidelines: fix tstamp explanation

### DIFF
--- a/source/docs/01-introduction.xml
+++ b/source/docs/01-introduction.xml
@@ -671,7 +671,7 @@
                         rend="italic">Events</hi> are located (see <ptr
                         target="#eventsControlevents"/>). Therefore, the allowed range of timestamps
                      stretches from 0 to the current meter count + 1. By definition, a timestamp of
-                     1 indicates the position of the left bar line, while a timestamp of 5 (in case
+                     0 indicates the position of the left bar line, while a timestamp of 5 (in case
                      of a 4/4 meter) indicates the right bar line. This makes it possible to encode
                      open-ended slurs in a graphical way. However, it should be kept in mind that
                      such timestamps may not be converted to <att>startid</att> and


### PR DESCRIPTION
Guidelines explanation of timestamps ([section 1.3.3](https://music-encoding.org/guidelines/dev/content/introduction.html#timestamps)) states that tstamp=1 is the left bar line. I think it should be 0 (that seems to be how it's interpreted in Verovio).