### PR TITLE
schema: add attribute class and attribute for recording the status of a file

### DIFF
--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -700,6 +700,13 @@
                         <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/header/header-sample077.txt" parse="text"/></egXML>
                      </figure>
                   </p>
+                  <p>Within the change log the status of the document and its content can be recorded using the <att>status</att> attribute. This indicates the status a document became at a specific change. If the status of the document differs from the newest <gi scheme="MEI">change</gi> record, the status of the document can also be recorded in the root element of the file (<gi scheme="MEI">mei</gi>, <gi scheme="MEI">meiHead</gi>, <gi scheme="MEI">meiCorpus</gi>, <gi scheme="MEI">music</gi>). <att>status</att> is only available in <gi scheme="MEI">change</gi> and the root elements of regular MEI, also in <label>mei-all_anyStart</label> (see <ptr target="#meiCustomizations"/>).</p>
+                  <p>
+                     <figure>
+                        <head></head>
+                        <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/header/header-sample097.txt" parse="text"/></egXML>
+                     </figure>
+                  </p>
                </div>
             </div>
             <div xml:id="FRBR" type="div2">

--- a/source/examples/header/header-sample097.txt
+++ b/source/examples/header/header-sample097.txt
@@ -16,7 +16,7 @@
   </change>
   <change isodate="2025-10-01" resp="#DR" status="draft">
     <changeDesc>
-      <p>The document was created.</p>
+      <p>Creation of the document.</p>
     </changeDesc>
   </change>
 </revisionDesc>

--- a/source/examples/header/header-sample097.txt
+++ b/source/examples/header/header-sample097.txt
@@ -1,0 +1,22 @@
+<revisionDesc>
+  <change isodate="2025-11-27" resp="#DR" status="embargoed">
+    <changeDesc>
+      <p>The rightholder didn't gave publishing permission. This document has embargoed access until 2027-01-01.</p>
+    </changeDesc>
+  </change>
+  <change isodate="2025-10-16" resp="#CG" status="approved">
+    <changeDesc>
+      <p>The document has been proofread. It's ready for publishing</p>
+    </changeDesc>
+  </change>
+  <change isodate="2025-10-05" resp="#DR" status="candidate">
+    <changeDesc>
+      <p>The content of the document is elaborated and the document is now a candidate for publishing. It can be proofread.</p>
+    </changeDesc>
+  </change>
+  <change isodate="2025-10-01" resp="#DR" status="draft">
+    <changeDesc>
+      <p>The document was created.</p>
+    </changeDesc>
+  </change>
+</revisionDesc>

--- a/source/modules/MEI.corpus.xml
+++ b/source/modules/MEI.corpus.xml
@@ -35,6 +35,7 @@
       <memberOf key="att.common"/>
       <memberOf key="att.meiVersion"/>
       <memberOf key="model.startLike.corpus"/>
+      <memberOf key="att.docStatus"/>
     </classes>
     <content>
       <rng:ref name="meiHead"/>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -1697,6 +1697,7 @@
       <memberOf key="att.meiVersion"/>
       <memberOf key="att.responsibility"/>
       <memberOf key="model.startLike.header"/>
+      <memberOf key="att.docStatus"/>
     </classes>
     <content>
       <rng:zeroOrMore>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -2311,7 +2311,6 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
-      <memberOf key="att.docStatus"/>
     </classes>
     <content>
       <rng:zeroOrMore>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -725,6 +725,7 @@
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
       <memberOf key="att.datable"/>
+      <memberOf key="att.docStatus"/>
     </classes>
     <content>
       <rng:optional>
@@ -2309,6 +2310,7 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
+      <memberOf key="att.docStatus"/>
     </classes>
     <content>
       <rng:zeroOrMore>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -6729,6 +6729,7 @@
       <memberOf key="att.id"/>
       <memberOf key="att.meiVersion"/>
       <memberOf key="att.responsibility"/>
+      <memberOf key="att.docStatus"/>
     </classes>
     <content>
       <rng:ref name="meiHead"/>
@@ -6835,6 +6836,7 @@
       <memberOf key="att.common"/>
       <memberOf key="att.meiVersion"/>
       <memberOf key="att.metadataPointing"/>
+      <memberOf key="att.docStatus"/>
     </classes>
     <content>
       <rng:zeroOrMore>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1110,7 +1110,6 @@
         <datatype>
             <rng:data type="NMTOKEN"/>
         </datatype>
-        <defaultVal>draft</defaultVal>
         <valList type="semi">
           <valItem ident="draft">
             <desc>Initial or preliminary version of the document.</desc>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1146,17 +1146,17 @@
           </change>
           <change isodate="2025-10-16" resp="#CG" status="approved">
             <changeDesc>
