### PR TITLE
schema: centralize definition of `@context` attribute definition

### DIFF
--- a/source/modules/MEI.header.xml
+++ b/source/modules/MEI.header.xml
@@ -133,6 +133,25 @@
       </attDef>
     </attList>
   </classSpec>
+  <classSpec ident="att.context" type="atts">
+    <desc xml:lang="en">Attributes that provide means of specifying an XPath context.</desc>
+    <constraintSpec ident="context_attribute_requires_content" scheme="schematron">
+      <constraint>
+        <sch:rule context="@context">
+          <sch:assert role="warning" test="not(normalize-space(.) eq '')">@context attribute should
+        contain an XPath expression.</sch:assert>
+        </sch:rule>
+      </constraint>
+    </constraintSpec>
+    <attList>
+      <attDef ident="context" usage="opt">
+        <desc xml:lang="en">Circumstances in which the attribute appears, an XPath expression.</desc>
+          <datatype>
+            <dataRef name="string"/>
+          </datatype>
+         </attDef>
+    </attList>
+   </classSpec>
   <classSpec ident="att.foliumSurfaces" module="MEI.header" type="atts">
     <desc xml:lang="en">Attributes that link a folium element with a <gi scheme="MEI">surface</gi> element.</desc>
     <attList>
@@ -508,31 +527,18 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
+      <memberOf key="att.context"/>
     </classes>
     <content>
       <rng:optional>
         <rng:ref name="desc"/>
       </rng:optional>
     </content>
-    <constraintSpec ident="context_attribute_requires_content" scheme="schematron">
-      <constraint>
-        <sch:rule context="@context">
-          <sch:assert role="warning" test="not(normalize-space(.) eq '')">@context attribute should
-            contain an XPath expression.</sch:assert>
-        </sch:rule>
-      </constraint>
-    </constraintSpec>
     <attList>
       <attDef ident="name" usage="req">
         <desc xml:lang="en">Name of the attribute.</desc>
         <datatype>
           <rng:ref name="data.NMTOKEN"/>
-        </datatype>
-      </attDef>
-      <attDef ident="context" usage="opt">
-        <desc xml:lang="en">Circumstances in which the attribute appears, an XPath expression.</desc>
-        <datatype>
-          <rng:data type="string"/>
         </datatype>
       </attDef>
     </attList>
@@ -2595,6 +2601,7 @@
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.bibl"/>
+      <memberOf key="att.context"/>
     </classes>
     <content>
       <rng:optional>
@@ -2604,25 +2611,11 @@
         <rng:ref name="attUsage"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="context_attribute_requires_content" scheme="schematron">
-      <constraint>
-        <sch:rule context="@context">
-          <sch:assert role="warning" test="not(normalize-space(.) eq '')">@context attribute should
-            contain an XPath expression.</sch:assert>
-        </sch:rule>
-      </constraint>
-    </constraintSpec>
     <attList>
       <attDef ident="name" usage="req">
         <desc xml:lang="en">Name of the element.</desc>
         <datatype>
           <rng:ref name="data.NMTOKEN"/>
-        </datatype>
-      </attDef>
-      <attDef ident="context" usage="opt">
-        <desc xml:lang="en">Circumstances in which the element appears, an XPath expression.</desc>
-        <datatype>
-          <rng:data type="string"/>
         </datatype>
       </attDef>
       <attDef ident="occurs" usage="opt">


### PR DESCRIPTION
- Remove repeated <attDef ident="context"> blocks from elementSpec definitions
- Add classSpec att.context
- Make attUsage and tagUsage to new class