### PR TITLE
schema: develop text phrase like

### DIFF
--- a/source/modules/MEI.figtable.xml
+++ b/source/modules/MEI.figtable.xml
@@ -49,7 +49,7 @@
     <desc xml:lang="en">Groups elements representing or containing graphic information such as an illustration or
       figure.</desc>
     <classes>
-      <memberOf key="model.textPhraseLike.bare"/>
+      <memberOf key="model.textPhraseLike.basic"/>
     </classes>
   </classSpec>
   <classSpec ident="model.graphicLike" module="MEI.figtable" type="model">

--- a/source/modules/MEI.figtable.xml
+++ b/source/modules/MEI.figtable.xml
@@ -49,7 +49,7 @@
     <desc xml:lang="en">Groups elements representing or containing graphic information such as an illustration or
       figure.</desc>
     <classes>
-      <memberOf key="model.textPhraseLike.limited"/>
+      <memberOf key="model.textPhraseLike.bare"/>
     </classes>
   </classSpec>
   <classSpec ident="model.graphicLike" module="MEI.figtable" type="model">

--- a/source/modules/MEI.namesdates.xml
+++ b/source/modules/MEI.namesdates.xml
@@ -41,6 +41,7 @@
     <classes>
       <memberOf key="model.eventPart"/>
       <memberOf key="model.nameLike"/>
+      <memberOf key="model.textPhraseLike.limited"/>
     </classes>
   </classSpec>
   <classSpec ident="model.nameLike.geogName" module="MEI.namesdates" type="model">
@@ -53,6 +54,7 @@
   <classSpec ident="model.nameLike.label" module="MEI.namesdates" type="model">
     <desc xml:lang="en">Groups elements that serve as stylistic labels.</desc>
     <classes>
+      <memberOf key="model.nameLike"/>
       <memberOf key="model.textPhraseLike.limited"/>
     </classes>
   </classSpec>
@@ -60,6 +62,7 @@
     <desc xml:lang="en">Groups place name elements.</desc>
     <classes>
       <memberOf key="model.nameLike"/>
+      <memberOf key="model.textPhraseLike.limited"/>
     </classes>
   </classSpec>
   <classSpec ident="model.persNamePart" module="MEI.namesdates" type="model">

--- a/source/modules/MEI.ptrref.xml
+++ b/source/modules/MEI.ptrref.xml
@@ -27,7 +27,7 @@
   <classSpec ident="model.locrefLike" module="MEI.ptrref" type="model">
     <desc xml:lang="en">Groups elements used for purposes of location and reference.</desc>
     <classes>
-      <memberOf key="model.textPhraseLike.basic"/>
+      <memberOf key="model.textPhraseLike.bare"/>
     </classes>
   </classSpec>
   <elementSpec ident="ptr" module="MEI.ptrref">

--- a/source/modules/MEI.ptrref.xml
+++ b/source/modules/MEI.ptrref.xml
@@ -27,7 +27,7 @@
   <classSpec ident="model.locrefLike" module="MEI.ptrref" type="model">
     <desc xml:lang="en">Groups elements used for purposes of location and reference.</desc>
     <classes>
-      <memberOf key="model.textPhraseLike.limited"/>
+      <memberOf key="model.textPhraseLike.basic"/>
     </classes>
   </classSpec>
   <elementSpec ident="ptr" module="MEI.ptrref">

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -4551,7 +4551,7 @@
     <desc xml:lang="en">Groups rudimentary textual elements that occur at the level of individual words or
       phrases.</desc>
     <classes>
-      <memberOf key="model.texPhraseLike.limited"/>
+      <memberOf key="model.textPhraseLike.limited"/>
     </classes>
   </classSpec>
   <classSpec ident="model.textPhraseLike.limited" module="MEI.shared" type="model">

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -4211,7 +4211,7 @@
   <classSpec ident="model.addressLike" module="MEI.shared" type="model">
     <desc xml:lang="en">Groups elements used to represent a postal address.</desc>
     <classes>
-      <memberOf key="model.textPhraseLike.limited"/>
+      <memberOf key="model.textPhraseLike.basic"/>
       <memberOf key="model.pubStmtPart"/>
       <memberOf key="model.eventPart"/>
     </classes>
@@ -4219,13 +4219,13 @@
   <classSpec ident="model.annotLike" module="MEI.shared" type="model">
     <desc xml:lang="en">Groups annotation-like elements.</desc>
     <classes>
-      <memberOf key="model.textPhraseLike.limited"/>
+      <memberOf key="model.textPhraseLike.basic"/>
     </classes>
   </classSpec>
   <classSpec ident="model.biblLike" module="MEI.shared" type="model">
     <desc xml:lang="en">Groups elements containing a bibliographic description.</desc>
     <classes>
