### PR TITLE
schema: simplify anyXML macro definition

### DIFF
--- a/source/mei-source.xml
+++ b/source/mei-source.xml
@@ -130,7 +130,8 @@
          <div>
             <schemaSpec ident="mei"
                         ns="http://www.music-encoding.org/ns/mei"
-                        start="mei">
+                        start="mei"
+                        defaultExceptions="http://www.music-encoding.org/ns/mei">
                <xi:include href="modules/MEI.xml"/>
                <xi:include href="modules/MEI.analytical.xml"/>
                <xi:include href="modules/MEI.cmn.xml"/>

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -28,25 +28,7 @@
   <macroSpec ident="macro.anyXML" module="MEI.shared" type="pe">
     <desc xml:lang="en">Permits any XML elements except those from the MEI or SVG namespace.</desc>
     <content>
-      <rng:element>
-        <rng:anyName>
-          <rng:except>
-            <rng:nsName ns="http://www.music-encoding.org/ns/mei"/>
-            <rng:nsName ns="http://www.w3.org/2000/svg"/>
-          </rng:except>
-        </rng:anyName>
-        <rng:zeroOrMore>
-          <rng:attribute>
-            <rng:anyName/>
-          </rng:attribute>
-        </rng:zeroOrMore>
-        <rng:zeroOrMore>
-          <rng:choice>
-            <rng:text/>
-            <rng:ref name="macro.anyXML"/>
-          </rng:choice>
-        </rng:zeroOrMore>
-      </rng:element>
+      <anyElement except="http://www.music-encoding.org/ns/mei http://www.w3.org/2000/svg"/>
     </content>
   </macroSpec>
   <macroSpec ident="macro.metaLike.page" module="MEI.shared" type="pe">


### PR DESCRIPTION
Replace verbose RNG element definition with compact pureODD anyElement syntax. This reduces boilerplate while maintaining the same validation behaviour of permitting any XML elements except those from MEI and SVG namespaces.