### PR TITLE
schema: remove defaultVal from meiversion attributes

### DIFF
--- a/customizations/mei-CMN.xml
+++ b/customizations/mei-CMN.xml
@@ -105,8 +105,8 @@
         <classSpec ident="att.meiVersion" module="MEI.shared" type="atts" mode="change">
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
-              <defaultVal>5.1-dev+CMN</defaultVal>
               <valList type="closed" mode="change">
+                <valItem ident="5.1-dev+CMN"/>
                 <valItem ident="5.1-dev+anyStart" mode="delete"/>
                 <valItem ident="5.1-dev+basic" mode="delete"/>
                 <valItem ident="5.1-dev+Mensural" mode="delete"/>

--- a/customizations/mei-CMN.xml
+++ b/customizations/mei-CMN.xml
@@ -106,6 +106,7 @@
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
               <valList type="closed" mode="change">
+                <valItem ident="5.1-dev"/>
                 <valItem ident="5.1-dev+CMN"/>
                 <valItem ident="5.1-dev+anyStart" mode="delete"/>
                 <valItem ident="5.1-dev+basic" mode="delete"/>

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -106,6 +106,7 @@
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
               <valList type="closed" mode="change">
+                <valItem ident="5.1-dev"/>
                 <valItem ident="5.1-dev+Mensural"/>
                 <valItem ident="5.1-dev+anyStart" mode="delete"/>
                 <valItem ident="5.1-dev+basic" mode="delete"/>

--- a/customizations/mei-Mensural.xml
+++ b/customizations/mei-Mensural.xml
@@ -105,8 +105,8 @@
         <classSpec ident="att.meiVersion" module="MEI.shared" type="atts" mode="change">
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
-              <defaultVal>5.1-dev+Mensural</defaultVal>
               <valList type="closed" mode="change">
+                <valItem ident="5.1-dev+Mensural"/>
                 <valItem ident="5.1-dev+anyStart" mode="delete"/>
                 <valItem ident="5.1-dev+basic" mode="delete"/>
                 <valItem ident="5.1-dev+CMN" mode="delete"/>

--- a/customizations/mei-Neumes.xml
+++ b/customizations/mei-Neumes.xml
@@ -106,8 +106,8 @@
         <classSpec ident="att.meiVersion" module="MEI.shared" type="atts" mode="change">
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
-              <defaultVal>5.1-dev+Neumes</defaultVal>
               <valList type="closed" mode="change">
+                <valItem ident="5.1-dev+Neumes"/>
                 <valItem ident="5.1-dev+anyStart" mode="delete"/>
                 <valItem ident="5.1-dev+basic" mode="delete"/>
                 <valItem ident="5.1-dev+CMN" mode="delete"/>

--- a/customizations/mei-Neumes.xml
+++ b/customizations/mei-Neumes.xml
@@ -107,6 +107,7 @@
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
               <valList type="closed" mode="change">
+                <valItem ident="5.1-dev"/>
                 <valItem ident="5.1-dev+Neumes"/>
                 <valItem ident="5.1-dev+anyStart" mode="delete"/>
                 <valItem ident="5.1-dev+basic" mode="delete"/>

--- a/customizations/mei-all.xml
+++ b/customizations/mei-all.xml
@@ -108,8 +108,9 @@
         <classSpec ident="att.meiVersion" module="MEI.shared" type="atts" mode="change">
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
-              <defaultVal>5.1-dev</defaultVal>
+
               <valList type="closed" mode="change">
+                <valItem ident="5.1-dev"/>
                 <valItem ident="5.1-dev+anyStart" mode="delete"/>
                 <valItem ident="5.1-dev+basic" mode="delete"/>
                 <valItem ident="5.1-dev+CMN" mode="delete"/>

--- a/customizations/mei-all_anyStart.xml
+++ b/customizations/mei-all_anyStart.xml
@@ -170,6 +170,7 @@
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
               <valList type="closed" mode="change">
+                <valItem ident="5.1-dev"/>
                 <valItem ident="5.1-dev+anyStart"/>
                 <valItem ident="5.1-dev+basic" mode="delete"/>
                 <valItem ident="5.1-dev+CMN" mode="delete"/>

