### PR TITLE
schema: purify text nodes

### DIFF
--- a/source/modules/MEI.analytical.xml
+++ b/source/modules/MEI.analytical.xml
@@ -499,7 +499,7 @@
         <desc xml:lang="en">Contains sol-fa designation, <abbr>e.g.</abbr>, do, re, mi, etc., in either a fixed or movable Do
           system.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -1226,15 +1226,13 @@
       <!--<memberOf key="model.controlEventLike"/>-->
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:text/>
-          <rng:ref name="model.textPhraseLike.limited"/>
-          <rng:ref name="model.graphicPrimitiveLike"/>
-          <rng:ref name="model.editLike"/>
-          <rng:ref name="model.transcriptionLike"/>
-        </rng:choice>
-      </rng:zeroOrMore>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <textNode/>
+        <classRef key="model.textPhraseLike.limited"/>
+        <classRef key="model.graphicPrimitiveLike"/>
+        <classRef key="model.editLike"/>
+        <classRef key="model.transcriptionLike"/>
+      </alternate>
     </content>
     <constraintSpec ident="attacca_start-type_attributes_required" scheme="schematron">
       <constraint>
@@ -1267,15 +1265,13 @@
       <memberOf key="model.eventLike.cmn"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:ref name="model.eventLike"/>
-          <rng:ref name="model.eventLike.cmn"/>
-          <rng:ref name="model.appLike"/>
-          <rng:ref name="model.editLike"/>
-          <rng:ref name="model.transcriptionLike"/>
-        </rng:choice>
-      </rng:zeroOrMore>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <classRef key="model.eventLike"/>
+        <classRef key="model.eventLike.cmn"/>
+        <classRef key="model.appLike"/>
+        <classRef key="model.editLike"/>
+        <classRef key="model.transcriptionLike"/>
+      </alternate>
     </content>
     <constraintSpec ident="When_not_copyof_beam_content" scheme="schematron">
       <constraint>
@@ -1391,12 +1387,10 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:text/>
-          <rng:ref name="model.textPhraseLike.limited"/>
-        </rng:choice>
-      </rng:zeroOrMore>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <textNode/>
+        <classRef key="model.textPhraseLike.limited"/>
+      </alternate>
     </content>
     <constraintSpec ident="bracketSpan_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
@@ -1467,10 +1461,10 @@
       <memberOf key="model.eventLike.cmn"/>
     </classes>
     <content>
-      <rng:choice>
-        <rng:ref name="chord"/>
-        <rng:ref name="note"/>
-      </rng:choice>
+      <alternate>
+        <elementRef key="chord"/>
+        <elementRef key="note"/>
+      </alternate>
     </content>
   </elementSpec>
   <elementSpec ident="fermata" module="MEI.cmn">
@@ -1559,12 +1553,10 @@
       <memberOf key="model.controlEventLike"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:text/>
-          <rng:ref name="model.textPhraseLike.limited"/>
-        </rng:choice>
-      </rng:zeroOrMore>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <textNode/>
+        <classRef key="model.textPhraseLike.limited"/>
+      </alternate>
     </content>
     <constraintSpec ident="gliss_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
@@ -1601,15 +1593,13 @@
       <memberOf key="model.eventLike.cmn"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:ref name="model.eventLike"/>
-          <rng:ref name="model.eventLike.cmn"/>
-          <rng:ref name="model.appLike"/>
-          <rng:ref name="model.editLike"/>
-          <rng:ref name="model.transcriptionLike"/>
-        </rng:choice>
-      </rng:zeroOrMore>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <classRef key="model.eventLike"/>
+        <classRef key="model.eventLike.cmn"/>
+        <classRef key="model.appLike"/>
+        <classRef key="model.editLike"/>
+        <classRef key="model.transcriptionLike"/>
+      </alternate>
     </content>
     <constraintSpec ident="When_not_copyof_graceGrp_content" scheme="schematron">
       <constraint>
@@ -1726,9 +1716,7 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:ref name="curve"/>
-      </rng:zeroOrMore>
+      <elementRef key="curve" minOccurs="0" maxOccurs="unbounded"/>
     </content>
     <constraintSpec ident="lv_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
@@ -1772,22 +1760,18 @@
       <memberOf key="model.measureLike"/>
     </classes>
     <content>
