### PR TITLE
schema: remove `<rest[@line]` schematron rule

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -7629,12 +7629,12 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="Check_restline" scheme="schematron">
+    <constraintSpec ident="Check_restloc" scheme="schematron">
       <constraint>
-        <sch:rule context="mei:rest[@line]">
+        <sch:rule context="mei:rest[@loc]">
           <sch:let name="thisstaff" value="ancestor::mei:staff/@n"/>
           <sch:assert
-            test="number(@line) &lt;= number(preceding::mei:staffDef[@n=$thisstaff and @lines][1]/@lines)"
+            test="number(@loc) &lt;= number(preceding::mei:staffDef[@n=$thisstaff and @lines][1]/@lines)"
             >The value of @line must be less than or equal to the number of lines on the
             staff.</sch:assert>
         </sch:rule>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -7629,17 +7629,6 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="Check_restloc" scheme="schematron">
-      <constraint>
-        <sch:rule context="mei:rest[@loc]">
-          <sch:let name="thisstaff" value="ancestor::mei:staff/@n"/>
-          <sch:assert
-            test="number(@loc) &lt;= number(preceding::mei:staffDef[@n=$thisstaff and @lines][1]/@lines)"
-            >The value of @loc must be less than or equal to the number of lines on the
-            staff.</sch:assert>
-        </sch:rule>
-      </constraint>
-    </constraintSpec>
     <remarks xml:lang="en">
       <p>See (Read, p. 96-102). Do not confuse this element with the <gi scheme="MEI">space</gi>
         element, which is used as an aid for visual alignment.</p>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -7635,7 +7635,7 @@
           <sch:let name="thisstaff" value="ancestor::mei:staff/@n"/>
           <sch:assert
             test="number(@loc) &lt;= number(preceding::mei:staffDef[@n=$thisstaff and @lines][1]/@lines)"
-            >The value of @line must be less than or equal to the number of lines on the
+            >The value of @loc must be less than or equal to the number of lines on the
             staff.</sch:assert>
         </sch:rule>
       </constraint>


### PR DESCRIPTION
Per a conversation with @bwbohl on [slack](https://music-encoding.slack.com/archives/C5HNVG41E/p1749649921472739), I've altered this rule to validate using loc. 