### PR TITLE
schema: clean up attributes on figured bass

### DIFF
--- a/source/modules/MEI.harmony.xml
+++ b/source/modules/MEI.harmony.xml
@@ -41,7 +41,6 @@
   <classSpec ident="att.f.log" module="MEI.harmony" type="atts">
     <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
-      <memberOf key="att.controlEvent"/>
       <memberOf key="att.duration.additive"/>
       <memberOf key="att.startEndId"/>
       <memberOf key="att.timestamp2.log"/>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -544,7 +544,6 @@
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>
       <memberOf key="att.extender"/>
-      <memberOf key="att.placementRelStaff"/>
       <memberOf key="att.visualOffset"/>
       <memberOf key="att.xy"/>
     </classes>


### PR DESCRIPTION
This PR moves the `remarks` on `f@tstamp2` to the respective attribute in the logical domain.

Also it removes the memberships on `att.controlEvent` and `att.placementRelStaff`that are conflicting with the information encoded in its ancestor `harm` element.

Closes #1668
