### PR TITLE
build: improve guidelines index page (II)

### DIFF
--- a/customizations/mei-all.xml
+++ b/customizations/mei-all.xml
@@ -53,14 +53,15 @@
         <p/>
       </sourceDesc>
     </fileDesc>
-      <profileDesc>
-          <abstract><p>A customization integrating all aspects of MEI.</p></abstract>
-          <textClass>
-              <keywords>
-                  <term>testing</term>
-              </keywords>
-          </textClass>
-      </profileDesc>
+    <profileDesc>
+        <abstract><p>A customization integrating all aspects of MEI.</p></abstract>
+        <textClass>
+            <keywords>
+                <term>validation</term>
+                <term>testing</term>
+            </keywords>
+        </textClass>
+    </profileDesc>
     <revisionDesc>
       <change n="3" when="2025-05-03" who="#BWB">
         <desc>Restructure titles in titleStmt (series, main, short). Add abstract and textClass.</desc>

--- a/customizations/mei-all_anyStart.xml
+++ b/customizations/mei-all_anyStart.xml
@@ -58,6 +58,7 @@
       </abstract>
       <textClass>
         <keywords>
+          <term>validation</term>
           <term>testing</term>
         </keywords>
       </textClass>

--- a/customizations/mei-mensural.xml
+++ b/customizations/mei-mensural.xml
@@ -55,7 +55,7 @@
     </fileDesc>
     <profileDesc>
       <abstract>
-          <p>A customization for <hi rend="italic">Mensural Notation</hi>, both black and white.</p>
+          <p>A customization for encoding mensural notation, both black and white.</p>
       </abstract>
       <textClass>
         <keywords>

--- a/customizations/mei-neumes.xml
+++ b/customizations/mei-neumes.xml
@@ -55,7 +55,7 @@
     </fileDesc>
     <profileDesc>
       <abstract>
-        <p>A customization for <hi rend="italic">Neume Notation</hi>.</p>
+        <p>A customization for encoding neume notation.</p>
       </abstract>
       <textClass>
         <keywords>

--- a/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:math="http://www.w3.org/2005/xpath-functions/math" xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" xmlns:map="http://www.w3.org/2005/xpath-functions/map" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:tei="http://www.tei-c.org/ns/1.0" exclude-result-prefixes="xs math xd" version="3.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:math="http://www.w3.org/2005/xpath-functions/math" xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" xmlns:map="http://www.w3.org/2005/xpath-functions/map" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:tei="http://www.tei-c.org/ns/1.0" exclude-result-prefixes="xs math xd map mei" version="3.0">
     <xd:doc scope="stylesheet">
         <xd:desc>
             <xd:p><xd:b>Created on:</xd:b> Jun 2, 2025</xd:p>

--- a/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
@@ -25,12 +25,12 @@
         <xsl:result-document href="{string-join(($output.folder, 'index.html'), '/')}">
 
             <xsl:variable name="all-customizations" select="tokenize($customizationIndexPages, ';')"/>
-            <xsl:variable name="testing-customizations"
+            <xsl:variable name="universal-customizations"
                 select="$all-customizations[
                     doc('../../../customizations/' || tokenize(., '/')[1] || '.xml')
                     //tei:profileDesc/tei:textClass/tei:keywords/tei:term = 'testing'
                 ]"/>