-      <rng:optional>
-        <rng:ref name="mNum"/>
-      </rng:optional>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:ref name="model.annotLike"/>
-          <rng:ref name="model.appLike"/>
-          <rng:ref name="model.editLike"/>
-          <rng:ref name="model.graphicPrimitiveLike"/>
-          <rng:ref name="model.measurePart"/>
-          <rng:ref name="model.milestoneLike.music"/>
-          <rng:ref name="model.relationLike"/>
-          <rng:ref name="model.staffDefLike"/>
-          <rng:ref name="model.transcriptionLike"/>
-        </rng:choice>
-      </rng:zeroOrMore>
+      <elementRef key="mNum" minOccurs="0"/>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <classRef key="model.annotLike"/>
+        <classRef key="model.appLike"/>
+        <classRef key="model.editLike"/>
+        <classRef key="model.graphicPrimitiveLike"/>
+        <classRef key="model.measurePart"/>
+        <classRef key="model.milestoneLike.music"/>
+        <classRef key="model.relationLike"/>
+        <classRef key="model.staffDefLike"/>
+        <classRef key="model.transcriptionLike"/>
+      </alternate>
     </content>
     <remarks xml:lang="en">
       <p>In MEI, the <gi scheme="MEI">measure</gi> element is a grouping mechanism for events and
@@ -1826,10 +1810,7 @@
       <memberOf key="model.meterSigLike"/>
     </classes>
     <content>
-      <rng:ref name="model.meterSigLike"/>
-      <rng:oneOrMore>
-        <rng:ref name="model.meterSigLike"/>
-      </rng:oneOrMore>
+      <elementRef key="model.meterSigLike" minOccurs="2" maxOccurs="unbounded"/>
     </content>
   </elementSpec>
   <elementSpec ident="mNum" module="MEI.cmn">
@@ -1848,13 +1829,11 @@
       <memberOf key="att.mNum.anl"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:text/>
-          <rng:ref name="model.lbLike"/>
-          <rng:ref name="model.rendLike"/>
-        </rng:choice>
-      </rng:zeroOrMore>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <textNode/>
+        <classRef key="model.lbLike"/>
+        <classRef key="model.rendLike"/>
+      </alternate>
     </content>
     <remarks xml:lang="en">
       <p> <gi scheme="MEI">mNum</gi> uses a subset of model.textPhraseLike.limited.</p>
@@ -1994,12 +1973,10 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:text/>
-          <rng:ref name="model.textPhraseLike.limited"/>
-        </rng:choice>
-      </rng:zeroOrMore>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <textNode/>
+        <classRef key="model.textPhraseLike.limited"/>
+      </alternate>
     </content>
     <constraintSpec ident="octave_start-_and_end-type_attributes_required" scheme="schematron">
       <constraint>
@@ -2041,17 +2018,15 @@
       <memberOf key="att.layer.anl"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:ref name="model.annotLike"/>
-          <rng:ref name="model.appLike"/>
-          <rng:ref name="model.editLike"/>
-          <rng:ref name="model.graphicPrimitiveLike"/>
-          <rng:ref name="model.layerPart"/>
-          <rng:ref name="model.milestoneLike.music"/>
-          <rng:ref name="model.transcriptionLike"/>
-        </rng:choice>
-      </rng:zeroOrMore>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <classRef key="model.annotLike"/>
+        <classRef key="model.appLike"/>
+        <classRef key="model.editLike"/>
+        <classRef key="model.graphicPrimitiveLike"/>
+        <classRef key="model.layerPart"/>
+        <classRef key="model.milestoneLike.music"/>
+        <classRef key="model.transcriptionLike"/>
+      </alternate>
     </content>
   </elementSpec>
   <elementSpec ident="ossia" module="MEI.cmn">
@@ -2128,19 +2103,17 @@
       <memberOf key="att.staff.anl"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:ref name="model.annotLike"/>
-          <rng:ref name="model.appLike"/>
-          <rng:ref name="model.editLike"/>
-          <rng:ref name="model.graphicPrimitiveLike"/>
-          <rng:ref name="model.milestoneLike.music"/>
-          <rng:ref name="model.relationLike"/>
-          <rng:ref name="model.staffDefLike"/>
-          <rng:ref name="model.staffPart"/>
-          <rng:ref name="model.transcriptionLike"/>
-        </rng:choice>
-      </rng:zeroOrMore>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <classRef key="model.annotLike"/>
+        <classRef key="model.appLike"/>
+        <classRef key="model.editLike"/>
+        <classRef key="model.graphicPrimitiveLike"/>
+        <classRef key="model.milestoneLike.music"/>
+        <classRef key="model.relationLike"/>
+        <classRef key="model.staffDefLike"/>
+        <classRef key="model.staffPart"/>
+        <classRef key="model.transcriptionLike"/>
+      </alternate>
     </content>
   </elementSpec>
   <elementSpec ident="pedal" module="MEI.cmn">
