### PR TITLE
schema: add unspecified as value for bracket spans

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -368,6 +368,9 @@
           <valItem ident="ligature">
             <desc xml:lang="en">Represents a ligature in the mensural notation source material.</desc>
           </valItem>
+          <valItem ident="unspecified">
+            <desc xml:lang="en">Unspecified bracket.</desc>
+          </valItem>
         </valList>
       </attDef>
     </attList>


### PR DESCRIPTION
This adds another value to the `func` attribute for `brackSpan` as proposed by @pe-ro in #1065.