### PR TITLE
build: add build-schematron target for custom schema

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -388,7 +388,7 @@
         <basename property="selectedSchema" file="${customization.path}" suffix=".xml"/>
         <!-- Convert path to file URI for Saxon/XSLT -->
         <path-to-file-uri path="${canonicalized.source.path}" property="canonicalized.source.uri"/>
-        <echo>building rng ${selectedSchema} from ${customization.path}</echo>
+        <echo>building schematron for ${selectedSchema} from ${customization.path}</echo>
         <echo>    source: ${canonicalized.source.uri}</echo>
         <echo>    output: ${dir.dist.schemata}/${selectedSchema}.sch</echo>
         <ant dir="${dir.lib.stylesheets}/rng/" antfile="build-to.xml" target="dist" inheritall="true" usenativebasedir="true"><!-- check whether nativebasdir is required -->

--- a/build.xml
+++ b/build.xml
@@ -384,6 +384,23 @@
         </ant>
     </target>
 
+    <target name="build-schematron" description="Builds the Schematron schema of a specific customization submitted as absolute path with -Dcustomization.path input param." depends="validate-source">
+        <basename property="selectedSchema" file="${customization.path}" suffix=".xml"/>
+        <!-- Convert path to file URI for Saxon/XSLT -->
+        <path-to-file-uri path="${canonicalized.source.path}" property="canonicalized.source.uri"/>
+        <echo>building rng ${selectedSchema} from ${customization.path}</echo>
+        <echo>    source: ${canonicalized.source.uri}</echo>
+        <echo>    output: ${dir.dist.schemata}/${selectedSchema}.sch</echo>
+        <ant dir="${dir.lib.stylesheets}/rng/" antfile="build-to.xml" target="dist" inheritall="true" usenativebasedir="true"><!-- check whether nativebasdir is required -->
+            <property name="inputFile" value="${customization.path}"/>
+            <property name="outputFile" value="${dir.dist.schemata}/${selectedSchema}.sch"/>
+            <property name="defaultSource" value="${canonicalized.source.uri}"/>
+            <reference refid="mei.classpath" torefid="classpath"/>
+            <property name="verbose" value="${verbose}"/>
+            <property name="processODD" value="true"/>
+        </ant>
+    </target>
+
     <target name="build-guidelines-html" description="Builds the HTML version of the MEI guidelines for all customizations." depends="validate-source, get-local-git-sha, get-local-git-branch" unless="${build-guidelines-html.done}">
         <antcall target="build-customization-guidelines-html">
             <param name="customization.path" location="customizations/mei-all.xml"/>

--- a/build.xml
+++ b/build.xml
@@ -385,19 +385,20 @@
     </target>
 
     <target name="build-schematron" description="Builds the Schematron schema of a specific customization submitted as absolute path with -Dcustomization.path input param." depends="validate-source">
+        <fail unless="customization.path" message="Missing input: You must specify a customization path using -Dcustomization.path=/path/to/file.xml" />
         <basename property="selectedSchema" file="${customization.path}" suffix=".xml"/>
         <!-- Convert path to file URI for Saxon/XSLT -->
         <path-to-file-uri path="${canonicalized.source.path}" property="canonicalized.source.uri"/>
         <echo>building schematron for ${selectedSchema} from ${customization.path}</echo>
         <echo>    source: ${canonicalized.source.uri}</echo>
         <echo>    output: ${dir.dist.schemata}/${selectedSchema}.sch</echo>
-        <ant dir="${dir.lib.stylesheets}/rng/" antfile="build-to.xml" target="dist" inheritall="true" usenativebasedir="true"><!-- check whether nativebasdir is required -->
+        <ant dir="${dir.lib.stylesheets}/rng/" antfile="build-to.xml" target="dist" inheritall="true" usenativebasedir="true">
             <property name="inputFile" value="${customization.path}"/>
             <property name="outputFile" value="${dir.dist.schemata}/${selectedSchema}.sch"/>
             <property name="defaultSource" value="${canonicalized.source.uri}"/>
-            <reference refid="mei.classpath" torefid="classpath"/>
             <property name="verbose" value="${verbose}"/>
             <property name="processODD" value="true"/>
+            <reference refid="mei.classpath" torefid="classpath"/>
         </ant>
     </target>
 


### PR DESCRIPTION
Add new Ant build target that generates Schematron schemas from
customization files. The target accepts a customization path as input
parameter and produces a compiled Schematron schema file in the
distribution directory. This enables users to build Schematron
validation schemas for specific MEI customizations.