-              <p>Proofreading of the document.</p>
+              <p>The document has been proofread. It's ready for publishing</p>
             </changeDesc>
           </change>
           <change isodate="2025-10-05" resp="#DR" status="candidate">
             <changeDesc>
-              <p>Elaborating the content of the document.</p>
+              <p>The content of the document is elaborated and the document is now a candidate for publishing. It can be proofread.</p>
             </changeDesc>
           </change>
           <change isodate="2025-10-01" resp="#DR" status="draft">
             <changeDesc>
-              <p>Creating the document.</p>
+              <p>The document was created.</p>
             </changeDesc>
           </change>
         </revisionDesc>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1102,6 +1102,65 @@
       </attDef>
     </attList>
   </classSpec>
+  <classSpec ident="att.docStatus" module="MEI.shared" type="atts">
+    <desc versionDate="2016-10-16" xml:lang="en">Attributes for describing the status of a document.</desc>
+    <attList>
+      <attDef ident="status" usage="opt">
+        <desc versionDate="2016-10-16" xml:lang="en">Used to describe the status of a document (currently or at the time indicated by a date).</desc>
+        <datatype>
+            <rng:data type="NMTOKEN"/>
+        </datatype>
+        <defaultVal>draft</defaultVal>
+        <valList type="semi">
+          <valItem ident="approved">
+            <desc>The content of the document is ready for publishing.</desc>
+          </valItem>
+          <valItem ident="candidate">
+            <desc>The content of the document is elaborated and need to be proofread.</desc>
+          </valItem>
+          <valItem ident="draft">
+            <desc>Document is created or the content is a draft.</desc>
+          </valItem>
+          <valItem ident="embargoed">
+            <desc>The content of the document can't be published because of restrictions.</desc>
+          </valItem>
+          <valItem ident="proposed">
+            <desc>The content of the document is ready for reviewing.</desc>
+          </valItem>
+          <valItem ident="published">
+            <desc>The document is published.</desc>
+          </valItem>
+          <valItem ident="withdrawn">
+            <desc>The publication of the document has been reversed.</desc>
+          </valItem>
+        </valList>
+      </attDef>
+    </attList>
+    <exemplum>
+      <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:space="preserve" valid="true">
+        <revisionDesc status="published">
+          <change isodate="2025-10-16" resp="#CG" status="approved">
+            <changeDesc>
+              <p>Proofreading of the document.</p>
+            </changeDesc>
+          </change>
+          <change isodate="2025-10-05" resp="#DR" status="candidate">
+            <changeDesc>
+              <p>Elaborating the content of the document.</p>
+            </changeDesc>
+          </change>
+          <change isodate="2025-10-01" resp="#DR" status="draft">
+            <changeDesc>
+              <p>Creating the document.</p>
+            </changeDesc>
+          </change>
+        </revisionDesc>
+      </egXML>
+    </exemplum>
+    <remarks>
+      <p>The model of this attribute class is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-att.docStatus.html">att.docStatus</ref> class of the Text Encoding Initiative (TEI).</p>
+    </remarks>
+  </classSpec>
   <classSpec ident="att.mdiv.log" module="MEI.shared" type="atts">
     <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1103,35 +1103,35 @@
     </attList>
   </classSpec>
   <classSpec ident="att.docStatus" module="MEI.shared" type="atts">
-    <desc versionDate="2016-10-16" xml:lang="en">Attributes for describing the status of a document.</desc>
+    <desc versionDate="2025-11-27" xml:lang="en">Attributes for describing the status of a document.</desc>
     <attList>
       <attDef ident="status" usage="opt">
-        <desc versionDate="2016-10-16" xml:lang="en">Used to describe the status of a document (currently or at the time indicated by a date).</desc>
+        <desc versionDate="2025-11-27" xml:lang="en">Used to describe the status of a document (currently or at the time indicated by a date).</desc>
         <datatype>
             <rng:data type="NMTOKEN"/>
         </datatype>
         <defaultVal>draft</defaultVal>
         <valList type="semi">
-          <valItem ident="approved">
-            <desc>The content of the document is ready for publishing.</desc>
-          </valItem>
-          <valItem ident="candidate">
-            <desc>The content of the document is elaborated and need to be proofread.</desc>
-          </valItem>
           <valItem ident="draft">
             <desc>Document is created or the content is a draft.</desc>
           </valItem>
-          <valItem ident="embargoed">
-            <desc>The content of the document can't be published because of restrictions.</desc>
-          </valItem>
           <valItem ident="proposed">
