### PR TITLE
MEI.shared: fix – add `rng`-prefix to rng elements remove `mei_` prefix from references

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -80,44 +80,43 @@
     </content>
   </macroSpec>
   <macroSpec ident="macro.profileDescPart" module="MEI.shared" type="pe">
-    <desc xml:lang="en">Groups elements that capture a portion of a bibliographic
-      description.</desc>
+    <desc xml:lang="en">Groups elements that capture a portion of a bibliographic description.</desc>
     <content>
-      <interleave>
-        <optional>
-          <ref name="mei_audience"/>
-        </optional>
-        <optional>
-          <ref name="mei_classification"/>
-        </optional>
-        <optional>
-          <ref name="mei_contents"/>
-        </optional>
-        <optional>
-          <ref name="mei_context"/>
-        </optional>
-        <optional>
-          <ref name="mei_creation"/>
-        </optional>
-        <optional>
-          <ref name="mei_dedication"/>
-        </optional>
-        <optional>
-          <ref name="mei_history"/>
-        </optional>
-        <optional>
-          <ref name="mei_langUsage"/>
-        </optional>
-        <optional>
-          <ref name="mei_otherChar"/>
-        </optional>
-        <optional>
-          <ref name="mei_perfDuration"/>
-        </optional>
-        <optional>
-          <ref name="mei_perfMedium"/>
-        </optional>
-      </interleave>
+      <rng:interleave>
+        <rng:optional>
+          <rng:ref name="audience"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="classification"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="contents"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="context"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="creation"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="dedication"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="history"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="langUsage"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="otherChar"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="perfDuration"/>
+        </rng:optional>
+        <rng:optional>
+          <rng:ref name="perfMedium"/>
+        </rng:optional>
+      </rng:interleave>
     </content>
   </macroSpec>
   <macroSpec ident="macro.struc-unstrucContent" module="MEI.shared" type="pe">


### PR DESCRIPTION
The build failed due to a malformed syntax this PR fixes that