### PR TITLE
utils: fix example images being created with the wrong suffix

### DIFF
--- a/utils/guidelines_xslt/odd2html/guidelines.xsl
+++ b/utils/guidelines_xslt/odd2html/guidelines.xsl
@@ -567,7 +567,7 @@
         <xsl:variable name="verovioClass" select="if($renderedLive) then(' verovio') else('')" as="xs:string"/>
         <xsl:variable name="id" select="generate-id(.)"/>
         <xsl:if test="$renderedLive">
-            <xsl:variable name="imageUrl" select="$assets.folder.generated.images.rel || $id || '.mei.svg'"/>
+            <xsl:variable name="imageUrl" select="$assets.folder.generated.images.rel || $id || '.svg'"/>
             <img alt="example" class="graphic liveExample" src="{tools:adjustImageUrl($imageUrl)}"/>
         </xsl:if>
         <div id="{$id}" xml:space="preserve" class="pre code {$validClass}{$verovioClass}">


### PR DESCRIPTION
When generate_examples.py was migrated to use Python's pathlib in 4ee9761d, the suffixes of generated example images (in assets/images/GeneratedImages) went from being ".mei.svg" to just ".svg" because Path.with_suffix() replaces, rather than appends to, the existing suffix. This caused references to those files on the site to be broken.

This change reverts to the previous behavior, restoring those links.

Refs #1458