### PR TITLE
utils: add namespace attribute to examples where specified

### DIFF
--- a/utils/guidelines_xslt/odd2html/renderXML.xsl
+++ b/utils/guidelines_xslt/odd2html/renderXML.xsl
@@ -108,7 +108,7 @@
                     <span data-indentation="{$indent.level}" class="element">&lt;/<xsl:value-of select="name($element)"/>&gt;</span></div>
             </xsl:when>
             <xsl:otherwise>
-                <div class="indent indent{$indent.level}"><span data-indentation="{$indent.level}" class="element">&lt;<xsl:value-of select="name($element)"/><xsl:apply-templates select="$element/@*" mode="#current"/><xsl:if test="not($element/node())">/</xsl:if>&gt;</span><xsl:apply-templates select="$element/node()" mode="#current"><xsl:with-param name="indent" select="$indent.level + 1" as="xs:integer"/></xsl:apply-templates><xsl:if test="$element/node()"><span data-indentation="{$indent.level}" class="element">&lt;/<xsl:value-of select="name($element)"/>&gt;</span></xsl:if></div>
+                <div class="indent indent{$indent.level}"><span data-indentation="{$indent.level}" class="element">&lt;<xsl:value-of select="name($element)"/><xsl:if test="$indent.level = 1 and namespace-uri()"><xsl:value-of select="' '"/><span class="attribute"><xsl:value-of select="'xmlns'"/>=</span><span class="attributevalue">"<xsl:value-of select="namespace-uri()"/>"</span></xsl:if><xsl:apply-templates select="$element/@*" mode="#current"/><xsl:if test="not($element/node())">/</xsl:if>&gt;</span><xsl:apply-templates select="$element/node()" mode="#current"><xsl:with-param name="indent" select="$indent.level + 1" as="xs:integer"/></xsl:apply-templates><xsl:if test="$element/node()"><span data-indentation="{$indent.level}" class="element">&lt;/<xsl:value-of select="name($element)"/>&gt;</span></xsl:if></div>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>


### PR DESCRIPTION
This extends the generation of the examples in the Guidleines to show the `xmlns` atrribute (where specified):

<img width="959" height="379" alt="Bildschirmfoto 2025-10-21 um 19 28 13" src="https://github.com/user-attachments/assets/0d3870c3-58ac-416c-9707-23e2c9b26c82" />

closes #1329