### PR TITLE
feat: simplify font size pattern validation

### DIFF
--- a/source/modules/MEI.xml
+++ b/source/modules/MEI.xml
@@ -1425,24 +1425,7 @@
     <desc xml:lang="en">Font size expressed as numbers; <abbr>i.e.</abbr>, points or virtual units.</desc>
     <content>
       <rng:data type="token">
-        <rng:param name="pattern">\d*(\.\d+)?(pt|vu)</rng:param>
-        <rng:except>
-          <!-- disallow no-value or all-zero patterns -->
-          <rng:choice>
-            <rng:data type="token">
-              <rng:param name="pattern">(pt|vu)</rng:param>
-            </rng:data>
-            <rng:data type="token">
-              <rng:param name="pattern">0+(pt|vu)</rng:param>
-            </rng:data>
-            <rng:data type="token">
-              <rng:param name="pattern">0+(\.0+)?(pt|vu)</rng:param>
-            </rng:data>
-            <rng:data type="token">
-              <rng:param name="pattern">\.0+(pt|vu)</rng:param>
-            </rng:data>
-          </rng:choice>
-        </rng:except>
+          <rng:param name="pattern">([1-9]\d*(\.\d+)?|\d*\.[0-9]*[1-9][0-9]*)(pt|vu)</rng:param>
       </rng:data>
     </content>
   </macroSpec>


### PR DESCRIPTION
Replace complex exception-based pattern with single regex that enforces non-zero values. The new pattern directly matches valid font sizes (pt or vu units) with numeric values greater than zero, eliminating the need for multiple exclusion rules.