-            <xsl:variable name="other-customizations"
+            <xsl:variable name="special-customizations"
                 select="$all-customizations[
                     not(doc('../../../customizations/' || tokenize(., '/')[1] || '.xml')
                     //tei:profileDesc/tei:textClass/tei:keywords/tei:term = 'testing')
@@ -38,24 +38,27 @@
 
             <xsl:variable name="contents">
 
-                <xsl:element name="h2">Guidelines for the MEI customizations</xsl:element>
+                <xsl:element name="h2">Guidelines for the MEI Customizations</xsl:element>
                 
+                <xsl:element name="h4">Special Purpose Customizations</xsl:element>
+
                 <xsl:element name="div">
                     <xsl:attribute name="class">columns filter-body projects</xsl:attribute>
 
-                    <xsl:for-each select="$other-customizations">
+
+                    <xsl:for-each select="$special-customizations">
                             <xsl:call-template name="generate-customization-card">
                                 <xsl:with-param name="customizationName" select="tokenize(., '/')[1]"/>
                             </xsl:call-template>
                     </xsl:for-each>
                 </xsl:element>
 
-                <xsl:element name="h3">Special purpose customizations</xsl:element>
+                <xsl:element name="h4">All-Inclusive MEI Customizations (Use Only for Testing or Validation)</xsl:element>
 
                 <xsl:element name="div">
                     <xsl:attribute name="class">columns filter-body projects</xsl:attribute>
 
-                    <xsl:for-each select="$testing-customizations">
+                    <xsl:for-each select="$universal-customizations">
                             <xsl:call-template name="generate-customization-card">
                                 <xsl:with-param name="customizationName" select="tokenize(., '/')[1]"/>
                             </xsl:call-template>

--- a/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
@@ -36,28 +36,10 @@
 
         <xsl:result-document href="{string-join(($output.folder, 'index.html'), '/')}">
 
-
-            <xsl:variable name="contents">
-
-                <xsl:element name="h2">Guidelines for the MEI Customizations</xsl:element>
         <xsl:variable name="all-customizations" as="map(*)*" >
             
             <xsl:for-each select="tokenize($customizationIndexPages, ';')">
                 
-                <xsl:element name="h4">Special Purpose Customizations</xsl:element>
-
-                <xsl:element name="div">
-                    <xsl:attribute name="class">columns filter-body projects</xsl:attribute>
-
-
-                    <xsl:for-each select="$special-customizations">
-                            <xsl:call-template name="generate-customization-card">
-                                <xsl:with-param name="customizationName" select="tokenize(., '/')[1]"/>
-                            </xsl:call-template>
-                    </xsl:for-each>
-                </xsl:element>
-
-                <xsl:element name="h4">All-Inclusive MEI Customizations (Use Only for Testing or Validation)</xsl:element>
                 <xsl:variable name="path" select="." as="xs:string"/>
                 <xsl:variable name="customizationName" select="tokenize(., '/')[1]" as="xs:string"/>
                 <xsl:variable name="node" select="doc('../../../customizations/' || $customizationName || '.xml')/tei:TEI" as="node()"/>
@@ -72,19 +54,28 @@
             </xsl:for-each>
             
         </xsl:variable>
+            
+        <xsl:variable name="contents">
 
+            <xsl:element name="h2">Guidelines for the MEI Customizations</xsl:element>
+            
+            <xsl:for-each-group select="$all-customizations" group-by="map:get(.,'group')">
+                
+                <xsl:sort select="current-grouping-key()" order="ascending" />
+                
+                <xsl:element name="h4"><xsl:value-of select="mei:getCustomizationGroupHeading(current-grouping-key())"/></xsl:element>
+                
                 <xsl:element name="div">
                     <xsl:attribute name="class">columns filter-body projects</xsl:attribute>
-
-                    <xsl:for-each select="$universal-customizations">
-                            <xsl:call-template name="generate-customization-card">
-                                <xsl:with-param name="customizationName" select="tokenize(., '/')[1]"/>
-                            </xsl:call-template>
+                    <xsl:for-each select="current-group()">
+                        <xsl:call-template name="generate-customization-card">
+                            <xsl:with-param name="customization" select="." />
+                        </xsl:call-template>
                     </xsl:for-each>
-
                 </xsl:element>
+            </xsl:for-each-group>
 
-            </xsl:variable>
+        </xsl:variable>
 
             <xsl:call-template name="getSinglePage">
                 <xsl:with-param name="contents" select="$contents" as="node()*"/>

--- a/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
@@ -20,6 +20,25 @@
     
     <xsl:variable name="isCompiledOdd" select="xs:boolean('false')" as="xs:boolean" />
     
+    <xsl:variable name="all-customizations" as="map(*)*" >
+        
+        <xsl:for-each select="tokenize($customizationIndexPages, ';')">
+            
+            <xsl:variable name="path" select="." as="xs:string"/>
+            <xsl:variable name="customizationName" select="tokenize(., '/')[1]" as="xs:string"/>
+            <xsl:variable name="node" select="doc('../../../customizations/' || $customizationName || '.xml')/tei:TEI" as="node()"/>
+            
+            <xsl:map>
+                <xsl:map-entry key="'name'" select="$customizationName"/>
+                <xsl:map-entry key="'node'" select="$node"/>
+                <xsl:map-entry key="'path'" select="."/>
+                <xsl:map-entry key="'group'" select="mei:getCustomizationGroupingKey($node)"/>
+            </xsl:map>
+            
+        </xsl:for-each>
+        
+    </xsl:variable>
+    
     <xsl:function name="mei:getCustomizationGroupHeading">
         
         <xsl:param name="groupingKey" as="xs:integer" required="yes"/>
@@ -54,25 +73,6 @@
 
         <xsl:result-document href="{string-join(($output.folder, 'index.html'), '/')}">
 
-        <xsl:variable name="all-customizations" as="map(*)*" >
-            
-            <xsl:for-each select="tokenize($customizationIndexPages, ';')">
-                
-                <xsl:variable name="path" select="." as="xs:string"/>
-                <xsl:variable name="customizationName" select="tokenize(., '/')[1]" as="xs:string"/>
-                <xsl:variable name="node" select="doc('../../../customizations/' || $customizationName || '.xml')/tei:TEI" as="node()"/>
-                
-                <xsl:map>
-                    <xsl:map-entry key="'name'" select="$customizationName"/>
-                    <xsl:map-entry key="'node'" select="$node"/>
-                    <xsl:map-entry key="'path'" select="."/>
-                    <xsl:map-entry key="'group'" select="mei:getCustomizationGroupingKey($node)"/>
-                </xsl:map>
-                
-            </xsl:for-each>
-            
-        </xsl:variable>
-            
         <xsl:variable name="contents">
 
             <xsl:element name="h2">Guidelines for the MEI Customizations</xsl:element>

--- a/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
@@ -20,6 +20,18 @@
     
     <xsl:variable name="isCompiledOdd" select="xs:boolean('false')" as="xs:boolean" />
     
+    <xsl:function name="mei:getCustomizationGroupingKey" as="xs:integer">
+        
+        <xsl:param name="customization" required="yes"/>
+        
+        <xsl:choose>
+            <xsl:when test="$customization//tei:profileDesc/tei:textClass/tei:keywords/tei:term = ('repertoire', 'interchange', 'interoperability')">1</xsl:when>
+            <xsl:when test="$customization//tei:profileDesc/tei:textClass/tei:keywords/tei:term = ('testing', 'validation')">2</xsl:when>
+            <xsl:otherwise>3</xsl:otherwise>
+        </xsl:choose>
+        
+    </xsl:function>
+    
     <xsl:template name="initial-template">
 
         <xsl:result-document href="{string-join(($output.folder, 'index.html'), '/')}">

--- a/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
@@ -128,7 +128,7 @@
                     <xsl:attribute name="class">card-footer</xsl:attribute>
                     <xsl:element name="a">
                         <xsl:attribute name="class">btn float-right btn-sm</xsl:attribute>
-                        <xsl:attribute name="href" select="."/>
+                        <xsl:attribute name="href" select="map:get($customization, 'path')"/>
                         <xsl:text>Proceed to Guidelines…</xsl:text>
                     </xsl:element>
                     <xsl:for-each select="$customization.node//tei:profileDesc/tei:textClass/tei:keywords/tei:term">

--- a/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
@@ -107,8 +107,8 @@
     </xsl:template>
 
     <xsl:template name="generate-customization-card">
-        <xsl:param name="customizationName" as="xs:string"/>
         <xsl:variable name="customization.file" select="doc('../../../customizations/' || $customizationName || '.xml')/tei:TEI" as="node()"/>
+        <xsl:param name="customization" as="map(*)" required="yes"/>
         <xsl:element name="div">
             <xsl:attribute name="class">column col-4 col-sm-12 col-lg-6 filter-item</xsl:attribute>
             <xsl:element name="div">

--- a/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
@@ -117,11 +117,11 @@
                     <xsl:attribute name="class">card-header</xsl:attribute>
                     <xsl:element name="div">
                         <xsl:attribute name="class">card-title h5</xsl:attribute>
-                        <xsl:value-of select="($customization.file//tei:fileDesc/tei:titleStmt/tei:title[@type='short'], $customizationName)[1]"/>
+                        <xsl:value-of select="($customization.node//tei:fileDesc/tei:titleStmt/tei:title[@type='short'], map:get($customization, 'name'))[1]"/>
                     </xsl:element>
                     <xsl:element name="div">
                         <xsl:attribute name="class">card-subtitle text-gray</xsl:attribute>
-                        <xsl:apply-templates select="$customization.file//tei:profileDesc/tei:abstract/tei:p" mode="guidelines"/>
+                        <xsl:apply-templates select="$customization.node//tei:profileDesc/tei:abstract/tei:p" mode="guidelines"/>
                     </xsl:element>
                 </xsl:element>
                 <xsl:element name="div">
@@ -131,7 +131,7 @@
                         <xsl:attribute name="href" select="."/>
                         <xsl:text>Proceed to Guidelines…</xsl:text>
                     </xsl:element>
-                    <xsl:for-each select="$customization.file//tei:profileDesc/tei:textClass/tei:keywords/tei:term">
+                    <xsl:for-each select="$customization.node//tei:profileDesc/tei:textClass/tei:keywords/tei:term">
                         <xsl:element name="label">
                             <xsl:attribute name="class">chip</xsl:attribute>
                             <xsl:value-of select="."/>

--- a/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
@@ -51,7 +51,7 @@
                 <xsl:text>All-Inclusive MEI Customizations (Use Only for Testing or Validation)</xsl:text>
             </xsl:when>
             <xsl:when test="$groupingKey = 3">
-                <xsl:text>Other Customzations</xsl:text>
+                <xsl:text>Other Customizations</xsl:text>
             </xsl:when>
         </xsl:choose>
         

--- a/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
@@ -121,7 +121,8 @@
         </xd:desc>
     </xd:doc>
     <xsl:template match="tei:gi" mode="guidelines">
-        <xsl:variable name="text" select="string(text())" as="xs:string"/>        <xsl:value-of select="."/>
+        <xsl:variable name="text" select="string(text())" as="xs:string"/>
+        <xsl:value-of select="."/>
     </xsl:template>
     
 </xsl:stylesheet>

--- a/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
@@ -107,8 +107,8 @@
     </xsl:template>
 
     <xsl:template name="generate-customization-card">
-        <xsl:variable name="customization.file" select="doc('../../../customizations/' || $customizationName || '.xml')/tei:TEI" as="node()"/>
         <xsl:param name="customization" as="map(*)" required="yes"/>
+        <xsl:param name="customization.node" select="map:get($customization, 'node')" as="node()"/>
         <xsl:element name="div">
             <xsl:attribute name="class">column col-4 col-sm-12 col-lg-6 filter-item</xsl:attribute>
             <xsl:element name="div">

--- a/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
@@ -88,7 +88,7 @@
 
     <xsl:template name="generate-customization-card">
         <xsl:param name="customization" as="map(*)" required="yes"/>
-        <xsl:param name="customization.node" select="map:get($customization, 'node')" as="node()"/>
+        <xsl:param name="customizationNode" select="map:get($customization, 'node')" as="node()"/>
         <xsl:element name="div">
             <xsl:attribute name="class">column col-4 col-sm-12 col-lg-6 filter-item</xsl:attribute>
             <xsl:element name="div">
@@ -97,11 +97,11 @@
                     <xsl:attribute name="class">card-header</xsl:attribute>
                     <xsl:element name="div">
                         <xsl:attribute name="class">card-title h5</xsl:attribute>
-                        <xsl:value-of select="($customization.node//tei:fileDesc/tei:titleStmt/tei:title[@type='short'], map:get($customization, 'name'))[1]"/>
+                        <xsl:value-of select="($customizationNode//tei:fileDesc/tei:titleStmt/tei:title[@type='short'], map:get($customization, 'name'))[1]"/>
                     </xsl:element>
                     <xsl:element name="div">
                         <xsl:attribute name="class">card-subtitle text-gray</xsl:attribute>
-                        <xsl:apply-templates select="$customization.node//tei:profileDesc/tei:abstract/tei:p" mode="guidelines"/>
+                        <xsl:apply-templates select="$customizationNode//tei:profileDesc/tei:abstract/tei:p" mode="guidelines"/>
                     </xsl:element>
                 </xsl:element>
                 <xsl:element name="div">
@@ -111,7 +111,7 @@
                         <xsl:attribute name="href" select="map:get($customization, 'path')"/>
                         <xsl:text>Proceed to Guidelines…</xsl:text>
                     </xsl:element>
-                    <xsl:for-each select="$customization.node//tei:profileDesc/tei:textClass/tei:keywords/tei:term">
+                    <xsl:for-each select="$customizationNode//tei:profileDesc/tei:textClass/tei:keywords/tei:term">
                         <xsl:element name="label">
                             <xsl:attribute name="class">chip</xsl:attribute>
                             <xsl:value-of select="."/>

--- a/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
@@ -24,21 +24,13 @@
 
         <xsl:result-document href="{string-join(($output.folder, 'index.html'), '/')}">
 
-            <xsl:variable name="all-customizations" select="tokenize($customizationIndexPages, ';')"/>
-            <xsl:variable name="universal-customizations"
-                select="$all-customizations[
-                    doc('../../../customizations/' || tokenize(., '/')[1] || '.xml')
-                    //tei:profileDesc/tei:textClass/tei:keywords/tei:term = 'testing'
-                ]"/>
-            <xsl:variable name="special-customizations"
-                select="$all-customizations[
-                    not(doc('../../../customizations/' || tokenize(., '/')[1] || '.xml')
-                    //tei:profileDesc/tei:textClass/tei:keywords/tei:term = 'testing')
-                ]"/>
 
             <xsl:variable name="contents">
 
                 <xsl:element name="h2">Guidelines for the MEI Customizations</xsl:element>