@@ -2186,13 +2159,11 @@
       <memberOf key="model.controlEventLike.cmn"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:text/>
-          <rng:ref name="model.lbLike"/>
-          <rng:ref name="model.rendLike"/>
-        </rng:choice>
-      </rng:zeroOrMore>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <textNode/>
+        <classRef key="model.lbLike"/>
+        <classRef key="model.rendLike"/>
+      </alternate>
     </content>
     <remarks xml:lang="en">
       <p>It may also be called a "rehearsal figure", or when numbers are used instead of letters, a
@@ -2216,15 +2187,13 @@
       <memberOf key="model.controlEventLike"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:text/>
-          <rng:ref name="model.textPhraseLike.limited"/>
-          <rng:ref name="model.graphicPrimitiveLike"/>
-          <rng:ref name="model.editLike"/>
-          <rng:ref name="model.transcriptionLike"/>
-        </rng:choice>
-      </rng:zeroOrMore>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <textNode/>
+        <classRef key="model.textPhraseLike.limited"/>
+        <classRef key="model.graphicPrimitiveLike"/>
+        <classRef key="model.editLike"/>
+        <classRef key="model.transcriptionLike"/>
+      </alternate>
     </content>
     <constraintSpec ident="repeatMark_start-type_attributes_required" scheme="isoschematron">
       <constraint>
@@ -2364,15 +2333,13 @@
       <memberOf key="model.eventLike.cmn"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:ref name="model.appLike"/>
-          <rng:ref name="model.editLike"/>
-          <rng:ref name="model.eventLike"/>
-          <rng:ref name="model.eventLike.cmn"/>
-          <rng:ref name="model.transcriptionLike"/>
-        </rng:choice>
-      </rng:zeroOrMore>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <classRef key="model.appLike"/>
+        <classRef key="model.editLike"/>
+        <classRef key="model.eventLike"/>
+        <classRef key="model.eventLike.cmn"/>
+        <classRef key="model.transcriptionLike"/>
+      </alternate>
     </content>
     <remarks xml:lang="en">
       <p>The <gi scheme="MEI">beam</gi> sub-element is allowed so that custom beaming may be

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -372,7 +372,7 @@
         <gloss xml:lang="en">function</gloss>
         <desc xml:lang="en">Describes the function of the bracketed event sequence.</desc>
         <datatype>
-          <rng:data type="NMTOKENS"/>
+          <dataRef name="NMTOKENS"/>
         </datatype>
         <valList type="semi">
           <valItem ident="coloration">

--- a/source/modules/MEI.corpus.xml
+++ b/source/modules/MEI.corpus.xml
@@ -37,10 +37,8 @@
       <memberOf key="model.startLike.corpus"/>
     </classes>
     <content>
-      <rng:ref name="meiHead"/>
-      <rng:zeroOrMore>
-        <rng:ref name="mei"/>
-      </rng:zeroOrMore>
+      <elementRef key="meiHead"/>
+      <elementRef key="mei" minOccurs="0" maxOccurs="unbounded"/>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-teiCorpus.html">teiCorpus</ref> element of the Text Encoding Initiative (TEI). The MEI instances making up the corpus may be related in a number of ways, for

--- a/source/modules/MEI.edittrans.xml
+++ b/source/modules/MEI.edittrans.xml
@@ -234,11 +234,7 @@
       <memberOf key="model.editLike"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:ref name="model.choicePart"/>
-        </rng:choice>
-      </rng:zeroOrMore>
+      <classRef key="model.choicePart" minOccurs="0" maxOccurs="unbounded"/>
     </content>
     <remarks xml:lang="en">
       <p>Because the children of a <gi scheme="MEI">choice</gi> element all represent alternative

--- a/source/modules/MEI.externalsymbols.xml
+++ b/source/modules/MEI.externalsymbols.xml
@@ -31,7 +31,7 @@
         <desc xml:lang="en">A name or label associated with the controlled vocabulary from which the value of
           <att>glyph.name</att> or <att>glyph.num</att> is taken, or the textual content of the element.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="smufl">