-      <memberOf key="model.textPhraseLike.limited"/>
+      <memberOf key="model.textPhraseLike.basic"/>
     </classes>
   </classSpec>
   <classSpec ident="model.biblPart" module="MEI.shared" type="model">
@@ -4252,7 +4252,7 @@
   <classSpec ident="model.dateLike" module="MEI.shared" type="model">
     <desc xml:lang="en">Groups elements containing date expressions.</desc>
     <classes>
-      <memberOf key="model.textPhraseLike.limited"/>
+      <memberOf key="model.textPhraseLike.basic"/>
       <memberOf key="model.pubStmtPart"/>
       <memberOf key="model.eventPart"/>
       <memberOf key="model.titlePagePart"/>
@@ -4278,7 +4278,7 @@
   <classSpec ident="model.editorialLike" module="MEI.shared" type="model">
     <desc xml:lang="en">Groups editorial intervention elements.</desc>
     <classes>
-      <memberOf key="model.textPhraseLike.limited"/>
+      <memberOf key="model.textPhraseLike.basic"/>
       <memberOf key="model.choicePart"/>
     </classes>
   </classSpec>
@@ -4302,7 +4302,7 @@
   <classSpec ident="model.identifierLike" module="MEI.shared" type="model">
     <desc xml:lang="en">Groups identifier-like elements.</desc>
     <classes>
-      <memberOf key="model.textPhraseLike.limited"/>
+      <memberOf key="model.textPhraseLike.basic"/>
       <memberOf key="model.pubStmtPart"/>
       <memberOf key="model.titlePagePart"/>
     </classes>
@@ -4367,7 +4367,7 @@
   <classSpec ident="model.measurementLike" module="MEI.shared" type="model">
     <desc xml:lang="en">Groups elements that represent a measurement.</desc>
     <classes>
-      <memberOf key="model.textPhraseLike.limited"/>
+      <memberOf key="model.textPhraseLike.basic"/>
     </classes>
   </classSpec>
   <classSpec ident="model.meterSigLike" module="MEI.shared" type="model">
@@ -4566,7 +4566,7 @@
   <classSpec ident="model.titleLike" module="MEI.shared" type="model">
     <desc xml:lang="en">Groups elements that denote the name of a bibliographic item.</desc>
     <classes>
-      <memberOf key="model.textPhraseLike.limited"/>
+      <memberOf key="model.textPhraseLike.basic"/>
       <memberOf key="model.titlePagePart"/>
     </classes>
   </classSpec>
@@ -6802,6 +6802,7 @@
       <memberOf key="att.responsibility"/>
       <memberOf key="model.eventPart"/>
       <memberOf key="model.nameLike"/>
+      <memberOf key="model.textPhraseLike.basic"/>
     </classes>
     <content>
       <rng:zeroOrMore>
@@ -8404,7 +8405,7 @@
       <memberOf key="att.bibl"/>
       <memberOf key="att.dataPointing"/>
       <memberOf key="att.lang"/>
-      <memberOf key="model.textPhraseLike.limited"/>
+      <memberOf key="model.textPhraseLike.basic"/>
     </classes>
     <content>
       <rng:zeroOrMore>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -4358,7 +4358,7 @@
     <desc xml:lang="en">Groups elements that function like line beginnings.</desc>
     <classes>
       <memberOf key="model.milestoneLike.text"/>
-      <memberOf key="model.textPhraseLike.basic"/>
+      <memberOf key="model.textPhraseLike.bare"/>
     </classes>
   </classSpec>
   <classSpec ident="model.mdivLike" module="MEI.shared" type="model">
@@ -4434,7 +4434,7 @@
   <classSpec ident="model.rendLike" module="MEI.shared" type="model">
     <desc xml:lang="en">Groups elements that mark typographical features.</desc>
     <classes>
-      <memberOf key="model.textPhraseLike.basic"/>
+      <memberOf key="model.textPhraseLike.bare"/>
     </classes>
   </classSpec>
   <classSpec ident="model.repositoryLike" module="MEI.shared" type="model">
@@ -4547,8 +4547,15 @@
       <memberOf key="model.paracontentPart"/>
     </classes>
   </classSpec>
-  <classSpec ident="model.textPhraseLike.basic" module="MEI.shared" type="model">
+  <classSpec ident="model.textPhraseLike.bare" module="MEI.shared" type="model">
     <desc xml:lang="en">Groups rudimentary textual elements that occur at the level of individual words or
+      phrases.</desc>
+    <classes>
+      <memberOf key="model.textPhraseLike.basic"/>
+    </classes>
+  </classSpec>
+  <classSpec ident="model.textPhraseLike.basic" module="MEI.shared" type="model">
+    <desc xml:lang="en">Groups basic textual elements that occur at the level of individual words or
       phrases.</desc>
     <classes>
       <memberOf key="model.textPhraseLike.limited"/>
