### PR TITLE
docs: `<chordDef>` has uses beyond chord tablature definitions

### DIFF
--- a/source/modules/MEI.harmony.xml
+++ b/source/modules/MEI.harmony.xml
@@ -102,7 +102,8 @@
   </classSpec>
   <elementSpec ident="chordDef" module="MEI.harmony">
     <gloss xml:lang="en">chord definition</gloss>
-    <desc xml:lang="en">Chord tablature definition.</desc>
+    <desc xml:lang="en">Complements <gi scheme="MEI">harm</gi> with a more detailed description of
+      the notes in a chord. Can describe chord tablature grids.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.chordDef.anl"/>


### PR DESCRIPTION
`source/docs/10-analysisharm.xml` describes uses that are unrelated to chord grids (see also the [MEI 5 docs](https://music-encoding.org/guidelines/v5/content/analysisharm.html#harmonyMetadataInscoreDef)).

This came up discussing #1798.