### PR TITLE
schema: allow mid-measure changes to instrument and staff layout

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -8050,6 +8050,7 @@
       <memberOf key="att.staffDef.ges"/>
       <memberOf key="att.staffDef.log"/>
       <memberOf key="att.staffDef.vis"/>
+      <memberOf key="model.eventLike"/>
       <memberOf key="model.staffDefLike"/>
     </classes>
     <content>
@@ -8179,6 +8180,25 @@
             <sch:let name="scorePPQ" value="preceding::mei:scoreDef[@ppq][1]/@ppq"/>
             <sch:assert test="($scorePPQ mod $staffPPQ) = 0">The value of ppq must be a factor of
               the value of ppq on a preceding scoreDef.</sch:assert>
+          </sch:rule>
+        </sch:pattern>
+      </constraint>
+    </constraintSpec>
+    <constraintSpec ident="Check_staffDef_in_layer" scheme="schematron">
+      <constraint>
+        <sch:pattern>
+          <sch:rule context="mei:staffDef[ancestor::mei:layer or ancestor::mei:oLayer]">
+            <sch:let name="staff" value="ancestor::*[self:mei:staff or self::mei:oStaff][1]"/>
+            <sch:let name="layers" value="$staff//mei:layer|$staff//mei:oLayer]"/>
+            <sch:let name="mainLayer" value="$layers[.//mei:staffDef[not(@sameas)]]"/>
+            <sch:let name="mainStaffDefs" value="$mainLayer//mei:staffDef[not(@sameas)]"/>
+            <sch:let name="secondaryStaffDefs" value="$layers//mei:staffDef[@sameas]"/>
+            <sch:assert
+              test="count($mainLayer) = 1
+                and not($layers[count(.//mei:staffDef) != count($mainStaffDefs)])
+                and count($secondaryStaffDefs) = count($mainStaffDefs) * (count($layers) - 1)"
+              >One layer must be used for main staffDefs. All other sibling layers must have
+              secondary staffDefs pointing to main staffDefs with @sameas.</sch:assert>
           </sch:rule>
         </sch:pattern>
       </constraint>


### PR DESCRIPTION
This allows changing the staff layout and instruments mid-measure.  Here is an example:

```xml
<score>
  <scoreDef>
    <staffGrp>
      <staffDef n="1" lines="1" clef.shape="perc" clef.line="1">
        <label>Tambourin</label>
        <instrDef midi.instrname="Tambourine"/>
      </staffDef>
    </staffGrp>
  </scoreDef>
  <section>
    <measure n="1">
      <staff n="1">
        <layer n="1">
          <note dur="4"/>
          <rest dur="4"/>
          <rest dur="4"/>
          <staffDef n="1" lines="5" clef.shape="G" clef.line="2" trans.semi="12" xml:id="instrChange">
            <label>Glockenspiel</label>
            <instrDef midi.instrname="Glockenspiel"/>
          </staffDef>
          <note pname="e" oct="4" dur="8"/>
          <note pname="f" oct="4" dur="8"/>
        </layer>
        <layer n="2">
          <space dur="2" dots="1"/>
          <staffDef sameas="#instrChange"/>
          <note pname="c" oct="4" dur="4"/>
        </layer>
      </staff>
    </measure>
  </section>
</score>
```

This encodes:

* A change in the number of staff lines
* A change of the instrument and its sound
* A change of transposition

... all of which is not possible mid-measure, unless `<staffDef>` is allowed inside `<layer>`.

`<staffDef>` is similar to `<clef>` and `<keySig>`. All of them have the issue that when there are multiple `<layer>`s in a `<staff>`, they should probably be repeated on every `<layer>` with `@sameas`. I made this a draft pull request as the Schematron rules enforcing this are still untested and I think there is a need to discuss whether this makes sense at all.