### PR TITLE
guidelines: correct misleading filename, id and title of chapter 12

### DIFF
--- a/source/docs/12-facsimilesperformances.xml
+++ b/source/docs/12-facsimilesperformances.xml
@@ -93,8 +93,8 @@
    </teiHeader>
    <text>
       <body>
-         <div xml:id="facsimilesrecordings" type="div1">
-            <head>Facsimiles and Recordings</head>
+         <div xml:id="facsimilesperformances" type="div1">
+            <head>Facsimiles and Performances</head>
             <p>MEI can be used to connect an encoding of some sort – either a transcription of existing material, or the specification of some expected output in some form – with existing sources. This existing material may be in different formats – music notation in any combination of print and manuscript, or audio or video footage. The concepts for establishing such connections between encoded music and source material is described in the following chapters.</p>
             <div xml:id="facsimiles" type="div2">
                <head>Facsimiles</head>

--- a/source/mei-source.xml
+++ b/source/mei-source.xml
@@ -121,7 +121,7 @@
          <xi:include href="docs/09-textencoding.xml" xpointer="textencoding"/>
          <xi:include href="docs/10-analysisharm.xml" xpointer="analysisharm"/>
          <xi:include href="docs/11-scholarlyediting.xml" xpointer="scholarlyediting"/>
-         <xi:include href="docs/12-facsimilesrecordings.xml" xpointer="facsimilesrecordings"/>
+         <xi:include href="docs/12-facsimilesperformances.xml" xpointer="facsimilesperformances"/>
          <xi:include href="docs/13-linkingdata.xml" xpointer="linkingdata"/>
          <xi:include href="docs/14-integration.xml" xpointer="integration"/>
       </body>


### PR DESCRIPTION
Chapter 12 changes

- title from "Facsimiles and Recordings" to "Facsimiles and Performances"
- id fom facsimilesrecordings to facsimilesperformances
- file name from docs/12-facsimilesrecordings.xml to docs/12-facsimilesperformances.xml

Closes #1490