### PR TITLE
schema: clarifiy difference between `@head.shape` and `@glyph.*`

### DIFF
--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -1348,7 +1348,8 @@
     </classes>
   </classSpec>
   <classSpec ident="att.note.vis" module="MEI.visual" type="atts">
-    <desc xml:lang="en">Visual domain attributes.</desc>
+    <desc xml:lang="en">Visual domain attributes. <att>glyph.name</att> and <att>glyph.num</att>
+      describe the entirety of the note, while <att>head.shape</att> encodes the head only.</desc>
     <classes>
       <memberOf key="att.altSym"/>
       <memberOf key="att.color"/>


### PR DESCRIPTION
**Edit:** This pull request now clarifies the difference between `@head.shape` and `@glyph.*`. Misunderstanding them lead to the original version of this PR.

~~I noticed that we have both `@head.shape`/`@head.auth` and `@glyph.name`/`@glyph.num`/`@glyph.auth` for encoding smufl (or other auth based) head shapes. I suggest only using the more generally available `@glyph.*` attributes, which also means that `@head.shape' has better validation because it currently can be set to any token.~~

~~Or am I misunderstanding the idea behind the `@glyph.*` attributes in this context and they are intended to represent the note in its "entirety"?  ("Entirety" being a vague concept for notes as it's not clear what parts of the note this would include or exclude.)~~  In that case, I'd open another pull request, documenting the difference between `@head.*` and `@glyph.*`.