### PR TITLE
schema: purify simple datatypes

### DIFF
--- a/source/modules/MEI.analytical.xml
+++ b/source/modules/MEI.analytical.xml
@@ -499,7 +499,7 @@
         <desc xml:lang="en">Contains sol-fa designation, <abbr>e.g.</abbr>, do, re, mi, etc., in either a fixed or movable Do
           system.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -305,7 +305,7 @@
       <attDef ident="slope" usage="opt">
         <desc xml:lang="en">Records the slope of the beam.</desc>
         <datatype>
-          <rng:data type="decimal"/>
+          <dataRef name="decimal"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -318,7 +318,7 @@
           following this note/chord. The value of the attribute records the number of beams which
           should remain unbroken.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -806,7 +806,7 @@
         <gloss xml:lang="en">number</gloss>
         <desc xml:lang="en">Records a number or count accompanying a notational feature.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -209,7 +209,7 @@
         <desc xml:lang="en">Provides an example of how automated beaming (including secondary beams) is to be
           performed.</desc>
         <datatype>
-          <rng:data type="string"/>
+          <dataRef name="string"/>
         </datatype>
       </attDef>
       <attDef ident="beam.rests" usage="opt">

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -887,7 +887,7 @@
         <desc xml:lang="en">Indicates the function of the depressed pedal, but not necessarily the text associated
           with its use. Use the <gi scheme="MEI">dir</gi> element for such text.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="sustain">

--- a/source/modules/MEI.critapp.xml
+++ b/source/modules/MEI.critapp.xml
@@ -36,7 +36,7 @@
         <desc xml:lang="en">Classifies the cause for the variant reading, according to any appropriate typology of
           possible origins.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.edittrans.xml
+++ b/source/modules/MEI.edittrans.xml
@@ -657,7 +657,7 @@
       <attDef ident="function" usage="opt">
         <desc xml:lang="en">Describes the purpose of the metaMark.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="confirmation">

--- a/source/modules/MEI.edittrans.xml
+++ b/source/modules/MEI.edittrans.xml
@@ -31,7 +31,7 @@
         <desc xml:lang="en">Signifies the causative agent of damage, illegibility, or other loss of original
           text.</desc>
         <datatype>
-          <rng:data type="string"/>
+          <dataRef name="string"/>
         </datatype>
       </attDef>
     </attList>
@@ -74,7 +74,7 @@
         <desc xml:lang="en">Holds a short phrase describing the reason for missing textual material (gap), why
           material is supplied (supplied), or why transcription is difficult (unclear).</desc>
         <datatype>
-          <rng:data type="string"/>
+          <dataRef name="string"/>
         </datatype>
       </attDef>
     </attList>
@@ -159,7 +159,7 @@
       <attDef ident="expan" usage="opt">
         <desc xml:lang="en">Records the expansion of a text abbreviation.</desc>
         <datatype>
-          <rng:data type="string"/>
+          <dataRef name="string"/>
         </datatype>
       </attDef>
     </attList>
@@ -401,7 +401,7 @@
       <attDef ident="degree" usage="opt">
         <desc xml:lang="en">Records the degree of damage.</desc>
         <datatype>
-          <rng:data type="string"/>
+          <dataRef name="string"/>
         </datatype>
       </attDef>
     </attList>
@@ -500,7 +500,7 @@
         <gloss xml:lang="en">abbreviation</gloss>
         <desc xml:lang="en">Captures the abbreviated form of the text.</desc>
         <datatype>
-          <rng:data type="string"/>
+          <dataRef name="string"/>
         </datatype>
       </attDef>
     </attList>
@@ -835,7 +835,7 @@
         <desc xml:lang="en">Provides a description of the means of restoration, <val>stet</val> or <val>strike-down</val>, 
           for example.</desc>
         <datatype>
-          <rng:data type="string"/>
+          <dataRef name="string"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.externalsymbols.xml
+++ b/source/modules/MEI.externalsymbols.xml
@@ -31,7 +31,7 @@
         <desc xml:lang="en">A name or label associated with the controlled vocabulary from which the value of
           <att>glyph.name</att> or <att>glyph.num</att> is taken, or the textual content of the element.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="smufl">

--- a/source/modules/MEI.externalsymbols.xml
+++ b/source/modules/MEI.externalsymbols.xml
@@ -54,7 +54,7 @@
       <attDef ident="glyph.name" usage="opt">
         <desc xml:lang="en">Glyph name.</desc>
         <datatype>
-          <rng:data type="string"/>
+          <dataRef name="string"/>
         </datatype>
         <constraintSpec ident="check_glyph.name" scheme="schematron">
           <constraint>

--- a/source/modules/MEI.figtable.xml
+++ b/source/modules/MEI.figtable.xml
@@ -30,13 +30,13 @@
       <attDef ident="colspan" usage="opt">
         <desc xml:lang="en">The number of columns spanned by this cell.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
       <attDef ident="rowspan" usage="opt">
         <desc xml:lang="en">The number of rows spanned by this cell.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.gestural.xml
+++ b/source/modules/MEI.gestural.xml
@@ -246,7 +246,7 @@
         <desc xml:lang="en">Duration recorded as pulses-per-quarter note, <abbr>e.g.</abbr>, MIDI clicks or MusicXML
           divisions.</desc>
         <datatype>
-          <rng:data type="nonNegativeInteger"/>
+          <dataRef name="nonNegativeInteger"/>
         </datatype>
       </attDef>
       <attDef ident="dur.real" usage="opt">

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -524,7 +524,7 @@
       <attDef ident="context" usage="opt">
         <desc xml:lang="en">Circumstances in which the attribute appears, an XPath expression.</desc>
         <datatype>
-          <rng:data type="string"/>
+          <dataRef name="string"/>
         </datatype>
       </attDef>
     </attList>
@@ -2638,7 +2638,7 @@
       <attDef ident="context" usage="opt">
         <desc xml:lang="en">Circumstances in which the element appears, an XPath expression.</desc>
         <datatype>
-          <rng:data type="string"/>
+          <dataRef name="string"/>
         </datatype>
       </attDef>
       <attDef ident="occurs" usage="opt">

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -487,7 +487,7 @@
         <desc xml:lang="en">Supplies a version number for an application, independent of its identifier or display
           name.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
       </attDef>
     </attList>
@@ -1082,7 +1082,7 @@
       <attDef ident="removed.by" usage="opt">
         <desc xml:lang="en">Describes the method of removing the cutout.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="cut">
@@ -1547,7 +1547,7 @@
       <attDef ident="form" usage="opt">
         <desc xml:lang="en">Form of the encoded incipit.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="plaineAndEasie">
@@ -1949,7 +1949,7 @@
       <attDef ident="attached.by" usage="opt">
         <desc xml:lang="en">Describes the method of attachment of the patch.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="glue">
@@ -2209,7 +2209,7 @@
       <attDef ident="currency" usage="opt">
         <desc xml:lang="en">Monetary unit.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -151,7 +151,7 @@
       <attDef ident="count" usage="opt">
         <desc xml:lang="en">Indicates the number of performers.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -2447,7 +2447,7 @@
       <attDef ident="num" usage="opt">
         <desc xml:lang="en">Records the channel configuration in numeric form.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -2644,14 +2644,14 @@
       <attDef ident="occurs" usage="opt">
         <desc xml:lang="en">Number of occurrences in the defined context.</desc>
         <datatype>
-          <rng:data type="nonNegativeInteger"/>
+          <dataRef name="nonNegativeInteger"/>
         </datatype>
       </attDef>
       <attDef ident="withid" usage="opt">
         <desc xml:lang="en">Number of occurrences in the defined context that have an <att>xml:id</att>
           attribute.</desc>
         <datatype>
