### PR TITLE
schema: add exemplums for `@intm`

### DIFF
--- a/source/modules/MEI.analytical.xml
+++ b/source/modules/MEI.analytical.xml
@@ -268,9 +268,9 @@
               <staff>
                 <layer>
                   <note dur="4" oct="4" pname="c" />
-                  <note dur="4" oct="4" pname="d" intm="1.1" />
-                  <note dur="4" oct="5" pname="d" intm="7.9" />
-                  <note dur="4" oct="5" pname="c" intm="-2.334" />
+                  <note dur="4" oct="4" pname="d" intm="2hs" />
+                  <note dur="4" oct="5" pname="d" intm="12hs" />
+                  <note dur="4" oct="5" pname="c" intm="-2.334hs" />
                 </layer>
               </staff>
             </measure>

--- a/source/modules/MEI.analytical.xml
+++ b/source/modules/MEI.analytical.xml
@@ -229,6 +229,53 @@
         <datatype>
           <rng:ref name="data.INTERVAL.MELODIC"/>
         </datatype>
+        <exemplum xml:lang="en">
+          <p>The following example shows interval relationships indicated by the Parsons Code:</p>
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <measure n="1">
+              <staff n="1">
+                <layer>
+                  <note dur="4" oct="4" pname="c" />
+                  <note dur="4" oct="4" pname="d" intm="u" />
+                  <note dur="4" oct="4" pname="e" intm="u" />
+                  <note dur="4" oct="4" pname="f" intm="u" />
+                  <note dur="2" oct="4" pname="g" intm="u" />
+                  <note dur="2" oct="4" pname="g" intm="s" />
+                  <note dur="4" oct="4" pname="f" intm="d" />
+                </layer>
+              </staff>
+            </measure>
+          </egXML>
+        </exemplum>
+        <exemplum xml:lang="en">
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <measure>
+              <staff>
+                <layer>
+                  <note dur="4" oct="5" pname="c" />
+                  <note dur="4" oct="5" pname="d" intm="+M2" />
+                  <note dur="4" oct="5" pname="c" intm="-M2" />
+                  <note dur="4" oct="4" pname="b" intm="-m2" />
+                  <note dur="4" oct="3" pname="b" intm="-P8" />
+                </layer>
+              </staff>
+            </measure>
+          </egXML>
+        </exemplum>
+        <exemplum xml:lang="en">
+          <egXML xmlns="http://www.tei-c.org/ns/Examples">
+            <measure>
+              <staff>
+                <layer>
+                  <note dur="4" oct="4" pname="c" />
+                  <note dur="4" oct="4" pname="d" intm="1.1" />
+                  <note dur="4" oct="5" pname="d" intm="7.9" />
+                  <note dur="4" oct="5" pname="c" intm="-2.334" />
+                </layer>
+              </staff>
+            </measure>
+          </egXML>
+        </exemplum>
       </attDef>
     </attList>
   </classSpec>

--- a/source/modules/MEI.edittrans.xml
+++ b/source/modules/MEI.edittrans.xml
@@ -328,17 +328,17 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <exemplum>
+    <exemplum xml:lang="en">
       <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:space="preserve">
           <cpMark tstamp="1" tstamp2="5m+4" staff="8" origin.tstamp="-6m+1">a. b. c. d. e. f. g.</cpMark>
         </egXML>
     </exemplum>
-    <exemplum>
+    <exemplum xml:lang="en">
       <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:space="preserve">
           <cpMark tstamp="1.5" tstamp2="1m+3.5" staff="9" origin.staff="8">unis:</cpMark>
         </egXML>
     </exemplum>
-    <exemplum>
+    <exemplum xml:lang="en">
       <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:space="preserve">
           <cpMark tstamp="2" tstamp2="2m+3.5" staff="9" origin.staff="8" dis="8" dis.place="below">in 8va</cpMark>
         </egXML>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -953,7 +953,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <exemplum>
+    <exemplum xml:lang="en">
       <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:space="preserve">
 <contents>
   <p>A suitable tone ; Left hand coloring ; Rhythm and accent ; Tempo ; 
@@ -961,7 +961,7 @@
 </contents>
             </egXML>
     </exemplum>
-    <exemplum>
+    <exemplum xml:lang="en">
       <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:space="preserve">
 <contents>
   <head>Contents</head>
@@ -974,7 +974,7 @@
 </contents>
             </egXML>
     </exemplum>
-    <exemplum>
+    <exemplum xml:lang="en">
       <egXML xmlns="http://www.tei-c.org/ns/Examples" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
 <contents target="http://www.contentProvider.org/toc/toc01.html"/>
             </egXML>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3402,7 +3402,7 @@
         <rng:param name="pattern">[i|m|t][1-6]</rng:param>
       </rng:data>
     </content>
-    <exemplum>
+    <exemplum xml:lang="en">
       <egXML xmlns="http://www.tei-c.org/ns/Examples" xml:space="preserve" valid="feasible">
 <note slur="i1 i2"/>
 <note slur="t1"/>


### PR DESCRIPTION
Trying to extend the exemplums we currently have in the schema. First adding three examples back from the Guidelines to `@intm`. 
Additionally use markup for the citation and change the HTML generation for `tei:bibl`.
