### PR TITLE
schema: rename metaMark attribute 'function' to 'func'

### DIFF
--- a/source/modules/MEI.edittrans.xml
+++ b/source/modules/MEI.edittrans.xml
@@ -652,7 +652,7 @@
       </constraint>
     </constraintSpec>
     <attList>
-      <attDef ident="function" usage="opt">
+      <attDef ident="func" usage="opt">
         <desc xml:lang="en">Describes the purpose of the metaMark.</desc>
         <datatype>
           <rng:data type="NMTOKEN"/>


### PR DESCRIPTION
For consistency's sake, `@function` should be renamed to `@func`.