### PR TITLE
schema: allow name in application only once

### DIFF
--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -471,9 +471,7 @@
       <memberOf key="att.datable"/>
     </classes>
     <content>
-      <rng:oneOrMore>
-        <rng:ref name="name"/>
-      </rng:oneOrMore>
+      <rng:ref name="name"/>
       <rng:choice>
         <rng:zeroOrMore>
           <rng:ref name="model.locrefLike"/>


### PR DESCRIPTION
I couldn't think of any case where the following would make sense:

```xml
<encodingDesc>
   <appInfo>
      <application>
         <name>This name</name>
         <name>That name</name>
         <name>Yet antother name</name>
         <name>Your mother's name</name>
         <name>No name</name>
         <name></name>
      </application>
   </appInfo>
</encodingDesc>
```

This PR proposes to allow `name` only once as child of `application`.