### PR TITLE
guidelines: fix tablature examples dots

### DIFF
--- a/source/examples/tablature/tablature-sample016.txt
+++ b/source/examples/tablature/tablature-sample016.txt
@@ -83,7 +83,7 @@
                     <note tab.course="4" tab.fret="0" tab.line="1"/>
                 </tabGrp>
             </beam>
-            <tabGrp dur="8" dot="1">
+            <tabGrp dur="8" dots="1">
                 <tabDurSym/>
                 <note tab.course="1" tab.fret="3" tab.line="4"/>
                 <note tab.course="2" tab.fret="3" tab.line="3"/>

--- a/source/examples/tablature/tablature-sample017.txt
+++ b/source/examples/tablature/tablature-sample017.txt
@@ -30,7 +30,7 @@
                     <note tab.course="4" tab.fret="0" tab.line="1" layer="4"/>
                 </tabGrp>
             </beam>
-            <tabGrp dur="8" dot="1">
+            <tabGrp dur="8" dots="1">
                 <tabDurSym/>
                 <note tab.course="1" tab.fret="3" tab.line="4" layer="1"/>
                 <note tab.course="2" tab.fret="3" tab.line="3" layer="2"/>


### PR DESCRIPTION
In tablature examples tablature-sample016.txt and tablature-sample017.txt syntax error in both: 

&lt;tabGrp dur="8" **dot**="1"&gt; should be &lt;tabGrp dur="8" **dots**="1"&gt;