### PR TITLE
schema: add more clefshapes

### DIFF
--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -629,7 +629,7 @@
           <desc xml:lang="en">F clef (Unicode 1D122).</desc>
         </valItem>
         <valItem ident="gamma">
-          <desc xml:lang="en">Gamma clef depicting the locus of Γ-ut</desc>
+          <desc xml:lang="en">Gamma clef depicting the locus of gamma-ut</desc>
         </valItem>
         <valItem ident="perc">
           <desc xml:lang="en">Drum clef (Unicode 1D125 or Unicode 1D126).</desc>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
   NOTICE: Copyright (c) by the Music Encoding Initiative (MEI) Board (formerly known as "MEI Council").
-  Licensed under the Educational Community License, Version 2.0 (the "License"); you may
+
+    Licensed under the Educational Community License, Version 2.0 (the "License"); you may
   not use this file except in compliance with the License. You may obtain a copy of the License
   at https://opensource.org/licenses/ECL-2.0.
   

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -637,8 +637,8 @@
         <valItem ident="TAB">
           <desc xml:lang="en">Tablature "clef"; <abbr>i.e.</abbr>, usually "TAB" rendered vertically.</desc>
         </valItem>
-        <valItem ident="indian">
-          <desc xml:lang="en">Indian drum clef (SMuFL U+ED70).</desc>
+        <valItem ident="indian-drum">
+          <desc xml:lang="en">Drum clef for Indian Tabla, Pakhawaj, Dholak, Dhol, Mridangam, Khol and Thavil by Kuljit Bhamra (SMuFL U+ED70).</desc>
         </valItem>
         <valItem ident="diatonic">
           <desc xml:lang="en">Diatonic accordion clef (SMuFL U+E079).</desc>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -619,28 +619,22 @@
           <desc xml:lang="en">G clef (Unicode 1D11E).</desc>
         </valItem>
         <valItem ident="GG">
-          <desc xml:lang="en">Double G clef. Sounds one octave lower than G clef. (See remarks on usage below.)</desc>
+          <desc xml:lang="en">Double G clef. Sounds one octave lower than G clef. (<abbr>e.g.</abbr>, SMuFL E055) See remarks on usage below.</desc>
         </valItem>
         <valItem ident="C">
-          <desc xml:lang="en">C clef (Unicode 1D121).</desc>
+          <desc xml:lang="en">C clef (<abbr>e.g.</abbr>, Unicode 1D121).</desc>
         </valItem>
         <valItem ident="F">
-          <desc xml:lang="en">F clef (Unicode 1D122).</desc>
+          <desc xml:lang="en">F clef (<abbr>e.g.</abbr>, Unicode 1D122).</desc>
         </valItem>
         <valItem ident="gamma">
           <desc xml:lang="en">Gamma clef depicting the locus of gamma-ut</desc>
         </valItem>
         <valItem ident="perc">
-          <desc xml:lang="en">Drum clef (Unicode 1D125 or Unicode 1D126).</desc>
+          <desc xml:lang="en">Drum clef (<abbr>e.g.</abbr>, Unicode 1D125 or Unicode 1D126).</desc>
         </valItem>
         <valItem ident="TAB">
           <desc xml:lang="en">Tablature "clef"; <abbr>i.e.</abbr>, usually "TAB" rendered vertically.</desc>
-        </valItem>
-        <valItem ident="indian-drum">
-          <desc xml:lang="en">Drum clef for Indian Tabla, Pakhawaj, Dholak, Dhol, Mridangam, Khol and Thavil by Kuljit Bhamra (SMuFL U+ED70).</desc>
-        </valItem>
-        <valItem ident="diatonic">
-          <desc xml:lang="en">Diatonic accordion clef (SMuFL U+E079).</desc>
         </valItem>
       </valList>
     </content>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
+<!--
   NOTICE: Copyright (c) by the Music Encoding Initiative (MEI) Board (formerly known as "MEI Council").
 
   Licensed under the Educational Community License, Version 2.0 (the "License"); you may
   not use this file except in compliance with the License. You may obtain a copy of the License
   at https://opensource.org/licenses/ECL-2.0.