--- a/source/modules/MEI.facsimile.xml
+++ b/source/modules/MEI.facsimile.xml
@@ -57,12 +57,8 @@
       <memberOf key="model.resourceLike"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:ref name="graphic"/>
-      </rng:zeroOrMore>
-      <rng:zeroOrMore>
-        <rng:ref name="surface"/>
-      </rng:zeroOrMore>
+      <elementRef key="graphic" minOccurs="0" maxOccurs="unbounded"/>
+      <elementRef key="surface" minOccurs="0" maxOccurs="unbounded"/>
     </content>
     <remarks xml:lang="en">
       <p>The <gi scheme="MEI">graphic</gi> element is provided within facsimile for association of
@@ -87,15 +83,9 @@
       <memberOf key="att.startId"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:ref name="model.figDescLike"/>
-      </rng:zeroOrMore>
-      <rng:zeroOrMore>
-        <rng:ref name="model.graphicLike"/>
-      </rng:zeroOrMore>
-      <rng:zeroOrMore>
-        <rng:ref name="zone"/>
-      </rng:zeroOrMore>
+      <classRef key="model.figDescLike" minOccurs="0" maxOccurs="unbounded"/>
+      <classRef key="model.graphicLike" minOccurs="0" maxOccurs="unbounded"/>
+      <elementRef key="zone" minOccurs="0" maxOccurs="unbounded"/>
     </content>
     <remarks xml:lang="en">
       <p>Scalable Vector Graphics (SVG) markup may be used when allowed by the graphicLike
@@ -113,12 +103,8 @@
       <memberOf key="att.dataPointing"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:ref name="model.figDescLike"/>
-      </rng:zeroOrMore>
-      <rng:zeroOrMore>
-        <rng:ref name="model.graphicLike"/>
-      </rng:zeroOrMore>
+      <classRef key="model.figDescLike" minOccurs="0" maxOccurs="unbounded"/>
+      <classRef key="model.graphicLike" minOccurs="0" maxOccurs="unbounded"/>
     </content>
     <remarks xml:lang="en">
       <p>Scalable Vector Graphics (SVG) markup may be used when allowed by the graphicLike

--- a/source/modules/MEI.fingering.xml
+++ b/source/modules/MEI.fingering.xml
@@ -77,14 +77,12 @@
       <memberOf key="model.fingeringLike"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:text/>
-          <rng:ref name="model.textPhraseLike.limited"/>
-          <rng:ref name="model.editLike"/>
-          <rng:ref name="model.transcriptionLike"/>
-        </rng:choice>
-      </rng:zeroOrMore>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <textNode/>
+        <classRef key="model.textPhraseLike.limited"/>
+        <classRef key="model.editLike"/>
+        <classRef key="model.transcriptionLike"/>
+      </alternate>
     </content>
     <constraintSpec ident="fing_start-type_attributes_required" scheme="schematron">
       <constraint>
@@ -117,13 +115,11 @@
       <memberOf key="model.fingeringLike"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:ref name="model.fingeringLike"/>
-          <rng:ref name="model.editLike"/>
-          <rng:ref name="model.transcriptionLike"/>
-        </rng:choice>
-      </rng:zeroOrMore>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <classRef key="model.fingeringLike"/>
+        <classRef key="model.editLike"/>
+        <classRef key="model.transcriptionLike"/>
+      </alternate>
     </content>
     <constraintSpec ident="require_fingeringLike_children" scheme="schematron">
       <constraint>

--- a/source/modules/MEI.frbr.xml
+++ b/source/modules/MEI.frbr.xml
@@ -348,7 +348,7 @@
       <rng:optional>
         <rng:ref name="titleStmt"/>
       </rng:optional>
-      <rng:ref name="macro.bibldescPart"/>
+      <macroRef key="macro.bibldescPart"/>
       <rng:optional>
         <rng:ref name="creation"/>
       </rng:optional>

--- a/source/modules/MEI.harmony.xml
+++ b/source/modules/MEI.harmony.xml
@@ -111,12 +111,8 @@
       <memberOf key="att.chordDef.vis"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:ref name="chordMember"/>
