### PR TITLE
fix: update constraint scheme from isoschematron to schematron

### DIFF
--- a/source/modules/MEI.cmn.xml
+++ b/source/modules/MEI.cmn.xml
@@ -2237,7 +2237,7 @@
         </rng:choice>
       </rng:zeroOrMore>
     </content>
-    <constraintSpec ident="repeatMark_start-type_attributes_required" scheme="isoschematron">
+    <constraintSpec ident="repeatMark_start-type_attributes_required" scheme="schematron">
       <constraint>
         <sch:rule context="mei:repeatMark">
           <sch:assert test="@startid or @tstamp or @tstamp.ges or @tstamp.real">Must have one of the
@@ -2245,7 +2245,7 @@
         </sch:rule>
       </constraint>
     </constraintSpec>
-    <constraintSpec ident="repeatMark_with_glyph_has_to_be_empty" scheme="isoschematron">
+    <constraintSpec ident="repeatMark_with_glyph_has_to_be_empty" scheme="schematron">
       <constraint>
         <sch:rule context="mei:repeatMark[@glyph.num or @glyph.name]">
           <sch:assert test="not(element()) and not(text())">When @glyph.name or @glyph.num is present, repeatMark must not have content.</sch:assert>


### PR DESCRIPTION
Update two constraintSpec elements in the repeatMark definition to use the standard "schematron" scheme instead of the deprecated "isoschematron" scheme.