-  
+
   Unless required by applicable law or agreed to in writing, software distributed under the
   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
   OF ANY KIND, either express or implied. See the License for the specific language
   governing permissions and limitations under the License.
-  
+
   This is a derivative work based on earlier versions of the schema © 2001-2006 Perry Roland
   and the Rector and Visitors of the University of Virginia; licensed under the Educational
   Community License version 1.0.
-  
+
   CONTACT: info@music-encoding.org
 -->
 <?xml-model href="../validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
@@ -584,8 +584,8 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.CERTAINTY" module="MEI" type="dt">
-    <desc xml:lang="en">Values for certainty attribute. Certainty may be expressed by one of the predefined symbolic values <val>high</val>, 
-      <val>medium</val>, or <val>low</val>. The value <val>unknown</val> should be used in cases where the encoder 
+    <desc xml:lang="en">Values for certainty attribute. Certainty may be expressed by one of the predefined symbolic values <val>high</val>,
+      <val>medium</val>, or <val>low</val>. The value <val>unknown</val> should be used in cases where the encoder
       does not wish to assert an opinion about the matter.</desc>
     <content>
       <valList type="closed">
@@ -634,13 +634,18 @@
         <valItem ident="TAB">
           <desc xml:lang="en">Tablature "clef"; <abbr>i.e.</abbr>, usually "TAB" rendered vertically.</desc>
         </valItem>
+
+        <valItem ident="mensural-G"
+          <desc xml:lang="en">Mensural G clef (Unicode U+E900)</desc>
+        </valItem>
+
       </valList>
     </content>
     <remarks xml:lang="en">
       <p>Double-G clefs sound one octave lower, so do not combine with <att>dis</att>/
         <att>dis.place</att>/<att>clef.dis</att>/<att>clef.dis.place</att>. In some cases
-        the double G clef may be used to indicate that two voices share one staff and 
-        does not sound one octave lower. In this case the <att>oct</att> attribute may be 
+        the double G clef may be used to indicate that two voices share one staff and
+        does not sound one octave lower. In this case the <att>oct</att> attribute may be
         used to clarify the sounding octave of the instruments for the clef.
       </p>
     </remarks>
@@ -3188,7 +3193,7 @@
             shown by upward-pointing "blips".</desc>
         </valItem>
         <valItem ident="pedline">
-          <desc xml:lang="en">Pedal down and half pedal rendered with "Ped." followed by a line with 
+          <desc xml:lang="en">Pedal down and half pedal rendered with "Ped." followed by a line with
             end position rendered by vertical bars and bounces shown by upward-pointing "blips".</desc>
         </valItem>
         <valItem ident="pedstar">

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
+<!-- 
   NOTICE: Copyright (c) by the Music Encoding Initiative (MEI) Board (formerly known as "MEI Council").
-
+  
   Licensed under the Educational Community License, Version 2.0 (the "License"); you may
   not use this file except in compliance with the License. You may obtain a copy of the License
   at https://opensource.org/licenses/ECL-2.0.
-
+  
   Unless required by applicable law or agreed to in writing, software distributed under the
   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS
   OF ANY KIND, either express or implied. See the License for the specific language
   governing permissions and limitations under the License.
-
+  
   This is a derivative work based on earlier versions of the schema © 2001-2006 Perry Roland
   and the Rector and Visitors of the University of Virginia; licensed under the Educational
   Community License version 1.0.
@@ -584,8 +584,8 @@
     </content>
   </macroSpec>
   <macroSpec ident="data.CERTAINTY" module="MEI" type="dt">