+        <xsl:variable name="all-customizations" as="map(*)*" >
+            
+            <xsl:for-each select="tokenize($customizationIndexPages, ';')">
                 
                 <xsl:element name="h4">Special Purpose Customizations</xsl:element>
 
@@ -54,6 +46,20 @@
                 </xsl:element>
 
                 <xsl:element name="h4">All-Inclusive MEI Customizations (Use Only for Testing or Validation)</xsl:element>
+                <xsl:variable name="path" select="." as="xs:string"/>
+                <xsl:variable name="customizationName" select="tokenize(., '/')[1]" as="xs:string"/>
+                <xsl:variable name="node" select="doc('../../../customizations/' || $customizationName || '.xml')/tei:TEI" as="node()"/>
+                
+                <xsl:map>
+                    <xsl:map-entry key="'name'" select="$customizationName"/>
+                    <xsl:map-entry key="'node'" select="$node"/>
+                    <xsl:map-entry key="'path'" select="."/>
+                    <xsl:map-entry key="'group'" select="mei:getCustomizationGroupingKey($node)"/>
+                </xsl:map>
+                
+            </xsl:for-each>
+            
+        </xsl:variable>
 
                 <xsl:element name="div">
                     <xsl:attribute name="class">columns filter-body projects</xsl:attribute>

