### PR TITLE
Clarify the implications of `@cutout="cutout"`

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -450,11 +450,12 @@
         <desc xml:lang="en">"Cut-out" style.</desc>
         <valList type="closed">
           <valItem ident="cutout">
-            <desc xml:lang="en">The staff lines should not be drawn for the duration of the element.
-              It is sufficient to set <att scheme="MEI">cutout</att> on a single layer. Directly
-              adjacent barlines are only shown if on the other side of the barline, staff lines are
-              drawn (within the same system). The visibility of other elements is not
-              affected.</desc>
+            <desc xml:lang="en">Means that the staff lines "behind" the element are hidden for the
+              entire duration of the element, based on <att scheme="MEI">dur</att> and <att
+                scheme="MEI">dots</att>. <att scheme="MEI">cutout</att> does not imply that any
+              other elements are hidden. Only barlines directly adjacent to the cut-out area may be
+              hidden or shortened. When rendering, barline handling is up to the rendering
+              application.</desc>
           </valItem>
         </valList>
       </attDef>

--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -450,7 +450,11 @@
         <desc xml:lang="en">"Cut-out" style.</desc>
         <valList type="closed">
           <valItem ident="cutout">
-            <desc xml:lang="en">The staff lines should not be drawn.</desc>
+            <desc xml:lang="en">The staff lines should not be drawn for the duration of the element.
+              It is sufficient to set <att scheme="MEI">cutout</att> on a single layer. Directly
+              adjacent barlines are only shown if on the other side of the barline, staff lines are
+              drawn (within the same system). The visibility of other elements is not
+              affected.</desc>
           </valItem>
         </valList>
       </attDef>


### PR DESCRIPTION
Clarification based on discussion at #1478.