--- a/customizations/mei-all_anyStart.xml
+++ b/customizations/mei-all_anyStart.xml
@@ -170,6 +170,7 @@
           <attList>
             <attDef ident="meiversion" usage="rec" mode="change">
               <valList type="closed" mode="change">
+                <valItem ident="5.1-dev+anyStart"/>
                 <valItem ident="5.1-dev+basic" mode="delete"/>
                 <valItem ident="5.1-dev+CMN" mode="delete"/>
                 <valItem ident="5.1-dev+Mensural" mode="delete"/>

--- a/customizations/mei-all_anyStart.xml
+++ b/customizations/mei-all_anyStart.xml
@@ -30,6 +30,7 @@
           <resp>Authored by</resp>
           <name xml:id="PR">Perry Roland</name>
           <name xml:id="bwb">Benjamin W. Bohl</name>
+          <name xml:id="stm">Stefan Münnich</name>
         </respStmt>
       </titleStmt>
       <publicationStmt>
@@ -43,6 +44,14 @@
       </sourceDesc>
     </fileDesc>
     <revisionDesc>
+      <change n="3" when="2024-11-27" who="#bwb #stm">
+        <desc>
+          <list>
+            <item>rephrasing errors of schematron rules associated with @meiversion</item>
+            <item>changing context of schematron rule 'tempo_in_header_disallow_most_attrs' to tempo if it is not root element</item>
+          </list>
+        </desc>
+      </change>
       <change n="2" when="2021-11-05" who="#bwb">
         <desc>
           <list>
@@ -155,15 +164,15 @@
           <constraintSpec ident="meiVersion.root" scheme="schematron">
             <desc>Require meiversion attribute on the root element.</desc>
             <constraint>
-              <sch:rule context="root()">
-                <sch:assert test="/mei:*[@meiversion]">The root element must have the @meiversion attribute in order to indicate the MEI version of the snippet.</sch:assert>
+              <sch:rule context="/mei:*">
+                <sch:assert test="@meiversion">The document root element must have the @meiversion attribute in order to indicate the MEI version in use.</sch:assert>
               </sch:rule>
             </constraint>
           </constraintSpec>
           <constraintSpec ident="meiVersion.warning.anyStart" scheme="schematron" mode="add">
             <constraint>
               <sch:rule context="/mei:*">
-                <sch:report role="error" test="not(local-name(.) = ('mei', 'meiHead', 'meiCorpus', 'music')) and not(@meiversion = '5.1-dev+anyStart')">If the root element is any other than mei, meiHead, meiCorpus, or music the value of @meiversion must be '5.1-dev+anyStart'.</sch:report>
+                <sch:report role="error" test="not(local-name(.) = ('mei', 'meiHead', 'meiCorpus', 'music')) and not(@meiversion = '5.1-dev+anyStart')">If the document root element is any other than mei, meiHead, meiCorpus, or music the value of @meiversion must be '5.1-dev+anyStart'.</sch:report>
               </sch:rule>
             </constraint>
           </constraintSpec>
@@ -212,6 +221,19 @@
             <memberOf key="att.metadataPointing"/>
           </classes>
         </elementSpec>
+          
+          <elementSpec ident="tempo" module="MEI.shared" mode="change">
+              <constraintSpec ident="tempo_in_header_disallow_most_attrs" scheme="schematron" mode="change">
+                <constraint>
+                  <sch:rule context="/*//mei:tempo[not(ancestor::mei:score or ancestor::mei:part)]">
+                    <sch:assert
+                      test="not(@*[name() != 'analog' and name() != 'class' and name() != 'label' and name() != 'mm' and name() != 'mm.dots' and name() != 'translit' and name() != 'type' and name() != 'mm.unit' and name() != 'n' and name() != 'xml:base' and name() != 'xml:id' and name() != 'xml:lang'])"
+                      >Only analog, class, label, mm, mm.dots, mm.unit, n, translit, type, xml:base, xml:id,
+                      and xml:lang attributes are allowed when tempo is not the document root element or a descendant of a score or part.</sch:assert>
+                  </sch:rule>
+                </constraint>
+    </constraintSpec>
+          </elementSpec>
 
       </schemaSpec>
     </body>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -1040,6 +1040,7 @@
                     <attList>
                         <attDef ident="meiversion" usage="req" mode="change">
                             <valList type="closed" mode="change">
