### PR TITLE
docs: clarify that arpeg can be a straight line

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -1206,16 +1206,19 @@
       <empty/>
     </content>
     <remarks xml:lang="en">
-      <p>The modern arpeggiation symbol is a vertical wavy line preceding the chord. When the notes
-        of the chord are to be performed from highest to lowest, an arrowhead may be added to the
-        lower end of the line. Even though it is redundant, an arrowhead is sometimes added to the
-        upper end of the line for the sake of consistency or when the direction of successive
-        arpeggios alternates. In music for keyboard instruments, sometimes a distinction is made
-        between a single arpeggio in which both hands play successively and simultaneous arpeggios
-        in two hands. In the case of the former, multiple values may be required in the
-        <att>staff</att> and <att>layer</att> attributes. Arpeggios that do not cross staves, but
-        still involve more than one layer require multiple values for the <att>layer</att>
-        attribute.</p>
+      <p>The modern arpeggiation symbol is a vertical, usually wavy line preceding the chord. When
+        the notes of the chord are to be performed from highest to lowest, an arrowhead may be added
+        to the lower end of the line. Even though it is redundant, an arrowhead is sometimes added
+        to the upper end of the line for the sake of consistency or when the direction of successive
+        arpeggios alternates.</p>
+      <p>In music for keyboard instruments, sometimes a distinction is made between a single
+        arpeggio in which both hands play successively and simultaneous arpeggios in two hands. In
+        the case of the former, multiple values may be required in the <att>staff</att> and
+          <att>layer</att> attributes. Arpeggios that do not cross staves, but still involve more
+        than one layer require multiple values for the <att>layer</att> attribute.</p>
+      <p>For arpeggios written as a straight line, which are common in guitar music,
+        <att>lform</att> takes the value <val>solid</val>. Such arpeggios always have an
+        arrowhead.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="attacca" module="MEI.cmn">


### PR DESCRIPTION
I noticed that the specs say

> The modern arpeggiation symbol is a vertical wavy line 

Which I think is misleading. In guitar music, also straight lines are used. I picked some examples from my collection of pedagogical guitar books of different publishers:

<img width="270" height="138" alt="image" src="https://github.com/user-attachments/assets/b1a98dfd-f253-40a1-a576-e82dfe8996db" /><br/><sup>Maria Linnemann: Leichte Folklorestücke für Gitarre (Ricordi), p. 8</sup>

<img width="261" height="103" alt="image" src="https://github.com/user-attachments/assets/bfbe7d1b-ea1f-4d4d-b449-1b68c24efb07" /><br/><sup>Dieter Kreidler: Gitarrenschule Band 2 (Schott), last foldout page</sup>

<img width="191" height="129" alt="image" src="https://github.com/user-attachments/assets/277f711b-e369-443e-981d-a84151fdf429" /><br/><sup>Klaus Schindler: Caribbean Sound (Vogt & Fritz), p. 7</sup>

My understanding is: Straight line arpeggios are always performed by strumming, while wiggly arpeggios may either be picked or strummed, or a mixture of both (strumming the lower strings and continuing with picking the higher strings). But I don't think that's of relevance for the encoding.