### PR TITLE
schema: simplify meterSigGrp model

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -1863,15 +1863,9 @@
       <memberOf key="model.meterSigLike"/>
     </classes>
     <content>
-      <rng:choice>
-        <rng:ref name="meterSig"/>
-        <rng:ref name="meterSigGrp"/>
-      </rng:choice>
+      <rng:ref name="model.meterSigLike"/>
       <rng:oneOrMore>
-        <rng:choice>
-          <rng:ref name="meterSig"/>
-          <rng:ref name="meterSigGrp"/>
-        </rng:choice>
+        <rng:ref name="model.meterSigLike"/>
       </rng:oneOrMore>
     </content>
   </elementSpec>


### PR DESCRIPTION
This PR remodels `meterSigGrp` to use `model.meterSigLike` as proposed by @kepper 
closes #970