### PR TITLE
schema: update and clean up of `MEI.stringtab` attributes with regard to `<chordTable>`

### DIFF
--- a/source/docs/10-analysisharm.xml
+++ b/source/docs/10-analysisharm.xml
@@ -262,7 +262,7 @@
                            <specDesc key="att.stringtab.position" atts="tab.pos"/>
                            <specDesc key="chordMember"/>
                            <specDesc key="att.intervalHarmonic" atts="inth"/>
-                           <specDesc key="att.stringtab" atts="tab.fing tab.fret tab.course"/>
+                           <specDesc key="att.stringtab" atts="tab.fret tab.course"/>
                            <specDesc key="barre"/>
                            <specDesc key="barre" atts="tab.fret"/>
                         </specList>
@@ -294,7 +294,7 @@
                   </div>
                   <div xml:id="harmonyTablatureGrids" type="div4">
                      <head>Chord Tablature Grids</head>
-                     <p>The <att>tab.pos</att> attribute on <gi scheme="MEI">chordDef</gi>, the <att>tab.course</att>, <att>tab.fing</att> and <att>tab.fret</att> attributes on <gi scheme="MEI">chordMember</gi>, and the <gi scheme="MEI">barre</gi> element child of <gi scheme="MEI">chordDef</gi> are provided in order to create displayable and performable chord tablature grids for guitar and other fretted string instruments. The fret at which a finger should be placed is recorded in the <att>tab.fret</att> attribute, while <att>tab.fing</att> indicates which finger, if any, should be used to play an individual string. The values x and o are used to indicate muffled and open strings, respectively.</p>
+                     <p>The <att>tab.pos</att> attribute on <gi scheme="MEI">chordDef</gi>, the <att>tab.course</att> and <att>tab.fret</att> attributes on <gi scheme="MEI">chordMember</gi>, and the <gi scheme="MEI">barre</gi> element child of <gi scheme="MEI">chordDef</gi> are provided in order to create displayable and performable chord tablature grids for guitar and other fretted string instruments. The fret at which a finger should be placed is recorded in the <att>tab.fret</att> attribute, while (placeholder for the new attribute) indicates which finger, if any, should be used to play an individual string. The values x and o are used to indicate muffled and open strings, respectively.</p>
                      <p>The <gi scheme="MEI">chordDef</gi> element may contain <gi scheme="MEI">barre</gi> sub-elements when a single finger is used to stop multiple strings. Here the <att>tab.fret</att> attribute gives the fret position at which the barre should be created, while the <att>startid</att> and <att>endid</att> attributes are used to indicate the <gi scheme="MEI">chordMember</gi> elements on which the barre starts and finishes.</p>
                   </div>
                   <div xml:id="harmonyMusicText" type="div4">

--- a/source/docs/10-analysisharm.xml
+++ b/source/docs/10-analysisharm.xml
@@ -262,9 +262,9 @@
                            <specDesc key="att.stringtab.position" atts="tab.pos"/>
                            <specDesc key="chordMember"/>
                            <specDesc key="att.intervalHarmonic" atts="inth"/>
-                           <specDesc key="att.stringtab" atts="tab.fing tab.fret"/>
+                           <specDesc key="att.stringtab" atts="tab.fing tab.fret tab.course"/>
                            <specDesc key="barre"/>
-                           <specDesc key="barre" atts="fret"/>
+                           <specDesc key="barre" atts="tab.fret"/>
                         </specList>
                      </p>
                      <p>The <gi scheme="MEI">chordTable</gi> element is a container for a set of chord definitions, while the <gi scheme="MEI">chordDef</gi> element defines a single chord. Chord definitions may be created <hi rend="italic">a priori</hi> or as the result of analysis of the pitch content of the music at hand, for instance, by examination of the notes occurring on the downbeat of each measure. In this way, the chord definitions serve as a record of the analysis.</p>
@@ -294,8 +294,8 @@
                   </div>
                   <div xml:id="harmonyTablatureGrids" type="div4">
                      <head>Chord Tablature Grids</head>