-          <rng:data type="nonNegativeInteger"/>
+          <dataRef name="nonNegativeInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -2757,7 +2757,7 @@
       <attDef ident="num" usage="opt">
         <desc xml:lang="en">Records the track configuration in numeric form.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.mensural.xml
+++ b/source/modules/MEI.mensural.xml
@@ -227,14 +227,14 @@
         <desc xml:lang="en">Together, proport.num and proport.numbase specify a proportional change as a ratio,
           <abbr>e.g.</abbr>, 1:3. Proport.num is for the first value in the ratio.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
       <attDef ident="proport.numbase" usage="opt">
         <desc xml:lang="en">Together, proport.num and proport.numbase specify a proportional change as a ratio,
           <abbr>e.g.</abbr>, 1:3. Proport.numbase is for the second value in the ratio.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -328,7 +328,7 @@
       <attDef ident="spaces" usage="opt">
         <desc xml:lang="en">States how many spaces are covered by the rest.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.midi.xml
+++ b/source/modules/MEI.midi.xml
@@ -48,7 +48,7 @@
       <attDef ident="midi.track" usage="opt">
         <desc xml:lang="en">Sets the MIDI track.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -232,7 +232,7 @@
           quarter note. Unlike MIDI, MEI permits different values for a score and individual
           staves.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -473,9 +473,9 @@
       <attDef ident="num" usage="req">
         <desc xml:lang="en">Number in the range 0-65535.</desc>
         <datatype>
-          <rng:data type="nonNegativeInteger">
-            <rng:param name="maxInclusive">65535</rng:param>
-          </rng:data>
+          <dataRef name="nonNegativeInteger">
+            <dataFacet name="maxInclusive" value="65535"/>
+          </dataRef>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.midi.xml
+++ b/source/modules/MEI.midi.xml
@@ -140,7 +140,7 @@
       <attDef ident="midi.patchname" usage="opt">
         <desc xml:lang="en">Records a non-General MIDI patch/instrument name.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
       </attDef>
       <attDef ident="midi.patchnum" usage="opt">

--- a/source/modules/MEI.msDesc.xml
+++ b/source/modules/MEI.msDesc.xml
@@ -828,7 +828,7 @@
         <desc xml:lang="en">Short, project-defined name for the material composing the majority of the
           support.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="paper">

--- a/source/modules/MEI.msDesc.xml
+++ b/source/modules/MEI.msDesc.xml
@@ -364,7 +364,7 @@
       <attDef ident="cols" usage="opt">
         <desc xml:lang="en">Specifies the number of columns per page.</desc>
         <datatype minOccurs="1" maxOccurs="2">
-          <rng:data type="nonNegativeInteger"/>
+          <dataRef name="nonNegativeInteger"/>
         </datatype>
         <remarks xml:lang="en">
           <p>A single number indicates that all pages have this number of columns. Two numbers mean
@@ -374,7 +374,7 @@
       <attDef ident="ruledlines" usage="opt">
         <desc xml:lang="en">Specifies the number of ruled text lines per column.</desc>
         <datatype minOccurs="1" maxOccurs="2">
-          <rng:data type="nonNegativeInteger"/>
+          <dataRef name="nonNegativeInteger"/>
         </datatype>
         <remarks xml:lang="en">
           <p> A single number indicates that all columns have this number of ruled lines. Two
@@ -385,7 +385,7 @@
       <attDef ident="writtenlines" usage="opt">
         <desc xml:lang="en">Specifies the number of written text lines per column.</desc>
         <datatype minOccurs="1" maxOccurs="2">
-          <rng:data type="nonNegativeInteger"/>
+          <dataRef name="nonNegativeInteger"/>
         </datatype>
         <remarks xml:lang="en">
           <p>A single number indicates that all columns have this number of written text lines. Two
@@ -396,7 +396,7 @@
       <attDef ident="ruledstaves" usage="opt">
         <desc xml:lang="en">Specifies the number of ruled staves per column.</desc>
         <datatype minOccurs="1" maxOccurs="2">
-          <rng:data type="nonNegativeInteger"/>
+          <dataRef name="nonNegativeInteger"/>
         </datatype>
         <remarks xml:lang="en">
           <p>A single number indicates that all columns have this number of ruled staves. Two
@@ -407,7 +407,7 @@
       <attDef ident="writtenstaves" usage="opt">
         <desc xml:lang="en">Specifies the number of written staves per column.</desc>
         <datatype minOccurs="1" maxOccurs="2">
-          <rng:data type="nonNegativeInteger"/>
+          <dataRef name="nonNegativeInteger"/>
         </datatype>
         <remarks xml:lang="en">
           <p>A single number indicates that all columns have this number of written staves. Two

--- a/source/modules/MEI.neumes.xml
+++ b/source/modules/MEI.neumes.xml
@@ -33,7 +33,7 @@
       <attDef ident="form" usage="opt">
         <desc xml:lang="en">Identifies the different kinds of division.</desc>
         <datatype maxOccurs="unbounded">
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="caesura"/>
@@ -201,7 +201,7 @@
         <desc xml:lang="en">Designation which characterizes the element in some sense, using any convenient
           classification scheme or typology that employs single-token labels.</desc>
         <datatype maxOccurs="unbounded">
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="apostropha"/>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -673,13 +673,13 @@
       <attDef ident="lrx" usage="opt">
         <desc xml:lang="en">Indicates the lower-right corner x coordinate.</desc>
         <datatype>
-          <rng:data type="nonNegativeInteger"/>
+          <dataRef name="nonNegativeInteger"/>
         </datatype>
       </attDef>
       <attDef ident="lry" usage="opt">
         <desc xml:lang="en">Indicates the lower-right corner y coordinate.</desc>
         <datatype>
-          <rng:data type="nonNegativeInteger"/>
+          <dataRef name="nonNegativeInteger"/>
         </datatype>
       </attDef>
       <attDef ident="rotate" usage="opt">
@@ -705,13 +705,13 @@
       <attDef ident="ulx" usage="opt">
         <desc xml:lang="en">Indicates the upper-left corner x coordinate.</desc>
         <datatype>
-          <rng:data type="nonNegativeInteger"/>
+          <dataRef name="nonNegativeInteger"/>
         </datatype>
       </attDef>
       <attDef ident="uly" usage="opt">
         <desc xml:lang="en">Indicates the upper-left corner y coordinate.</desc>
         <datatype>
-          <rng:data type="nonNegativeInteger"/>
+          <dataRef name="nonNegativeInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -1005,14 +1005,14 @@
         <desc xml:lang="en">Along with numbase.default, describes the default duration as a ratio. num.default is
           the first value in the ratio.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
       <attDef ident="numbase.default" usage="opt">
         <desc xml:lang="en">Along with num.default, describes the default duration as a ratio. numbase.default is
           the second value in the ratio.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -1038,14 +1038,14 @@
         <desc xml:lang="en">Along with numbase, describes duration as a ratio. num is the first value in the
           ratio, while numbase is the second.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
       <attDef ident="numbase" usage="opt">
         <desc xml:lang="en">Along with num, describes duration as a ratio. num is the first value in the ratio,
           while numbase is the second.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -1201,7 +1201,7 @@
         <desc xml:lang="en">Holds the number of initial characters (such as those constituting an article or
           preposition) that should not be used for sorting a title or name.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -1227,7 +1227,7 @@
       <attDef ident="level" usage="opt">
         <desc xml:lang="en">Indicates the nesting level of staff grouping symbols.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -1478,7 +1478,7 @@
       <attDef ident="layer" usage="opt">
         <desc xml:lang="en">Identifies the layer to which a feature applies.</desc>
         <datatype maxOccurs="unbounded">
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -1557,9 +1557,9 @@
           may fall, while a single value indicates a fixed amount of space; that is, the minimum and
           maximum values are equal.</desc>
         <datatype minOccurs="1" maxOccurs="2">
