### PR TITLE
schema: extract data class for harp pedal position

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -73,6 +73,22 @@
       </valList>
     </content>
   </macroSpec>
+  <macroSpec ident="data.HARPPEDALPOSITION" module="MEI.cmn" type="dt">
+    <desc xml:lang="en">Indicates the pedal setting for a harp strings.</desc>
+    <content>
+      <valList type="closed">
+        <valItem ident="f">
+          <desc xml:lang="en">Flat.</desc>
+        </valItem>
+        <valItem ident="n">
+          <desc xml:lang="en">Natural.</desc>
+        </valItem>
+        <valItem ident="s">
+          <desc xml:lang="en">Sharp.</desc>
+        </valItem>
+      </valList>
+    </content>
+  </macroSpec>
   <macroSpec ident="data.STAFFITEM.cmn" module="MEI.cmn" type="dt">
     <desc xml:lang="en">Items in the CMN repertoire that may be printed near a staff.</desc>
     <content>
@@ -583,108 +599,52 @@
     <attList>
       <attDef ident="c" usage="opt">
         <desc xml:lang="en">Indicates the pedal setting for the harp’s C strings.</desc>
+        <datatype>
+          <rng:ref name="data.HARPPEDALPOSITION"/>
+        </datatype>
         <defaultVal>n</defaultVal>
-        <valList type="closed">
-          <valItem ident="f">
-            <desc xml:lang="en">Flat.</desc>
-          </valItem>
-          <valItem ident="n">
-            <desc xml:lang="en">Natural.</desc>
-          </valItem>
-          <valItem ident="s">
-            <desc xml:lang="en">Sharp.</desc>
-          </valItem>
-        </valList>
       </attDef>
       <attDef ident="d" usage="opt">
         <desc xml:lang="en">Indicates the pedal setting for the harp’s D strings.</desc>
+        <datatype>
+          <rng:ref name="data.HARPPEDALPOSITION"/>
+        </datatype>
         <defaultVal>n</defaultVal>
-        <valList type="closed">
-          <valItem ident="f">
-            <desc xml:lang="en">Flat.</desc>
-          </valItem>
-          <valItem ident="n">
-            <desc xml:lang="en">Natural.</desc>
-          </valItem>
-          <valItem ident="s">
-            <desc xml:lang="en">Sharp.</desc>
-          </valItem>
-        </valList>
       </attDef>
       <attDef ident="e" usage="opt">
         <desc xml:lang="en">Indicates the pedal setting for the harp’s E strings.</desc>
+        <datatype>
+          <rng:ref name="data.HARPPEDALPOSITION"/>
+        </datatype>
         <defaultVal>n</defaultVal>
-        <valList type="closed">
-          <valItem ident="f">
-            <desc xml:lang="en">Flat.</desc>
-          </valItem>
-          <valItem ident="n">
-            <desc xml:lang="en">Natural.</desc>
-          </valItem>
-          <valItem ident="s">
-            <desc xml:lang="en">Sharp.</desc>
-          </valItem>
-        </valList>
       </attDef>
       <attDef ident="f" usage="opt">
         <desc xml:lang="en">Indicates the pedal setting for the harp’s F strings.</desc>
+        <datatype>
+          <rng:ref name="data.HARPPEDALPOSITION"/>
+        </datatype>
         <defaultVal>n</defaultVal>
-        <valList type="closed">
-          <valItem ident="f">
-            <desc xml:lang="en">Flat.</desc>
-          </valItem>
-          <valItem ident="n">
-            <desc xml:lang="en">Natural.</desc>
-          </valItem>
-          <valItem ident="s">
-            <desc xml:lang="en">Sharp.</desc>
-          </valItem>
-        </valList>
       </attDef>
       <attDef ident="g" usage="opt">
         <desc xml:lang="en">Indicates the pedal setting for the harp’s G strings.</desc>
+        <datatype>
+          <rng:ref name="data.HARPPEDALPOSITION"/>
+        </datatype>
         <defaultVal>n</defaultVal>
-        <valList type="closed">
-          <valItem ident="f">
-            <desc xml:lang="en">Flat.</desc>
-          </valItem>
-          <valItem ident="n">
-            <desc xml:lang="en">Natural.</desc>
-          </valItem>
-          <valItem ident="s">
-            <desc xml:lang="en">Sharp.</desc>
-          </valItem>
-        </valList>
       </attDef>
       <attDef ident="a" usage="opt">
         <desc xml:lang="en">Indicates the pedal setting for the harp’s A strings.</desc>
+        <datatype>
+          <rng:ref name="data.HARPPEDALPOSITION"/>
+        </datatype>
         <defaultVal>n</defaultVal>
-        <valList type="closed">
-          <valItem ident="f">
-            <desc xml:lang="en">Flat.</desc>
-          </valItem>
-          <valItem ident="n">
-            <desc xml:lang="en">Natural.</desc>
-          </valItem>
-          <valItem ident="s">
-            <desc xml:lang="en">Sharp.</desc>
-          </valItem>
-        </valList>
       </attDef>
       <attDef ident="b" usage="opt">
         <desc xml:lang="en">Indicates the pedal setting for the harp’s B strings.</desc>
+        <datatype>
+          <rng:ref name="data.HARPPEDALPOSITION"/>
+        </datatype>
         <defaultVal>n</defaultVal>
-        <valList type="closed">
-          <valItem ident="f">
-            <desc xml:lang="en">Flat.</desc>
-          </valItem>
-          <valItem ident="n">
-            <desc xml:lang="en">Natural.</desc>
-          </valItem>
-          <valItem ident="s">
-            <desc xml:lang="en">Sharp.</desc>
-          </valItem>
-        </valList>
       </attDef>
     </attList>
   </classSpec>


### PR DESCRIPTION
This PR introduces `data.HARPPEDALPOSITION` for the pitch-named attributes in `att.harpPedal.log`, because they were all the same. 

Background: This doesn't change the schema itself, but helps in application built on it like LibMEI. Currently in LibMEI there are special data types for every single pitch, which means that you need a spearate converter for all of them.