@@ -8325,7 +8332,7 @@
       <memberOf key="att.symbol.ges"/>
       <memberOf key="att.symbol.log"/>
       <memberOf key="att.symbol.vis"/>
-      <memberOf key="model.textPhraseLike.basic"/>
+      <memberOf key="model.textPhraseLike.bare"/>
     </classes>
     <content>
       <empty/>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -5570,7 +5570,7 @@
       <memberOf key="att.lang"/>
       <memberOf key="att.measurement"/>
       <memberOf key="model.physDescPart"/>
-      <memberOf key="model.textPhraseLike.limited"/>
+      <memberOf key="model.textPhraseLike.basic"/>
     </classes>
     <content>
       <rng:ref name="macro.struc-unstrucContent"/>
@@ -6052,7 +6052,7 @@
       <memberOf key="att.lang"/>
       <memberOf key="att.quantity"/>
       <memberOf key="model.physDescPart"/>
-      <memberOf key="model.textPhraseLike.limited"/>
+      <memberOf key="model.textPhraseLike.basic"/>
     </classes>
     <content>
       <rng:zeroOrMore>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -4358,7 +4358,7 @@
     <desc xml:lang="en">Groups elements that function like line beginnings.</desc>
     <classes>
       <memberOf key="model.milestoneLike.text"/>
-      <memberOf key="model.textPhraseLike.limited"/>
+      <memberOf key="model.textPhraseLike.basic"/>
     </classes>
   </classSpec>
   <classSpec ident="model.mdivLike" module="MEI.shared" type="model">
@@ -4434,7 +4434,7 @@
   <classSpec ident="model.rendLike" module="MEI.shared" type="model">
     <desc xml:lang="en">Groups elements that mark typographical features.</desc>
     <classes>
-      <memberOf key="model.textPhraseLike.limited"/>
+      <memberOf key="model.textPhraseLike.basic"/>
     </classes>
   </classSpec>
   <classSpec ident="model.repositoryLike" module="MEI.shared" type="model">
@@ -4545,6 +4545,13 @@
     <desc xml:lang="en">Groups textual elements that occur at the level of individual words or phrases.</desc>
     <classes>
       <memberOf key="model.paracontentPart"/>
+    </classes>
+  </classSpec>
+  <classSpec ident="model.textPhraseLike.basic" module="MEI.shared" type="model">
+    <desc xml:lang="en">Groups rudimentary textual elements that occur at the level of individual words or
+      phrases.</desc>
+    <classes>
+      <memberOf key="model.texPhraseLike.limited"/>
     </classes>
   </classSpec>
   <classSpec ident="model.textPhraseLike.limited" module="MEI.shared" type="model">
@@ -8317,7 +8324,7 @@
       <memberOf key="att.symbol.ges"/>
       <memberOf key="att.symbol.log"/>
       <memberOf key="att.symbol.vis"/>
-      <memberOf key="model.textPhraseLike.limited"/>
+      <memberOf key="model.textPhraseLike.basic"/>
     </classes>
     <content>
       <empty/>

--- a/source/modules/MEI.text.xml
+++ b/source/modules/MEI.text.xml
@@ -456,7 +456,7 @@
       <memberOf key="att.common"/>
       <memberOf key="att.facsimile"/>
       <memberOf key="att.lang"/>
-      <memberOf key="model.textPhraseLike.limited"/>
+      <memberOf key="model.textPhraseLike.bare"/>
     </classes>
     <content>
       <rng:zeroOrMore>


### PR DESCRIPTION
This request lays the groundwork for future requests by creating new textPhraseLike classes that are more basic/elemental than textPhraseLike.limited; i.e. textPhraseLike.bare and textPhraseLike.basic, and by modifying the textPhraseLike.limited class.

The textPhraseLike.bare class only allows the following elements: lb, ptr, ref, rend, stack, seg, and symbol.

The textPhraseLike.basic class allows: abbr, address, annot, bibl, biblStruct, date, dimensions, expan, extent, fig, identifier, name, num, term, and title, plus the members of textPhraseLike.bare.

The textPhraseLike.limited class allows: bloc, corpName, country, depth, dim, dimensions, district, extent, geogFeat, geogName, height, periodName, persName, postBox, postCode, q, region, relation, relationList, repository, settlement,  street, styleName, and width, plus the members of textPhraseLike.basic.

Just to refresh the collective memory, the textPhraseLike class allows all the members of textPhraseLike.limited, plus the `<pb>` element. It has not been modified.

The new class hierarchy can be used to specify what's allowed in text with more detail than before, for example, in metadata elements.