-          <rng:data type="positiveInteger">
-            <rng:param name="minInclusive">2</rng:param>
-          </rng:data>
+          <dataRef name="positiveInteger">
+            <dataFacet name="minInclusive" value="2"/>
+          </dataRef>
         </datatype>
         <constraintSpec ident="check_lsegs" scheme="schematron">
           <constraint>
@@ -2144,7 +2144,7 @@
         <desc xml:lang="en">Provides a numeric designation that indicates an element’s position in a sequence of
           similar elements. Its value must be a non-negative integer.</desc>
         <datatype>
-          <rng:data type="nonNegativeInteger"/>
+          <dataRef name="nonNegativeInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -2738,9 +2738,9 @@
         <desc xml:lang="en">Numeric value capturing a measurement or count. Can only be interpreted in combination
           with the unit attribute.</desc>
         <datatype>
-          <rng:data type="decimal">
-            <rng:param name="minInclusive">0</rng:param>
-          </rng:data>
+          <dataRef name="decimal">
+            <dataFacet name="minInclusive" value="0"/>
+          </dataRef>
         </datatype>
       </attDef>
     </attList>
@@ -2919,7 +2919,7 @@
         <desc xml:lang="en">Used to assign a sequence number related to the order in which the encoded features
           carrying this attribute are believed to have occurred.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -3059,7 +3059,7 @@
       <attDef ident="lines" usage="opt">
         <desc xml:lang="en">Indicates the number of staff lines.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -3100,7 +3100,7 @@
         <desc xml:lang="en">Signifies the staff on which a notated event occurs or to which a control event
           applies. Mandatory when applicable.</desc>
         <datatype maxOccurs="unbounded">
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -3712,7 +3712,7 @@
       <attDef ident="vgrp" usage="opt">
         <desc xml:lang="en">Provides a label for members of a vertically aligned group.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -4964,7 +4964,7 @@
       <attDef ident="n" usage="req">
         <desc xml:lang="en">Records the column number.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
         <constraintSpec ident="check_cb" scheme="schematron">
           <constraint>
@@ -5094,7 +5094,7 @@
       <attDef ident="cols" usage="req">
         <desc xml:lang="en">Records the number of columns.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -458,7 +458,7 @@
         <desc xml:lang="en">Indicates the calendar system to which a date belongs, for example, Gregorian, Julian,
           Roman, Mosaic, Revolutionary, Islamic, etc.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
       </attDef>
     </attList>
@@ -472,7 +472,7 @@
           database or a unique value in the coded list identified by the <att>auth</att> or
           <att>auth.uri</att> attributes.</desc>
         <datatype maxOccurs="unbounded">
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
       </attDef>
     </attList>
@@ -1121,7 +1121,7 @@
         <desc xml:lang="en">Indicates the nature of the evidence supporting the reliability or accuracy of the
           intervention or interpretation.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="internal">
@@ -1419,7 +1419,7 @@
       <attDef ident="translit" usage="opt">
         <desc xml:lang="en">Specifies the transliteration technique used.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <remarks xml:lang="en">
           <p>There is no standard list of transliteration schemes.</p>
@@ -1789,7 +1789,7 @@
       <attDef ident="unit" usage="opt">
         <desc xml:lang="en">Indicates the unit of measurement.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="byte">
@@ -2218,7 +2218,7 @@
         <desc xml:lang="en">A name or label associated with the controlled vocabulary from which a numerical value
           of <att>head.shape</att> is taken.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <constraintSpec ident="check_head.auth" scheme="schematron">
           <constraint>
@@ -2714,7 +2714,7 @@
         <desc xml:lang="en">Characterization of target resource(s) using any convenient classification scheme or
           typology.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
       </attDef>
       <!-- @xlink:title duplicates @label.  Use @label instead! -->
@@ -3459,7 +3459,7 @@
       <attDef ident="altrend" usage="opt">
         <desc xml:lang="en">Used to extend the values of the rend attribute.</desc>
         <datatype maxOccurs="unbounded">
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
       </attDef>
       <attDef ident="rend" usage="opt">
@@ -3634,7 +3634,7 @@
         <desc xml:lang="en">Designation which characterizes the element in some sense, using any convenient
           classification scheme or typology that employs single-token labels.</desc>
         <datatype maxOccurs="unbounded">
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
       </attDef>
     </attList>
@@ -5334,7 +5334,7 @@
       <attDef ident="form" usage="req">
         <desc xml:lang="en">Aspect of the object being measured.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="alt">

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -332,7 +332,7 @@
         <desc xml:lang="en">A name or label associated with a controlled vocabulary or other authoritative source
           for this element or its content.</desc>
         <datatype>
-          <rng:data type="string"/>
+          <dataRef name="string"/>
         </datatype>
       </attDef>
       <attDef ident="auth.uri" usage="opt">
@@ -430,7 +430,7 @@
         <desc xml:lang="en">Contains a reference to a field or element in another descriptive encoding system to
           which this MEI element is comparable.</desc>
         <datatype>
-          <rng:data type="string"/>
+          <dataRef name="string"/>
         </datatype>
       </attDef>
     </attList>
@@ -1164,7 +1164,7 @@
         <desc xml:lang="en">Captures a measurement, count, or description. When extent contains a numeric value,
           use the unit attribute to indicate the measurement unit.</desc>
         <datatype>
-          <rng:data type="string"/>
+          <dataRef name="string"/>
         </datatype>
         <constraintSpec ident="check_extent" scheme="schematron">
           <constraint>
@@ -1299,7 +1299,7 @@
           should be a valid MIME media type defined by the Internet Engineering Task Force in RFC
           2046.</desc>
         <datatype>
-          <rng:data type="string"/>
+          <dataRef name="string"/>
         </datatype>
       </attDef>
     </attList>
@@ -1390,7 +1390,7 @@
           "tool tip" or prefatory text, for example. Should not be used to record document
           content.</desc>
         <datatype>
-          <rng:data type="string"/>
+          <dataRef name="string"/>
         </datatype>
         <remarks xml:lang="en">
           <p> <att>label</att> is used to provide a display label for an element’s contents, for
@@ -1891,7 +1891,7 @@
       <attDef ident="medium" usage="opt">
         <desc xml:lang="en">Describes the writing medium.</desc>
         <datatype>
-          <rng:data type="string"/>
+          <dataRef name="string"/>
         </datatype>
       </attDef>
     </attList>
@@ -2722,7 +2722,7 @@
       <!--<attDef ident="xlink:title" usage="opt">
               <desc xml:lang="en">Contains a human-readable description of the entire link.</desc>
               <datatype>
-                <rng:data type="string"/>
+                <dataRef name="string"/>
               </datatype>
             </attDef>-->
     </attList>
@@ -3347,7 +3347,7 @@
       <attDef ident="syl" usage="opt">
         <desc xml:lang="en">Holds an associated sung text syllable.</desc>
         <datatype>
-          <rng:data type="string"/>
+          <dataRef name="string"/>
         </datatype>
       </attDef>
     </attList>
@@ -7850,7 +7850,7 @@
         <desc xml:lang="en">Indicates the delimiter used to mark the portions of text that are to be
           stacked.</desc>
         <datatype>
