### PR TITLE
schema: fix version number in edition

### DIFF
--- a/source/mei-source.xml
+++ b/source/mei-source.xml
@@ -80,7 +80,7 @@
             </respStmt>
          </titleStmt>
          <editionStmt>
-            <edition>MEI 6.0</edition>
+            <edition>MEI 6.0-dev</edition>
          </editionStmt>
          <publicationStmt>
             <distributor>Music Encoding Initiative (MEI) Board</distributor>


### PR DESCRIPTION
This PR fixes the version number in source's edition to include dev. That was overlooked in #1586 