-                     <p>The <att>pos</att> attribute on <gi scheme="MEI">chordDef</gi>, the <att>fing</att> and <att>fret</att> attributes on <gi scheme="MEI">chordMember</gi>, and the <gi scheme="MEI">barre</gi> element child of <gi scheme="MEI">chordDef</gi> are provided in order to create displayable and performable chord tablature grids for guitar and other fretted string instruments. The fret at which a finger should be placed is recorded in the <att>fret</att> attribute, while <att>fing</att> indicates which finger, if any, should be used to play an individual string. The values x and o are used to indicate muffled and open strings, respectively.</p>
-                     <p>The <gi scheme="MEI">chordDef</gi> element may contain <gi scheme="MEI">barre</gi> sub-elements when a single finger is used to stop multiple strings. Here the <att>fret</att> attribute gives the fret position at which the barre should be created, while the <att>startid</att> and <att>endid</att> attributes are used to indicate the <gi scheme="MEI">chordMember</gi> elements on which the barre starts and finishes.</p>
+                     <p>The <att>tab.pos</att> attribute on <gi scheme="MEI">chordDef</gi>, the <att>tab.course</att>, <att>tab.fing</att> and <att>tab.fret</att> attributes on <gi scheme="MEI">chordMember</gi>, and the <gi scheme="MEI">barre</gi> element child of <gi scheme="MEI">chordDef</gi> are provided in order to create displayable and performable chord tablature grids for guitar and other fretted string instruments. The fret at which a finger should be placed is recorded in the <att>tab.fret</att> attribute, while <att>tab.fing</att> indicates which finger, if any, should be used to play an individual string. The values x and o are used to indicate muffled and open strings, respectively.</p>
+                     <p>The <gi scheme="MEI">chordDef</gi> element may contain <gi scheme="MEI">barre</gi> sub-elements when a single finger is used to stop multiple strings. Here the <att>tab.fret</att> attribute gives the fret position at which the barre should be created, while the <att>startid</att> and <att>endid</att> attributes are used to indicate the <gi scheme="MEI">chordMember</gi> elements on which the barre starts and finishes.</p>
                   </div>
                   <div xml:id="harmonyMusicText" type="div4">
                      <head>Indications of Harmony in the Music Text</head>

--- a/source/modules/MEI.gestural.xml
+++ b/source/modules/MEI.gestural.xml
@@ -734,7 +734,6 @@
     <desc xml:lang="en">Gestural domain attributes for staffDef in the CMN repertoire.</desc>
     <classes>
       <memberOf key="att.instrumentIdent"/>
-      <memberOf key="att.stringtab.tuning"/>
       <memberOf key="att.timeBase"/>
       <memberOf key="att.tuning"/>
     </classes>

--- a/source/modules/MEI.harmony.xml
+++ b/source/modules/MEI.harmony.xml
@@ -29,7 +29,6 @@
     <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>
       <memberOf key="att.stringtab.position"/>
-      <memberOf key="att.stringtab.tuning"/>
     </classes>
   </classSpec>
   <classSpec ident="att.chordMember.log" module="MEI.harmony" type="atts">

--- a/source/modules/MEI.harmony.xml
+++ b/source/modules/MEI.harmony.xml
@@ -139,8 +139,8 @@
       <empty/>
     </content>
     <remarks xml:lang="en">
-      <p>The <att>tab.course</att>, <att>tab.fret</att>, and <att>tab.fing</att> attributes are provided in
-        order to create displayable chord tablature grids. The <att>inth</att> (harmonic interval)
+      <p>The <att>tab.course</att> and <att>tab.fret</att> attributes are provided in
+        order to create displayable chord tablature grids. The <att>inth</a> (harmonic interval)
         attribute may be used to facilitate automated performance of a chord. It gives the number of
         diatonic steps above the bass. Of course, for the bass note itself, <att>inth</att> should be set
         to <val>P1</val>.</p>

--- a/source/modules/MEI.harmony.xml
+++ b/source/modules/MEI.harmony.xml
@@ -140,7 +140,7 @@
     </content>
     <remarks xml:lang="en">
       <p>The <att>tab.course</att> and <att>tab.fret</att> attributes are provided in
-        order to create displayable chord tablature grids. The <att>inth</a> (harmonic interval)
+        order to create displayable chord tablature grids. The <att>inth</att> (harmonic interval)
         attribute may be used to facilitate automated performance of a chord. It gives the number of
         diatonic steps above the bass. Of course, for the bass note itself, <att>inth</att> should be set
         to <val>P1</val>.</p>

--- a/source/modules/MEI.harmony.xml
+++ b/source/modules/MEI.harmony.xml
@@ -140,7 +140,7 @@
       <empty/>
     </content>
     <remarks xml:lang="en">