+                                <valItem ident="5.1-dev"/>
                                 <valItem ident="5.1-dev+basic"/>
                                 <valItem ident="5.1-dev+anyStart" mode="delete"/>
                                 <valItem ident="5.1-dev+CMN" mode="delete"/>

--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -1040,6 +1040,7 @@
                     <attList>
                         <attDef ident="meiversion" usage="req" mode="change">
                             <valList type="closed" mode="change">
+                                <valItem ident="5.1-dev+basic"/>
                                 <valItem ident="5.1-dev+anyStart" mode="delete"/>
                                 <valItem ident="5.1-dev+CMN" mode="delete"/>
                                 <valItem ident="5.1-dev+Mensural" mode="delete"/>

--- a/source/mei-source.xml
+++ b/source/mei-source.xml
@@ -80,7 +80,7 @@
             </respStmt>
          </titleStmt>
          <editionStmt>
-            <edition>Development Version</edition>
+            <edition>MEI 5.1-dev</edition>
          </editionStmt>
          <publicationStmt>
             <distributor>Music Encoding Initiative (MEI) Board</distributor>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1907,19 +1907,19 @@
             <desc xml:lang="en">Development version</desc>
           </valItem>
           <valItem ident="5.1-dev+anyStart">
-            <desc>Development version</desc>
+            <desc>Development version for MEI all_anyStart customization</desc>
           </valItem>
           <valItem ident="5.1-dev+basic">
-              <desc>Development version</desc>
+              <desc>Development version for MEI basic customization</desc>
           </valItem>
           <valItem ident="5.1-dev+CMN">
-            <desc>Development version</desc>
+            <desc>Development version for MEI CMN customization</desc>
           </valItem>
           <valItem ident="5.1-dev+Mensural">
-            <desc>Development version</desc>
+            <desc>Development version for MEI Mensural customization</desc>
           </valItem>
           <valItem ident="5.1-dev+Neumes">
-            <desc>Development version</desc>
+            <desc>Development version for MEI Neumes customization</desc>
           </valItem>
         </valList>
       </attDef>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1901,7 +1901,6 @@
     <attList>
       <attDef ident="meiversion" usage="opt">
         <desc xml:lang="en">Specifies a generic MEI version label.</desc>
-        <defaultVal>5.1-dev</defaultVal>
         <valList type="closed">
           <valItem ident="5.1-dev">
             <desc xml:lang="en">Development version</desc>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1903,22 +1903,22 @@
         <desc xml:lang="en">Specifies a generic MEI version label.</desc>
         <valList type="closed">
           <valItem ident="5.1-dev">
-            <desc xml:lang="en">Development version</desc>
+            <desc xml:lang="en">Version of MEI</desc>
           </valItem>
           <valItem ident="5.1-dev+anyStart">
-            <desc>Development version for MEI all_anyStart customization</desc>
+            <desc>Version of MEI all_anyStart customization</desc>
           </valItem>
           <valItem ident="5.1-dev+basic">
-              <desc>Development version for MEI basic customization</desc>
+              <desc>Version of MEI basic customization</desc>
           </valItem>
           <valItem ident="5.1-dev+CMN">
-            <desc>Development version for MEI CMN customization</desc>
+            <desc>Version of MEI cmn customization</desc>
           </valItem>
           <valItem ident="5.1-dev+Mensural">
-            <desc>Development version for MEI Mensural customization</desc>
+            <desc>Version of MEI mensural customization</desc>
           </valItem>
           <valItem ident="5.1-dev+Neumes">
