### PR TITLE
schema: add usage to attribute definitions

### DIFF
--- a/source/modules/MEI.edittrans.xml
+++ b/source/modules/MEI.edittrans.xml
@@ -204,7 +204,7 @@
       </rng:zeroOrMore>
     </content>
     <attList>
-      <attDef ident="place">
+      <attDef ident="place" usage="opt">
         <desc xml:lang="en">Location of the addition.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.PLACEMENT"/>
@@ -654,7 +654,7 @@
       </constraint>
     </constraintSpec>
     <attList>
-      <attDef ident="function">
+      <attDef ident="function" usage="opt">
         <desc xml:lang="en">Describes the purpose of the metaMark.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>

--- a/source/modules/MEI.frbr.xml
+++ b/source/modules/MEI.frbr.xml
@@ -399,7 +399,7 @@
       </constraint>
     </constraintSpec>
     <attList>
-      <attDef ident="singleton">
+      <attDef ident="singleton" usage="opt">
         <desc xml:lang="en">Indicates the manifestation is a unique physical object.</desc>
         <datatype>
           <rng:ref name="data.BOOLEAN"/>

--- a/source/modules/MEI.genetic.xml
+++ b/source/modules/MEI.genetic.xml
@@ -39,7 +39,7 @@
       </constraint>
     </constraintSpec>
     <attList>
-      <attDef ident="instant">
+      <attDef ident="instant" usage="opt">
         <desc xml:lang="en">The @instant attribute is syntactic sugar for classifying a scribal intervention as an
           ad-hoc modification; that is, one which does not interrupt the writing process.</desc>
         <datatype>
@@ -49,7 +49,7 @@
           </rng:choice>
         </datatype>
       </attDef>
-      <attDef ident="state">
+      <attDef ident="state" usage="opt">
         <desc xml:lang="en">Points to the genetic state that results from this modification.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.URI"/>
@@ -75,7 +75,7 @@
       </rng:zeroOrMore>
     </content>
     <attList>
-      <attDef ident="ordered">
+      <attDef ident="ordered" usage="opt">
         <desc xml:lang="en">When set to "true" the child elements are known to be in chronological order. When set
           to "false" or when not provided, the order of child elements is unknown.</desc>
         <datatype>

--- a/source/modules/MEI.gestural.xml
+++ b/source/modules/MEI.gestural.xml
@@ -95,7 +95,7 @@
   <classSpec ident="att.attacking" module="MEI.gestural" type="atts">
     <desc xml:lang="en">Attributes whether an element is performed "attacca".</desc>
     <attList>
-      <attDef ident="attacca">
+      <attDef ident="attacca" usage="opt">
         <desc xml:lang="en">Indicates that the performance of the next musical division should begin immediately
           following this one.</desc>
         <datatype>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -188,7 +188,7 @@
     <desc xml:lang="en">Attributes that define the characteristics and components of the bibliographic
       description.</desc>
     <attList>
-      <attDef ident="recordtype">
+      <attDef ident="recordtype" usage="opt">
         <valList type="closed">
           <valItem ident="a">
             <desc xml:lang="en">Language material.</desc>

--- a/source/modules/MEI.msDesc.xml
+++ b/source/modules/MEI.msDesc.xml
@@ -541,7 +541,7 @@
       <rng:ref name="macro.struc-unstrucContent"/>
     </content>
     <attList>
-      <attDef ident="func">
+      <attDef ident="func" usage="opt">
         <valList type="closed">
           <valItem ident="initial">
             <desc xml:lang="en">Signals beginning of a text division.</desc>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -682,7 +682,7 @@
           <rng:data type="nonNegativeInteger"/>
         </datatype>
       </attDef>
-      <attDef ident="rotate">
+      <attDef ident="rotate" usage="opt">
         <desc xml:lang="en">
           Indicates the amount by which the contents of this element have been rotated clockwise or, if applicable, how the orientation of
           the element self should be interpreted, with respect to the normal orientation of the parent surface.
@@ -3101,21 +3101,21 @@
   <classSpec ident="att.staffItems" module="MEI.shared" type="atts">
     <desc xml:lang="en">Attributes that describe items printed near (above, below, or between) staves</desc>
     <attList>
-      <attDef ident="aboveorder">
+      <attDef ident="aboveorder" usage="opt">
         <desc xml:lang="en">Describes vertical order of items printed above a staff, from closest to farthest away
           from the staff.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.STAFFITEM"/>
         </datatype>
       </attDef>
-      <attDef ident="beloworder">
+      <attDef ident="beloworder" usage="opt">
         <desc xml:lang="en">Describes vertical order of items printed below a staff, from closest to farthest away
           from the staff.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.STAFFITEM"/>
         </datatype>
       </attDef>
-      <attDef ident="betweenorder">
+      <attDef ident="betweenorder" usage="opt">
         <desc xml:lang="en">Describes vertical order of items printed between staves, from top to bottom.</desc>
         <datatype maxOccurs="unbounded">
           <rng:ref name="data.STAFFITEM"/>
@@ -3421,7 +3421,7 @@
       <memberOf key="att.timestamp2.log"/>
     </classes>
     <attList>
-      <attDef ident="func">
+      <attDef ident="func" usage="opt">
         <desc xml:lang="en">Records the function of a tempo indication.</desc>
         <valList type="closed">
           <valItem ident="continuous">


### PR DESCRIPTION
This is a small PR adding a `usage` attributes to all attribute definitions, as most of them had one. 
It only adds the default value in all instances, so effective change to the schema.