-    <desc xml:lang="en">Values for certainty attribute. Certainty may be expressed by one of the predefined symbolic values <val>high</val>,
-      <val>medium</val>, or <val>low</val>. The value <val>unknown</val> should be used in cases where the encoder
+    <desc xml:lang="en">Values for certainty attribute. Certainty may be expressed by one of the predefined symbolic values <val>high</val>, 
+      <val>medium</val>, or <val>low</val>. The value <val>unknown</val> should be used in cases where the encoder 
       does not wish to assert an opinion about the matter.</desc>
     <content>
       <valList type="closed">
@@ -649,7 +649,7 @@
       <p>Double-G clefs sound one octave lower, so do not combine with <att>dis</att>/
         <att>dis.place</att>/<att>clef.dis</att>/<att>clef.dis.place</att>. In some cases
         the double G clef may be used to indicate that two voices share one staff and
-        does not sound one octave lower. In this case the <att>oct</att> attribute may be
+        does not sound one octave lower. In this case the <att>oct</att> attribute may be 
         used to clarify the sounding octave of the instruments for the clef.
       </p>
     </remarks>
@@ -3197,7 +3197,7 @@
             shown by upward-pointing "blips".</desc>
         </valItem>
         <valItem ident="pedline">
-          <desc xml:lang="en">Pedal down and half pedal rendered with "Ped." followed by a line with
+          <desc xml:lang="en">Pedal down and half pedal rendered with "Ped." followed by a line with 
             end position rendered by vertical bars and bounces shown by upward-pointing "blips".</desc>
         </valItem>
         <valItem ident="pedstar">

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -716,6 +716,9 @@
         <valItem ident="italian-F">
           <desc xml:lang="en">Italian F fa ut clef (SMuFL U+EBF0).</desc>
         </valItem>
+        <valItem ident="kievan">
+          <desc xml:lang="en">Kievan C clef (SMuFL U+EC30 and U+1D1DE).</desc>
+        </valItem>
       </valList>
     </content>
     <remarks xml:lang="en">

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -628,7 +628,7 @@
         <valItem ident="F">
           <desc xml:lang="en">F clef (Unicode 1D122).</desc>
         </valItem>
-        <valItem ident="Γ">
+        <valItem ident="gamma">
           <desc xml:lang="en">Gamma clef depicting the locus of Γ-ut</desc>
         </valItem>
         <valItem ident="perc">
@@ -648,7 +648,7 @@
     <remarks xml:lang="en">
       <p>Double-G clefs sound one octave lower, so do not combine with <att>dis</att>/
         <att>dis.place</att>/<att>clef.dis</att>/<att>clef.dis.place</att>. In some cases
-        the double G clef may be used to indicate that two voices share one staff and
+        the double G clef may be used to indicate that two voices share one staff and 
         does not sound one octave lower. In this case the <att>oct</att> attribute may be 
         used to clarify the sounding octave of the instruments for the clef.
       </p>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- 
   NOTICE: Copyright (c) by the Music Encoding Initiative (MEI) Board (formerly known as "MEI Council").
-  
   Licensed under the Educational Community License, Version 2.0 (the "License"); you may
   not use this file except in compliance with the License. You may obtain a copy of the License
   at https://opensource.org/licenses/ECL-2.0.
@@ -14,7 +13,7 @@
   This is a derivative work based on earlier versions of the schema © 2001-2006 Perry Roland
   and the Rector and Visitors of the University of Virginia; licensed under the Educational
   Community License version 1.0.
-
+  
   CONTACT: info@music-encoding.org
 -->
 <?xml-model href="../validation/mei_odds.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -622,30 +622,14 @@
         <valItem ident="GG">
           <desc xml:lang="en">Double G clef. Sounds one octave lower than G clef. (See remarks on usage below.)</desc>
         </valItem>
-        <valItem ident="GC">
-          <desc xml:lang="en">Tenor G clef used <abbr>i.e.</abbr> by Ricordi. Sounds one octave lower than G clef
-          (SMuFL U+E056).</desc>
-        </valItem>
         <valItem ident="C">
           <desc xml:lang="en">C clef (Unicode 1D121).</desc>
         </valItem>
         <valItem ident="F">
           <desc xml:lang="en">F clef (Unicode 1D122).</desc>
         </valItem>