-      <p>The <att>string</att>, <att>fret</att>, and <att>fing</att> attributes are provided in
+      <p>The <att>tab.course</att>, <att>tab.fret</att>, and <att>tab.fing</att> attributes are provided in
         order to create displayable chord tablature grids. The <att>inth</att> (harmonic interval)
         attribute may be used to facilitate automated performance of a chord. It gives the number of
         diatonic steps above the bass. Of course, for the bass note itself, <att>inth</att> should be set

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -8385,27 +8385,6 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="Check_tab_strings_lines" scheme="schematron">
-      <constraint>
-        <sch:rule context="mei:staffDef[@tab.strings and @lines]">
-          <sch:let name="countTokens" value="count(tokenize(normalize-space(@tab.strings), '\s'))"/>
-          <sch:assert test="$countTokens = @lines">The tab.strings attribute must have the same
-            number of values as there are staff lines.</sch:assert>
-        </sch:rule>
-      </constraint>
-    </constraintSpec>
-    <constraintSpec ident="Check_tab_strings_nolines" scheme="schematron">
-      <constraint>
-        <sch:rule context="mei:staffDef[@tab.strings and not(@lines)]">
-          <sch:let name="countTokens" value="count(tokenize(normalize-space(@tab.strings), '\s'))"/>
-          <sch:let name="thisstaff" value="@n"/>
-          <sch:assert
-            test="$countTokens = preceding::mei:staffDef[@n=$thisstaff and @lines][1]/@lines">The
-            tab.strings attribute must have the same number of values as there are staff
-            lines.</sch:assert>
-        </sch:rule>
-      </constraint>
-    </constraintSpec>
     <constraintSpec ident="Check_lines_color" scheme="schematron">
       <constraint>
         <sch:pattern>

--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -93,12 +93,6 @@
   <classSpec ident="att.stringtab" module="MEI.stringtab" type="atts">
     <desc xml:lang="en">String tablature string and fret information.</desc>
     <attList>
-      <attDef ident="tab.fing" usage="opt">
-        <desc xml:lang="en">This attribute is deprecated and will be removed in a future version. Indicates which finger, if any, should be used to play an individual string. The index, middle, ring, and little fingers are represented by the values 1-4, while <val>t</val> is for the thumb. The values <val>x</val> and <val>o</val> indicate muffled and open strings, respectively.</desc>
-        <datatype>
-          <rng:ref name="data.FINGER.FRET"/>
-        </datatype>
-      </attDef>
       <attDef ident="tab.fret" usage="opt">
         <desc xml:lang="en">Records the location at which a string should be stopped against a fret. The value <val>0</val> (zero) indicates the open string. The value <val>omit</val> indicates an omitted string that does not sound.</desc>
         <datatype>

--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -136,38 +136,6 @@
       </attDef>
     </attList>
   </classSpec>
-  <classSpec ident="att.stringtab.tuning" module="MEI.stringtab" type="atts">
-    <desc xml:lang="en">This collection of attributes is deprecated in favor of the new <gi scheme="MEI">tuning</gi> element and will be removed in a future version. String tablature tuning information.</desc>
-    <attList>
-      <attDef ident="tab.strings" usage="opt">
-        <desc xml:lang="en">This attribute is deprecated in favor of the new <gi scheme="MEI">tuning</gi> element and will be removed in a future version. Provides a *written* pitch and octave for each open string or course of
-          strings.</desc>
-        <datatype>
-          <rng:list>
-            <rng:oneOrMore>
-              <rng:data type="token">
-                <rng:param name="pattern">
-                  [a-g][0-9](s|f|ss|x|ff|xs|sx|ts|tf|n|nf|ns|su|sd|fu|fd|nu|nd|1qf|3qf|1qs|3qs)?([a-g][0-9](s|f|ss|x|ff|xs|sx|ts|tf|n|nf|ns|su|sd|fu|fd|nu|nd|1qf|3qf|1qs|3qs)?)*</rng:param>
-              </rng:data>
-            </rng:oneOrMore>
-          </rng:list>
-        </datatype>
-      </attDef>
-      <attDef ident="tab.courses" usage="opt">
-        <desc xml:lang="en">This attribute is deprecated in favor of the new <gi scheme="MEI">tuning</gi> element and will be removed in a future version. Provides a *written* pitch and octave for each open string or course of strings.</desc>
-        <datatype>
-          <rng:list>
-            <rng:oneOrMore>
-              <rng:data type="token">
-                <rng:param name="pattern">
-                  [a-g][0-9](s|f|ss|x|ff|xs|sx|ts|tf|n|nf|ns|su|sd|fu|fd|nu|nd|1qf|3qf|1qs|3qs)?([a-g][0-9](s|f|ss|x|ff|xs|sx|ts|tf|n|nf|ns|su|sd|fu|fd|nu|nd|1qf|3qf|1qs|3qs)?)*</rng:param>
-              </rng:data>
-            </rng:oneOrMore>
-          </rng:list>
-        </datatype>
-      </attDef>
-    </attList>
-  </classSpec>
   <classSpec ident="att.tabDurSym.log" module="MEI.stringtab" type="atts">
     <desc xml:lang="en">Logical domain attributes.</desc>
     <classes>

