### PR TITLE
schema: add additional options to repeatMark's `@func`

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -2890,6 +2890,27 @@
           <valItem ident="fine">
             <desc xml:lang="en">Fine. (text)</desc>
           </valItem>
+          <valItem ident="daCapoAlFine">
+            <desc xml:lang="en">D.C. al Fine. (text)</desc>
+          </valItem>
+          <valItem ident="dalSegnoAlFine">
+            <desc xml:lang="en">D.S. al Fine. (text)</desc>
+          </valItem>
+          <valItem ident="daCapoAlCoda">
+            <desc xml:lang="en">D.C. al Coda. (text)</desc>
+          </valItem>
+          <valItem ident="dalSegnoAlCoda">
+            <desc xml:lang="en">D.S. al Coda. (text)</desc>
+          </valItem>
+          <valItem ident="repeatLeft">
+            <desc xml:lang="en">Left repeat barline as a separate symbol disconnected from staff lines (SMuFL E04C or Unicode 1D106)</desc>
+          </valItem>
+          <valItem ident="repeatRight">
+            <desc xml:lang="en">Right repeat barline as a separate symbol disconnected from staff lines (SMuFL E04D or Unicode 1D107)</desc>
+          </valItem>
+          <valItem ident="repeatRightLeft">
+            <desc xml:lang="en">Right and left repeat barline as a separate symbol disconnected from staff lines (SMuFL E042)</desc>
+          </valItem>
         </valList>
       </attDef>
     </attList>


### PR DESCRIPTION
Fixes #1643

Some small notes on this change:
- As discussed in the issue, repeatLeft and repeatRight should render their SMuFL small versions by default, so I used those codes in the docs (E04C leftRepeatSmall and E04D rightRepeatSmall) rather than the characters whose name matches the respective `@func` value (E040 repeatLeft and E041 repeatRight).
- However, SMuFL does not have a small variant of repeatRightLeft, so I used the full-size code for that one.
- Unicode has no repeatRightLeft character at all, so I left the Unicode character out for that one.