### PR TITLE
schema: add `note/@ledger.visible`

### DIFF
--- a/source/modules/MEI.shared.xml
+++ b/source/modules/MEI.shared.xml
@@ -2632,6 +2632,17 @@
       </attDef>
     </attList>
   </classSpec>
+  <classSpec ident="att.ledgerLines" module="MEI.shared" type="atts">
+    <desc xml:lang="en">Attributes pertaining to the ledger line part of a note.</desc>
+    <attList>
+      <attDef ident="ledger.visible" usage="opt">
+        <desc xml:lang="en">Determines whether ledger lines are to be displayed for this note.</desc>
+        <datatype>
+          <rng:ref name="data.BOOLEAN"/>
+        </datatype>
+      </attDef>
+    </attList>
+  </classSpec>
   <classSpec ident="att.octave" module="MEI.shared" type="atts">
     <desc xml:lang="en">Attributes that record written octave.</desc>
     <attList>

--- a/source/modules/MEI.visual.xml
+++ b/source/modules/MEI.visual.xml
@@ -50,6 +50,7 @@
     <classes>
       <memberOf key="att.color"/>
       <memberOf key="att.enclosingChars"/>
+      <memberOf key="att.ledgerLines"/>
       <memberOf key="att.noteHeads"/>
       <memberOf key="att.staffLoc"/>
       <memberOf key="att.stems"/>


### PR DESCRIPTION
Use cases for this attribute:
* Extreme pitches (Gould p. 13)
    <img width="737" height="158" alt="image" src="https://github.com/user-attachments/assets/a8afb7f6-9816-4840-a4f6-0c95a720ac93" />
* Rhythmic slash notation:
    <img width="885" height="151" alt="image" src="https://github.com/user-attachments/assets/0714e734-a19e-4f74-89d5-f86883a8e2f8" />
* Headless notes, e.g. for specifying the rhythmic details of a glissando (Rebecca Saunders: Nether):
    <img width="513" height="78" alt="image" src="https://github.com/user-attachments/assets/de76b078-6b45-469f-9d21-591974b78e14" />
