### PR TITLE
schema: allow only one staff within measure ossias

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -2071,9 +2071,7 @@
           <rng:oneOrMore>
             <rng:ref name="oStaff"/>
           </rng:oneOrMore>
-          <rng:oneOrMore>
-            <rng:ref name="model.staffLike"/>
-          </rng:oneOrMore>
+          <rng:ref name="model.staffLike"/>
         </rng:interleave>
         <rng:interleave>
           <rng:oneOrMore>


### PR DESCRIPTION
If I understand the concept correctly there should only be one "normal" staff allowed within an ossia within measure. @pe-ro ?