-        <valItem ident="french20-C">
-          <desc xml:lang="en">20th century french C clef (SMuFL uniE05C.salt03).</desc>
-        </valItem>
-        <valItem ident="19-C">
-          <desc xml:lang="en">19th century square-shaped C clef (SMuFL U+E060).</desc>
-        </valItem>
-        <valItem ident="french19-F">
-          <desc xml:lang="en">19th century French F clef (SMuFL uniE062.salt02).</desc>
-        </valItem>
-        <valItem ident="french18-C">
-          <desc xml:lang="en">18th century French C clef (SMuFL uniE05C.salt01).</desc>
-        </valItem>
-        <valItem ident="french18-F">
-          <desc xml:lang="en">18th century French F clef (SMuFL uniE062.salt01).</desc>
+        <valItem ident="Γ">
+          <desc xml:lang="en">Gamma clef depicting the locus of Γ-ut</desc>
         </valItem>
         <valItem ident="perc">
           <desc xml:lang="en">Drum clef (Unicode 1D125 or Unicode 1D126).</desc>
@@ -658,66 +642,6 @@
         </valItem>
         <valItem ident="diatonic">
           <desc xml:lang="en">Diatonic accordion clef (SMuFL U+E079).</desc>
-        </valItem>
-        <valItem ident="mensural-G">
-          <desc xml:lang="en">Mensural G clef (SMuFL U+E900).</desc>
-        </valItem>
-        <valItem ident="mensural-C">
-          <desc xml:lang="en">Mensural C clef (SMuFL U+E905).</desc>
-        </valItem>
-        <valItem ident="mensural-F">
-          <desc xml:lang="en">Mensural F clef (SMuFL U+E903).</desc>
-        </valItem>
-        <valItem ident="petrucci-G">
-          <desc xml:lang="en">Mensural G clef after Petrucci (SMuFL U+E901).</desc>
-        </valItem>
-        <valItem ident="petrucci-C-highest">
-          <desc xml:lang="en">Mensural C clef after Petrucci in highest position (SMuFL U+E90B).</desc>
-        </valItem>
-        <valItem ident="petrucci-C-high">
-          <desc xml:lang="en">Mensural C clef after Petrucci in high position (SMuFL U+E90A).</desc>
-        </valItem>
-        <valItem ident="petrucci-C">
-          <desc xml:lang="en">Mensural C clef after Petrucci in middle (SMuFL U+E909).</desc>
-        </valItem>
-        <valItem ident="petrucci-C-low">
-          <desc xml:lang="en">Mensural C clef after Petrucci in low position (SMuFL U+E908).</desc>
-        </valItem>
-        <valItem ident="petrucci-C-lowest">
-          <desc xml:lang="en">Mensural C clef after Petrucci in lowest position (SMuFL U+E907).</desc>
-        </valItem>
-        <valItem ident="petrucci-F">
-          <desc xml:lang="en">Mensural F clef after Petrucci (SMuFL U+E904).</desc>
-        </valItem>
-        <valItem ident="chant-C">
-          <desc xml:lang="en">Chant C clef (SMuFL U+E906 and U+1D1D0).</desc>
-        </valItem>
-        <valItem ident="chant-F">
-          <desc xml:lang="en">Chant F clef (SMuFL U+E902 and U+1D1D1).</desc>
-        </valItem>
-        <valItem ident="whitemensural-C">
-          <desc xml:lang="en">Whitemensural C clef (SMuFL uniE905.salt01).</desc>
-        </valItem>
-        <valItem ident="blackmensural-C">
-          <desc xml:lang="en">Blackmensural C clef (SMuFL uniE905.salt02).</desc>
-        </valItem>
-        <valItem ident="hufnagel-C">
-          <desc xml:lang="en">Hufnagel C clef (SMuFL uniE906.salt01).</desc>
-        </valItem>
-        <valItem ident="hufnagel-F">
-          <desc xml:lang="en">Hufnagel F clef (SMuFL uniE902.salt01).</desc>
-        </valItem>
-        <valItem ident="monodicum-G">
-          <desc xml:lang="en">Corpus Monodicum G clef (SMuFL U+EA24).</desc>
-        </valItem>
-        <valItem ident="italian-C">
-          <desc xml:lang="en">Italian C sol fa ut clef (SMuFL U+EBF1).</desc>
-        </valItem>
-        <valItem ident="italian-F">
-          <desc xml:lang="en">Italian F fa ut clef (SMuFL U+EBF0).</desc>
-        </valItem>
-        <valItem ident="kievan">
-          <desc xml:lang="en">Kievan C clef (SMuFL U+EC30 and U+1D1DE).</desc>
         </valItem>
       </valList>
     </content>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -622,11 +622,30 @@
         <valItem ident="GG">
           <desc xml:lang="en">Double G clef. Sounds one octave lower than G clef. (See remarks on usage below.)</desc>
         </valItem>