-      </rng:zeroOrMore>
-      <rng:zeroOrMore>
-        <rng:ref name="barre"/>
-      </rng:zeroOrMore>
+      <elementRef key="chordMember" minOccurs="0" maxOccurs="unbounded"/>
+      <elementRef key="barre" minOccurs="0" maxOccurs="unbounded"/>
     </content>
     <remarks xml:lang="en">
       <p>An <att>xml:id</att> attribute, while not required by the schema, is needed so that <gi
@@ -154,9 +150,7 @@
       <memberOf key="model.chordTableLike"/>
     </classes>
     <content>
-      <rng:oneOrMore>
-        <rng:ref name="chordDef"/>
-      </rng:oneOrMore>
+      <elementRef key="chordDef" minOccurs="1" maxOccurs="unbounded"/>
     </content>
     <remarks xml:lang="en">
       <p>A chordTable may be shared between MEI instances through the use of an external parsed
@@ -176,14 +170,12 @@
       <memberOf key="model.fLike"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:text/>
-          <rng:ref name="model.textPhraseLike.limited"/>
-          <rng:ref name="model.editLike"/>
-          <rng:ref name="model.transcriptionLike"/>
-        </rng:choice>
-      </rng:zeroOrMore>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <textNode/>
+        <classRef key="model.textPhraseLike.limited"/>
+        <classRef key="model.editLike"/>
+        <classRef key="model.transcriptionLike"/>
+      </alternate>
     </content>
   </elementSpec>
   <elementSpec ident="fb" module="MEI.harmony">
@@ -196,13 +188,11 @@
       <memberOf key="model.figbassLike"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:ref name="model.fLike"/>
-          <rng:ref name="model.editLike"/>
-          <rng:ref name="model.transcriptionLike"/>
-        </rng:choice>
-      </rng:zeroOrMore>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <classRef key="model.fLike"/>
+        <classRef key="model.editLike"/>
+        <classRef key="model.transcriptionLike"/>
+      </alternate>
     </content>
   </elementSpec>
   <elementSpec ident="harm" module="MEI.harmony">
@@ -219,16 +209,14 @@
       <memberOf key="model.harmLike"/>
     </classes>
     <content>
-      <rng:zeroOrMore>
-        <rng:choice>
-          <rng:text/>
-          <rng:ref name="model.textPhraseLike.limited"/>
-          <rng:ref name="model.graphicPrimitiveLike"/>
-          <rng:ref name="model.editLike"/>
-          <rng:ref name="model.transcriptionLike"/>
-          <rng:ref name="model.figbassLike"/>
-        </rng:choice>
-      </rng:zeroOrMore>
+      <alternate minOccurs="0" maxOccurs="unbounded">
+        <textNode/>
+        <classRef key="model.textPhraseLike.limited"/>
+        <classRef key="model.graphicPrimitiveLike"/>
+        <classRef key="model.editLike"/>
+        <classRef key="model.transcriptionLike"/>
+        <classRef key="model.figbassLike"/>
+      </alternate>
     </content>
     <constraintSpec ident="harm_start-type_attributes_required" scheme="schematron">
       <constraint>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -2853,7 +2853,7 @@
       <memberOf key="model.imprintPart"/>
     </classes>
     <content>
-      <rng:text/>
+      <textNode/>
     </content>
     <remarks xml:lang="en">
       <p>A short phrase indicating the nature of or the reason for the unpublished status may be

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -1533,7 +1533,7 @@
       <memberOf key="att.whitespace"/>
     </classes>
     <content>
-      <rng:text/>
+      <textNode/>
     </content>
     <constraintSpec ident="Check_incipCode_form_mimetype" scheme="schematron">
       <constraint>
@@ -1630,7 +1630,7 @@
       <memberOf key="model.workIdent"/>
     </classes>
     <content>
-      <rng:text/>
+      <textNode/>
     </content>
     <remarks xml:lang="en">
       <p>This element is used exclusively within bibliographic descriptions. Do not confuse this
@@ -1778,7 +1778,7 @@
       <memberOf key="model.workIdent"/>
     </classes>
     <content>
-      <rng:text/>
+      <textNode/>
     </content>
   </elementSpec>
   <elementSpec ident="meter" module="MEI.header">
@@ -1791,7 +1791,7 @@
       <memberOf key="model.workIdent"/>
     </classes>
     <content>
-      <rng:text/>
+      <textNode/>
     </content>
     <remarks xml:lang="en">
       <p>This element is used exclusively within bibliographic descriptions. Do not confuse <gi

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -1905,10 +1905,10 @@
       <memberOf key="model.paperModLike"/>
     </classes>
     <content>