-            <desc>Development version for MEI Neumes customization</desc>
+            <desc>Version of MEI neumes customization</desc>
           </valItem>
         </valList>
       </attDef>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1898,6 +1898,14 @@
   </classSpec>
   <classSpec ident="att.meiVersion" module="MEI.shared" type="atts">
     <desc xml:lang="en">Attributes that record the version of MEI in use.</desc>
+    <constraintSpec ident="meiVersion.onlyRoot" scheme="schematron">
+      <desc>Prohibit meiversion attribute on non root elements.</desc>
+      <constraint>
+        <sch:rule context="/mei:*//*">
+          <sch:report test="@meiversion">The @meiversion attribute is not allowed on elements that are not the document root element.</sch:report>
+        </sch:rule>
+      </constraint>
+    </constraintSpec>
     <attList>
       <attDef ident="meiversion" usage="opt">
         <desc xml:lang="en">Specifies a generic MEI version label.</desc>

--- a/utils/compare_versions/comparison.xsl
+++ b/utils/compare_versions/comparison.xsl
@@ -15,7 +15,7 @@
     <xsl:output method="html" indent="yes"/>
 
     <xsl:variable name="new.file" select="//tei:back" as="node()"/>
-    <xsl:variable name="new.version" select="//tei:attDef[@ident='meiversion']//tei:defaultVal" as="xs:string"/>
+    <xsl:variable name="new.version" select="tokenize(//tei:edition, ' ')[last()]" as="xs:string"/>
     <xsl:variable name="new.version.major" as="xs:string*">
         <xsl:choose>
             <xsl:when test="tokenize($new.version, '-')[2] = 'dev'">
@@ -31,7 +31,7 @@
 
     <xsl:param name="old.version.filename" select="''" as="xs:string"/>
     <xsl:variable name="old.file" select="doc($old.version.filename)//tei:back" as="node()"/>
-    <xsl:variable name="old.version" select="doc($old.version.filename)//tei:attDef[@ident='meiversion']//tei:defaultVal" as="xs:string"/>
+    <xsl:variable name="old.version" select="tokenize(doc($old.version.filename)//tei:edition, ' ')[last()]" as="xs:string"/>
     <xsl:variable name="old.version.major" select="concat('v',tokenize($old.version, '\.')[1])" as="xs:string"/>
 
     <xsl:variable name="html.guidelines" select="'https://music-encoding.org/guidelines/'"/>

--- a/utils/guidelines_xslt/odd2html.xsl
+++ b/utils/guidelines_xslt/odd2html.xsl
@@ -107,7 +107,7 @@
             <xd:p>The version of the Guidelines</xd:p>
         </xd:desc>
     </xd:doc>
-    <xsl:param name="version" select="//tei:classSpec[@ident = ('att.meiversion','att.meiVersion')]//tei:defaultVal/text()" as="xs:string"/>
+    <xsl:param name="version" select="tokenize(//tei:edition, ' ')[last()]" as="xs:string"/>
         
     <xd:doc>
         <xd:desc>


### PR DESCRIPTION
This PR removes the defaultVal from the meiversion attributes in the customizations.

Fixes #1347

TODOs

- [x] fix schematron rule for tempo about allowed attributes when not in score or part in anyStart customisation
- [x] add schematron rule for meiversion by @pe-ro from #1347 
- [x] Fix rule schematron rule for tempo https://github.com/music-encoding/music-encoding/issues/1347#issuecomment-1751286288
- [x] make meiversion easily accessible, e.g., encode meiversion in editionStmt
- [x] get rid of meiversion defaultVal
- [x] fix usage of defaultVal in comparison.xsl
  https://github.com/music-encoding/music-encoding/blob/0c10d2a53ffa5212dd17636cf497a786cfb40551/utils/compare_versions/comparison.xsl#L18

   https://github.com/music-encoding/music-encoding/blob/0c10d2a53ffa5212dd17636cf497a786cfb40551/utils/compare_versions/comparison.xsl#L34

- [x] fix usage of defaultVal in odd2html.xsl
  https://github.com/music-encoding/music-encoding/blob/0c10d2a53ffa5212dd17636cf497a786cfb40551/utils/guidelines_xslt/odd2html.xsl#L110)