-            <desc>The content of the document is ready for reviewing.</desc>
+            <desc>Content of the document is proposed for review or still in progress (if the status "candidate" is used).</desc>
+          </valItem>
+          <valItem ident="candidate">
+            <desc>Content of the document is ready for reviewing.</desc>
+          </valItem>
+          <valItem ident="approved">
+            <desc>Content of the document is reviewed and ready for publishing.</desc>
           </valItem>
           <valItem ident="published">
-            <desc>The document is published.</desc>
+            <desc>Document is published.</desc>
           </valItem>
           <valItem ident="withdrawn">
-            <desc>The publication of the document has been reversed.</desc>
+            <desc>Publication of the document has been reversed.</desc>
+          </valItem>
+          <valItem ident="embargoed">
+            <desc>Document can't be published (full or in parts) because of an embargo.</desc>
           </valItem>
         </valList>
       </attDef>
@@ -1139,6 +1139,11 @@
     <exemplum>
       <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:space="preserve" valid="true">
         <revisionDesc status="published">
+          <change isodate="2025-11-27" resp="#DR" status="embargoed">
+            <changeDesc>
+              <p>The rightholder didn't gave publishing permission. This document has embargoed access until 2027-01-01.</p>
+            </changeDesc>
+          </change>
           <change isodate="2025-10-16" resp="#CG" status="approved">
             <changeDesc>
               <p>Proofreading of the document.</p>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1115,11 +1115,11 @@
           <valItem ident="draft">
             <desc>Document is created or the content is a draft.</desc>
           </valItem>
-          <valItem ident="proposed">
-            <desc>Content of the document is proposed for review or still in progress (if the status "candidate" is used).</desc>
+          <valItem ident="in-process">
+            <desc>Document is under development.</desc>
           </valItem>
           <valItem ident="candidate">
-            <desc>Content of the document is ready for reviewing.</desc>
+            <desc>Content of the document is ready for review.</desc>
           </valItem>
           <valItem ident="approved">
             <desc>Content of the document is reviewed and ready for publishing.</desc>
@@ -1131,14 +1131,14 @@
             <desc>Publication of the document has been reversed.</desc>
           </valItem>
           <valItem ident="embargoed">
-            <desc>Document can't be published (full or in parts) because of an embargo.</desc>
+            <desc>Document cannot be published (in full or in part) due to an embargo.</desc>
           </valItem>
         </valList>
       </attDef>
     </attList>
     <exemplum>
       <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:space="preserve" valid="true">
-        <revisionDesc status="published">
+        <revisionDesc>
           <change isodate="2025-11-27" resp="#DR" status="embargoed">
             <changeDesc>
               <p>The rightholder didn't gave publishing permission. This document has embargoed access until 2027-01-01.</p>
@@ -1156,7 +1156,7 @@
           </change>
           <change isodate="2025-10-01" resp="#DR" status="draft">
             <changeDesc>
-              <p>The document was created.</p>
+              <p>Creation of the document.</p>
             </changeDesc>
           </change>
         </revisionDesc>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1122,7 +1122,7 @@
             <desc>Content of the document is ready for review.</desc>
           </valItem>
           <valItem ident="approved">
-            <desc>Content of the document is reviewed and ready for publishing.</desc>
+            <desc>Content of the document is reviewed and ready to be published.</desc>
           </valItem>
           <valItem ident="published">
             <desc>Document is published.</desc>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1113,7 +1113,7 @@
         <defaultVal>draft</defaultVal>
         <valList type="semi">
           <valItem ident="draft">
-            <desc>Document is created or the content is a draft.</desc>
+            <desc>Initial or preliminary version of the document.</desc>
           </valItem>
           <valItem ident="proposed">
             <desc>Content of the document is proposed for review or still in progress (if the status "candidate" is used).</desc>


### PR DESCRIPTION
This PR introduces an attribute class for attributes that describe or define a status. The idea came up in https://github.com/Edirom/MerMEId/issues/283 and has been discussed in the @music-encoding/ig-metadata meetings and the [working meeting](https://github.com/music-encoding/metadata-ig/wiki/2025#2025-11-13-10am-utc1) in November 2025.

The attribute `@status` will be allowed in `<change>` to make possible documentation of the change of a documents status. Further it will be allowed in all elements that can be root in mei-all (`<mei>`, `<meiHead>`, `<meiCorpus>`, `<music>`).

At the moment it is also allowed in `<revisionDesc>`, analogously to TEI, but this just an option to be discussed.

The value list for `@status` is also a reduced setup of the definition in TEI. Descriptions for the single values have been added. @pe-ro offered to revise the wording.
The value list is proposed as a basic setup, but adjustable if not sufficient, since it is semi-open!

ToDo:

- [x] Adding documentation to the Guidelines