### PR TITLE
remove att.keyMode

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -1689,17 +1689,6 @@
       <memberOf key="att.pitched"/>
     </classes>
   </classSpec>
-  <classSpec ident="att.keyMode" module="MEI.shared" type="atts">
-    <desc xml:lang="en">Attributes for describing key mode.</desc>
-    <attList>
-      <attDef ident="mode" usage="opt">
-        <desc xml:lang="en">Indicates major, minor, or other tonality.</desc>
-        <datatype>
-          <rng:ref name="data.MODE"/>
-        </datatype>
-      </attDef>
-    </attList>
-  </classSpec>
   <classSpec ident="att.keySig.log" module="MEI.shared" type="atts">
     <desc xml:lang="en">Logical domain attributes.</desc>
     <attList>


### PR DESCRIPTION
The attribute `mode` has been moved in #1210, so this can be deleted now.