### PR TITLE
Allow zone inside clip

### DIFF
--- a/source/docs/12-facsimilesperformances.xml
+++ b/source/docs/12-facsimilesperformances.xml
@@ -210,6 +210,13 @@
                         <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/performances/performances-sample323.txt" parse="text"/></egXML>
                      </figure>
                   </p>
+                  <p>When the associated media is video, one or more nested <gi scheme="MEI">zone</gi> elements may identify a spatial region of interest within that temporal segment, for example a performer visible on screen. Spatial coordinates belong on <gi scheme="MEI">zone</gi>; <gi scheme="MEI">clip</gi> itself does not carry <ident type="class">att.coordinated</ident>.</p>
+                  <p>
+                     <figure>
+                        <head/>
+                        <egXML xmlns="http://www.tei-c.org/ns/Examples" rend="code" xml:space="preserve"><xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="../examples/performances/performances-sample337.txt" parse="text"/></egXML>
+                     </figure>
+                  </p>
                   <p>Beyond these relatively simple uses, complex situations may occur that require equally complex markup. For example, a single performance may be represented by multiple digital media files. Because they have differing durations, the media files must be the result of separate recording acts, even if these recording acts took place at the same time:</p>
                   <p>
                      <figure>

--- a/source/examples/performances/performances-sample337.txt
+++ b/source/examples/performances/performances-sample337.txt
@@ -1,0 +1,6 @@
+<recording begin="00:00:00.00" betype="time" end="00:12:03.00">
+   <avFile mimetype="video/mp4" target="concert.mp4"/>
+   <clip begin="00:07:12.00" betype="time" end="00:08:05.00">
+      <zone lrx="640" lry="480" ulx="120" uly="80"/>
+   </clip>
+</recording>

--- a/source/modules/MEI.facsimile.xml
+++ b/source/modules/MEI.facsimile.xml
@@ -107,7 +107,8 @@
     </remarks>
   </elementSpec>
   <elementSpec ident="zone" module="MEI.facsimile">
-    <desc xml:lang="en">Defines an area of interest within a <gi scheme="MEI">surface</gi> or graphic file.</desc>
+    <desc xml:lang="en">Defines an area of interest within a <gi scheme="MEI">surface</gi>, graphic file, or
+      <gi scheme="MEI">clip</gi>.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.coordinated"/>

--- a/source/modules/MEI.performance.xml
+++ b/source/modules/MEI.performance.xml
@@ -80,7 +80,8 @@
   </elementSpec>
   <elementSpec ident="clip" module="MEI.performance">
     <desc xml:lang="en">Defines a time segment of interest within a recording or within a digital audio or video
-      file.</desc>
+      file. Nested <gi scheme="MEI">zone</gi> elements may bound a spatial region of a video
+      clip.</desc>
     <classes>
       <memberOf key="att.common"/>
       <memberOf key="att.dataPointing"/>
@@ -95,6 +96,9 @@
       <rng:zeroOrMore>
         <rng:ref name="when"/>
       </rng:zeroOrMore>
+      <rng:zeroOrMore>
+        <rng:ref name="zone"/>
+      </rng:zeroOrMore>
     </content>
     <constraintSpec ident="betype_required_when_begin_or_end" scheme="schematron">
       <constraint>
@@ -106,7 +110,9 @@
     </constraintSpec>
     <remarks xml:lang="en">
       <p>This element is analogous to the <gi scheme="MEI">zone</gi> element in the facsimile
-        module.</p>
+        module. <gi scheme="MEI">clip</gi> remains a temporal feature; spatial coordinates of a
+        video region are encoded on nested <gi scheme="MEI">zone</gi> children rather than on
+        <gi scheme="MEI">clip</gi> itself.</p>
     </remarks>
   </elementSpec>
   <elementSpec ident="performance" module="MEI.performance">

--- a/tests/mei-all_anyStart/clip-allows-zone.mei
+++ b/tests/mei-all_anyStart/clip-allows-zone.mei
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="../../dist/schemata/mei-all_anyStart.rng" type="application/xml" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="../../dist/schemata/mei-all_anyStart.rng" type="application/xml" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+
+<!-- Nested zone on clip for spatial bounds of a video segment. Refs #952 -->
+<clip xmlns="http://www.music-encoding.org/ns/mei"
+  xmlns:mei="http://www.music-encoding.org/ns/mei" xmlns:xlink="http://www.w3.org/1999/xlink"
+  begin="00:02:00.00" end="00:02:20.00" betype="time">
+  <avFile mimetype="video/mp4" target="https://example.com/recording.mp4"/>
+  <zone xml:id="violaSolo" ulx="120" uly="80" lrx="640" lry="480"/>
+</clip>


### PR DESCRIPTION
Fixes #952

Berlin 2022 (kepper, quoting fujinaga, lpugin, pe-ro, musicEnfanthen) agreed to allow nested `zone` inside `clip` rather than putting `att.coordinated` on `clip`. Clip stays temporal; zone stays spatial.

Changes:
- `clip` content model: `avFile*`, `when*`, then `zone*` using the same `rng:ref` pattern as `surface`
- short updates to the `clip`/`zone` descriptions, remarks, and the performances guidelines
- sample fragment `tests/mei-all_anyStart/clip-allows-zone.mei`

`att.coordinated` is not added to `clip`.

Local checks (Apache Ant 1.10.15, OpenJDK 17; Homebrew `ant` is a different CLI):
- `ant validate-source`
- `ant validate-purification`
- `ant -Dcustomization.path=customizations/mei-all_anyStart.xml build-rng`
- `xmllint --noout --relaxng dist/schemata/mei-all_anyStart.rng tests/mei-all_anyStart/clip-allows-zone.mei` (valid)
- clip without `zone` still valid; `ulx` on `clip` rejected

Full `build-customizations` was not run. The compiled `mei-all_anyStart` RNG contains `mei_zone` children on `mei_clip` and does not attach `att.coordinated` to `clip`.

### AI/LLM disclosure

- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.