--- a/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
@@ -21,28 +21,21 @@
     <xsl:variable name="isCompiledOdd" select="xs:boolean('false')" as="xs:boolean" />
     
     <xsl:variable name="all-customizations" as="map(*)*" >
-        
         <xsl:for-each select="tokenize($customizationIndexPages, ';')">
-            
             <xsl:variable name="path" select="." as="xs:string"/>
             <xsl:variable name="customizationName" select="tokenize(., '/')[1]" as="xs:string"/>
             <xsl:variable name="node" select="doc('../../../customizations/' || $customizationName || '.xml')/tei:TEI" as="node()"/>
-            
             <xsl:map>
                 <xsl:map-entry key="'name'" select="$customizationName"/>
                 <xsl:map-entry key="'node'" select="$node"/>
                 <xsl:map-entry key="'path'" select="."/>
                 <xsl:map-entry key="'group'" select="mei:getCustomizationGroupingKey($node)"/>
             </xsl:map>
-            
         </xsl:for-each>
-        
     </xsl:variable>
     
     <xsl:function name="mei:getCustomizationGroupHeading">
-        
         <xsl:param name="groupingKey" as="xs:integer" required="yes"/>
-        
         <xsl:choose>
             <xsl:when test="$groupingKey = 1">
                 <xsl:text>Special Purpose Customizations</xsl:text>
