### PR TITLE
docs: update verovio version in BUILD_COMMANDLINE.md

### DIFF
--- a/BUILD_COMMANDLINE.md
+++ b/BUILD_COMMANDLINE.md
@@ -8,7 +8,7 @@
    |----|----------------|
    |Java| Java Development Kit (JDK) 17 recommended (at least Java 8 at runtime to support Apache Ant™)|
    |Apache Ant|1.10.14|
-   |Verovio Toolkit|4.2.1|
+   |Verovio Toolkit|4.5.1|
    |Prince XML|15.3|
    |Saxon HE*|12.5|
    |TEI Stylesheets*|7.57.1|

--- a/BUILD_COMMANDLINE.md
+++ b/BUILD_COMMANDLINE.md
@@ -8,7 +8,7 @@
    |----|----------------|
    |Java| Java Development Kit (JDK) 17 recommended (at least Java 8 at runtime to support Apache Ant™)|
    |Apache Ant|1.10.14|
-   |Verovio Toolkit|4.5.1|
+   |Verovio Toolkit|5.0.0|
    |Prince XML|15.3|
    |Saxon HE*|12.5|
    |TEI Stylesheets*|7.57.1|


### PR DESCRIPTION
This PR updates the verovio version in BUILD_COMMANDLINE.md according to music-encoding/docker-mei#65 and music-encoding/docker-mei#74