### PR TITLE
schema: make `<term>` member of att.authorized

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -8482,6 +8482,7 @@
     <desc xml:lang="en">Keyword or phrase which describes a resource.</desc>
     <classes>
       <memberOf key="att.common"/>
+      <memberOf key="att.authorized"/>
       <memberOf key="att.bibl"/>
       <memberOf key="att.dataPointing"/>
       <memberOf key="att.lang"/>


### PR DESCRIPTION
Adding `att.authorized` class makes it possible to associate a term with an authorizing source.