### PR TITLE
schema: restructure the struc-unstrucContent macro

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -80,7 +80,7 @@
     </content>
   </macroSpec>
   <macroSpec ident="macro.struc-unstrucContent" module="MEI.shared" type="pe">
-    <desc xml:lang="en">Provides a choice between structured and unstructured/mixed content.</desc>
+    <desc xml:lang="en">Provides a choice between structured and unstructured text content.</desc>
     <content>
       <rng:choice>
         <rng:group>
@@ -94,7 +94,7 @@
         <rng:zeroOrMore>
           <rng:choice>
             <rng:text/>
-            <rng:ref name="model.textPhraseLike.limited"/>
+            <rng:ref name="model.textPhraseLike.basic"/>
           </rng:choice>
         </rng:zeroOrMore>
       </rng:choice>


### PR DESCRIPTION
Restricting the struc-unstrucContent macro will allow fewer sub-elements in those places where the macro is used; that is, mostly in metadata elements in the header.  If more markup granularity is desired, one can use the `<p>` element that's part of the structured part of the macro.