### PR TITLE
schema: make mdiv member of att.lang

### DIFF
--- a/customizations/mei-basic.xml
+++ b/customizations/mei-basic.xml
@@ -1236,6 +1236,7 @@
                     <classes mode="replace">
                         <memberOf key="att.common"/>
                         <!--<memberOf key="att.facsimile"/>-->
+                        <memberOf key="att.lang"/>
                         <!--<memberOf key="att.metadataPointing"/>-->
                         <!--<memberOf key="att.mdiv.anl"/>-->
                         <memberOf key="att.mdiv.ges"/>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -6699,6 +6699,7 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
+      <memberOf key="att.lang"/>
       <memberOf key="att.metadataPointing"/>
       <memberOf key="att.mdiv.anl"/>
       <memberOf key="att.mdiv.ges"/>


### PR DESCRIPTION
I noticed, that it not possible to have multiple versions of a pice in different languages in multiple mdivs by specifying the language of the mdiv. This PR adds `@xml:lang` to `mdiv` to allow structures like

```xml
<music>
    <mdiv xml:lang="de">
        <!-- German version -->
    </mdiv>
    <mdiv xml:lang="en">
        <!-- English version -->
    </mdiv>
    <mdiv xml:lang="fr">
        <!-- French version -->
    </mdiv>
</music>
```