-      <rng:choice>
-        <rng:ref name="model.foliumLike"/>
-        <rng:ref name="model.bifoliumLike"/>
-      </rng:choice>
+      <alternate>
+        <classRef key="model.foliumLike"/>
+        <classRef key="model.bifoliumLike"/>
+      </alternate>
     </content>
     <constraintSpec ident="check_attached_position" scheme="schematron">
       <constraint>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -375,7 +375,7 @@
       <memberOf key="model.titlePagePart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
       <p>May indicate the nature of restrictions or the lack of restrictions. Do not confuse this
@@ -540,7 +540,7 @@
       <memberOf key="att.lang"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
   </elementSpec>
   <elementSpec ident="availability" module="MEI.header">
@@ -554,7 +554,7 @@
       <memberOf key="model.imprintPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.availabilityPart"/>
+      <macroRef key="macro.availabilityPart"/>
     </content>
     <remarks xml:lang="en">
       <p>When used within the <gi scheme="MEI">fileDesc</gi> element, <gi scheme="MEI"
@@ -618,7 +618,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
   </elementSpec>
   <elementSpec ident="carrierForm" module="MEI.header">
@@ -636,7 +636,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
   </elementSpec>
   <elementSpec ident="category" module="MEI.header">
@@ -890,7 +890,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the respective element of the Encoded Archival Description (EAD).</p>
@@ -992,7 +992,7 @@
       <memberOf key="att.lang"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
   </elementSpec>
   <elementSpec ident="correction" module="MEI.header">
@@ -1335,7 +1335,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
   </elementSpec>
   <elementSpec ident="fileDesc" module="MEI.header">
@@ -1594,7 +1594,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
   </elementSpec>
   <elementSpec ident="interpretation" module="MEI.header">
@@ -1891,7 +1891,7 @@
       <memberOf key="att.lang"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
   </elementSpec>
   <elementSpec ident="patch" module="MEI.header">
@@ -1997,7 +1997,7 @@
       <memberOf key="model.titlePagePart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <attList>
       <attDef ident="isodur" usage="opt">
@@ -2134,7 +2134,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
       <p>All materials may be described in a single <gi scheme="MEI">physMedium</gi> element or
@@ -2156,7 +2156,7 @@
       <memberOf key="model.titlePagePart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
       <p>While it is often called a "plate number", it does not always contain numbers. The
@@ -2174,7 +2174,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
   </elementSpec>
   <elementSpec ident="price" module="MEI.header">
@@ -2359,7 +2359,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
   </elementSpec>
   <elementSpec ident="segmentation" module="MEI.header">
@@ -2544,7 +2544,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
   </elementSpec>
   <elementSpec ident="stdVals" module="MEI.header">
@@ -2580,7 +2580,7 @@
       <memberOf key="model.titlePagePart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
   </elementSpec>
   <elementSpec ident="tagsDecl" module="MEI.header">
@@ -2751,7 +2751,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <attList>
       <attDef ident="num" usage="opt">
@@ -2872,7 +2872,7 @@
       <memberOf key="model.titlePagePart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
       <p> <gi scheme="MEI">useRestrict</gi> may indicate limitations imposed by an owner,
@@ -2895,7 +2895,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
       <p>The <att>facs</att> attribute may be used to record the location of the watermark in a

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -487,7 +487,7 @@
         <desc xml:lang="en">Supplies a version number for an application, independent of its identifier or display
           name.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
       </attDef>
     </attList>

--- a/source/modules/MEI.midi.xml
+++ b/source/modules/MEI.midi.xml
@@ -140,7 +140,7 @@
       <attDef ident="midi.patchname" usage="opt">
         <desc xml:lang="en">Records a non-General MIDI patch/instrument name.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
       </attDef>
       <attDef ident="midi.patchnum" usage="opt">

--- a/source/modules/MEI.midi.xml
+++ b/source/modules/MEI.midi.xml
@@ -304,7 +304,7 @@
       <memberOf key="att.midi.event"/>
     </classes>
     <content>
-      <rng:text/>
+      <textNode/>
     </content>
   </elementSpec>
   <elementSpec ident="hex" module="MEI.midi">
@@ -314,7 +314,7 @@
       <memberOf key="att.midi.event"/>
     </classes>
     <content>
-      <rng:text/>
+      <textNode/>
     </content>
     <remarks xml:lang="en">
       <p>The element’s content must be wrapped in a CDATA section to avoid parsing errors.</p>
