### PR TITLE
schema: revise `incipCode/@form` attribute documentation

### DIFF
--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -1557,15 +1557,21 @@
           </valItem>
           <valItem ident="parsons">
             <desc xml:lang="en">Parsons code containing intervallic direction only 
-              (e.g., "sususddsdsdsd").</desc>
+              (e.g., "sususddsdsdsd"). Permitted values are composed of a series of tokens, which may 
+              be "u" (Up), "d" (Down) or "s" (Same). Each token should not be separated by a space.</desc>
           </valItem>
-          <valItem ident="diatonicMelodicContour">
-            <desc xml:lang="en">Representation of intervallic direction and diatonic quality
-              (e.g., "P0 +P5 +P0 +M2 +P0 -M2").</desc>
+          <valItem ident="intervals">
+            <desc xml:lang="en">Representation of interval quality and direction 
+              (e.g., "P1 +P5 P1 +M2 P1 -M2"). Values must be composed of a series of space-separated tokens, where each token
+              is comprised of three components: a direction indicator ("+" for "up" and "-" for down); an interval quality, being one of 
+              "P" (Perfect), "M" (Major), "m" (Minor), "A" (Augmented), or "d" (Diminished); and finally an integer indicating 
+              interval size, where "1" is a Unison. (For a Perfect Unison, P1, the direction indicator may be omitted.). 
+            </desc>
           </valItem>
-          <valItem ident="steppedMelodicContour">
-            <desc xml:lang="en">Representation of intervallic direction and size in half steps
-              (e.g., "0 +7 +0 +2 +0 -2").</desc>
+          <valItem ident="semitones">
+            <desc xml:lang="en">Representation of intervallic direction and size in half steps (semitones)
+              (e.g., "0 +7 +0 +2 +0 -2"). Values must be composed of a series of space-separated positive or negative 
+              integers indicating the number of semitones to ascend or descend, respectively.</desc>
           </valItem>
         </valList>
       </attDef>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -1556,12 +1556,12 @@
             <desc xml:lang="en">**kern representation of the Humdrum format.</desc>
           </valItem>
           <valItem ident="parsons">
-            <desc xml:lang="en">Parsons code containing intervallic direction only 
+            <desc xml:lang="en">Parsons code containing intervallic direction only
               (e.g., "sususddsdsdsd"). Permitted values are composed of a series of tokens, which may 
               be "u" (Up), "d" (Down) or "s" (Same). Tokens should not be separated by spaces.</desc>
           </valItem>
           <valItem ident="intervals">
-            <desc xml:lang="en">Representation of interval quality and direction 
+            <desc xml:lang="en">Representation of interval quality and direction
               (e.g., "P1 +P5 P1 +M2 P1 -M2"). Values must be composed of a series of space-separated tokens, where each token
               is comprised of three components: a direction indicator ("+" for "up" and "-" for down); an interval quality, being one of 
               "P" (Perfect), "M" (Major), "m" (Minor), "A" (Augmented), or "d" (Diminished); and finally an integer indicating 

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -1555,11 +1555,17 @@
           <valItem ident="humdrumKern">
             <desc xml:lang="en">**kern representation of the Humdrum format.</desc>
           </valItem>
-          <valItem ident="melodicContour">
-            <desc xml:lang="en">Representation of 1] intervallic direction and diatonic quality
-              (e.g., "P0 +P5 +P0 +M2 +P0 -M2"), 2] intervallic direction and size in half steps
-              (e.g., "0 +7 +0 +2 +0 -2"), or 3] general intervallic direction only (e.g.,
-              "sususddsdsdsd", often called "Parsons code").</desc>
+          <valItem ident="parsons">
+            <desc xml:lang="en">Parsons code containing intervallic direction only 
+              (e.g., "sususddsdsdsd").</desc>
+          </valItem>
+          <valItem ident="diatonicMelodicContour">
+            <desc xml:lang="en">Representation of intervallic direction and diatonic quality
+              (e.g., "P0 +P5 +P0 +M2 +P0 -M2").</desc>
+          </valItem>
+          <valItem ident="steppedMelodicContour">
+            <desc xml:lang="en">Representation of intervallic direction and size in half steps
+              (e.g., "0 +7 +0 +2 +0 -2").</desc>
           </valItem>
         </valList>
       </attDef>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -1563,9 +1563,9 @@
           <valItem ident="intervals">
             <desc xml:lang="en">Representation of interval quality and direction
               (e.g., "P1 +P5 P1 +M2 P1 -M2"). Values must be composed of a series of space-separated tokens, where each token
-              is comprised of three components: a direction indicator ("+" for "up" and "-" for down); an interval quality, being one of 
+              is comprised of three components: a direction indicator ("+" for "up" and "-" for "down"); an interval quality, being one of 
               "P" (Perfect), "M" (Major), "m" (Minor), "A" (Augmented), or "d" (Diminished); and finally an integer indicating 
-              interval size, where "1" is a Unison. (For a Perfect Unison, P1, the direction indicator may be omitted.). 
+              interval size, where "1" is a Unison. (For a Perfect Unison, P1, the direction indicator may be omitted). 
             </desc>
           </valItem>
           <valItem ident="semitones">

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -1558,7 +1558,7 @@
           <valItem ident="parsons">
             <desc xml:lang="en">Parsons code containing intervallic direction only 
               (e.g., "sususddsdsdsd"). Permitted values are composed of a series of tokens, which may 
-              be "u" (Up), "d" (Down) or "s" (Same). Each token should not be separated by a space.</desc>
+              be "u" (Up), "d" (Down) or "s" (Same). Tokens should not be separated by spaces.</desc>
           </valItem>
           <valItem ident="intervals">
             <desc xml:lang="en">Representation of interval quality and direction 

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -1555,8 +1555,11 @@
           <valItem ident="humdrumKern">
             <desc xml:lang="en">**kern representation of the Humdrum format.</desc>
           </valItem>
-          <valItem ident="parsons">
-            <desc xml:lang="en">Parsons code.</desc>
+          <valItem ident="melodicContour">
+            <desc xml:lang="en">Representation of 1] intervallic direction and diatonic quality
+              (e.g., "P0 +P5 +P0 +M2 +P0 -M2"), 2] intervallic direction and size in half steps
+              (e.g., "0 +7 +0 +2 +0 -2"), or 3] general intervallic direction only (e.g.,
+              "sususddsdsdsd", often called "Parsons code").</desc>
           </valItem>
         </valList>
       </attDef>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -1570,7 +1570,7 @@
           </valItem>
           <valItem ident="semitones">
             <desc xml:lang="en">Representation of intervallic direction and size in half steps (semitones)
-              (e.g., "0 +7 +0 +2 +0 -2"). Values must be composed of a series of space-separated positive or negative 
+              (e.g., "0 +7 0 +2 0 -2"). Values must be composed of a series of space-separated positive or negative 
               integers indicating the number of semitones to ascend or descend, respectively.</desc>
           </valItem>
         </valList>


### PR DESCRIPTION
Currently, `incipCode/@form` uses the value "parsons" to indicate that the incipit contains an encoding of melodic contour. A better value here would be "melodicContour", defined as 

> "Representation of 1] diatonic interval direction and quality (e.g., "P0 +P5 +P0 +M2 +P0 -M2"), 2] precise interval direction with size in half steps (e.g., "0 +7 +0 +2 +0 -2"), or 3] general interval direction only (e.g., "sususddsdsdsd", often called "Parsons code")."

This change will better align the `@form` attribute values with the intended values of the `<incipCode>` element.