### PR TITLE
schema: add a couple of neume types

### DIFF
--- a/source/modules/MEI.neumes.xml
+++ b/source/modules/MEI.neumes.xml
@@ -206,8 +206,10 @@
         <valList type="semi">
           <valItem ident="apostropha"/>
           <valItem ident="bistropha"/>
+          <valItem ident="cephalicus"/>
           <valItem ident="climacus"/>
           <valItem ident="clivis"/>
+          <valItem ident="epiphonus"/>
           <valItem ident="oriscus"/>
           <valItem ident="pes"/>
           <valItem ident="pessubpunctis"/>


### PR DESCRIPTION
I am adding two extra values for the neume@type attribute semi-open list: https://music-encoding.org/guidelines/v5/attribute-classes/att.neumeType.html. 

These two neume types are very well known (for chant scholars): 

- cephalicus
  <img width="34" height="69" alt="smufl_chant-cephalicus" src="https://github.com/user-attachments/assets/10b5aa5f-a969-4c56-996c-2d0a32fb9d4f" />

- epiphonus
  <img width="34" height="60" alt="smufl_chant-epiphonus" src="https://github.com/user-attachments/assets/a4937086-dc22-4773-a038-6ae498639285" />

I am aware that there is a discussion about changing this `neume@type` attribute into `@neumetype` (or `@neumename` or something similar): https://github.com/music-encoding/music-encoding/issues/1633. But until this is not decided, I prefer to not include this change in this PR, and just include the extra values. I can make another PR in the future to account for the new attribute.

---
This would be related to the issue added in Verovio to render these two shapes (already available in SMuFL): https://github.com/rism-digital/verovio/issues/4119