@@ -54,46 +47,34 @@
                 <xsl:text>Other Customizations</xsl:text>
             </xsl:when>
         </xsl:choose>
-        
     </xsl:function>
     
     <xsl:function name="mei:getCustomizationGroupingKey" as="xs:integer">
-        
         <xsl:param name="customization" required="yes"/>
-        
         <xsl:choose>
             <xsl:when test="$customization//tei:profileDesc/tei:textClass/tei:keywords/tei:term = ('repertoire', 'interchange', 'interoperability')">1</xsl:when>
             <xsl:when test="$customization//tei:profileDesc/tei:textClass/tei:keywords/tei:term = ('testing', 'validation')">2</xsl:when>
             <xsl:otherwise>3</xsl:otherwise>
         </xsl:choose>
-        
     </xsl:function>
     
     <xsl:template name="initial-template">
-
         <xsl:result-document href="{string-join(($output.folder, 'index.html'), '/')}">
-
-        <xsl:variable name="contents">
-
-            <xsl:element name="h2">Guidelines for the MEI Customizations</xsl:element>
-            
-            <xsl:for-each-group select="$all-customizations" group-by="map:get(.,'group')">
-                
-                <xsl:sort select="current-grouping-key()" order="ascending" />
-                
-                <xsl:element name="h4"><xsl:value-of select="mei:getCustomizationGroupHeading(current-grouping-key())"/></xsl:element>
-                
-                <xsl:element name="div">
-                    <xsl:attribute name="class">columns filter-body projects</xsl:attribute>
-                    <xsl:for-each select="current-group()">
-                        <xsl:call-template name="generate-customization-card">
-                            <xsl:with-param name="customization" select="." />
-                        </xsl:call-template>
-                    </xsl:for-each>
-                </xsl:element>
-            </xsl:for-each-group>
-
-        </xsl:variable>
+            <xsl:variable name="contents">
+                <xsl:element name="h2">Guidelines for the MEI Customizations</xsl:element>
+                <xsl:for-each-group select="$all-customizations" group-by="map:get(.,'group')">
+                    <xsl:sort select="current-grouping-key()" order="ascending" />
+                    <xsl:element name="h4"><xsl:value-of select="mei:getCustomizationGroupHeading(current-grouping-key())"/></xsl:element>
+                    <xsl:element name="div">
+                        <xsl:attribute name="class">columns filter-body projects</xsl:attribute>
+                        <xsl:for-each select="current-group()">
+                            <xsl:call-template name="generate-customization-card">
+                                <xsl:with-param name="customization" select="." />
+                            </xsl:call-template>
+                        </xsl:for-each>
+                    </xsl:element>
+                </xsl:for-each-group>
+            </xsl:variable>
 
             <xsl:call-template name="getSinglePage">
                 <xsl:with-param name="contents" select="$contents" as="node()*"/>
