### PR TITLE
schema: update remarks for `<persName>` element

### DIFF
--- a/source/modules/MEI.namesdates.xml
+++ b/source/modules/MEI.namesdates.xml
@@ -425,11 +425,15 @@
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
-      <p>Parts of a personal name may be captured using <gi scheme="MEI">persName</gi> sub-elements.
-        For greater specificity, however, use foreName, famName, genName, addName, genName,
-        nameLink, and roleName elements. The name of the list from which a controlled value for
-        persName is taken may be recorded using the <att>auth</att> attribute.</p>
-      <p>The model of this element is based on the <ref target="https://www.loc.gov/ead/EAD3taglib/EAD3-TL-eng.html#elem-persname">persname</ref> element of the Encoded Archival Description (EAD).</p>
+      <p>Parts of a personal name may be captured using <gi scheme="MEI">name</gi> or 
+        <gi scheme="MEI">persName</gi> sub-elements. For greater specificity, however, the use
+        of <gi scheme="MEI">foreName</gi>, <gi scheme="MEI">famName</gi>, <gi scheme="MEI">genName</gi>, 
+        <gi scheme="MEI">addName</gi>, <gi scheme="MEI">genName</gi>, <gi scheme="MEI">nameLink</gi>, and 
+        <gi scheme="MEI">roleName</gi> elements is recommended. The name of the list from which a controlled
+        value for persName is taken may be recorded using the <att>auth</att> attribute.</p>
+      <p>The model of this element is based on the 
+        <ref target="https://www.loc.gov/ead/EAD3taglib/EAD3-TL-eng.html#elem-persname">persname</ref> element
+        of the Encoded Archival Description (EAD).</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="postBox" module="MEI.namesdates">

--- a/source/modules/MEI.namesdates.xml
+++ b/source/modules/MEI.namesdates.xml
@@ -428,7 +428,7 @@
       <p>Parts of a personal name may be captured using <gi scheme="MEI">name</gi> or 
         <gi scheme="MEI">persName</gi> sub-elements. For greater specificity, however, the use
         of <gi scheme="MEI">foreName</gi>, <gi scheme="MEI">famName</gi>, <gi scheme="MEI">genName</gi>, 
-        <gi scheme="MEI">addName</gi>, <gi scheme="MEI">genName</gi>, <gi scheme="MEI">nameLink</gi>, and 
+        <gi scheme="MEI">addName</gi>, <gi scheme="MEI">nameLink</gi>, and 
         <gi scheme="MEI">roleName</gi> elements is recommended. The name of the list from which a controlled
         value for persName is taken may be recorded using the <att>auth</att> attribute.</p>
       <p>The model of this element is based on the 


### PR DESCRIPTION
In addition to `<persName>` sub-elements, `<name>` sub-elements are permitted.