### PR TITLE
schema: refine `data.INTERVAL.HARMONIC`

### DIFF
--- a/source/docs/10-analysisharm.xml
+++ b/source/docs/10-analysisharm.xml
@@ -289,7 +289,7 @@
                            <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/harmony/harmony-sample261.txt" parse="text"/></egXML>
                         </figure>
                      </p>
-                     <p>The preceding encoding possibilities provide the detailed information necessary to create playable chord annotations. For more generic uses, however, the encoding can be taken one step further; that is, it can be reduced to its minimum intervallic content by eliminating octave duplications and expressing all chord members, including the bass note, using intervals above the bass. Of course, the <att>inth</att> attribute for the bass note itself should be set to 0. For example:</p>
+                     <p>The preceding encoding possibilities provide the detailed information necessary to create playable chord annotations. For more generic uses, however, the encoding can be taken one step further; that is, it can be reduced to its minimum intervallic content by eliminating octave duplications and expressing all chord members, including the bass note, using intervals above the bass. Of course, the <att>inth</att> attribute for the bass note itself should be set to P1. For example:</p>
                      <p>
                         <figure>
                            <head/>

--- a/source/examples/harmony/harmony-sample261.txt
+++ b/source/examples/harmony/harmony-sample261.txt
@@ -1,7 +1,7 @@
 <chordDef xml:id="harmonychordA2">
    <chordMember oct="2" pname="a"/>
-   <chordMember inth="7"/>
-   <chordMember inth="16"/>
-   <chordMember inth="19"/>
-   <chordMember inth="24"/>
+   <chordMember inth="P5"/>
+   <chordMember inth="M10"/>
+   <chordMember inth="P12"/>
+   <chordMember inth="P15"/>
 </chordDef>

--- a/source/examples/harmony/harmony-sample262.txt
+++ b/source/examples/harmony/harmony-sample262.txt
@@ -1,5 +1,5 @@
 <chordDef xml:id="harmonychordA3">
-   <chordMember inth="0"/>
-   <chordMember inth="4"/>
-   <chordMember inth="7"/>
+   <chordMember inth="P1"/>
+   <chordMember inth="M3"/>
+   <chordMember inth="P5"/>
 </chordDef>

--- a/source/modules/MEI.harmony.xml
+++ b/source/modules/MEI.harmony.xml
@@ -143,8 +143,8 @@
       <p>The <att>string</att>, <att>fret</att>, and <att>fing</att> attributes are provided in
         order to create displayable chord tablature grids. The <att>inth</att> (harmonic interval)
         attribute may be used to facilitate automated performance of a chord. It gives the number of
-        1/2 steps above the bass. Of course, for the bass note itself, <att>inth</att> should be set
-        to <val>0</val>.</p>
+        diatonic steps above the bass. Of course, for the bass note itself, <att>inth</att> should be set
+        to <val>P1</val>.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="chordTable" module="MEI.harmony">

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -1668,7 +1668,7 @@
     </content>
   </macroSpec>-->
   <macroSpec ident="data.INTERVAL.HARMONIC" module="MEI" type="dt">
-    <desc xml:lang="en">A token indicating diatonic interval quality and size.</desc>
+    <desc xml:lang="en">A token indicating diatonic interval quality and size in shorthand notation.</desc>
     <content>
       <rng:choice>
         <rng:data type="token">
@@ -1676,6 +1676,23 @@
         </rng:data>
       </rng:choice>
     </content>
+    <remarks xml:lang="en">
+      <p>
+        <list>
+          <head>Interval quality and size:</head>
+          <item>
+            <list>
+              <item>A = augmented,</item>
+              <item>d = diminished,</item>
+              <item>M = major,</item>
+              <item>m = minor,</item>
+              <item>P = perfect</item>
+            </list>
+          </item>
+          <item>integer value</item>
+        </list>
+      </p>
+    </remarks>
   </macroSpec>
   <macroSpec ident="data.INTERVAL.MELODIC" module="MEI" type="dt">
     <desc xml:lang="en">A token indicating direction of the interval but not its precise value, a diatonic

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -1672,7 +1672,7 @@
     <content>
       <rng:choice>
         <rng:data type="token">
-          <rng:param name="pattern">[AdMmP][0-9]+</rng:param>
+          <rng:param name="pattern">[AdMmP][1-9][0-9]*</rng:param>
         </rng:data>
       </rng:choice>
     </content>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -1679,17 +1679,12 @@
     <remarks xml:lang="en">
       <p>
         <list>
-          <head>Interval quality and size:</head>
-          <item>
-            <list>
-              <item>A = augmented,</item>
-              <item>d = diminished,</item>
-              <item>M = major,</item>
-              <item>m = minor,</item>
-              <item>P = perfect</item>
-            </list>
-          </item>
-          <item>integer value</item>
+          <head>Interval qualities:</head>
+          <item>A = augmented,</item>
+          <item>d = diminished,</item>
+          <item>M = major,</item>
+          <item>m = minor,</item>
+          <item>P = perfect</item>
         </list>
       </p>
     </remarks>


### PR DESCRIPTION
This PR fixes the inconsitencies with `@inth`: 

- refines `data.INTERVAL.HARMONIC` to only allow sensible intervals
- adds remarks about the quality indicator
- updates the remarks for `chordMember`
- fixes the given examples in the Guidelines

Closes #642