@@ -103,7 +84,6 @@
             </xsl:call-template>
             
         </xsl:result-document>
-        
     </xsl:template>
 
     <xsl:template name="generate-customization-card">

--- a/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
@@ -24,62 +24,41 @@
 
         <xsl:result-document href="{string-join(($output.folder, 'index.html'), '/')}">
 
+            <xsl:variable name="all-customizations" select="tokenize($customizationIndexPages, ';')"/>
+            <xsl:variable name="testing-customizations"
+                select="$all-customizations[
+                    doc('../../../customizations/' || tokenize(., '/')[1] || '.xml')
+                    //tei:profileDesc/tei:textClass/tei:keywords/tei:term = 'testing'
+                ]"/>
+            <xsl:variable name="other-customizations"
+                select="$all-customizations[
+                    not(doc('../../../customizations/' || tokenize(., '/')[1] || '.xml')
+                    //tei:profileDesc/tei:textClass/tei:keywords/tei:term = 'testing')
+                ]"/>
+
             <xsl:variable name="contents">
+
+                <xsl:element name="h2">Guidelines for the MEI customizations</xsl:element>
+                
+                <xsl:element name="div">
+                    <xsl:attribute name="class">columns filter-body projects</xsl:attribute>
+
+                    <xsl:for-each select="$other-customizations">
+                            <xsl:call-template name="generate-customization-card">
+                                <xsl:with-param name="customizationName" select="tokenize(., '/')[1]"/>
+                            </xsl:call-template>
+                    </xsl:for-each>
+                </xsl:element>
+
+                <xsl:element name="h3">Special purpose customizations</xsl:element>
 
                 <xsl:element name="div">
                     <xsl:attribute name="class">columns filter-body projects</xsl:attribute>
 
