### PR TITLE
schema: restrict content model of `<titleStmt>`

### DIFF
--- a/source/examples/header/header-sample022.txt
+++ b/source/examples/header/header-sample022.txt
@@ -1,5 +1,5 @@
 <titleStmt>
    <title>Auf dem Hügel sitz ich spähend : an electronic transcription</title>
-   <composer>Ludwig van Beethoven</composer>
-   <lyricist>Aloys Jeitteles</lyricist>
+   <persName role="composer">Ludwig van Beethoven</persName>
+   <persName role="lyricist">Aloys Jeitteles</persName>
 </titleStmt>

--- a/source/examples/header/header-sample023.txt
+++ b/source/examples/header/header-sample023.txt
@@ -1,7 +1,7 @@
 <titleStmt>
    <title>Auf dem Hügel sitz ich spähend : an electronic transcription</title>
-   <composer>Ludwig van Beethoven</composer>
-   <lyricist>Aloys Jeitteles</lyricist>
+   <persName role="composer">Ludwig van Beethoven</persName>
+   <persName role="lyricist">Aloys Jeitteles</persName>
    <respStmt>
       <resp>Encoded by</resp>
       <name>Maja Hartwig</name>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -2713,7 +2713,10 @@
         <rng:ref name="model.titleLike"/>
       </rng:oneOrMore>
       <rng:zeroOrMore>
-        <rng:ref name="model.respLike"/>
+        <rng:ref name="model.nameLike.agent"/>
+      </rng:zeroOrMore>
+      <rng:zeroOrMore>
+        <rng:ref name="name"/>
       </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -2718,6 +2718,9 @@
       <rng:zeroOrMore>
         <rng:ref name="name"/>
       </rng:zeroOrMore>
+      <rng:zeroOrMore>
+        <rng:ref name="respStmt"/>
+      </rng:zeroOrMore>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-titleStmt.html">titleStmt</ref> element of the Text Encoding Initiative (TEI).</p>


### PR DESCRIPTION
In #1593 there are these tasks:

- [x] remove model.respLike from content of <titleStmt> to avoid misuse of elements like <composer>
- [x] revise GL 3.3.2 (text)
- [x] revise GL 3.3.2 (examples)

This PR contains longer outstanding commits from my fork.

Fix #1593 