### PR TITLE
schema: fix casing for Basic

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -2151,7 +2151,7 @@
               <desc>Version of MEI Basic customization</desc>
           </valItem>
           <valItem ident="6.0-dev+cmn">
-            <desc>Version of MEI cmn customization</desc>
+            <desc>Version of MEI CMN customization</desc>
           </valItem>
           <valItem ident="6.0-dev+mensural">
             <desc>Version of MEI mensural customization</desc>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -2148,7 +2148,7 @@
             <desc>Version of MEI all_anyStart customization</desc>
           </valItem>
           <valItem ident="6.0-dev+basic">
-              <desc>Version of MEI basic customization</desc>
+              <desc>Version of MEI Basic customization</desc>
           </valItem>
           <valItem ident="6.0-dev+cmn">
             <desc>Version of MEI cmn customization</desc>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -2157,7 +2157,7 @@
             <desc>Version of MEI mensural customization</desc>
           </valItem>
           <valItem ident="6.0-dev+neumes">
-            <desc>Version of MEI neumes customization</desc>
+            <desc>Version of MEI Neumes customization</desc>
           </valItem>
         </valList>
       </attDef>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -2154,7 +2154,7 @@
             <desc>Version of MEI CMN customization</desc>
           </valItem>
           <valItem ident="6.0-dev+mensural">
-            <desc>Version of MEI mensural customization</desc>
+            <desc>Version of MEI Mensural customization</desc>
           </valItem>
           <valItem ident="6.0-dev+neumes">
             <desc>Version of MEI Neumes customization</desc>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -2145,7 +2145,7 @@
             <desc xml:lang="en">Version of MEI</desc>
           </valItem>
           <valItem ident="6.0-dev+anyStart">
-            <desc>Version of MEI all_anyStart customization</desc>
+            <desc>Version of MEI All AnyStart customization</desc>
           </valItem>
           <valItem ident="6.0-dev+basic">
               <desc>Version of MEI Basic customization</desc>


### PR DESCRIPTION
Fixing one case we missed aligning the correct casing for `MEI Basic`.