### PR TITLE
build: ensure cross-platform compatibility for index page generation

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -575,7 +575,6 @@
     </target>
     
     <target name="generate-guidelines-index-page" depends="init-mei-classpath">
-        
         <!-- create a path that includes the customization index pages -->
         <path id="customizationIndexPath" >
             <fileset dir="${dir.dist.guidelines}">

--- a/build.xml
+++ b/build.xml
@@ -576,22 +576,34 @@
     
     <target name="generate-guidelines-index-page" depends="init-mei-classpath">
         
-        <path id="dev-index">
+        <!-- create a path that includes the customization index pages -->
+        <path id="customizationIndexPath" >
             <fileset dir="${dir.dist.guidelines}">
                 <include name="*/index.html"/>
-                <!--<exclude name="${filename.volume}"/>
-                <contains text='bazga:type="bazga:work"'/>-->
             </fileset>
         </path>
-        
-        <echo message="${toString:dev-index}" />
+
+        <!-- convert path to a semicolon-separated string -->
+        <pathconvert property="customizationIndexPages.raw" refid="customizationIndexPath" pathsep=";"/>
+
+        <loadresource property="customizationIndexPages">
+            <string value="${customizationIndexPages.raw}"/>
+            <filterchain>
+                 <!-- Replace backslashes with forward slashes for cross-platform compatibility -->
+                <replaceregex pattern="\\" replace="/" flags="g"/>
+                <!-- Remove everything up to and including ${dir.dist.guidelines}/ -->
+                <replaceregex pattern="[^;]*${dir.dist.guidelines}/" replace="" flags="g"/>
+            </filterchain>
+        </loadresource>
+
+        <echo message="Generating guidelines index including: ${customizationIndexPages}"/>
         
         <java classname="net.sf.saxon.Transform" classpathref="mei.classpath" failonerror="true" fork="true">
             <arg value="-it:initial-template"/>
             <arg value="-xsl:${basedir}/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl"/>
             <arg value="-xi:off"/>
             <arg value="output.folder=${dir.dist.guidelines}"/>
-            <arg value="customizationIndexPages=${toString:dev-index}" />
+            <arg value="customizationIndexPages=${customizationIndexPages}" />
         </java>
         
         <antcall target="copy-guidelines-assets">

--- a/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
@@ -24,9 +24,7 @@
                 <xsl:element name="div">
                     <xsl:attribute name="class">columns filter-body customizations</xsl:attribute>
 
-                    <xsl:variable name="customizationIndexPage" select="tokenize($customizationIndexPages, ';')"/>
-
-                    <xsl:for-each select="$customizationIndexPage">
+                    <xsl:for-each select="tokenize($customizationIndexPages, ';')">
 
                         <xsl:variable name="customizationName" select="tokenize(., '/')[1]"/>
 

--- a/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
@@ -24,10 +24,11 @@
                 <xsl:element name="div">
                     <xsl:attribute name="class">columns filter-body customizations</xsl:attribute>
 
-                    <xsl:for-each select="tokenize($customizationIndexPages, ':')">
+                    <xsl:variable name="customizationIndexPage" select="tokenize($customizationIndexPages, ';')"/>
 
-                        <xsl:variable name="customizationUri" select="substring-after(., $output.folder || '/')"/>
-                        <xsl:variable name="customizationName" select="tokenize($customizationUri, '/')[1]"/>
+                    <xsl:for-each select="$customizationIndexPage">
+
+                        <xsl:variable name="customizationName" select="tokenize(., '/')[1]"/>
 
                         <xsl:element name="div">
                             <xsl:attribute name="class">column col-4 col-sm-12 col-lg-6 filter-item</xsl:attribute>
@@ -52,7 +53,7 @@
                                     <xsl:attribute name="class">card-footer</xsl:attribute>
                                     <xsl:element name="a">
                                         <xsl:attribute name="class">btn float-right btn-sm</xsl:attribute>
-                                        <xsl:attribute name="href" select="$customizationUri"/>
+                                        <xsl:attribute name="href" select="."/>
                                         <xsl:text>More…</xsl:text>
                                     </xsl:element>
                                     <xsl:element name="label">


### PR DESCRIPTION
This PR updates the index page generation logic to ensure cross-platform compatibility. 

It normalizes the customizationIndexPages path to a semicolon-separated list with forward slashes of only the folder names and their index.html. This way, the full path does not need to be processed by the XSLT (leading to some issues on non-unix systems).

Goes to customizationDocs branch, so #1658 