-          <rng:data type="string"/>
+          <dataRef name="string"/>
         </datatype>
       </attDef>
       <attDef ident="align" usage="opt">

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -2018,7 +2018,7 @@
         <desc xml:lang="en">Contains the number indicating the beat unit, that is, the bottom number of the meter
           signature.</desc>
         <datatype>
-          <rng:data type="decimal"/>
+          <dataRef name="decimal"/>
         </datatype>
       </attDef>
     </attList>
@@ -2751,27 +2751,27 @@
       <attDef ident="atleast" usage="opt">
         <desc xml:lang="en">Gives a minimum estimated value for an approximate measurement.</desc>
         <datatype>
-          <rng:data type="decimal"/>
+          <dataRef name="decimal"/>
         </datatype>
       </attDef>
       <attDef ident="atmost" usage="opt">
         <desc xml:lang="en">Gives a maximum estimated value for an approximate measurement.</desc>
         <datatype>
-          <rng:data type="decimal"/>
+          <dataRef name="decimal"/>
         </datatype>
       </attDef>
       <attDef ident="min" usage="opt">
         <desc xml:lang="en">Where the measurement summarizes more than one observation or a range of values,
           supplies the minimum value observed.</desc>
         <datatype>
-          <rng:data type="decimal"/>
+          <dataRef name="decimal"/>
         </datatype>
       </attDef>
       <attDef ident="max" usage="opt">
         <desc xml:lang="en">Where the measurement summarizes more than one observation or a range of values,
           supplies the maximum value observed.</desc>
         <datatype>
-          <rng:data type="decimal"/>
+          <dataRef name="decimal"/>
         </datatype>
       </attDef>
       <attDef ident="confidence" usage="opt">
@@ -2988,13 +2988,13 @@
       <attDef ident="spacing.packexp" usage="opt">
         <desc xml:lang="en">Describes a note’s spacing relative to its time value.</desc>
         <datatype>
-          <rng:data type="decimal"/>
+          <dataRef name="decimal"/>
         </datatype>
       </attDef>
       <attDef ident="spacing.packfact" usage="opt">
         <desc xml:lang="en">Describes the note spacing of output.</desc>
         <datatype>
-          <rng:data type="decimal"/>
+          <dataRef name="decimal"/>
         </datatype>
       </attDef>
       <attDef ident="spacing.staff" usage="opt">
@@ -3278,13 +3278,13 @@
       <attDef ident="stem.x" usage="opt">
         <desc xml:lang="en">Records the output x coordinate of the stem’s attachment point.</desc>
         <datatype>
-          <rng:data type="decimal"/>
+          <dataRef name="decimal"/>
         </datatype>
       </attDef>
       <attDef ident="stem.y" usage="opt">
         <desc xml:lang="en">Records the output y coordinate of the stem’s attachment point.</desc>
         <datatype>
-          <rng:data type="decimal"/>
+          <dataRef name="decimal"/>
         </datatype>
       </attDef>
     </attList>
@@ -3594,7 +3594,7 @@
       <attDef ident="tune.Hz" usage="opt">
         <desc xml:lang="en">Holds a value for cycles per second, <abbr>i.e.</abbr>, Hertz, for a tuning reference pitch.</desc>
         <datatype>
-          <rng:data type="decimal"/>
+          <dataRef name="decimal"/>
         </datatype>
       </attDef>
       <attDef ident="tune.pname" usage="opt">
@@ -3923,7 +3923,7 @@
           necessary to record the placement of a feature in a facsimile image, use the facs
           attribute.</desc>
         <datatype>
-          <rng:data type="decimal"/>
+          <dataRef name="decimal"/>
         </datatype>
       </attDef>
       <attDef ident="y" usage="opt">
@@ -3931,7 +3931,7 @@
           necessary to record the placement of a feature in a facsimile image, use the facs
           attribute.</desc>
         <datatype>
-          <rng:data type="decimal"/>
+          <dataRef name="decimal"/>
         </datatype>
       </attDef>
     </attList>
@@ -3945,13 +3945,13 @@
       <attDef ident="x2" usage="opt">
         <desc xml:lang="en">Encodes the optional 2nd x coordinate.</desc>
         <datatype>
-          <rng:data type="decimal"/>
+          <dataRef name="decimal"/>
         </datatype>
       </attDef>
       <attDef ident="y2" usage="opt">
         <desc xml:lang="en">Encodes the optional 2nd y coordinate.</desc>
         <datatype>
-          <rng:data type="decimal"/>
+          <dataRef name="decimal"/>
         </datatype>
       </attDef>
     </attList>
@@ -6811,7 +6811,7 @@
         <desc xml:lang="en">Numeric value capturing a measurement or count. Can only be interpreted in combination
           with the unit attribute.</desc>
         <datatype>
-          <rng:data type="decimal"/>
+          <dataRef name="decimal"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -27,7 +27,7 @@
   <macroSpec ident="data.COURSENUMBER" module="MEI.stringtab" type="dt">
     <desc xml:lang="en">In string tablature, the number of the course to be played.</desc>
     <content>
-      <rng:data type="positiveInteger"/>
+      <dataRef name="positiveInteger"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.COURSETUNING" module="MEI.stringtab" type="dt">
@@ -130,7 +130,7 @@
       <attDef ident="tab.pos" usage="opt">
         <desc xml:lang="en">Records fret position.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -196,10 +196,10 @@
       <attDef ident="fret" usage="opt">
         <desc xml:lang="en">This attribute is deprecated in favor of <att>tab.fret</att>, and will be removed in a future version. Records the location at which the strings should be stopped against a fret in a fretboard diagram. This may or may not be the same as the actual location on the fretboard of the instrument in performance.</desc>
         <datatype>
-          <rng:data type="positiveInteger">
-            <rng:param name="minInclusive">1</rng:param>
-            <rng:param name="maxInclusive">5</rng:param>
-          </rng:data>
+          <dataRef name="positiveInteger">
+            <dataFacet name="minInclusive" value="1"/>
+            <dataFacet name="maxInclusive" value="5"/>
+          </dataRef>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.text.xml
+++ b/source/modules/MEI.text.xml
@@ -226,7 +226,7 @@
         <desc xml:lang="en">Used to specify a rhythm for the lyric syllables that differs from that of the notes
           on the staff, <abbr>e.g.</abbr>, '4,4,4,4' when the rhythm of the notes is '4.,8,4.,8'.</desc>
         <datatype>
-          <rng:data type="string"/>
+          <dataRef name="string"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.text.xml
+++ b/source/modules/MEI.text.xml
@@ -379,7 +379,7 @@
     <attList>
       <attDef ident="type" usage="opt">
         <datatype maxOccurs="unbounded">
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="spoken">

--- a/source/modules/MEI.usersymbols.xml
+++ b/source/modules/MEI.usersymbols.xml
@@ -60,7 +60,7 @@
       <attDef ident="func" usage="rec">
         <desc xml:lang="en">Indicates the function of the text.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="unknown">
@@ -79,7 +79,7 @@
       <attDef ident="func" usage="rec">
         <desc xml:lang="en">Indicates the function of the curve.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="unknown">
@@ -101,7 +101,7 @@
       <attDef ident="func" usage="rec">
         <desc xml:lang="en">Indicates the function of the line.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="coloration">

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -229,7 +229,7 @@
       <attDef ident="beam.slope" usage="opt">
         <desc xml:lang="en">Captures beam slope.</desc>
         <datatype>
-          <rng:data type="decimal"/>
+          <dataRef name="decimal"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -643,16 +643,16 @@
       <attDef ident="beams" usage="opt">
         <desc xml:lang="en">Indicates the number of beams present.</desc>
         <datatype>
