### PR TITLE
guidelines: add missing contributors

### DIFF
--- a/source/contributors/curated.contributors.json
+++ b/source/contributors/curated.contributors.json
@@ -270,6 +270,15 @@
         "suppress":false
     },
     {
+        "login": "maxrothman ",
+        "name": "Max Rothman",
+        "github": "https://github.com/maxrothman",
+        "viaf": "",
+        "orcid": "",
+        "avatar": "https://avatars.githubusercontent.com/u/2607086?v=4",
+        "suppress":false
+    },
+    {
         "login": "mss2221",
         "name": "Mark Saccomano",
         "github": "https://github.com/mss2221",


### PR DESCRIPTION
This PR includes some more contributors that were not returned by the GitHub API due to page limitations (=30).

See https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api?apiVersion=2022-11-28