### PR TITLE
gh-actions: build schemata and provide as artifact

### DIFF
--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -19,7 +19,7 @@ jobs:
         run: ant build-customizations
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: mei-schemata-${{ github.sha }}
           path: dist/schemata

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   build_schemata:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout main repo

--- a/.github/workflows/ci_build.yml
+++ b/.github/workflows/ci_build.yml
@@ -1,0 +1,25 @@
+name: Build Schemata
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  build_schemata:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout main repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build schemata
+        run: ant build-customizations
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4.4.3
+        with:
+          name: mei-schemata-${{ github.sha }}
+          path: dist/schemata


### PR DESCRIPTION
This PR adds a simple workflow to build the RelaxNGs for all customizations and provides them as artifact.

Maybe it would be make sense to combine this with the `PR Source Validation` workflow?

closes #1690
