### PR TITLE
Fix indexing in Guidlines 

### DIFF
--- a/utils/guidelines_xslt/odd2html/config.xsl
+++ b/utils/guidelines_xslt/odd2html/config.xsl
@@ -64,7 +64,7 @@
                 <!-- todo: add some validation if that given $basedir really exists? -->
                 <xsl:value-of select="$basedir || '/'"/>
             </xsl:otherwise>
-        </xsl:choose>    
+        </xsl:choose>
     </xsl:variable>
 
     <xd:doc>

--- a/utils/guidelines_xslt/odd2html/functions.xsl
+++ b/utils/guidelines_xslt/odd2html/functions.xsl
@@ -79,8 +79,8 @@
             
             <xsl:variable name="index" select="if($origElemSource) then(count($origElemSource/preceding-sibling::tei:div) + 1) else(count($origElemCustomization/preceding-sibling::tei:div) + 1)" as="xs:integer"/>
             <chapter level="{$level}" xml:id="{$current.div/@xml:id}" number="{$chapter.prefix || $parent.chapter.number || $index}" head="{normalize-space(string-join($current.div/tei:head/text(),' '))}">
-                <xsl:sequence select="tools:buildChapterList($current.div, $level + 1, chapter.prefix || $parent.chapter.number || $index || '.', '')"/>    
-            </chapter>            
+                <xsl:sequence select="tools:buildChapterList($current.div, $level + 1, chapter.prefix || $parent.chapter.number || $index || '.', '')"/>
+            </chapter>
         </xsl:for-each>
     </xsl:function>
     
@@ -143,10 +143,10 @@
                 Music Encoding Initiative
                 <small class="out">Guidelines</small>
             </h1>
