### PR TITLE
guidelines: add basic documentation for `<epigraph>`

### DIFF
--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -1478,6 +1478,13 @@
                         </figure>
                      </p>
                      <p>The physical appearance of title page information is often of considerable importance. One approach to capturing the appearance is to use the <gi scheme="MEI">rend</gi> element, described in chapter <ptr target="#sharedTextRendition"/> to specify the placement of each of the components of the title page. Another would be to employ a CSS stylesheet. Finally, a module customized for the description of typographic entities such as pages, lines, rules, etc., bearing special-purpose attributes to describe line-height, leading, degree of kerning, font, etc. could be employed.</p>
+                     <p>A title page can also contain an <gi scheme="MEI">epigraph</gi>, which is a short quotation or motto placed at the beginning of a text (or a major division of it) to set a tone, theme, or interpretive frame. An epigraph typically consists of the quoted text plus (when known) a citation/attribution.:</p>
+                     <p>
+                        <figure>
+                           <head>Example of <gi scheme="MEI">epigraph</gi></head>
+                           <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/header/header-sample102.txt" parse="text"/></egXML>
+                        </figure>
+                     </p>
                   </div>
                   <div xml:id="physicalProperties" type="div4">
                      <head>Physical Properties</head>

--- a/source/docs/03-metadata.xml
+++ b/source/docs/03-metadata.xml
@@ -1478,7 +1478,7 @@
                         </figure>
                      </p>
                      <p>The physical appearance of title page information is often of considerable importance. One approach to capturing the appearance is to use the <gi scheme="MEI">rend</gi> element, described in chapter <ptr target="#sharedTextRendition"/> to specify the placement of each of the components of the title page. Another would be to employ a CSS stylesheet. Finally, a module customized for the description of typographic entities such as pages, lines, rules, etc., bearing special-purpose attributes to describe line-height, leading, degree of kerning, font, etc. could be employed.</p>
-                     <p>A title page can also contain an <gi scheme="MEI">epigraph</gi>, which is a short quotation or motto placed at the beginning of a text (or a major division of it) to set a tone, theme, or interpretive frame. An epigraph typically consists of the quoted text plus (when known) a citation/attribution.:</p>
+                     <p>A title page can also contain an <gi scheme="MEI">epigraph</gi>, which is a short quotation or motto placed at the beginning of a text (or a major division of it) to set a tone, theme, or interpretive frame. An epigraph typically consists of the quoted text plus (when known) a citation/attribution.</p>
                      <p>
                         <figure>
                            <head>Example of <gi scheme="MEI">epigraph</gi></head>

--- a/source/examples/header/header-sample102.txt
+++ b/source/examples/header/header-sample102.txt
@@ -1,0 +1,4 @@
+<epigraph>
+  <quote>Non omnis moriar.</quote>
+  <bibl>Horace, <title>Odes</title> 3.30</bibl>
+</epigraph>


### PR DESCRIPTION
The element `<epigraph>` was missing in the `<titlePage>` section of the guidelines. This PR provides a basic description including an example.

fixes https://github.com/music-encoding/metadata-ig/issues/28