-                    <xsl:for-each select="tokenize($customizationIndexPages, ';')">
-                        
-                        <xsl:variable name="customizationName" select="tokenize(., '/')[1]"/>
-                        
-                        <xsl:variable name="customization.file" select="doc('../../../customizations/' || $customizationName || '.xml')/tei:TEI" as="node()"/>
-
-                        <xsl:element name="div">
-                            <xsl:attribute name="class">column col-4 col-sm-12 col-lg-6 filter-item</xsl:attribute>
-
-                            <xsl:element name="div">
-                                <xsl:attribute name="class">card project</xsl:attribute>
-
-                                <xsl:element name="div">
-                                    <xsl:attribute name="class">card-header</xsl:attribute>
-                                    <xsl:element name="div">
-                                        <xsl:attribute name="class">card-title h5</xsl:attribute>
-                                        <xsl:value-of select="($customization.file//tei:fileDesc/tei:titleStmt/tei:title[@type='short'], $customizationName)[1]"/>
-                                    </xsl:element>
-                                    <xsl:element name="div">
-                                        <xsl:attribute name="class">card-subtitle text-gray</xsl:attribute>
-                                        <xsl:apply-templates select="$customization.file//tei:fileDesc/tei:titleStmt/tei:title[@type='main']"/>
-                                    </xsl:element>
-                                </xsl:element>
-                                
-                                <xsl:element name="div">
-                                    <xsl:attribute name="class">card-body</xsl:attribute>
-                                    <xsl:apply-templates select="$customization.file//tei:profileDesc/tei:abstract/tei:p" mode="guidelines"/>
-                                </xsl:element>
-                                
-                                <xsl:element name="div">
-                                    <xsl:attribute name="class">card-footer</xsl:attribute>
-                                    <xsl:element name="a">
-                                        <xsl:attribute name="class">btn float-right btn-sm</xsl:attribute>
-                                        <xsl:attribute name="href" select="."/>
-                                        <xsl:text>Proceed to Guidelines…</xsl:text>
-                                    </xsl:element>
-                                    
-                                    <xsl:for-each select="$customization.file//tei:profileDesc/tei:textClass/tei:keywords/tei:term">
-                                        <xsl:element name="label">
-                                            <xsl:attribute name="class">chip</xsl:attribute>
-                                            <xsl:value-of select="."/>
-                                        </xsl:element>
-                                    </xsl:for-each>
-                                    
-
-                                </xsl:element>
-
-                            </xsl:element>
-
-                        </xsl:element>
-
+                    <xsl:for-each select="$testing-customizations">
+                            <xsl:call-template name="generate-customization-card">
+                                <xsl:with-param name="customizationName" select="tokenize(., '/')[1]"/>
+                            </xsl:call-template>
                     </xsl:for-each>
 
                 </xsl:element>