-            <img id="meiLogo" src="images/meilogo.png"/>    
+            <img id="meiLogo" src="images/meilogo.png"/>
             <div class="bottom">
                 <div class="versionDiv">Version <span id="version"><xsl:value-of select="$version"/></span> <span class="gitLinkWrapper">(<a id="gitVersionLink" href="{$git.link}">#<xsl:value-of select="$git.short"/></a>)</span></div>
-                <div class="generationDiv">generated on <span id="generationDate"><xsl:value-of select="format-date(current-date(), '[D1] [MNn] [Y1]')"/></span></div>                
+                <div class="generationDiv">generated on <span id="generationDate"><xsl:value-of select="format-date(current-date(), '[D1] [MNn] [Y1]')"/></span></div>
             </div>
         </section>
         <section class="imprintPage">
@@ -182,7 +182,7 @@
             <!-- TODO: Do we have front pages that need to be included? -->
             <ul class="toc toc_body">
                 <xsl:for-each select="$all.chapters">
-                    <xsl:sequence select="tools:generateTocChapterItem(.)"/>    
+                    <xsl:sequence select="tools:generateTocChapterItem(.)"/>
                 </xsl:for-each>
             </ul>
             <ul class="toc toc_back">
@@ -227,10 +227,10 @@
                         </li>
                         <li class="toc toc_2">
                             <a class="toc toc_2" href="#dataTypeIndex">Index of Data Types</a>
-                        </li>     
+                        </li>
                         <li class="toc toc_2">
                             <a class="toc toc_2" href="#contributorList">Contributors</a>
-                        </li>     
+                        </li>
                     </ul>
                 </li>
             </ul>
@@ -260,7 +260,7 @@
             <xsl:if test="$chapter/child::chapter">
                 <ul class="toc">
                     <xsl:for-each select="$chapter/child::chapter">
-                        <xsl:sequence select="tools:generateTocChapterItem(.)"/>    
+                        <xsl:sequence select="tools:generateTocChapterItem(.)"/>
                     </xsl:for-each>
                 </ul>
             </xsl:if>
@@ -434,7 +434,7 @@
                 explicitly mentioned in chapter <a href="#acknowledgments">1.1.1 Acknowledgments</a> of these Guidelines. However, we 
                 believe it is important to give proper recognition to everyone contributing to this community effort. Without 
                 their continued commitment, MEI would not be possible. 
-            </p>            
+            </p>
             <xsl:sequence select="tools:getContributors()"/>
             <p>
                 This list is automatically compiled from all contributors to the 
@@ -471,7 +471,7 @@
             <xsl:variable name="raw.contributors" as="node()*">
                 <xsl:if test="$retrieve-contributors">
                     <xsl:sequence select="tools:retrieveData($docs.repo.contributors)/child::json:array/json:map"/>
-                    <xsl:sequence select="tools:retrieveData($spec.repo.contributors)/child::json:array/json:map"/>    
+                    <xsl:sequence select="tools:retrieveData($spec.repo.contributors)/child::json:array/json:map"/>
                 </xsl:if>
             </xsl:variable>
             <xsl:variable name="unique.ids" select="distinct-values($raw.contributors//json:number[@key = 'id']/text())" as="xs:string*"/>
@@ -498,8 +498,8 @@
                         <string key="viaf"></string>
                         <string key="orcid"></string>
                         <string key="avatar"><xsl:value-of select="$user.data/json:string[@key = 'avatar_url']"/></string>
-                    </map>                    
-                </xsl:for-each>    
+                    </map>
+                </xsl:for-each>
             </array>
             
         </xsl:variable>
@@ -557,8 +557,8 @@
                                     <img class="contibutorAvatar" src="images/ORCID_iD.svg"/>
                                     <span><xsl:value-of select="substring-after($current.contributor/json:string[@key = 'orcid']/text(),'https://orcid.org/')"/></span>
                                 </a>
-                            </xsl:if>                            
-                        </td>                        
+                            </xsl:if>
+                        </td>
                         <td class="viaf">
                             <xsl:if test="$current.contributor/json:string[@key = 'viaf']/text() and string-length($current.contributor/json:string[@key = 'viaf']/text()) gt 0">
                                 <a class="contributorLink viafLink" href="{$current.contributor/json:string[@key = 'viaf']/text()}">

--- a/utils/guidelines_xslt/odd2html/functions.xsl
+++ b/utils/guidelines_xslt/odd2html/functions.xsl
@@ -15,6 +15,7 @@
     <xd:doc scope="stylesheet">
         <xd:desc>
             <xd:p><xd:b>Created on:</xd:b> Jul 8, 2021</xd:p>
+            <xd:p><xd:b>Modified on:</xd:b> Nov 28, 2025</xd:p>
             <xd:p><xd:b>Author:</xd:b> Johannes Kepper</xd:p>
             <xd:p>This XSLT is part of odd2html.xsl. It holds basic functions, which are
                 used to adjust input parameters like image paths.</xd:p>

--- a/utils/guidelines_xslt/odd2html/functions.xsl
+++ b/utils/guidelines_xslt/odd2html/functions.xsl
@@ -77,7 +77,7 @@
             <xsl:variable name="origElemSource" select="$mei.source//tei:div[@xml:id = $current.div/@xml:id]" as="node()?"/>
             <xsl:variable name="origElemCustomization" select="$mei.customization//tei:div[@xml:id = $current.div/@xml:id]" as="node()?"/>
             
-            <xsl:variable name="index" select="if($origElemSource) then(count($origElemSource/preceding-sibling::tei:div[@type = 'div1']) + 1) else(count($origElemCustomization/preceding-sibling::tei:div[@type = 'div1']) + 1)" as="xs:integer"/>
+            <xsl:variable name="index" select="if($origElemSource) then(count($origElemSource/preceding-sibling::tei:div) + 1) else(count($origElemCustomization/preceding-sibling::tei:div) + 1)" as="xs:integer"/>
             <chapter level="{$level}" xml:id="{$current.div/@xml:id}" number="{$chapter.prefix || $parent.chapter.number || $index}" head="{normalize-space(string-join($current.div/tei:head/text(),' '))}">
                 <xsl:sequence select="tools:buildChapterList($current.div, $level + 1, chapter.prefix || $parent.chapter.number || $index || '.', '')"/>    
             </chapter>            

--- a/utils/guidelines_xslt/odd2html/generateWebsite.xsl
+++ b/utils/guidelines_xslt/odd2html/generateWebsite.xsl
@@ -157,7 +157,7 @@
                         <p class="mainToc">
                             <a href="./modules/{@id}.html" title="{normalize-space(string-join(parent::section/div[@class='specs']/div[@class='desc']/text(),' '))}"><xsl:value-of select="normalize-space(string-join(.//text(),' '))"/></a>
                         </p>
-                    </xsl:for-each>    
+                    </xsl:for-each>
                 </div>
             </xsl:variable>
             <xsl:call-template name="getSinglePage">
@@ -220,7 +220,7 @@
                                 </xsl:for-each>
                             </div>
                         </div>
-                    </xsl:for-each>    
+                    </xsl:for-each>
                 </div>
             </xsl:variable>
             <xsl:call-template name="getSinglePage">
@@ -282,7 +282,7 @@
                                 </xsl:for-each>
                             </div>
                         </div>
-                    </xsl:for-each>    
+                    </xsl:for-each>
                 </div>
             </xsl:variable>
             <xsl:call-template name="getSinglePage">
@@ -344,7 +344,7 @@
                                 </xsl:for-each>
                             </div>
                         </div>
-                    </xsl:for-each>    
+                    </xsl:for-each>
                 </div>
             </xsl:variable>
             <xsl:call-template name="getSinglePage">
@@ -406,7 +406,7 @@
                                 </xsl:for-each>
                             </div>
                         </div>
-                    </xsl:for-each>    
+                    </xsl:for-each>
                 </div>
             </xsl:variable>
             <xsl:call-template name="getSinglePage">
@@ -468,7 +468,7 @@
                                 </xsl:for-each>
                             </div>
                         </div>
-                    </xsl:for-each>    
+                    </xsl:for-each>
                 </div>
             </xsl:variable>
             <xsl:call-template name="getSinglePage">
@@ -551,9 +551,9 @@
                                             </xsl:if>
                                         </xsl:for-each>
                                     </xsl:when>
-                                </xsl:choose>                                       
+                                </xsl:choose>
                             </page>
-                        </xsl:if>                        
+                        </xsl:if>
                     </xsl:for-each>
                 </xsl:variable>
                 
@@ -566,7 +566,7 @@
                             </a>
                             <div class="hide-lg">
                                 <xsl:for-each select="$menu/self::page">
-                                    <div class="dropdown dropdownCustomMenuToggle">                                    
+                                    <div class="dropdown dropdownCustomMenuToggle">
                                         <a href="{if(child::page) then('#') else('https://music-encoding.org' || @url)}" class="btn btn-link dropdown-toggle top-menu-link" tabindex="{position()}">
                                             <xsl:value-of select="@label"/> <xsl:if test="child::page"> <i class="icon icon-caret"></i></xsl:if>
                                         </a>
@@ -582,7 +582,7 @@
                                             </ul>
                                         </xsl:if>
                                     </div>
-                                </xsl:for-each>    
+                                </xsl:for-each>
                             </div>
                         </div>
                         <div class="navbar-section" id="socialLinks">
@@ -717,7 +717,7 @@
                             </xsl:if>
                             <xsl:sequence select="node()"/>
                         </xsl:copy>
-                    </xsl:for-each>        
+                    </xsl:for-each>
                 </xsl:when>
                 <xsl:otherwise>
                     <xsl:apply-templates select="group" mode="get.website.classTab"/>
@@ -789,8 +789,8 @@
                             <xsl:apply-templates select="node()" mode="get.website"/>
                         </xsl:copy></xsl:for-each>
                 </xsl:otherwise>
-            </xsl:choose>            
-        </div>        
+            </xsl:choose>
+        </div>
     </xsl:function>
     
     <xd:doc>
@@ -806,8 +806,8 @@
         <xsl:param name="facet.type" as="xs:string"/>
         
         <div id="{$facet.type}_class" class="facetTabbedContent class" data-label="by class">
-            <xsl:apply-templates select="$div/node()" mode="get.website.classTab"/>      
-        </div>        
+            <xsl:apply-templates select="$div/node()" mode="get.website.classTab"/>
+        </div>
     </xsl:function>
         
     <xd:doc>
@@ -827,7 +827,7 @@
             </div>
             <div class="classContent">
                 <xsl:apply-templates select="child::item" mode="#current"/>
-                <xsl:apply-templates select="child::group" mode="#current"/>                
+                <xsl:apply-templates select="child::group" mode="#current"/>
             </div>
         </div>
     </xsl:template>
@@ -841,8 +841,8 @@
         <div class="def">
             <xsl:if test="not(@class='attribute')">
                 <span class="ident" title="{normalize-space(string-join(child::desc//text(),' '))}">
-                    <xsl:apply-templates select="child::link/node()" mode="get.website"/>        
-                </span>    
+                    <xsl:apply-templates select="child::link/node()" mode="get.website"/>
+                </span>
             </xsl:if>
             <span class="desc">
                 <xsl:apply-templates select="child::desc/node()" mode="get.website"/>
@@ -896,11 +896,11 @@
                         <xsl:for-each select="$current.items">
                             <xsl:sort select="@ident"/>
                             <xsl:apply-templates select="." mode="get.website.classTab"/>
-                        </xsl:for-each>                        
+                        </xsl:for-each>
                     </div>
                 </div>
             </xsl:for-each>
-        </div>        
+        </div>
     </xsl:function>
     
     <xd:doc>
@@ -939,8 +939,8 @@
                         <span class="step end"><xsl:value-of select="$end"/></span>
                     </div>
                 </div>
-            </xsl:for-each>           
-        </div>        
+            </xsl:for-each>
+        </div>
     </xsl:function>
     
     <xd:doc>
@@ -975,7 +975,7 @@
                 </xsl:when>
                 <xsl:when test="'link_odd_dataType' = $classes">
                     <xsl:value-of select="replace(.,'#','../data-types/') || '.html'"/>
-                </xsl:when>     
+                </xsl:when>
                 <xsl:when test="'chapterLink' = $classes">
                     <xsl:variable name="chapter.id" select="replace(.,'#','')" as="xs:string"/>
                     <!--<xsl:variable name="first.level.chapter" select="$mei.source//tei:div[@type='div1' and .//@xml.id = $chapter.id]/@xml:id" as="xs:string?"/>-->
@@ -989,7 +989,7 @@
                 <xsl:otherwise>
                     <xsl:value-of select="."/>
                 </xsl:otherwise>
-            </xsl:choose>    
+            </xsl:choose>
         </xsl:variable>
         <xsl:attribute name="href" select="$target"/>
     </xsl:template>

--- a/utils/guidelines_xslt/odd2html/guidelines.xsl
+++ b/utils/guidelines_xslt/odd2html/guidelines.xsl
@@ -136,7 +136,7 @@
             </xsl:when>
             <xsl:otherwise>
                 <span class="missingLink"><xsl:value-of select="$text"/> [not available in this MEI customization]</span>
-                <xsl:message terminate="no" select="'WARNING: Unable to retrieve definition of element ' || $text || '. No link created. Please check spelling…'"/>                
+                <xsl:message terminate="no" select="'WARNING: Unable to retrieve definition of element ' || $text || '. No link created. Please check spelling…'"/>
             </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
@@ -169,7 +169,7 @@
     </xd:doc>
     <xsl:template match="tei:specList" mode="guidelines">
         <ul class="specList">
-            <xsl:apply-templates select="node() | @*" mode="#current"/>            
+            <xsl:apply-templates select="node() | @*" mode="#current"/>
         </ul>
     </xsl:template>
     
@@ -231,7 +231,7 @@
                         </tbody>
                     </table>
                 </xsl:otherwise>
-            </xsl:choose>    
+            </xsl:choose>
         </xsl:element>
         
     </xsl:template>
@@ -271,7 +271,7 @@
                 <xsl:variable name="tocInfo" select="$all.chapters/descendant-or-self::chapter[@xml:id = $chapter.id]" as="node()?"/>
                 <xsl:choose>
                     <xsl:when test="exists($tocInfo)">
-                        <a class="link_ref chapterLink" title="{$tocInfo/@number || ' ' || $tocInfo/@head}" href="#{$chapter.id}"><xsl:apply-templates select="node()" mode="#current"/></a>                        
+                        <a class="link_ref chapterLink" title="{$tocInfo/@number || ' ' || $tocInfo/@head}" href="#{$chapter.id}"><xsl:apply-templates select="node()" mode="#current"/></a>
                     </xsl:when>
                     <xsl:otherwise>
                         <span class="wrong_ref" data-target="{$chapter.id}"><xsl:apply-templates select="node()" mode="#current"/></span>
@@ -583,7 +583,7 @@
                         <xsl:choose>
                             <xsl:when test="exists($pi.start) and exists($pi.end)">
                                 <xsl:message select="'CUTTING EXAMPLE'"/>
-                                <xsl:apply-templates select="$pi.start/following-sibling::node()[following::processing-instruction('edit-end')]" mode="preserveSpace"/>        
+                                <xsl:apply-templates select="$pi.start/following-sibling::node()[following::processing-instruction('edit-end')]" mode="preserveSpace"/>
                             </xsl:when>
                             <xsl:otherwise>
                                 <xsl:apply-templates select="child::node()" mode="preserveSpace"/>
@@ -600,7 +600,7 @@
                             </xsl:call-template>
                         </xsl:if>-->
                     </xsl:otherwise>
-               </xsl:choose>            
+               </xsl:choose>
             </code>
             <!-- TODO: Insert code for switching tabs between code and rendered image -->
         </div>

--- a/utils/guidelines_xslt/odd2html/preparePDF.xsl
+++ b/utils/guidelines_xslt/odd2html/preparePDF.xsl
@@ -82,11 +82,11 @@
                                     <div class="classItem">
                                         <label>
                                             <a class="link_odd link_odd_elementSpec" href="#{$current.item/@ident}">&lt;<xsl:value-of select="$current.item/@ident"/>&gt;</a> / 
-                                            <span class="ident attribute">@<xsl:value-of select="$att.item/link/text()"/></span> 
+                                            <span class="ident attribute">@<xsl:value-of select="$att.item/link/text()"/></span>
                                         </label>
                                         <div class="desc"><xsl:apply-templates select="$att.item/desc/node()" mode="#current"/></div>
                                     </div>
-                                </xsl:for-each>                                    
+                                </xsl:for-each>
                             </xsl:when>
                             <xsl:when test="$att.classes/self::tei:classSpec[@ident = $current.item/@ident]">
                                 <div class="classItem">
@@ -134,7 +134,7 @@
                                 </xsl:for-each>
                                 <span class="step end"><xsl:value-of select="$mod.end"/></span>
                             </div>
-                        </div>        
+                        </div>
                     </xsl:when>
                     <xsl:otherwise>
                         <div class="classItem">
@@ -147,11 +147,11 @@
                                 </xsl:for-each>
                                 <span class="step end"><xsl:value-of select="$end"/></span>
                             </div>
-                        </div>        
+                        </div>
                     </xsl:otherwise>
                 </xsl:choose>
                 
-            </xsl:for-each>            
+            </xsl:for-each>
         </xsl:copy>
     </xsl:template>
     
@@ -170,7 +170,7 @@
             <xsl:otherwise>
                 <xsl:next-match/>
             </xsl:otherwise>
-        </xsl:choose>        
+        </xsl:choose>
     </xsl:template>
     
     <xd:doc>

--- a/utils/guidelines_xslt/odd2html/renderXML.xsl
+++ b/utils/guidelines_xslt/odd2html/renderXML.xsl
@@ -41,19 +41,19 @@
                 <xsl:choose>
                     <xsl:when test="exists($pi.start) and exists($pi.end)">
                         <!--<xsl:message select="'CUTTING EXAMPLE'"/>-->
-                        <xsl:apply-templates select="$pi.start/following-sibling::node()[following::processing-instruction('edit-end')]" mode="preserveSpace"/>        
+                        <xsl:apply-templates select="$pi.start/following-sibling::node()[following::processing-instruction('edit-end')]" mode="preserveSpace"/>
                     </xsl:when>
                     <xsl:otherwise>
                         <xsl:apply-templates select="$xml" mode="preserveSpace"/>
                     </xsl:otherwise>
                 </xsl:choose>
-                <!--<xsl:apply-templates select="$xml" mode="preserveSpace"/>-->        
+                <!--<xsl:apply-templates select="$xml" mode="preserveSpace"/>-->
                 <xsl:catch>
                     <xsl:message select="'ERROR: Unable to parse the following XML snippet, which is apparently not well-formed:'"/>
                     <xsl:message select="$input"/>
                     <xsl:copy-of select="$input"/>
                 </xsl:catch>
-            </xsl:try>    
+            </xsl:try>
         </xsl:variable>
         <xsl:sequence select="$output"/>
     </xsl:function>
@@ -102,7 +102,7 @@
                             <div class="indent indent{$indent.level + 2}"><xsl:value-of select="substring(text(),$indent.threshold * 2 + 1,$indent.threshold * 2)"/></div>
                         </xsl:when>
                         <xsl:when test="string-length(text()) gt $indent.threshold * 1">
-                            <div class="indent indent{$indent.level + 1}"><xsl:value-of select="substring(text(),1,100)"/></div>        
+                            <div class="indent indent{$indent.level + 1}"><xsl:value-of select="substring(text(),1,100)"/></div>
                         </xsl:when>
                     </xsl:choose>
                     <span data-indentation="{$indent.level}" class="element">&lt;/<xsl:value-of select="name($element)"/>&gt;</span></div>
@@ -123,7 +123,7 @@
         <xsl:param name="indent" as="xs:integer?"/>
         <xsl:variable name="indent.level" select="if($indent) then($indent) else(1)" as="xs:integer"/>
         <xsl:variable name="element" select="." as="node()"/>
-        <div class="indent indent{$indent.level}"><span data-indentation="{$indent.level}" class="comment">&lt;!--<xsl:value-of select="."/>--&gt;</span></div>   
+        <div class="indent indent{$indent.level}"><span data-indentation="{$indent.level}" class="comment">&lt;!--<xsl:value-of select="."/>--&gt;</span></div>
     </xsl:template>
     
     <xd:doc>

--- a/utils/guidelines_xslt/odd2html/specs/dataTypeSpecs.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/dataTypeSpecs.xsl
@@ -71,7 +71,7 @@
             <h2 id="{$data.type/@ident}"><xsl:value-of select="$data.type/@ident"/></h2>
             <div class="specs">
                 <div class="desc">
-                    <xsl:apply-templates select="$data.type/tei:desc/node()" mode="guidelines"/>                    
+                    <xsl:apply-templates select="$data.type/tei:desc/node()" mode="guidelines"/>
                 </div>
                 <xsl:sequence select="$moduleFacet"/>
                 <xsl:sequence select="$usedByFacet"/>

--- a/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/genericSpecFunctions.xsl
@@ -115,7 +115,7 @@
                 <label class="classLabel">
                     <xsl:choose>
                         <xsl:when test="$label = ($elements/@ident, $att.classes/@ident, $model.classes/@ident, $data.types/@ident, $macro.groups/@ident)">
-                            <a class="{tools:getLinkClasses($label)}" href="#{$label}"><xsl:value-of select="$label"/></a>        
+                            <a class="{tools:getLinkClasses($label)}" href="#{$label}"><xsl:value-of select="$label"/></a>
                         </xsl:when>
                         <xsl:otherwise>
                             <xsl:value-of select="$label"/>
@@ -144,7 +144,7 @@
             <link>
                 <xsl:choose>
                     <xsl:when test="$label = ($elements/@ident, $att.classes/@ident, $model.classes/@ident, $data.types/@ident, $macro.groups/@ident)">
-                        <a class="{tools:getLinkClasses($label)}" href="#{$label}"><xsl:value-of select="$label"/></a>        
+                        <a class="{tools:getLinkClasses($label)}" href="#{$label}"><xsl:value-of select="$label"/></a>
                     </xsl:when>
                     <xsl:otherwise>
                         <xsl:value-of select="$label"/>
@@ -153,7 +153,7 @@
             </link>
             <desc><xsl:sequence select="$desc"/></desc>
             <xsl:sequence select="$content"/>
-        </group>        
+        </group>
     </xsl:function>
     
     <xd:doc>
@@ -200,7 +200,7 @@
                                 <xsl:variable name="current.elem" select="." as="xs:string"/>
                                 
                                 <div class="elementRef">
-                                    <a class="{tools:getLinkClasses($current.elem)}" href="#{$current.elem}"><xsl:value-of select="$current.elem"/></a>        
+                                    <a class="{tools:getLinkClasses($current.elem)}" href="#{$current.elem}"><xsl:value-of select="$current.elem"/></a>
                                     <span class="elementDesc">
                                         <xsl:apply-templates select="$elements/self::tei:elementSpec[@ident = $current.elem]/tei:desc" mode="guidelines"/>
                                     </span>
@@ -236,7 +236,7 @@
                     <tab id="module" label="by module"><xsl:sequence select="$members.by.module"/></tab>
                 </xsl:variable>
                 
-                <xsl:sequence select="tools:getTabbedFacet('members','Members',$contents)"/>   -->     
+                <xsl:sequence select="tools:getTabbedFacet('members','Members',$contents)"/>   -->
                 
                 <div class="facet members">
                     <div class="label">Members</div>
@@ -426,7 +426,7 @@
                         <xsl:variable name="current.attribute" select="." as="node()"/>
                         <item class="attribute" ident="{$current.attribute/@ident}" module="{$current.element/@module}">
                             <link><xsl:value-of select="$current.attribute/@ident"/></link>
-                            <desc><xsl:apply-templates select="$current.attribute/tei:desc" mode="guidelines"/></desc>                    
+                            <desc><xsl:apply-templates select="$current.attribute/tei:desc" mode="guidelines"/></desc>
                         </item>
                     </xsl:for-each>
 
@@ -1159,7 +1159,7 @@
             </xsl:for-each>
             <xsl:if test="not($is.element) and not($is.macroGroup)">
                 <xsl:sequence select="tools:processAncestorModels($object)"/>
-            </xsl:if>            
+            </xsl:if>
         </xsl:variable>
         
         <xsl:if test="not($is.element) or count($direct.parents) gt 0">
@@ -1167,8 +1167,8 @@
         </xsl:if>
         
         <xsl:if test="$is.element">
-            <xsl:sequence select="tools:processAncestorModels($object)"/>  
-        </xsl:if>      
+            <xsl:sequence select="tools:processAncestorModels($object)"/>
+        </xsl:if>
         
     </xsl:function>
 
@@ -1188,7 +1188,7 @@
             <xsl:sequence select="$macro.parents"/>
         </xsl:variable>
         <xsl:for-each select="$ancestor.models">
-            <xsl:sequence select="tools:getParentsByModel(.)"/>    
+            <xsl:sequence select="tools:getParentsByModel(.)"/>
         </xsl:for-each>
     </xsl:function>
     
@@ -1225,7 +1225,7 @@
         
         <xsl:variable name="inheriting.models" select="$model.classes/self::tei:classSpec[.//tei:memberOf/@key = $className]/@ident" as="xs:string*"/>
         <xsl:for-each select="$inheriting.models">
-            <xsl:sequence select="tools:getChildren(.)"/>    
+            <xsl:sequence select="tools:getChildren(.)"/>
         </xsl:for-each>
         
     </xsl:function>
@@ -1256,7 +1256,7 @@
                 </xsl:if>
                 <xsl:sequence select="$elements/self::tei:elementSpec[@ident = $macroSpec//tei:content//rng:ref/@name]"/>
                 <xsl:for-each select="$macroSpec//tei:content//rng:ref[starts-with(@name,'model.')]">
-                    <xsl:sequence select="tools:getChildren(@name)"/>    
+                    <xsl:sequence select="tools:getChildren(@name)"/>
                 </xsl:for-each>
             </xsl:for-each>
         </xsl:variable>
@@ -1335,7 +1335,7 @@
                     <tab id="module" label="by module"><xsl:sequence select="$children.by.module"/></tab>
                 </xsl:variable>
                 
-                <xsl:sequence select="tools:getTabbedFacet('mayContain','May Contain',$contents)"/>    -->    
+                <xsl:sequence select="tools:getTabbedFacet('mayContain','May Contain',$contents)"/>    -->
                 
                 <div class="facet mayContain">
                     <div class="label">May Contain</div>
@@ -1404,7 +1404,7 @@
                 <xsl:if test="$allows.text">
                     <!--<div class="textualContent" title="textual content">
                         textual content
-                    </div>-->                    
+                    </div>-->
                     <text/>
                 </xsl:if>
                 <xsl:for-each select="$relevant.elements">
@@ -1432,7 +1432,7 @@
                         <xsl:sequence select="$macro.groups/self::tei:macroSpec[@ident = $object/tei:content//rng:ref/@name and not(@ident = $object/@ident)]"/>
                     </xsl:variable>
                     <xsl:for-each select="$inheriting.models">
-                        <xsl:sequence select="tools:getChildrenByModel(.)"/>    
+                        <xsl:sequence select="tools:getChildrenByModel(.)"/>
                     </xsl:for-each>
                 </xsl:if>
             </xsl:variable>
@@ -1445,7 +1445,7 @@
                 <xsl:sequence select="$macro.groups/self::tei:macroSpec[@ident = $object/tei:content//rng:ref/@name]"/>
             </xsl:variable>
             <xsl:for-each select="$inheriting.models">
-                <xsl:sequence select="tools:getChildrenByModel(.)"/>    
+                <xsl:sequence select="tools:getChildrenByModel(.)"/>
             </xsl:for-each>
         </xsl:if>
     </xsl:function>

--- a/utils/guidelines_xslt/odd2html/specs/macroGroupSpecs.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/macroGroupSpecs.xsl
@@ -77,7 +77,7 @@
                 </div>
                 <xsl:sequence select="$moduleFacet"/>
                 <!-- TODO: fix this: apparently recursive calls -->
-                <xsl:sequence select="$containedByFacet"/>                
+                <xsl:sequence select="$containedByFacet"/>
                 <xsl:sequence select="$mayContainFacet"/>
                 <xsl:sequence select="$declarationFacet"/>
             </div>

--- a/utils/guidelines_xslt/odd2html/specs/moduleSpecs.xsl
+++ b/utils/guidelines_xslt/odd2html/specs/moduleSpecs.xsl
@@ -77,7 +77,7 @@
             
             <div class="specs">
                 <div class="desc">
-                    <xsl:apply-templates select="$module/tei:desc/node()" mode="guidelines"/>                    
+                    <xsl:apply-templates select="$module/tei:desc/node()" mode="guidelines"/>
                 </div>
                 <div class="contentListBox">
                     <h3>Elements in <xsl:value-of select="$module/@ident"/></h3>
@@ -108,7 +108,7 @@
                             </xsl:for-each>
                         </xsl:variable>
                         <xsl:for-each select="$items">
-                            <a class="{tools:getLinkClasses(@ident)}" href="#{@ident}" title="{normalize-space(string-join(child::tei:desc//text(),' '))}"><xsl:value-of select="@ident"/></a><xsl:if test="position() lt count($items)">, </xsl:if>        
+                            <a class="{tools:getLinkClasses(@ident)}" href="#{@ident}" title="{normalize-space(string-join(child::tei:desc//text(),' '))}"><xsl:value-of select="@ident"/></a><xsl:if test="position() lt count($items)">, </xsl:if>
                         </xsl:for-each>
                         <xsl:if test="count($items) = 0">
                             <span class="placeholder">– no model classes defined in <xsl:value-of select="$module/@ident"/> – </span>
@@ -126,7 +126,7 @@
                             </xsl:for-each>
                         </xsl:variable>
                         <xsl:for-each select="$items">
-                            <a class="{tools:getLinkClasses(@ident)}" href="#{@ident}" title="{normalize-space(string-join(child::tei:desc//text(),' '))}"><xsl:value-of select="@ident"/></a><xsl:if test="position() lt count($items)">, </xsl:if>        
+                            <a class="{tools:getLinkClasses(@ident)}" href="#{@ident}" title="{normalize-space(string-join(child::tei:desc//text(),' '))}"><xsl:value-of select="@ident"/></a><xsl:if test="position() lt count($items)">, </xsl:if>
                         </xsl:for-each>
                         <xsl:if test="count($items) = 0">
                             <span class="placeholder">– no macro groups defined in <xsl:value-of select="$module/@ident"/> – </span>
@@ -144,7 +144,7 @@
                             </xsl:for-each>
                         </xsl:variable>
                         <xsl:for-each select="$items">
-                            <a class="{tools:getLinkClasses(@ident)}" href="#{@ident}" title="{normalize-space(string-join(child::tei:desc//text(),' '))}"><xsl:value-of select="@ident"/></a><xsl:if test="position() lt count($items)">, </xsl:if>        
+                            <a class="{tools:getLinkClasses(@ident)}" href="#{@ident}" title="{normalize-space(string-join(child::tei:desc//text(),' '))}"><xsl:value-of select="@ident"/></a><xsl:if test="position() lt count($items)">, </xsl:if>
                         </xsl:for-each>
                         <xsl:if test="count($items) = 0">
                             <span class="placeholder">– no attribute classes defined in <xsl:value-of select="$module/@ident"/> – </span>
@@ -162,7 +162,7 @@
                             </xsl:for-each>
                         </xsl:variable>
                         <xsl:for-each select="$items">
-                            <a class="{tools:getLinkClasses(@ident)}" href="#{@ident}" title="{normalize-space(string-join(child::tei:desc//text(),' '))}"><xsl:value-of select="@ident"/></a><xsl:if test="position() lt count($items)">, </xsl:if>        
+                            <a class="{tools:getLinkClasses(@ident)}" href="#{@ident}" title="{normalize-space(string-join(child::tei:desc//text(),' '))}"><xsl:value-of select="@ident"/></a><xsl:if test="position() lt count($items)">, </xsl:if>
                         </xsl:for-each>
                         <xsl:if test="count($items) = 0">
                             <span class="placeholder">– no data types defined in <xsl:value-of select="$module/@ident"/> – </span>


### PR DESCRIPTION
The new system of building Guidlines for all customizations broke the numbering of the chapters. 
This PR fixes this.

## before

<img width="458" height="488" alt="Bildschirmfoto 2025-11-28 um 18 27 28" src="https://github.com/user-attachments/assets/009a9f68-cf78-4f2a-b07e-151ab7e50f6c" />

## after

<img width="457" height="419" alt="Bildschirmfoto 2025-11-28 um 18 28 22" src="https://github.com/user-attachments/assets/2072aab7-88ca-4105-bf69-d09fcb17359b" />