-          <rng:data type="positiveInteger">
-            <rng:param name="minInclusive">1</rng:param>
-            <rng:param name="maxInclusive">6</rng:param>
-          </rng:data>
+          <dataRef name="positiveInteger">
+            <dataFacet name="minInclusive" value="1"/>
+            <dataFacet name="maxInclusive" value="6"/>
+          </dataRef>
         </datatype>
       </attDef>
       <attDef ident="beams.float" usage="opt">
         <desc xml:lang="en">Captures the number of "floating" beams, <abbr>i.e.</abbr>, those not attached to stems.</desc>
         <datatype>
-          <rng:data type="nonNegativeInteger"/>
+          <dataRef name="nonNegativeInteger"/>
         </datatype>
         <constraintSpec ident="check_beams.floating" scheme="schematron">
           <constraint>
@@ -964,7 +964,7 @@
             <desc xml:lang="en">Stores the number of segments used to render a dashed, dotted, or wavy
               line.</desc>
             <datatype>
-              <rng:data type="positiveInteger"/>
+              <dataRef name="positiveInteger"/>
             </datatype>
           </attDef>
         -->
@@ -1143,7 +1143,7 @@
         <desc xml:lang="en">Indicates the number lines added to the mensuration sign. For example, one slash is
           added for what we now call 'alla breve'.</desc>
         <datatype>
-          <rng:data type="positiveInteger"/>
+          <dataRef name="positiveInteger"/>
         </datatype>
       </attDef>
     </attList>
@@ -1515,10 +1515,10 @@
       <attDef ident="waves" usage="opt">
         <desc xml:lang="en">Number of "crests" of a wavy line.</desc>
         <datatype>
-          <rng:data type="positiveInteger">
-            <rng:param name="minInclusive">2</rng:param>
-            <rng:param name="maxInclusive">4</rng:param>
-          </rng:data>
+          <dataRef name="positiveInteger">
+            <dataFacet name="minInclusive" value="2"/>
+            <dataFacet name="maxInclusive" value="4"/>
+          </dataRef>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -1767,7 +1767,7 @@
     <desc xml:lang="en">ISO 24-hour time format: HH:MM:SS.ss, <abbr>i.e.</abbr>,
       [0-9][0-9]:[0-9][0-9]:[0-9][0-9](\.?[0-9]*)?.</desc>
     <content>
-      <rng:data type="time"/>
+      <dataRef name="time"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.KEYFIFTHS" module="MEI" type="dt">

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -392,9 +392,9 @@
   <macroSpec ident="data.AUGMENTDOT" module="MEI" type="dt">
     <desc xml:lang="en">Dots attribute values (number of augmentation dots) (Read, 113-119, ex. 8-21).</desc>
     <content>
-      <rng:data type="nonNegativeInteger">
-        <rng:param name="maxInclusive">4</rng:param>
-      </rng:data>
+      <dataRef name="nonNegativeInteger">
+        <dataFacet name="maxInclusive" value="4"/>
+      </dataRef>
     </content>
   </macroSpec>
   <macroSpec ident="data.BARMETHOD" module="MEI" type="dt">
@@ -494,9 +494,9 @@
   <macroSpec ident="data.BEAT" module="MEI" type="dt">
     <desc xml:lang="en">A beat location, <abbr>i.e.</abbr>, a decimal number.</desc>
     <content>
-      <rng:data type="decimal">
-        <rng:param name="minInclusive">0</rng:param>
-      </rng:data>
+      <dataRef name="decimal">
+        <dataFacet name="minInclusive" value="0"/>
+      </dataRef>
     </content>
     <remarks xml:lang="en">
       <p>The value must fall between 0 and the numerator of the time signature + 1,
@@ -592,7 +592,7 @@
     <desc xml:lang="en">Clef line attribute values. The value must be in the range between 1 and the number of
       lines on the staff. The numbering of lines starts with the lowest line of the staff.</desc>
     <content>
-      <rng:data type="positiveInteger"/>
+      <dataRef name="positiveInteger"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.CLEFSHAPE" module="MEI" type="dt">
@@ -649,10 +649,10 @@
     <desc xml:lang="en">Confidence is expressed as a real number between 0 and 1; 0 representing certainly false
       and 1 representing certainly true.</desc>
     <content>
-      <rng:data type="decimal">
-        <rng:param name="minInclusive">0</rng:param>
-        <rng:param name="maxInclusive">1</rng:param>
-      </rng:data>
+      <dataRef name="decimal">
+        <dataFacet name="minInclusive" value="0"/>
+        <dataFacet name="maxInclusive" value="1"/>
+      </dataRef>
     </content>
   </macroSpec>
   <macroSpec ident="data.COLORNAMES" module="MEI" type="dt">
@@ -1208,10 +1208,10 @@
     <desc xml:lang="en">360th-unit measure of a circle’s circumference; optionally signed decimal number between
       -360 and 360.</desc>
     <content>
-      <rng:data type="decimal">
-        <rng:param name="maxInclusive">360.0</rng:param>
-        <rng:param name="minInclusive">-360.0</rng:param>
-      </rng:data>
+      <dataRef name="decimal">
+        <dataFacet name="maxInclusive" value="360.0"/>
+        <dataFacet name="minInclusive" value="-360.0"/>
+      </dataRef>
     </content>
   </macroSpec>
   <macroSpec ident="data.DIVISIO" module="MEI" type="dt">
@@ -1429,10 +1429,10 @@
   <macroSpec ident="data.FONTSIZESCALE" module="MEI" type="dt">
     <desc xml:lang="en">Relative size of symbol that may begin/end a line.</desc>
     <content>
-      <rng:data type="integer">
-        <rng:param name="minInclusive">1</rng:param>
-        <rng:param name="maxInclusive">9</rng:param>
-      </rng:data>
+      <dataRef name="positiveInteger">
+        <dataFacet name="minInclusive" value="1"/>
+        <dataFacet name="maxInclusive" value="9"/>
+      </dataRef>
     </content>
   </macroSpec>
   <macroSpec ident="data.FONTSIZETERM" module="MEI" type="dt">
@@ -1502,7 +1502,7 @@
     <desc xml:lang="en">In string tablature, the fret number. The value <val>0</val> (zero) indicates the open
       string.</desc>
     <content>
-      <rng:data type="nonNegativeInteger"/>
+      <dataRef name="nonNegativeInteger"/>
     </content>
   </macroSpec>
   <!--<macroSpec ident="data.FRETNUMBER.limited" module="MEI" type="dt">
@@ -1511,10 +1511,10 @@
       subset of those available in data.FRETNUMBER. The pos (position) attribute on the chordDef
       element must be used to indicate at which fret this range begins.</desc>
     <content>
-      <rng:data type="nonNegativeInteger">
-        <rng:param name="minInclusive">0</rng:param>
-        <rng:param name="maxInclusive">5</rng:param>
-      </rng:data>
+      <dataRef name="nonNegativeInteger">
+        <dataFacet name="minInclusive" value="0"/>
+        <dataFacet name="maxInclusive" value="5"/>
+      </dataRef>
     </content>
   </macroSpec>-->
   <macroSpec ident="data.GLISSANDO" module="MEI" type="dt">
@@ -2227,7 +2227,7 @@
     <desc xml:lang="en">Tempo expressed as microseconds per "beat", where "beat" is always defined as a quarter
       note, *not the numerator of the time signature or the metronomic indication*.</desc>
     <content>