--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -100,9 +100,12 @@
         </datatype>
       </attDef>
       <attDef ident="tab.fret" usage="opt">
-        <desc xml:lang="en">Records the location at which a string should be stopped against a fret.</desc>
+        <desc xml:lang="en">Records the location at which a string should be stopped against a fret. The value <val>0</val> (zero) indicates the open string. The value <val>omit</val> indicates an omitted string that does not sound.</desc>
         <datatype>
-          <rng:ref name="data.FRETNUMBER"/>
+          <rng:choice>
+            <rng:ref name="data.FRETNUMBER"/>
+            <rng:ref name="data.FRETNUMBER.omit" />
+          </rng:choice>
         </datatype>
       </attDef>
       <attDef ident="tab.line" usage="opt">

--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -108,12 +108,6 @@
           <rng:ref name="data.CLEFLINE"/>
         </datatype>
       </attDef>
-      <attDef ident="tab.string" usage="opt">
-        <desc xml:lang="en">This attribute is deprecated in favor of <att>tab.course</att> and will be removed in a future version. Records which string is to be played.</desc>
-        <datatype>
-          <rng:ref name="data.STRINGNUMBER"/>
-        </datatype>
-      </attDef>
       <attDef ident="tab.course" usage="opt">
         <desc xml:lang="en">Records which course is to be played.</desc>
         <datatype>

--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -167,17 +167,6 @@
     <content>
       <empty/>
     </content>
-    <attList>
-      <attDef ident="fret" usage="opt">
-        <desc xml:lang="en">This attribute is deprecated in favor of <att>tab.fret</att>, and will be removed in a future version. Records the location at which the strings should be stopped against a fret in a fretboard diagram. This may or may not be the same as the actual location on the fretboard of the instrument in performance.</desc>
-        <datatype>
-          <rng:data type="positiveInteger">
-            <rng:param name="minInclusive">1</rng:param>
-            <rng:param name="maxInclusive">5</rng:param>
-          </rng:data>
-        </datatype>
-      </attDef>
-    </attList>
     <remarks xml:lang="en">
       <p>The <att>startid</att> and <att>endid</att> attributes are used to indicate the <gi
           scheme="MEI">chordMember</gi> elements on which the barre starts and finishes

--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -98,7 +98,7 @@
         <datatype>
           <rng:choice>
             <rng:ref name="data.FRETNUMBER"/>
-            <rng:ref name="data.FRETNUMBER.omit" />
+            <rng:ref name="data.FRETNUMBER.omit"/>
           </rng:choice>
         </datatype>
       </attDef>

--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -170,7 +170,7 @@
     <remarks xml:lang="en">
       <p>The <att>startid</att> and <att>endid</att> attributes are used to indicate the <gi
           scheme="MEI">chordMember</gi> elements on which the barre starts and finishes
-        respectively. The fret at which the barre should be created is recorded by the <att>fret</att>
+        respectively. The fret at which the barre should be created is recorded by the <att>tab.fret</att>
         attribute.</p>
     </remarks>
   </elementSpec>

--- a/source/modules/MEI.stringtab.xml
+++ b/source/modules/MEI.stringtab.xml
@@ -162,6 +162,7 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.startEndId"/>
+      <memberOf key="att.stringtab"/>
     </classes>
     <content>
       <empty/>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -1508,6 +1508,16 @@
       <rng:data type="nonNegativeInteger"/>
     </content>
   </macroSpec>
