### PR TITLE
guidelines: fix title attribute for attributes

### DIFF
--- a/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
@@ -632,7 +632,7 @@
         <item class="attribute" ident="{$current.att/@ident}" module="{$module}">
             <link><xsl:value-of select="$current.att/@ident"/></link>
             <desc>
-                <span class="ident attribute" title="{normalize-space(string-join($desc/descendant-or-self::text(),' '))}">@<xsl:value-of select="$current.att/@ident"/></span>
+                <span class="ident attribute" title="{replace(normalize-space(string-join($desc,' ')), ' ([,.])', '$1')}">@<xsl:value-of select="$current.att/@ident"/></span>
                 <xsl:if test="$usage">
                     <span class="attributeUsage">(<xsl:value-of select="$usage"/>)</span>
                 </xsl:if>

--- a/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
@@ -632,7 +632,7 @@
         <item class="attribute" ident="{$current.att/@ident}" module="{$module}">
             <link><xsl:value-of select="$current.att/@ident"/></link>
             <desc>
-                <span class="ident attribute" title="{replace(normalize-space(string-join($desc,' ')), ' ([,.])', '$1')}">@<xsl:value-of select="$current.att/@ident"/></span>
+                <span class="ident attribute" title="{normalize-space($current.att/tei:desc)}">@<xsl:value-of select="$current.att/@ident"/></span>
                 <xsl:if test="$usage">
                     <span class="attributeUsage">(<xsl:value-of select="$usage"/>)</span>
                 </xsl:if>


### PR DESCRIPTION
With this change proper `@title` content is generated:

<img width="1580" height="238" alt="Bildschirmfoto 2025-07-15 um 18 17 46" src="https://github.com/user-attachments/assets/a23a532d-60ee-4027-9d7e-64aec9fb26a3" />

closes #1663