-      <rng:data type="positiveInteger"/>
+      <dataRef name="positiveInteger"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.MIDINAMES" module="MEI" type="dt">
@@ -2925,19 +2925,19 @@
   <macroSpec ident="data.MODUSMAIOR" module="MEI" type="dt">
     <desc xml:lang="en">Maxima-long relationship values.</desc>
     <content>
-      <rng:data type="positiveInteger">
-        <rng:param name="minInclusive">2</rng:param>
-        <rng:param name="maxInclusive">3</rng:param>
-      </rng:data>
+      <dataRef name="positiveInteger">
+        <dataFacet name="minInclusive" value="2"/>
+        <dataFacet name="maxInclusive" value="3"/>
+      </dataRef>
     </content>
   </macroSpec>
   <macroSpec ident="data.MODUSMINOR" module="MEI" type="dt">
     <desc xml:lang="en">Long-breve relationship values.</desc>
     <content>
-      <rng:data type="positiveInteger">
-        <rng:param name="minInclusive">2</rng:param>
-        <rng:param name="maxInclusive">3</rng:param>
-      </rng:data>
+      <dataRef name="positiveInteger">
+        <dataFacet name="minInclusive" value="2"/>
+        <dataFacet name="maxInclusive" value="3"/>
+      </dataRef>
     </content>
   </macroSpec>
   <macroSpec ident="data.MUSICFONT" module="MEI" type="dt">
@@ -3117,18 +3117,16 @@
   <macroSpec ident="data.OCTAVE" module="MEI" type="dt">
     <desc xml:lang="en">Octave number. The default values conform to the Scientific Pitch Notation (SPN).</desc>
     <content>
-      <rng:data type="nonNegativeInteger">
-        <rng:param name="maxInclusive">9</rng:param>
-      </rng:data>
+      <dataRef name="nonNegativeInteger">
+        <dataFacet name="maxInclusive" value="9"/>
+      </dataRef>
     </content>
   </macroSpec>
   <macroSpec ident="data.OCTAVE.DIS" module="MEI" type="dt">
     <desc xml:lang="en">The amount of octave displacement; that is, '8' (as in '8va' for 1 octave), '15' (for 2
       octaves), or rarely '22' (for 3 octaves).</desc>
     <content>
-      <rng:data type="positiveInteger">
-        <rng:param name="pattern">8|15|22</rng:param>
-      </rng:data>
+      <dataRef name="positiveInteger" restriction="8|15|22"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.ORIENTATION" module="MEI" type="dt">
@@ -3156,10 +3154,10 @@
   <macroSpec ident="data.PAGE.PANELS" module="MEI" type="dt">
     <desc xml:lang="en">The number of panels per page.</desc>
     <content>
-      <rng:data type="positiveInteger">
-        <rng:param name="minInclusive">1</rng:param>
-        <rng:param name="maxInclusive">2</rng:param>
-      </rng:data>
+      <dataRef name="positiveInteger">
+        <dataFacet name="minInclusive" value="1"/>
+        <dataFacet name="maxInclusive" value="2"/>
+      </dataRef>
     </content>
   </macroSpec>
   <macroSpec ident="data.PEDALSTYLE" module="MEI" type="dt">
@@ -3245,9 +3243,9 @@
   <macroSpec ident="data.PITCHCLASS" module="MEI" type="dt">
     <desc xml:lang="en">Pclass (pitch class) attribute values.</desc>
     <content>
-      <rng:data type="nonNegativeInteger">
-        <rng:param name="maxInclusive">11</rng:param>
-      </rng:data>
+      <dataRef name="nonNegativeInteger">
+        <dataFacet name="maxInclusive" value="11"/>
+      </dataRef>
     </content>
   </macroSpec>
   <macroSpec ident="data.PITCHNAME" module="MEI" type="dt">
@@ -3271,7 +3269,7 @@
   <macroSpec ident="data.PITCHNUMBER" module="MEI" type="dt">
     <desc xml:lang="en">Pnum (pitch number, <abbr>e.g.</abbr>, MIDI) attribute values.</desc>
     <content>
-      <rng:data type="nonNegativeInteger"/>
+      <dataRef name="nonNegativeInteger"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.PLACEMENT" module="MEI" type="dt">
@@ -3298,10 +3296,10 @@
   <macroSpec ident="data.PROLATIO" module="MEI" type="dt">
     <desc xml:lang="en">Semibreve-minim relationship values.</desc>
     <content>
-      <rng:data type="positiveInteger">
-        <rng:param name="minInclusive">2</rng:param>
-        <rng:param name="maxInclusive">3</rng:param>
-      </rng:data>
+      <dataRef name="positiveInteger">
+        <dataFacet name="minInclusive" value="2"/>
+        <dataFacet name="maxInclusive" value="3"/>
+      </dataRef>
     </content>
   </macroSpec>
   <!--<macroSpec ident="data.RATIO" module="MEI" type="dt">
@@ -3370,10 +3368,10 @@
   <macroSpec ident="data.SLASH" module="MEI" type="dt">
     <desc xml:lang="en">The number of slashes to be rendered for tremolandi.</desc>
     <content>
-      <rng:data type="positiveInteger">
-        <rng:param name="minInclusive">1</rng:param>
-        <rng:param name="maxInclusive">6</rng:param>
-      </rng:data>
+      <dataRef name="positiveInteger">
+        <dataFacet name="minInclusive" value="1"/>
+        <dataFacet name="maxInclusive" value="6"/>
+      </dataRef>
     </content>
   </macroSpec>
   <macroSpec ident="data.SLUR" module="MEI" type="dt">
@@ -3601,7 +3599,7 @@
   <macroSpec ident="data.STRINGNUMBER" module="MEI" type="dt">
     <desc xml:lang="en">This datatype is deprecated in favor of data.COURSENUMBER and will be removed in a future version. In string tablature, the number of the string to be played.</desc>
     <content>
-      <rng:data type="positiveInteger"/>
+      <dataRef name="positiveInteger"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.TEMPERAMENT" module="MEI" type="dt">
@@ -3632,10 +3630,10 @@
   <macroSpec ident="data.TEMPUS" module="MEI" type="dt">
     <desc xml:lang="en">Breve-semibreve relationship values.</desc>
     <content>
-      <rng:data type="positiveInteger">
-        <rng:param name="minInclusive">2</rng:param>
-        <rng:param name="maxInclusive">3</rng:param>
-      </rng:data>
+      <dataRef name="positiveInteger">
+        <dataFacet name="minInclusive" value="2"/>
+        <dataFacet name="maxInclusive" value="3"/>
+      </dataRef>
     </content>
   </macroSpec>
   <macroSpec ident="data.TEXTRENDITIONLIST" module="MEI" type="dt">

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -2957,7 +2957,7 @@
     <desc xml:lang="en">"Convenience" datatype that permits combining enumerated values with user-supplied
       values.</desc>
     <content>
-      <rng:data type="NMTOKEN"/>
+      <dataRef name="NMTOKEN"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.NONSTAFFPLACE" module="MEI" type="dt">
@@ -3857,7 +3857,7 @@
         <desc xml:lang="en">Provides any sub-classification of the notation contained or described by the element,
           additional to that given by its notationtype attribute.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <constraintSpec ident="When_notationsubtype" scheme="schematron">
           <constraint>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3814,7 +3814,7 @@
   <macroSpec ident="data.URI" module="MEI" type="dt">
     <desc xml:lang="en">A Uniform Resource Identifier, see [RFC2396].</desc>
     <content>
-      <rng:data type="anyURI"/>
+      <dataRef name="anyURI"/>
     </content>
   </macroSpec>
   <macroSpec ident="data.VERTICALALIGNMENT" module="MEI" type="dt">