@@ -95,6 +74,42 @@
             
         </xsl:result-document>
         
+    </xsl:template>
+
+    <xsl:template name="generate-customization-card">
+        <xsl:param name="customizationName" as="xs:string"/>
+        <xsl:variable name="customization.file" select="doc('../../../customizations/' || $customizationName || '.xml')/tei:TEI" as="node()"/>
+        <xsl:element name="div">
+            <xsl:attribute name="class">column col-4 col-sm-12 col-lg-6 filter-item</xsl:attribute>
+            <xsl:element name="div">
+                <xsl:attribute name="class">card project</xsl:attribute>
+                <xsl:element name="div">
+                    <xsl:attribute name="class">card-header</xsl:attribute>
+                    <xsl:element name="div">
+                        <xsl:attribute name="class">card-title h5</xsl:attribute>
+                        <xsl:value-of select="($customization.file//tei:fileDesc/tei:titleStmt/tei:title[@type='short'], $customizationName)[1]"/>
+                    </xsl:element>
+                    <xsl:element name="div">
+                        <xsl:attribute name="class">card-subtitle text-gray</xsl:attribute>
+                        <xsl:apply-templates select="$customization.file//tei:profileDesc/tei:abstract/tei:p" mode="guidelines"/>
+                    </xsl:element>
+                </xsl:element>
+                <xsl:element name="div">
+                    <xsl:attribute name="class">card-footer</xsl:attribute>
+                    <xsl:element name="a">
+                        <xsl:attribute name="class">btn float-right btn-sm</xsl:attribute>
+                        <xsl:attribute name="href" select="."/>
+                        <xsl:text>Proceed to Guidelines…</xsl:text>
+                    </xsl:element>
+                    <xsl:for-each select="$customization.file//tei:profileDesc/tei:textClass/tei:keywords/tei:term">
+                        <xsl:element name="label">
+                            <xsl:attribute name="class">chip</xsl:attribute>
+                            <xsl:value-of select="."/>
+                        </xsl:element>
+                    </xsl:for-each>
+                </xsl:element>
+            </xsl:element>
+        </xsl:element>
     </xsl:template>
     
     <xd:doc>

--- a/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
@@ -20,6 +20,24 @@
     
     <xsl:variable name="isCompiledOdd" select="xs:boolean('false')" as="xs:boolean" />
     
+    <xsl:function name="mei:getCustomizationGroupHeading">
+        
+        <xsl:param name="groupingKey" as="xs:integer" required="yes"/>
+        
+        <xsl:choose>
+            <xsl:when test="$groupingKey = 1">
+                <xsl:text>Special Purpose Customizations</xsl:text>
+            </xsl:when>
+            <xsl:when test="$groupingKey = 2">
+                <xsl:text>All-Inclusive MEI Customizations (Use Only for Testing or Validation)</xsl:text>
+            </xsl:when>
+            <xsl:when test="$groupingKey = 3">
+                <xsl:text>Other Customzations</xsl:text>
+            </xsl:when>
+        </xsl:choose>
+        
+    </xsl:function>
+    
     <xsl:function name="mei:getCustomizationGroupingKey" as="xs:integer">
         
         <xsl:param name="customization" required="yes"/>

--- a/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsiteIndexPage.xsl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:math="http://www.w3.org/2005/xpath-functions/math" xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" xmlns:tei="http://www.tei-c.org/ns/1.0" exclude-result-prefixes="xs math xd" version="3.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:math="http://www.w3.org/2005/xpath-functions/math" xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" xmlns:map="http://www.w3.org/2005/xpath-functions/map" xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:tei="http://www.tei-c.org/ns/1.0" exclude-result-prefixes="xs math xd" version="3.0">
     <xd:doc scope="stylesheet">
         <xd:desc>
             <xd:p><xd:b>Created on:</xd:b> Jun 2, 2025</xd:p>


### PR DESCRIPTION
As a follow-up to #1678 this PR includes filtering of the customizations by keyword terms and unifies the naming/abstract a bit more.