-        <valItem ident="F">
-          <desc xml:lang="en">F clef (Unicode 1D122).</desc>
+        <valItem ident="GC">
+          <desc xml:lang="en">Tenor G clef used <abbr>i.e.</abbr> by Ricordi. Sounds one octave lower than G clef
+          (SMuFL U+E056).</desc>
         </valItem>
         <valItem ident="C">
           <desc xml:lang="en">C clef (Unicode 1D121).</desc>
+        </valItem>
+        <valItem ident="F">
+          <desc xml:lang="en">F clef (Unicode 1D122).</desc>
+        </valItem>
+        <valItem ident="french20-C">
+          <desc xml:lang="en">20th century french C clef (SMuFL uniE05C.salt03).</desc>
+        </valItem>
+        <valItem ident="19-C">
+          <desc xml:lang="en">19th century square-shaped C clef (SMuFL U+E060).</desc>
+        </valItem>
+        <valItem ident="french19-F">
+          <desc xml:lang="en">19th century French F clef (SMuFL uniE062.salt02).</desc>
+        </valItem>
+        <valItem ident="french18-C">
+          <desc xml:lang="en">18th century French C clef (SMuFL uniE05C.salt01).</desc>
+        </valItem>
+        <valItem ident="french18-F">
+          <desc xml:lang="en">18th century French F clef (SMuFL uniE062.salt01).</desc>
         </valItem>
         <valItem ident="perc">
           <desc xml:lang="en">Drum clef (Unicode 1D125 or Unicode 1D126).</desc>
@@ -634,11 +653,60 @@
         <valItem ident="TAB">
           <desc xml:lang="en">Tablature "clef"; <abbr>i.e.</abbr>, usually "TAB" rendered vertically.</desc>
         </valItem>
-
-        <valItem ident="mensural-G"
-          <desc xml:lang="en">Mensural G clef (Unicode U+E900)</desc>
+        <valItem ident="indian">
+          <desc xml:lang="en">Indian drum clef (SMuFL U+ED70).</desc>
         </valItem>