--- a/utils/guidelines_xslt/odd2html/functions.xsl
+++ b/utils/guidelines_xslt/odd2html/functions.xsl
@@ -83,8 +83,8 @@
             <xsl:variable name="current.div" select="." as="node()"/>
             <xsl:variable name="index" select="position()" as="xs:integer"/>
             <chapter level="{$level}" xml:id="{$current.div/@xml:id}" number="{$parent.number || $index}" head="{normalize-space(string-join($current.div/tei:head/text(),' '))}">
-                <xsl:sequence select="tools:buildChapterList($current.div, $level + 1, $parent.number || $index || '.')"/>    
-            </chapter>            
+                <xsl:sequence select="tools:buildChapterList($current.div, $level + 1, $parent.number || $index || '.')"/>
+            </chapter>
         </xsl:for-each>
     </xsl:function>
     
@@ -147,10 +147,10 @@
                 Music Encoding Initiative
                 <small class="out">Guidelines</small>
             </h1>
-            <img id="meiLogo" src="images/meilogo.png"/>    
+            <img id="meiLogo" src="images/meilogo.png"/>
             <div class="bottom">
                 <div class="versionDiv">Version <span id="version"><xsl:value-of select="$version"/></span> <span class="gitLinkWrapper">(<a id="gitVersionLink" href="{$git.link}">#<xsl:value-of select="$git.short"/></a>)</span></div>
-                <div class="generationDiv">generated on <span id="generationDate"><xsl:value-of select="format-date(current-date(), '[D1] [MNn] [Y1]')"/></span></div>                
+                <div class="generationDiv">generated on <span id="generationDate"><xsl:value-of select="format-date(current-date(), '[D1] [MNn] [Y1]')"/></span></div>
             </div>
         </section>
         <section class="imprintPage">
@@ -186,7 +186,7 @@
             <!-- TODO: Do we have front pages that need to be included? -->
             <ul class="toc toc_body">
                 <xsl:for-each select="$all.chapters">
-                    <xsl:sequence select="tools:generateTocChapterItem(.)"/>    
+                    <xsl:sequence select="tools:generateTocChapterItem(.)"/>
                 </xsl:for-each>
             </ul>
             <ul class="toc toc_back">
@@ -231,10 +231,10 @@
                         </li>
                         <li class="toc toc_2">
                             <a class="toc toc_2" href="#dataTypeIndex">Index of Data Types</a>
-                        </li>     
+                        </li>
                         <li class="toc toc_2">
                             <a class="toc toc_2" href="#contributorList">Contributors</a>
-                        </li>     
+                        </li>
                     </ul>
                 </li>
             </ul>
@@ -264,7 +264,7 @@
             <xsl:if test="$chapter/child::chapter">
                 <ul class="toc">
                     <xsl:for-each select="$chapter/child::chapter">
-                        <xsl:sequence select="tools:generateTocChapterItem(.)"/>    
+                        <xsl:sequence select="tools:generateTocChapterItem(.)"/>
                     </xsl:for-each>
                 </ul>
             </xsl:if>
@@ -434,7 +434,7 @@
                 explicitly mentioned in chapter <a href="#acknowledgments">1.1.1 Acknowledgments</a> of these Guidelines. However, we 
                 believe it is important to give proper recognition to everyone contributing to this community effort. Without 
                 their continued commitment, MEI would not be possible. 
-            </p>            
+            </p>
             <xsl:sequence select="tools:getContributors()"/>
             <p>
                 This list is automatically compiled from all contributors to the 
@@ -496,8 +496,8 @@
                         <string key="viaf"></string>
                         <string key="orcid"></string>
                         <string key="avatar"><xsl:value-of select="$user.data/json:string[@key = 'avatar_url']"/></string>
-                    </map>                    
-                </xsl:for-each>    
+                    </map>
+                </xsl:for-each>
             </array>
             
         </xsl:variable>
@@ -555,8 +555,8 @@
                                     <img class="contibutorAvatar" src="images/ORCID_iD.svg"/>
                                     <span><xsl:value-of select="substring-after($current.contributor/json:string[@key = 'orcid']/text(),'https://orcid.org/')"/></span>
                                 </a>
-                            </xsl:if>                            
-                        </td>                        
+                            </xsl:if>
+                        </td>
                         <td class="viaf">
                             <xsl:if test="$current.contributor/json:string[@key = 'viaf']/text() and string-length($current.contributor/json:string[@key = 'viaf']/text()) gt 0">
                                 <a class="contributorLink viafLink" href="{$current.contributor/json:string[@key = 'viaf']/text()}">

--- a/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
@@ -687,7 +687,7 @@
                             </xsl:variable>
                             Value conforms to either <xsl:sequence select="$refs"/>.
                         </xsl:when>
-                        <xsl:when test="$current.att/tei:datatype[rng:data]">
+                        <xsl:when test="$current.att/tei:datatype[rng:data|tei:dataRef/@name]">
                             <xsl:variable name="dt" select="$current.att/tei:datatype" as="node()"/>
                             <xsl:choose>
                                 <xsl:when test="$dt/@maxOccurs = '1'">
@@ -709,6 +709,9 @@
                                     Value is a valid <a target="_blank" href="https://www.w3.org/TR/xml-id/">xml:id</a>.
                                 </xsl:when>
                                 <xsl:when test="count($dt/child::rng:data) = 1 and $dt/child::rng:data/@type = 'decimal'">
+                                    Value is a decimal number.
+                                </xsl:when>
+                                <xsl:when test="count($dt/child::tei:dataRef) = 1 and $dt/child::tei:dataRef/@name = 'decimal'">
                                     Value is a decimal number.
                                 </xsl:when>
                                 <xsl:when test="count($dt/child::rng:data) = 1 and $dt/child::rng:data/@type = 'integer'">

--- a/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
@@ -687,7 +687,7 @@
                             </xsl:variable>
                             Value conforms to either <xsl:sequence select="$refs"/>.
                         </xsl:when>
-                        <xsl:when test="$current.att/tei:datatype[rng:data|tei:dataRef/@name]">
+                        <xsl:when test="$current.att/tei:datatype[rng:data]">
                             <xsl:variable name="dt" select="$current.att/tei:datatype" as="node()"/>
                             <xsl:choose>
                                 <xsl:when test="$dt/@maxOccurs = '1'">
@@ -709,9 +709,6 @@
                                     Value is a valid <a target="_blank" href="https://www.w3.org/TR/xml-id/">xml:id</a>.
                                 </xsl:when>
                                 <xsl:when test="count($dt/child::rng:data) = 1 and $dt/child::rng:data/@type = 'decimal'">
-                                    Value is a decimal number.
-                                </xsl:when>
-                                <xsl:when test="count($dt/child::tei:dataRef) = 1 and $dt/child::tei:dataRef/@name = 'decimal'">
                                     Value is a decimal number.
                                 </xsl:when>
                                 <xsl:when test="count($dt/child::rng:data) = 1 and $dt/child::rng:data/@type = 'integer'">
@@ -736,6 +733,58 @@
                                     Value is an <a target="_blank" href="https://www.w3.org/TR/xmlschema11-2/#duration">ISO duration</a>.
                                 </xsl:when>
                                 <xsl:when test="count($dt/child::rng:data) = 1 and $dt/child::rng:data/@type = 'token' and $dt/child::rng:data/child::rng:param[@name='pattern']">
+                                    Value conforms to the pattern "<span style="font-weight: 500;"><xsl:value-of select="$dt//rng:param[@name='pattern']/text()"/></span>".
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:message select="'ERROR: Unable to resolve the following datatype on attribute ' || $current.att/@ident"/>
+                                    <xsl:message terminate="yes" select="$dt"/>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                        </xsl:when>
+                        <!-- the following when statement is the pureODD replacement for the preceding one -->
+                        <xsl:when test="$current.att/tei:datatype[tei:dataRef/@name]">
+                            <xsl:variable name="dt" select="$current.att/tei:datatype" as="node()"/>
+                            <xsl:choose>
+                                <xsl:when test="$dt/@maxOccurs = '1'">
+                                    Value of datatype <span style="font-weight: 500;"><xsl:sequence select="tools:resolveData($dt//tei:dataRef[1])"/></span>.
+                                </xsl:when>
+                                <xsl:when test="$dt/@maxOccurs = '2'">
+                                    One or two values of datatype <span style="font-weight: 500;"><xsl:sequence select="tools:resolveData($dt//tei:dataRef[1])"/></span>, separated by a space.
+                                </xsl:when>
+                                <xsl:when test="$dt/@maxOccurs = 'unbounded'">
+                                    One or more values of datatype <span style="font-weight: 500;"><xsl:sequence select="tools:resolveData($dt//tei:dataRef[1])"/></span>, separated by spaces.
+                                </xsl:when>
+                                <xsl:when test="count($dt/child::tei:dataRef) = 1 and $dt/child::tei:dataRef/@name = 'string'">
+                                    Value is plain text.
+                                </xsl:when>
+                                <xsl:when test="count($dt/child::tei:dataRef) = 1 and $dt/child::tei:dataRef/@name = 'ID'">
+                                    Value is a valid <a target="_blank" href="https://www.w3.org/TR/xml-id/">xml:id</a>.
+                                </xsl:when>
+                                <xsl:when test="count($dt/child::tei:dataRef) = 1 and $dt/child::tei:dataRef/@name = 'decimal'">
+                                    Value is a decimal number.
+                                </xsl:when>
+                                <xsl:when test="count($dt/child::tei:dataRef) = 1 and $dt/child::tei:dataRef/@name = 'integer'">
+                                    Value is an integer.
+                                </xsl:when>
+                                <xsl:when test="count($dt/child::tei:dataRef) = 1 and $dt/child::tei:dataRef/@name = 'positiveInteger'">
+                                    Value is a positive integer.
+                                </xsl:when>
+                                <xsl:when test="count($dt/child::tei:dataRef) = 1 and $dt/child::tei:dataRef/@name = 'nonNegativeInteger'">
+                                    Value is a positive integer, including 0.
+                                </xsl:when>
+                                <xsl:when test="count($dt/child::tei:dataRef) = 1 and $dt/child::tei:dataRef/@name = 'language'">
+                                    Value is a <a target="_blank" href="https://www.w3.org/TR/xmlschema11-2/#language">language</a>.
+                                </xsl:when>
+                                <xsl:when test="count($dt/child::tei:dataRef) = 1 and $dt/child::tei:dataRef/@name = 'token'">
+                                    Value is a <a target="_blank" href="https://www.w3.org/TR/xmlschema11-2/#token">token</a>.
+                                </xsl:when>
+                                <xsl:when test="count($dt/child::tei:dataRef) = 1 and $dt/child::tei:dataRef/@name = 'NMTOKEN'">
+                                    Value is a <a target="_blank" href="https://www.w3.org/TR/xmlschema11-2/#NMTOKEN">NMTOKEN</a>.
+                                </xsl:when>
+                                <xsl:when test="count($dt/child::tei:dataRef) = 1 and $dt/child::tei:dataRef/@name = 'duration'">
+                                    Value is an <a target="_blank" href="https://www.w3.org/TR/xmlschema11-2/#duration">ISO duration</a>.
+                                </xsl:when>
+                                <xsl:when test="count($dt/child::tei:dataRef) = 1 and $dt/child::tei:dataRef/@name = 'token' and $dt/child::tei:dataRef/child::rng:param[@name='pattern']">
                                     Value conforms to the pattern "<span style="font-weight: 500;"><xsl:value-of select="$dt//rng:param[@name='pattern']/text()"/></span>".
                                 </xsl:when>
                                 <xsl:otherwise>
@@ -1005,6 +1054,37 @@
             </xsl:when>
             <xsl:when test="$data/@type = 'decimal' and $data/rng:param[@name = 'pattern']">
                 a decimal number matching the pattern "<xsl:value-of select="$data/rng:param/text()"/>"
+            </xsl:when>
+            <!-- below the respective replacements for pureODD -->
+            <xsl:when test="$data/@name = ('string','token') and $data/tei:dataFacet[@name = 'pattern']">
+                a string matching the following regular expression: "<xsl:value-of select="$data/tei:dataFacet/@value"/>"
+            </xsl:when>
+            <xsl:when test="$data/@name = 'decimal' and $data/tei:dataFacet[@name = 'minInclusive'] and $data/tei:dataFacet[@name = 'maxInclusive']">
+                a decimal number between <xsl:value-of select="$data/tei:dataFacet[@name = 'minInclusive']/@value"/> and <xsl:value-of select="$data/tei:dataFacet[@name = 'maxInclusive']/@value"/>
+            </xsl:when>
+            <xsl:when test="$data/@name = 'positiveInteger' and $data/tei:dataFacet[@name = 'minInclusive'] and $data/tei:dataFacet[@name = 'maxInclusive']">
+                a positive integer between <xsl:value-of select="$data/tei:dataFacet[@name = 'minInclusive']/@value"/> and <xsl:value-of select="$data/tei:dataFacet[@name = 'maxInclusive']/@value"/>
+            </xsl:when>
+            <xsl:when test="$data/@name = 'positiveInteger' and $data/tei:dataFacet[@name = 'maxInclusive']">
+                a positive integer no larger than <xsl:value-of select="$data/tei:dataFacet/@value"/>
+            </xsl:when>
+            <xsl:when test="$data/@name = 'positiveInteger' and $data/tei:dataFacet[@name = 'minInclusive']">
+                a positive integer no smaller than <xsl:value-of select="$data/tei:dataFacet/@value" />
+            </xsl:when>
+            <xsl:when test="$data/@name = 'nonNegativeInteger' and $data/tei:dataFacet[@name = 'maxInclusive']">
+                a non-negative integer no larger than <xsl:value-of select="$data/tei:dataFacet/@value"/>
+            </xsl:when>
+            <xsl:when test="$data/@name = 'decimal' and $data/tei:dataFacet[@name = 'minInclusive']">
+                a decimal number no smaller than <xsl:value-of select="$data/tei:dataFacet/@value"/>
+            </xsl:when>
+            <xsl:when test="$data/@name = 'decimal' and $data/tei:dataFacet[@name = 'minExclusive']">
+                a decimal number larger than <xsl:value-of select="$data/tei:dataFacet/@value"/>
+            </xsl:when>
+            <xsl:when test="$data/@name = 'positiveInteger' and $data/tei:dataFacet[@name = 'pattern']">
+                one of the following integers: <xsl:value-of select="string-join(tokenize($data/tei:dataFacet/@value,'|'),', ')"/>
+            </xsl:when>
+            <xsl:when test="$data/@name = 'decimal' and $data/tei:dataFacet[@name = 'pattern']">
+                a decimal number matching the pattern "<xsl:value-of select="$data/tei:dataFacet/@value"/>"
             </xsl:when>
             <xsl:otherwise>
                 <xsl:message select="'ERROR: Cannot resolve the following datatype:'"/>


### PR DESCRIPTION
This PR is another stone in the road to pure ODD. It updates simple datatypes from RNG (rng:data) to TEI (tei:dataRef).
This is complementary to the other two related PRs and functions independently.