### PR TITLE
guidelines: add missing documentation of physMedium (issue 1222)

### DIFF
--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -1543,6 +1543,17 @@
                         </figure>
                      </p>
                      <p><specList>
+                           <specDesc key="physMedium"/>
+                     </specList></p>
+                     <p><gi>physMedium</gi> is intended to capture technical metadata in a narrative form. One should think of this element as a container for notes on or a synopsis of the physical characteristics of an item rather than a place to capture the characteristics themselves. It can used instead of or in addition to the structured sub-elements of <gi>physDesc</gi>. For example,</p>
+                     <p>
+                        <figure>
+                           <head>Example of <gi scheme="MEI">physMedium</gi></head>
+                           <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/header/header-sample097.txt" parse="text"/></egXML>
+                        </figure>
+                     </p>
+                     <p>It is possible to use more than one <gi>physMedium</gi> elements.</p>
+                     <p><specList>
                         <specDesc key="scoreFormat"/>
                      </specList></p>
                      <p>The <gi scheme="MEI">scoreFormat</gi> element is a form of classification. This element is part of <gi scheme="MEI">physDesc</gi> because within the MARC21 standard, the format of the music (score, piano score, etc.) is defined as a physical property.</p>

--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -1545,14 +1545,14 @@
                      <p><specList>
                            <specDesc key="physMedium"/>
                      </specList></p>
-                     <p><gi>physMedium</gi> is intended to capture technical metadata in a narrative form. One should think of this element as a container for notes on or a synopsis of the physical characteristics of an item rather than a place to capture the characteristics themselves. It can used instead of or in addition to the structured sub-elements of <gi>physDesc</gi>. For example,</p>
+                     <p><gi scheme="MEI">physMedium</gi> is intended to capture technical metadata in a narrative form. One should think of this element as a container for notes on or a synopsis of the physical characteristics of an item rather than a place to capture the characteristics themselves. It can used instead of or in addition to the structured sub-elements of <gi scheme="MEI">physDesc</gi>. For example,</p>
                      <p>
                         <figure>
                            <head>Example of <gi scheme="MEI">physMedium</gi></head>
                            <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/header/header-sample097.txt" parse="text"/></egXML>
                         </figure>
                      </p>
-                     <p>It is possible to use more than one <gi>physMedium</gi> elements.</p>
+                     <p>It is possible to use more than one <gi scheme="MEI">physMedium</gi> elements.</p>
                      <p><specList>
                         <specDesc key="scoreFormat"/>
                      </specList></p>

--- a/source/examples/header/header-sample097.txt
+++ b/source/examples/header/header-sample097.txt
@@ -1,0 +1,13 @@
+<physDesc xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1+anyStart">
+  <carrierForm>sound disc</carrierForm>
+  <captureMode>analog</captureMode>
+  <dimensions unit="in" type="diameter">4.7</dimensions>
+  <perfDuration isodur="PT12H30M5S">1:33:02</perfDuration>
+  <soundChan num="2">stereo</soundChan>
+  <supportDesc>polycarbonate plastic</supportDesc>
+  <physMedium>1.2-millimetre (0.047 in) thick, polycarbonate plastic, and weighs 14–33
+    grams. A thin layer of aluminum or, more rarely, gold is applied to the surface,
+    making it reflective. The metal is protected by a film of lacquer normally spin coated
+    directly on the reflective layer. The label is printed on the lacquer layer, usually
+    by screen printing or offset printing. (https://en.wikipedia.org/wiki/Compact_disc)</physMedium>
+</physDesc>

--- a/source/examples/header/header-sample097.txt
+++ b/source/examples/header/header-sample097.txt
@@ -1,4 +1,4 @@
-<physDesc xmlns="http://www.music-encoding.org/ns/mei" meiversion="5.1+anyStart">
+<physDesc>
   <carrierForm>sound disc</carrierForm>
   <captureMode>analog</captureMode>
   <dimensions unit="in" type="diameter">4.7</dimensions>


### PR DESCRIPTION
Fixes #1222

This PR introduces documentation for `<physMedium>`. It has been adressed in https://github.com/music-encoding/metadata-ig/issues/29. The text has been revised by @pe-ro

closes https://github.com/music-encoding/metadata-ig/issues/29