-
+        <valItem ident="diatonic">
+          <desc xml:lang="en">Diatonic accordion clef (SMuFL U+E079).</desc>
+        </valItem>
+        <valItem ident="mensural-G">
+          <desc xml:lang="en">Mensural G clef (SMuFL U+E900).</desc>
+        </valItem>
+        <valItem ident="mensural-C">
+          <desc xml:lang="en">Mensural C clef (SMuFL U+E905).</desc>
+        </valItem>
+        <valItem ident="mensural-F">
+          <desc xml:lang="en">Mensural F clef (SMuFL U+E903).</desc>
+        </valItem>
+        <valItem ident="petrucci-G">
+          <desc xml:lang="en">Mensural G clef after Petrucci (SMuFL U+E901).</desc>
+        </valItem>
+        <valItem ident="petrucci-C-highest">
+          <desc xml:lang="en">Mensural C clef after Petrucci in highest position (SMuFL U+E90B).</desc>
+        </valItem>
+        <valItem ident="petrucci-C-high">
+          <desc xml:lang="en">Mensural C clef after Petrucci in high position (SMuFL U+E90A).</desc>
+        </valItem>
+        <valItem ident="petrucci-C">
+          <desc xml:lang="en">Mensural C clef after Petrucci in middle (SMuFL U+E909).</desc>
+        </valItem>
+        <valItem ident="petrucci-C-low">
+          <desc xml:lang="en">Mensural C clef after Petrucci in low position (SMuFL U+E908).</desc>
+        </valItem>
+        <valItem ident="petrucci-C-lowest">
+          <desc xml:lang="en">Mensural C clef after Petrucci in lowest position (SMuFL U+E907).</desc>
+        </valItem>
+        <valItem ident="petrucci-F">
+          <desc xml:lang="en">Mensural F clef after Petrucci (SMuFL U+E904).</desc>
+        </valItem>
+        <valItem ident="chant-C">
+          <desc xml:lang="en">Chant C clef (SMuFL U+E906 and U+1D1D0).</desc>
+        </valItem>
+        <valItem ident="chant-F">
+          <desc xml:lang="en">Chant F clef (SMuFL U+E902 and U+1D1D1).</desc>
+        </valItem>
+        <valItem ident="whitemensural-C">
+          <desc xml:lang="en">Whitemensural C clef (SMuFL uniE905.salt01).</desc>
+        </valItem>
+        <valItem ident="blackmensural-C">
+          <desc xml:lang="en">Blackmensural C clef (SMuFL uniE905.salt02).</desc>
+        </valItem>
+        <valItem ident="hufnagel-C">
+          <desc xml:lang="en">Hufnagel C clef (SMuFL uniE906.salt01).</desc>
+        </valItem>
+        <valItem ident="hufnagel-F">
+          <desc xml:lang="en">Hufnagel F clef (SMuFL uniE902.salt01).</desc>
+        </valItem>
       </valList>
     </content>
     <remarks xml:lang="en">

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -707,6 +707,15 @@
         <valItem ident="hufnagel-F">
           <desc xml:lang="en">Hufnagel F clef (SMuFL uniE902.salt01).</desc>
         </valItem>
+        <valItem ident="monodicum-G">
+          <desc xml:lang="en">Corpus Monodicum G clef (SMuFL U+EA24).</desc>
+        </valItem>
+        <valItem ident="italian-C">
+          <desc xml:lang="en">Italian C sol fa ut clef (SMuFL U+EBF1).</desc>
+        </valItem>
+        <valItem ident="italian-F">
+          <desc xml:lang="en">Italian F fa ut clef (SMuFL U+EBF0).</desc>
+        </valItem>
       </valList>
     </content>
     <remarks xml:lang="en">

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -617,7 +617,7 @@
     <content>
       <valList type="closed">
         <valItem ident="G">
-          <desc xml:lang="en">G clef (Unicode 1D11E).</desc>
+          <desc xml:lang="en">G clef (<abbr>e.g.</abbr>, Unicode 1D11E).</desc>
         </valItem>
         <valItem ident="GG">
           <desc xml:lang="en">Double G clef. Sounds one octave lower than G clef. (<abbr>e.g.</abbr>, SMuFL E055) See remarks on usage below.</desc>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -2,7 +2,7 @@
 <!-- 
   NOTICE: Copyright (c) by the Music Encoding Initiative (MEI) Board (formerly known as "MEI Council").
 
-    Licensed under the Educational Community License, Version 2.0 (the "License"); you may
+  Licensed under the Educational Community License, Version 2.0 (the "License"); you may
   not use this file except in compliance with the License. You may obtain a copy of the License
   at https://opensource.org/licenses/ECL-2.0.
   


### PR DESCRIPTION
Added more identification values for `"data.CLEFSHAPE`:
* modern clef variants
* early clef variants
* neume clef variants
* early modern clef variants
* other (Italian lute, Indian

Fixes #605