@@ -366,7 +366,7 @@
       <memberOf key="att.midi.event"/>
     </classes>
     <content>
-      <rng:text/>
+      <textNode/>
     </content>
   </elementSpec>
   <elementSpec ident="metaText" module="MEI.midi">
@@ -377,7 +377,7 @@
       <memberOf key="att.midi.event"/>
     </classes>
     <content>
-      <rng:text/>
+      <textNode/>
     </content>
   </elementSpec>
   <elementSpec ident="midi" module="MEI.midi">
@@ -489,7 +489,7 @@
       <memberOf key="att.midi.event"/>
     </classes>
     <content>
-      <rng:text/>
+      <textNode/>
     </content>
   </elementSpec>
   <elementSpec ident="vel" module="MEI.midi">

--- a/source/modules/MEI.msDesc.xml
+++ b/source/modules/MEI.msDesc.xml
@@ -828,7 +828,7 @@
         <desc xml:lang="en">Short, project-defined name for the material composing the majority of the
           support.</desc>
         <datatype>
-          <rng:data type="NMTOKEN"/>
+          <dataRef name="NMTOKEN"/>
         </datatype>
         <valList type="semi">
           <valItem ident="paper">

--- a/source/modules/MEI.msDesc.xml
+++ b/source/modules/MEI.msDesc.xml
@@ -82,7 +82,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-accMat.html">accMat</ref> element of the Text Encoding Initiative (TEI).</p>
@@ -99,7 +99,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-additions.html">additions</ref> element of the Text Encoding Initiative (TEI).</p>
@@ -182,7 +182,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <constraintSpec ident="check_catchwords_inline" scheme="schematron">
       <constraint>
@@ -206,7 +206,7 @@
       <memberOf key="att.lang"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-collation.html">collation</ref> element of the Text Encoding Initiative (TEI).</p>
@@ -223,7 +223,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-colophon.html">colophon</ref> element of the Text Encoding Initiative (TEI).</p>
@@ -310,7 +310,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-explicit.html">explicit</ref> element of the Text Encoding Initiative (TEI).</p>
@@ -325,7 +325,7 @@
       <memberOf key="att.lang"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-foliation.html">foliation</ref> element of the Text Encoding Initiative (TEI).</p>
@@ -343,7 +343,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-heraldry.html">heraldry</ref> element of the Text Encoding Initiative (TEI).</p>
@@ -358,7 +358,7 @@
       <memberOf key="att.lang"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <attList>
       <attDef ident="cols" usage="opt">
@@ -538,7 +538,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <attList>
       <attDef ident="func" usage="opt">
@@ -601,7 +601,7 @@
       <memberOf key="att.lang"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-scriptNote.html">scriptNote</ref> element of the Text Encoding Initiative (TEI).</p>
@@ -696,7 +696,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <constraintSpec ident="check_secFolio_inline" scheme="schematron">
       <constraint>
@@ -721,7 +721,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <constraintSpec ident="check_signatures_inline" scheme="schematron">
       <constraint>
@@ -749,7 +749,7 @@
       <memberOf key="model.physDescPart"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-stamp.html">stamp</ref> element of the Text Encoding Initiative (TEI).</p>
@@ -892,7 +892,7 @@
       <memberOf key="att.lang"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-typeNote.html">typeNote</ref> element in the Text Encoding Initiative (TEI).</p>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -5397,7 +5397,7 @@
       <memberOf key="model.textPhraseLike.limited"/>
     </classes>
     <content>
-      <rng:ref name="macro.struc-unstrucContent"/>
+      <macroRef key="macro.struc-unstrucContent"/>
     </content>
     <constraintSpec ident="check_dimensions" scheme="schematron">
       <constraint>
@@ -6140,7 +6140,7 @@
     </classes>
     <!-- Can XSLT be used within content to "select" an incipit from the
         already-encoded MEI transcription in the music element?
-        <rng:ref name="macro.XSLT"/> -->
+        <macroRef key="macro.XSLT"/> -->
     <content>
       <rng:zeroOrMore>
         <rng:ref name="model.headLike"/>
@@ -6974,7 +6974,7 @@
       <memberOf key="model.pbLike"/>
     </classes>
     <content>