+  <macroSpec ident="data.FRETNUMBER.omit" module="MEI" type="dt">
+    <desc xml:lang="en">In cases like those in chord tablature grids where a string is omitted, the value <val>omit</val> is used.</desc>
+    <content>
+      <valList type="closed">
+        <valItem ident="omit">
+          <desc xml:lang="en">The string is omitted, not sounding.</desc>
+        </valItem>
+      </valList>
+    </content>
+  </macroSpec>
   <!--<macroSpec ident="data.FRETNUMBER.limited" module="MEI" type="dt">
     <desc xml:lang="en">In a guitar chord diagram, the fret where the finger should be placed. Since guitar chord
       diagrams are limited to the range of frets that fall under the hand, the values here are a

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -3592,12 +3592,6 @@
       </valList>
     </content>
   </macroSpec>
-  <macroSpec ident="data.STRINGNUMBER" module="MEI" type="dt">
-    <desc xml:lang="en">This datatype is deprecated in favor of data.COURSENUMBER and will be removed in a future version. In string tablature, the number of the string to be played.</desc>
-    <content>
-      <rng:data type="positiveInteger"/>
-    </content>
-  </macroSpec>
   <macroSpec ident="data.TEMPERAMENT" module="MEI" type="dt">
     <desc xml:lang="en">Temperament or tuning system.</desc>
     <content>

--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -1382,23 +1382,6 @@
       </valList>
     </content>
   </macroSpec>
-  <macroSpec ident="data.FINGER.FRET" module="MEI" type="dt">
-    <desc xml:lang="en">In a guitar chord diagram, a label indicating which finger, if any, should be used to play
-      an individual string. The index, middle, ring, and little fingers are represented by the
-      values 1-4, while 't' is for the thumb. The values 'x' and 'o' indicate stopped and open
-      strings, respectively.</desc>
-    <content>
-      <rng:choice>
-        <rng:data type="positiveInteger">
-          <rng:param name="minInclusive">1</rng:param>
-          <rng:param name="maxInclusive">4</rng:param>
-        </rng:data>
-        <rng:data type="token">
-          <rng:param name="pattern">x|o|t</rng:param>
-        </rng:data>
-      </rng:choice>
-    </content>
-  </macroSpec>
   <macroSpec ident="data.FONTFAMILY" module="MEI" type="dt">
     <desc xml:lang="en">Font family (for text) attribute values.</desc>
     <content>


### PR DESCRIPTION
This PR updates values used in the `<chordTable>` and cleans up the deprecated attributes related to it. The following changes were made:

- The guidelines and definitions in `MEI.harmony` were updated to the current version of `MEI.stringtab` (`@fret` = `@tab.fret`, `@pos` = `@tab.pos`, `@string` = `@tab.course`)
- Deprecated attributes removed from `MEI.harmony`: `@tab.strings` and `@tab.courses` (in `<chordDef>`)
- Deprecated attributes removed from `MEI.gestural`: `@tab.strings` and `@tab.courses` (in `<staffDef>`)
- Deprecated attributes `@tab.strings` and `@tab.courses` removed from `MEI.stringtab`
- `"omit"` added as a value of `@tab.fret` in the case of an omitted course 
- Added `@tab.fret` to `<barre>`
- Deprecated `@fret` in `<barre>`
- Deprecated `@tab.fing` in favour of newly proposed attribute `@finger` (separate PR)
- Deprecated `@tab.string` in favour of existing `@tab.course`
- Removed constraints regarding `@tab.strings` and `@lines` (in `<staffDef>`) from `MEI.shared`

This PR cleans up and updates the schema and guidelines with regard to the issues [#1686](https://github.com/music-encoding/music-encoding/issues/1686) and [#1756](https://github.com/music-encoding/music-encoding/issues/1756), and outlines the necessary changes and preparations regarding the issue [#1795](https://github.com/music-encoding/music-encoding/issues/1795).

A validation test is available directly in the [mei-friend](https://mei-friend.mdw.ac.at/?file=&scale=74&breaks=encoded&select=e5rdrbo2&page=1&speed=false&notationOrientation=bottom&notationProportion=0.69). Alternatively, you can use [this minimal example](https://gist.githubusercontent.com/janjusolja/98e25b42108f3264b5bda91604a0cc2b/raw/80632b84fcc9170775d8732f30564ac60d3f4ea9/tab-chordMember-example.mei) and test it against [this RNG](https://gist.githubusercontent.com/janjusolja/1808b8eb57b8c63de8563501720a7423/raw/aaa87c67d5bcc4fe02628a5368661344264b39d9/mei-all.rng).

Special thanks to @reinierdevalk , @musicog , @DILewis  and @pe-ro  for their support!
