### PR TITLE
add macro, fixing issue 919

### DIFF
--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -420,12 +420,7 @@
       <memberOf key="att.lang"/>
     </classes>
     <content>
-      <rng:oneOrMore>
-        <rng:choice>
-          <rng:ref name="macro.histAccount"/>
-          <rng:text/>
-        </rng:choice>
-      </rng:oneOrMore>
+      <rng:ref name="macro.histAccount"/>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-acquisition.html">acquisition</ref> element of the Text Encoding Initiative (TEI).</p>
@@ -1291,12 +1286,7 @@
       <memberOf key="att.lang"/>
     </classes>
     <content>
-      <rng:oneOrMore>
-        <rng:choice>
-          <rng:ref name="macro.histAccount"/>
-          <rng:text/>
-        </rng:choice>
-      </rng:oneOrMore>
+      <rng:ref name="macro.histAccount"/>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <abbr>MARC</abbr> <ref target="https://www.loc.gov/marc/bibliographic/bd585.html">585</ref> field.</p>
@@ -2261,12 +2251,7 @@
       <memberOf key="att.lang"/>
     </classes>
     <content>
-      <rng:oneOrMore>
-        <rng:choice>
-          <rng:ref name="macro.histAccount"/>
-          <rng:text/>
-        </rng:choice>
-      </rng:oneOrMore>
+      <rng:ref name="macro.histAccount"/>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the respective element of the Encoded Archival Description (EAD) and the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-provenance.html">provenance</ref> element of the Text
@@ -2774,12 +2759,7 @@
       <memberOf key="att.lang"/>
     </classes>
     <content>
