### PR TITLE
schema: move `@betype` constraint to shared module

### DIFF
--- a/source/modules/MEI.performance.xml
+++ b/source/modules/MEI.performance.xml
@@ -96,14 +96,6 @@
         <rng:ref name="when"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="betype_required_when_begin_or_end" scheme="schematron">
-      <constraint>
-        <sch:rule context="mei:clip[@begin or @end]">
-          <sch:assert role="warning" test="@betype or ancestor::mei:*[@betype]">When @begin or @end
-            is used, @betype should appear on clip or one of its ancestors.</sch:assert>
-        </sch:rule>
-      </constraint>
-    </constraintSpec>
     <remarks xml:lang="en">
       <p>This element is analogous to the <gi scheme="MEI">zone</gi> element in the facsimile
         module.</p>
@@ -147,14 +139,6 @@
         <rng:ref name="clip"/>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="betype_required_when_begin_or_end" scheme="schematron">
-      <constraint>
-        <sch:rule context="mei:recording[@begin or @end]">
-          <sch:assert role="warning" test="@betype">When @begin or @end is used, @betype should be
-            present.</sch:assert>
-        </sch:rule>
-      </constraint>
-    </constraintSpec>
     <remarks xml:lang="en">
       <p>The <att>startid</att> attribute may be used to hold a reference to the first feature
         occurring in this performance. This element is analogous to the <gi scheme="MEI"

--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -2200,6 +2200,14 @@
   </classSpec>
   <classSpec ident="att.mediaBounds" module="MEI.shared" type="atts">
     <desc xml:lang="en">Attributes that establish the boundaries of a media object.</desc>
+    <constraintSpec ident="betype_required_when_begin_or_end" scheme="schematron">
+      <constraint>
+        <sch:rule context="mei:clip[@begin or @end]">
+          <sch:assert role="warning" test="@betype or ancestor::mei:*[@betype]">When @begin or @end
+            is used, @betype should appear on clip or one of its ancestors.</sch:assert>
+        </sch:rule>
+      </constraint>
+    </constraintSpec>
     <attList>
       <attDef ident="begin" usage="opt">
         <desc xml:lang="en">Specifies a point where the relevant content begins. A numerical value must be less


### PR DESCRIPTION
Move the betype_required_when_begin_or_end constraint from performance-specific elements to the att.mediaBounds attribute class in the shared module. This fixes the duplicate ID error and improves maintainability.