-      <rng:ref name="macro.metaLike.page"/>
+      <macroRef key="macro.metaLike.page"/>
     </content>
     <remarks xml:lang="en">
       <p>The <att>n</att> attribute should be used to record the page number displayed in the

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -4427,8 +4427,8 @@
       <memberOf key="att.metadataPointing"/>
     </classes>
     <content>
-      <rng:ref name="ambNote"/>
-      <rng:ref name="ambNote"/>
+      <elementRef key="ambNote"/>
+      <elementRef key="ambNote"/>
     </content>
   </elementSpec>
   <elementSpec ident="ambNote" module="MEI.shared">
@@ -6542,8 +6542,8 @@
       <memberOf key="att.responsibility"/>
     </classes>
     <content>
-      <rng:ref name="meiHead"/>
-      <rng:ref name="music"/>
+      <elementRef key="meiHead"/>
+      <elementRef key="music"/>
     </content>
     <constraintSpec ident="Check_staff" scheme="schematron">
       <constraint>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -5530,7 +5530,7 @@
         <desc xml:lang="en">Characterizes the textual division in some sense, using any convenient classification
           scheme or typology that employs single-token labels.</desc>
         <datatype>
-          <rng:data type="NMTOKENS"/>
+          <dataRef name="NMTOKENS"/>
         </datatype>
         <valList type="semi">
           <valItem ident="abstract">
@@ -6697,7 +6697,7 @@
         <desc xml:lang="en">Characterizes the name in some sense, using any convenient classification scheme or
           typology that employs single-token labels.</desc>
         <datatype>
-          <rng:data type="NMTOKENS"/>
+          <dataRef name="NMTOKENS"/>
         </datatype>
         <valList type="semi">
           <valItem ident="person">
@@ -8389,7 +8389,7 @@
         <desc xml:lang="en">Characterizes the title in some sense, using any convenient classification scheme or
           typology that employs single-token labels.</desc>
         <datatype>
-          <rng:data type="NMTOKENS"/>
+          <dataRef name="NMTOKENS"/>
         </datatype>
         <valList type="semi">
           <valItem ident="main">
@@ -8500,7 +8500,7 @@
         <desc xml:lang="en">Characterizes this title component in some sense, using any convenient classification
           scheme or typology that employs single-token labels.</desc>
         <datatype>
-          <rng:data type="NMTOKENS"/>
+          <dataRef name="NMTOKENS"/>
         </datatype>
         <valList type="semi">
           <valItem ident="alternative">

--- a/source/modules/MEI.text.xml
+++ b/source/modules/MEI.text.xml
@@ -318,7 +318,7 @@
       <attDef ident="type" usage="opt">
         <desc xml:lang="en">Captures the nature of the content of a list.</desc>
         <datatype>
-          <rng:data type="NMTOKENS"/>
+          <dataRef name="NMTOKENS"/>
         </datatype>
         <valList type="semi">
           <valItem ident="gloss">

--- a/source/modules/MEI.usersymbols.xml
+++ b/source/modules/MEI.usersymbols.xml
@@ -276,7 +276,7 @@
       <memberOf key="att.responsibility"/>
     </classes>
     <content>
-      <rng:text/>
+      <textNode/>
     </content>
     <attList>
       <attDef ident="type" usage="req">
@@ -299,7 +299,7 @@
       <memberOf key="att.common"/>
     </classes>
     <content>
-      <rng:text/>
+      <textNode/>
     </content>
   </elementSpec>
   <elementSpec ident="symbolDef" module="MEI.usersymbols">
@@ -350,7 +350,7 @@
       <memberOf key="att.common"/>
     </classes>
     <content>
-      <rng:text/>
+      <textNode/>
     </content>
   </elementSpec>
   <elementSpec ident="symProp" module="MEI.usersymbols">

--- a/source/modules/MEI.usersymbols.xml
+++ b/source/modules/MEI.usersymbols.xml
@@ -361,8 +361,8 @@
       <memberOf key="att.common"/>
     </classes>
     <content>
-      <rng:ref name="propName"/>
-      <rng:ref name="propValue"/>
+      <elementRef key="propName"/>
+      <elementRef key="propValue"/>
     </content>
   </elementSpec>
   <elementSpec ident="symbolTable" module="MEI.usersymbols">


### PR DESCRIPTION
This PR focuses on text nodes and updates `rng:text` to `tei:textNode`. 
In addition it updates `rng:ref` elements to their respective TEI elements `macroRef` and `elementRef`.

Works independently from the other PRs related to Pure ODD.