-      <rng:oneOrMore>
-        <rng:choice>
-          <rng:ref name="macro.histAccount"/>
-          <rng:text/>
-        </rng:choice>
-      </rng:oneOrMore>
+      <rng:ref name="macro.histAccount"/>
     </content>
     <remarks xml:lang="en">
       <p>Treatment history may also comprise details of the treatment process (<abbr>e.g.</abbr>, chemical
@@ -2798,12 +2778,7 @@
       <memberOf key="att.lang"/>
     </classes>
     <content>
-      <rng:oneOrMore>
-        <rng:choice>
-          <rng:ref name="macro.histAccount"/>
-          <rng:text/>
-        </rng:choice>
-      </rng:oneOrMore>
+      <rng:ref name="macro.histAccount"/>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the respective element of the Encoded Archival Description (EAD).</p>

--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -74,6 +74,30 @@
       </rng:zeroOrMore>
     </content>
   </macroSpec>
+  <macroSpec ident="macro.histAccount" module="MEI.header" type="pe">
+    <desc xml:lang="en">Content model for elements that can be used to describe historical account.</desc>
+    <content>
+      <rng:choice>
+        <rng:group>
+          <rng:zeroOrMore>
+            <rng:ref name="model.headLike"/>
+          </rng:zeroOrMore>
+          <rng:zeroOrMore>
+            <rng:choice>
+              <rng:ref name="eventList"/>
+              <rng:ref name="model.pLike"/>
+            </rng:choice>
+          </rng:zeroOrMore>
+        </rng:group>
+        <rng:zeroOrMore>
+          <rng:choice>
+            <rng:text/>
+            <rng:ref name="model.textPhraseLike.limited"/>
+          </rng:choice>
+        </rng:zeroOrMore>
+      </rng:choice>
+    </content>
+  </macroSpec>
   <classSpec ident="att.bifoliumSurfaces" module="MEI.header" type="atts">
     <desc xml:lang="en">Attributes that link a bifolium element with a <gi scheme="MEI">surface</gi>
       element.</desc>
@@ -396,25 +420,12 @@
       <memberOf key="att.lang"/>
     </classes>
     <content>
-      <rng:choice>
-        <rng:group>
-          <rng:zeroOrMore>
-            <rng:ref name="model.headLike"/>
-          </rng:zeroOrMore>
-          <rng:zeroOrMore>
-            <rng:choice>
-              <rng:ref name="eventList"/>
-              <rng:ref name="model.pLike"/>
-            </rng:choice>
-          </rng:zeroOrMore>
-        </rng:group>
-        <rng:zeroOrMore>
-          <rng:choice>
-            <rng:text/>
-            <rng:ref name="model.textPhraseLike.limited"/>
-          </rng:choice>
-        </rng:zeroOrMore>
-      </rng:choice>
+      <rng:oneOrMore>
+        <rng:choice>
+          <rng:ref name="macro.histAccount"/>
+          <rng:text/>
+        </rng:choice>
+      </rng:oneOrMore>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-acquisition.html">acquisition</ref> element of the Text Encoding Initiative (TEI).</p>
@@ -1280,25 +1291,12 @@
       <memberOf key="att.lang"/>
     </classes>
     <content>
-      <rng:choice>
-        <rng:group>
-          <rng:zeroOrMore>
-            <rng:ref name="model.headLike"/>
-          </rng:zeroOrMore>
-          <rng:zeroOrMore>
-            <rng:choice>
-              <rng:ref name="eventList"/>
-              <rng:ref name="model.pLike"/>
-            </rng:choice>
-          </rng:zeroOrMore>
-        </rng:group>
-        <rng:zeroOrMore>
-          <rng:choice>
-            <rng:text/>
-            <rng:ref name="model.textPhraseLike.limited"/>
-          </rng:choice>
-        </rng:zeroOrMore>
-      </rng:choice>
+      <rng:oneOrMore>
+        <rng:choice>
+          <rng:ref name="macro.histAccount"/>
+          <rng:text/>
+        </rng:choice>
+      </rng:oneOrMore>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the <abbr>MARC</abbr> <ref target="https://www.loc.gov/marc/bibliographic/bd585.html">585</ref> field.</p>
@@ -2263,25 +2261,12 @@
       <memberOf key="att.lang"/>
     </classes>
     <content>
-      <rng:choice>
-        <rng:group>
-          <rng:zeroOrMore>
-            <rng:ref name="model.headLike"/>
-          </rng:zeroOrMore>
-          <rng:zeroOrMore>
-            <rng:choice>
-              <rng:ref name="eventList"/>
-              <rng:ref name="model.pLike"/>
-            </rng:choice>
-          </rng:zeroOrMore>
-        </rng:group>
-        <rng:zeroOrMore>
-          <rng:choice>
-            <rng:text/>
-            <rng:ref name="model.textPhraseLike.limited"/>
-          </rng:choice>
-        </rng:zeroOrMore>
-      </rng:choice>
+      <rng:oneOrMore>
+        <rng:choice>
+          <rng:ref name="macro.histAccount"/>
+          <rng:text/>
+        </rng:choice>
+      </rng:oneOrMore>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the respective element of the Encoded Archival Description (EAD) and the <ref target="https://tei-c.org/release/doc/tei-p5-doc/en/html/ref-provenance.html">provenance</ref> element of the Text
@@ -2789,25 +2774,12 @@
       <memberOf key="att.lang"/>
     </classes>
     <content>
-      <rng:choice>
-        <rng:group>
-          <rng:zeroOrMore>
-            <rng:ref name="model.headLike"/>
-          </rng:zeroOrMore>
-          <rng:zeroOrMore>
-            <rng:choice>
-              <rng:ref name="eventList"/>
-              <rng:ref name="model.pLike"/>
-            </rng:choice>
-          </rng:zeroOrMore>
-        </rng:group>
-        <rng:zeroOrMore>
-          <rng:choice>
-            <rng:text/>
-            <rng:ref name="model.textPhraseLike.limited"/>
-          </rng:choice>
-        </rng:zeroOrMore>
-      </rng:choice>
+      <rng:oneOrMore>
+        <rng:choice>
+          <rng:ref name="macro.histAccount"/>
+          <rng:text/>
+        </rng:choice>
+      </rng:oneOrMore>
     </content>
     <remarks xml:lang="en">
       <p>Treatment history may also comprise details of the treatment process (<abbr>e.g.</abbr>, chemical
@@ -2826,25 +2798,12 @@
       <memberOf key="att.lang"/>
     </classes>
     <content>
-      <rng:choice>
-        <rng:group>
-          <rng:zeroOrMore>
-            <rng:ref name="model.headLike"/>
-          </rng:zeroOrMore>
-          <rng:zeroOrMore>
-            <rng:choice>
-              <rng:ref name="eventList"/>
-              <rng:ref name="model.pLike"/>
-            </rng:choice>
-          </rng:zeroOrMore>
-        </rng:group>
-        <rng:zeroOrMore>
-          <rng:choice>
-            <rng:text/>
-            <rng:ref name="model.textPhraseLike.limited"/>
-          </rng:choice>
-        </rng:zeroOrMore>
-      </rng:choice>
+      <rng:oneOrMore>
+        <rng:choice>
+          <rng:ref name="macro.histAccount"/>
+          <rng:text/>
+        </rng:choice>
+      </rng:oneOrMore>
     </content>
     <remarks xml:lang="en">
       <p>The model of this element is based on the respective element of the Encoded Archival Description (EAD).</p>


### PR DESCRIPTION
Adds a macro (content model) for elements on historical account, cause thir content model is identical. 

fixes #919